### PR TITLE
CARTA 1.0.1 patch (data folder changes)

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -118,5 +118,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
         else {
             this.props.appStore.appendFile(fileBrowserStore.fileList.directory, file, hdu);
         }
+        
+        fileBrowserStore.saveStartingDirectory();
     }
 }

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -15,7 +15,7 @@ export class FileBrowserStore {
     @observable loadingInfo = false;
     @observable fileInfoResp = false;
     @observable respErrmsg: string = "";
-    @observable startingDirectory: string = ""; // change to $DEFAULT once backend knows how to use that
+    @observable startingDirectory: string = "$BASE";
 
     @action showFileBrowser = (append = false) => {
         this.appendingFrame = append;

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -15,12 +15,13 @@ export class FileBrowserStore {
     @observable loadingInfo = false;
     @observable fileInfoResp = false;
     @observable respErrmsg: string = "";
+    @observable startingDirectory: string = ""; // change to $DEFAULT once backend knows how to use that
 
     @action showFileBrowser = (append = false) => {
         this.appendingFrame = append;
         this.fileBrowserDialogVisible = true;
         this.selectedTab = "fileInfo";
-        this.getFileList("");
+        this.getFileList(this.startingDirectory);
     };
 
     @action hideFileBrowser = () => {
@@ -88,6 +89,10 @@ export class FileBrowserStore {
 
     @action setSelectedTab(newId: TabId) {
         this.selectedTab = newId;
+    }
+    
+    @action saveStartingDirectory() {
+        this.startingDirectory = this.fileList.directory;
     }
 
     private backendService: BackendService;


### PR DESCRIPTION
These are the frontend changes for the CARTA 1.0.1 patch. **This PR should only be merged once `pam/folder_arguments` is merged into the backend master branch.**

1. The default starting file directory is set to "$BASE"
2. The last directory from which the user opened a file is remembered and used as the starting directory the next time the dialog is used.