### PR TITLE
fixed scaling issues when using renderHiDPI flag and set it enabled by default

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -202,7 +202,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                 {appStore.activeFrame &&
                 <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>
                     <Tag large={true}>
-                        {appStore.activeFrame.renderWidth} x {appStore.activeFrame.renderHeight} ({(appStore.activeFrame.renderWidth / appStore.activeFrame.renderHeight).toFixed(2)})
+                        {appStore.activeFrame.renderWidth * (appStore.activeFrame.renderHiDPI? devicePixelRatio : 1)} x {appStore.activeFrame.renderHeight * (appStore.activeFrame.renderHiDPI? devicePixelRatio : 1)} ({(appStore.activeFrame.renderWidth / appStore.activeFrame.renderHeight).toFixed(2)})
                     </Tag>
                 </div>
                 }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -154,8 +154,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private clearCanvas() {
         const frame = this.props.frame;
         // Resize and/or clear the canvas
-        this.canvas.width = frame.renderWidth;
-        this.canvas.height = frame.renderHeight;
+        this.canvas.width = frame.renderWidth * devicePixelRatio;
+        this.canvas.height = frame.renderHeight * devicePixelRatio;
     }
 
     private renderCanvas() {
@@ -181,7 +181,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             RB.x, RB.y, 0
         ].map(v => -1 + 2 * v));
 
-        this.gl.viewport(0, 0, frame.renderWidth, frame.renderHeight);
+        this.gl.viewport(0, 0, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
         this.gl.enable(WebGLRenderingContext.DEPTH_TEST);
         this.gl.clear(WebGLRenderingContext.COLOR_BUFFER_BIT | WebGLRenderingContext.DEPTH_BUFFER_BIT);
         this.gl.bindBuffer(WebGLRenderingContext.ARRAY_BUFFER, this.vertexUVBuffer);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -36,7 +36,7 @@ export class FrameStore {
 
     constructor(overlay: OverlayStore) {
         this.overlayStore = overlay;
-        this.renderHiDPI = false;
+        this.renderHiDPI = true;
         this.center = {x: 0, y: 0};
         this.stokes = 0;
         this.channel = 0;


### PR DESCRIPTION
@kswang1029 this is the issue we were discussing previously, where images were slightly blurry, even when viewed at 1.0 resolution. Can you give it a check?

fixes #156 