### PR TITLE
Angus/region list

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "private": true,
     "homepage": "./",
     "dependencies": {
-        "@blueprintjs/core": "^3.13.0",
+        "@blueprintjs/core": "^3.14.1",
         "@blueprintjs/icons": "^3.6.0",
-        "@blueprintjs/select": "^3.6.1",
+        "@blueprintjs/select": "^3.7.0",
+        "@blueprintjs/table": "^3.4.1",
         "chart.js": "^2.8.0-rc.1",
         "chartjs-plugin-annotation": "^0.5.7",
         "electron": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
         "@blueprintjs/core": "^3.14.1",
         "@blueprintjs/icons": "^3.6.0",
         "@blueprintjs/select": "^3.7.0",
-        "@blueprintjs/table": "^3.4.1",
         "chart.js": "^2.8.0-rc.1",
         "chartjs-plugin-annotation": "^0.5.7",
         "electron": "^4.0.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,12 +100,6 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         props: {appStore: this.props.appStore, id: "render-config-0", docked: true}
                     }, {
                         type: "react-component",
-                        component: "region-list",
-                        title: "Region List",
-                        id: "region-list-docked",
-                        props: {appStore: this.props.appStore, id: "region-list-docked", docked: true}
-                    }, {
-                        type: "react-component",
                         component: "log",
                         title: "Log",
                         id: "log-docked",
@@ -137,7 +131,13 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         title: "Animator",
                         id: "animator-0",
                         props: {appStore: this.props.appStore, id: "animator-0", docked: true}
-                    }]
+                    }, {
+                        type: "react-component",
+                        component: "region-list",
+                        title: "Region List",
+                        id: "region-list-docked",
+                        props: {appStore: this.props.appStore, id: "region-list-docked", docked: true}
+                    },]
                 }]
             }]
         }];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,7 +186,6 @@ export class App extends React.Component<{ appStore: AppStore }> {
 
         return (
             <div className={className}>
-                {process.env.NODE_ENV === "development" && <DevTools/>}
                 <RootMenuComponent appStore={appStore}/>
                 <OverlaySettingsDialogComponent appStore={appStore}/>
                 <URLConnectDialogComponent appStore={appStore}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,12 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         props: {appStore: this.props.appStore, id: "render-config-0", docked: true}
                     }, {
                         type: "react-component",
+                        component: "region-list",
+                        title: "Region List",
+                        id: "region-list-docked",
+                        props: {appStore: this.props.appStore, id: "region-list-docked", docked: true}
+                    }, {
+                        type: "react-component",
                         component: "log",
                         title: "Log",
                         id: "log-docked",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import DevTools from "mobx-react-devtools";
 import ReactResizeDetector from "react-resize-detector";
 import {Alert, Classes, Colors, Dialog, Hotkey, Hotkeys, HotkeysTarget} from "@blueprintjs/core";
 import {exportImage, FloatingWidgetManagerComponent, RootMenuComponent} from "./components";
-import {AboutDialogComponent, FileBrowserDialogComponent, OverlaySettingsDialogComponent, URLConnectDialogComponent} from "./components/Dialogs";
+import {AboutDialogComponent, FileBrowserDialogComponent, OverlaySettingsDialogComponent, RegionDialogComponent, URLConnectDialogComponent} from "./components/Dialogs";
 import {AppStore, dayPalette, FileBrowserStore, nightPalette, RegionMode} from "./stores";
 import {smoothStepOffset} from "./utilities";
 import GitCommit from "./static/gitInfo";
@@ -137,7 +137,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         title: "Region List",
                         id: "region-list-docked",
                         props: {appStore: this.props.appStore, id: "region-list-docked", docked: true}
-                    },]
+                    }]
                 }]
             }]
         }];
@@ -191,6 +191,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
                 <URLConnectDialogComponent appStore={appStore}/>
                 <FileBrowserDialogComponent appStore={appStore}/>
                 <AboutDialogComponent appStore={appStore}/>
+                <RegionDialogComponent appStore={appStore}/>
                 <Alert isOpen={appStore.alertStore.alertVisible} onClose={appStore.alertStore.dismissAlert} canEscapeKeyCancel={true}>
                     <p>{appStore.alertStore.alertText}</p>
                 </Alert>

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.scss
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.scss
@@ -1,0 +1,3 @@
+.about-dialog {
+
+}

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import {observer} from "mobx-react";
+import {AnchorButton, Classes, IDialogProps, Intent, NonIdealState} from "@blueprintjs/core";
+import {DraggableDialogComponent} from "components/Dialogs";
+import {AppStore} from "stores";
+import "./RegionDialogComponent.css";
+
+@observer
+export class RegionDialogComponent extends React.Component<{ appStore: AppStore }> {
+
+    public render() {
+        const appStore = this.props.appStore;
+
+        const dialogProps: IDialogProps = {
+            icon: "info-sign",
+            backdropClassName: "minimal-dialog-backdrop",
+            canOutsideClickClose: true,
+            lazy: true,
+            isOpen: appStore.regionDialogVisible,
+            onClose: appStore.hideRegionDialog,
+            className: "region-dialog",
+            canEscapeKeyClose: true,
+            title: "No region selected",
+        };
+
+        let bodyContent;
+
+        if (!appStore.activeFrame || !appStore.activeFrame.regionSet.selectedRegion) {
+            bodyContent = <NonIdealState icon={"folder-open"} title={"No region selected"} description={"Select a region using the list or image view"}/>;
+        } else {
+            const region = appStore.activeFrame.regionSet.selectedRegion;
+            dialogProps.title = region.regionId === 0 ? "Editing Cursor" : `Editing Region ${region.regionId}`;
+            bodyContent = <h1>Placeholder</h1>;
+        }
+
+        return (
+            <DraggableDialogComponent dialogProps={dialogProps} defaultWidth={600} defaultHeight={400} minHeight={300} minWidth={400} enableResizing={true}>
+                <div className={Classes.DIALOG_BODY}>
+                    {bodyContent}
+                </div>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <AnchorButton intent={Intent.SUCCESS} onClick={appStore.hideRegionDialog} text="Apply"/>
+                        <AnchorButton intent={Intent.NONE} onClick={appStore.hideRegionDialog} text="Close"/>
+                    </div>
+                </div>
+            </DraggableDialogComponent>
+        );
+    }
+}

--- a/src/components/Dialogs/index.ts
+++ b/src/components/Dialogs/index.ts
@@ -4,3 +4,4 @@ export * from "./FileBrowser/FileBrowserDialogComponent";
 export * from "./OverlaySettings/OverlaySettingsDialogComponent";
 export * from "./TaskProgressDialog/TaskProgressDialogComponent";
 export * from "./URLConnect/URLConnectDialogComponent";
+export * from "./RegionDialog/RegionDialogComponent";

--- a/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
+++ b/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {AnimatorComponent, FloatingWidgetComponent, ImageViewComponent, LogComponent, PlaceholderComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
+import {AnimatorComponent, FloatingWidgetComponent, ImageViewComponent, LogComponent, PlaceholderComponent, RegionListComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
 import {AppStore, WidgetConfig} from "stores";
 
 @observer
@@ -30,6 +30,8 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
                 return <SpatialProfilerComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
             case SpectralProfilerComponent.WIDGET_CONFIG.type:
                 return <SpectralProfilerComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+            case RegionListComponent.WIDGET_CONFIG.type:
+                return <RegionListComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
             default:
                 return <PlaceholderComponent appStore={appStore} id={widgetConfig.id} docked={false} label={widgetConfig.title}/>;
         }
@@ -46,7 +48,7 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
                         <FloatingWidgetComponent
                             isSelected={index === widgetConfigs.length - 1}
                             appStore={appStore}
-                            key={w.id}
+                            key={`${w.type}-${w.id}-${index}`}
                             widgetConfig={w}
                             zIndex={index}
                             showPinButton={true}

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -250,20 +250,22 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         let regionRects = null;
 
         if (regionSet && regionSet.regions.length) {
-            regionRects = regionSet.regions.filter(r => (r.regionType === CARTA.RegionType.RECTANGLE || r.regionType === CARTA.RegionType.ELLIPSE) && r.isValid).map(
-                r => (
-                    <RegionComponent
-                        key={r.regionId}
-                        region={r}
-                        frame={frame}
-                        layerWidth={this.props.width}
-                        layerHeight={this.props.height}
-                        selected={r === regionSet.selectedRegion}
-                        onSelect={regionSet.selectRegion}
-                        listening={regionSet.mode !== RegionMode.CREATING}
-                    />
-                )
-            );
+            regionRects = regionSet.regions.filter(r => (r.regionType === CARTA.RegionType.RECTANGLE || r.regionType === CARTA.RegionType.ELLIPSE) && r.isValid)
+                .sort((a, b) => a.boundingBoxArea > b.boundingBoxArea ? -1 : 1)
+                .map(
+                    r => (
+                        <RegionComponent
+                            key={r.regionId}
+                            region={r}
+                            frame={frame}
+                            layerWidth={this.props.width}
+                            layerHeight={this.props.height}
+                            selected={r === regionSet.selectedRegion}
+                            onSelect={regionSet.selectRegion}
+                            listening={regionSet.mode !== RegionMode.CREATING}
+                        />
+                    )
+                );
         }
 
         let cursorMarker = null;

--- a/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
+++ b/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
@@ -3,7 +3,7 @@ import * as GoldenLayout from "golden-layout";
 import {observer} from "mobx-react";
 import {Button, ButtonGroup, Tooltip} from "@blueprintjs/core";
 import {AppStore, WidgetConfig} from "stores";
-import {AnimatorComponent, LogComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
+import {AnimatorComponent, LogComponent, RegionListComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
 import "./ToolbarMenuComponent.css";
 
 @observer
@@ -36,6 +36,7 @@ export class ToolbarMenuComponent extends React.Component<{ appStore: AppStore }
             this.createDragSource(layout, RenderConfigComponent.WIDGET_CONFIG, "renderConfigButton");
             this.createDragSource(layout, LogComponent.WIDGET_CONFIG, "logButton");
             this.createDragSource(layout, AnimatorComponent.WIDGET_CONFIG, "animatorButton");
+            this.createDragSource(layout, RegionListComponent.WIDGET_CONFIG, "regionListButton");
             this.createDragSource(layout, SpatialProfilerComponent.WIDGET_CONFIG, "spatialProfilerButton");
             this.createDragSource(layout, SpectralProfilerComponent.WIDGET_CONFIG, "spectralProfilerButton");
             this.createdDragSources = true;
@@ -59,6 +60,9 @@ export class ToolbarMenuComponent extends React.Component<{ appStore: AppStore }
                 </Tooltip>
                 <Tooltip content={<span>Animator Widget{commonTooltip}</span>}>
                     <Button icon={"video"} id="animatorButton" onClick={this.props.appStore.widgetsStore.createFloatingAnimatorWidget}/>
+                </Tooltip>
+                <Tooltip content={<span>Region List Widget{commonTooltip}</span>}>
+                    <Button icon={"th-list"} id="regionListButton" onClick={this.props.appStore.widgetsStore.createFloatingRegionListWidget}/>
                 </Tooltip>
                 <Tooltip content={<span>Spatial Profiler{commonTooltip}</span>}>
                     <Button icon={"pulse"} id="spatialProfilerButton" className={"profiler-button"} onClick={this.props.appStore.widgetsStore.createFloatingSpatialProfilerWidget}>

--- a/src/components/RegionList/RegionListComponent.scss
+++ b/src/components/RegionList/RegionListComponent.scss
@@ -3,11 +3,65 @@
 .region-list-widget {
     width: 100%;
     height: 100%;
-    .bp3-table-cell {
-        font-size: 14px;
-    }
 
     .region-editing {
-        color: $red2;
+    }
+
+    table {
+        padding: 5px;
+        overflow: auto;
+        display: block;
+        thead {
+            tr {
+                display: block;
+
+                th {
+                    cursor: default;
+                    border-top: 1px solid $gray5;
+                    border-bottom: 1px solid $gray5;
+                    border-left: 1px solid $gray5;
+
+                    &:last-of-type {
+                        border-right: 1px solid $gray5;
+                    }
+                }
+            }
+        }
+
+        tbody {
+            display: block;
+            background: $white;
+            &.dark-theme {
+                background: $dark-gray2;
+
+                tr {
+                    td {
+                        border-left: 1px solid $dark-gray3;
+                        border-bottom: 1px solid $dark-gray5;
+
+                        &:last-of-type {
+                            border-right: 1px solid $dark-gray3;
+                        }
+                    }
+                }
+            }
+
+            tr {
+                &.selected {
+                    background: lighten($blue5, 30);
+                }
+
+                td {
+                    cursor: pointer;
+                    border-left: 1px solid $gray5;
+                    border-bottom: 1px solid $gray4;
+
+                    &:last-of-type {
+                        border-right: 1px solid $gray5;
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/src/components/RegionList/RegionListComponent.scss
+++ b/src/components/RegionList/RegionListComponent.scss
@@ -1,0 +1,13 @@
+@import "../../../node_modules/@blueprintjs/core/lib/scss/variables.scss";
+
+.region-list-widget {
+    width: 100%;
+    height: 100%;
+    .bp3-table-cell {
+        font-size: 14px;
+    }
+
+    .region-editing {
+        color: $red2;
+    }
+}

--- a/src/components/RegionList/RegionListComponent.scss
+++ b/src/components/RegionList/RegionListComponent.scss
@@ -16,6 +16,7 @@
                 display: block;
 
                 th {
+                    padding: 5px;
                     cursor: default;
                     border-top: 1px solid $gray5;
                     border-bottom: 1px solid $gray5;
@@ -52,6 +53,7 @@
                 }
 
                 td {
+                    padding: 5px;
                     cursor: pointer;
                     border-left: 1px solid $gray5;
                     border-bottom: 1px solid $gray4;

--- a/src/components/RegionList/RegionListComponent.scss
+++ b/src/components/RegionList/RegionListComponent.scss
@@ -11,7 +11,22 @@
         padding: 5px;
         overflow: auto;
         display: block;
+
         thead {
+            &.dark-theme {
+                tr {
+                    th {
+                        border-top: 1px solid $dark-gray4;
+                        border-bottom: 1px solid $dark-gray5;
+                        border-left: 1px solid $dark-gray4;
+
+                        &:last-of-type {
+                            border-right: 1px solid $dark-gray4;
+                        }
+                    }
+                }
+            }
+
             tr {
                 display: block;
 
@@ -19,7 +34,7 @@
                     padding: 5px;
                     cursor: default;
                     border-top: 1px solid $gray5;
-                    border-bottom: 1px solid $gray5;
+                    border-bottom: 1px solid $gray4;
                     border-left: 1px solid $gray5;
 
                     &:last-of-type {
@@ -32,6 +47,7 @@
         tbody {
             display: block;
             background: $white;
+
             &.dark-theme {
                 background: $dark-gray2;
 
@@ -43,6 +59,10 @@
                         &:last-of-type {
                             border-right: 1px solid $dark-gray3;
                         }
+                    }
+
+                    &.selected {
+                        background: $blue2;
                     }
                 }
             }

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {computed} from "mobx";
+import {computed, observable} from "mobx";
 import {observer} from "mobx-react";
-import {NonIdealState} from "@blueprintjs/core";
-import {Cell, Column, IRegion, RenderMode, SelectionModes, Table} from "@blueprintjs/table";
+import {HTMLTable, NonIdealState} from "@blueprintjs/core";
+import ReactResizeDetector from "react-resize-detector";
 import {RegionStore, WidgetConfig, WidgetProps} from "stores";
 import "./RegionListComponent.css";
+import {min} from "rxjs/operators";
 
 @observer
 export class RegionListComponent extends React.Component<WidgetProps> {
@@ -15,14 +16,8 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         return [];
     }
 
-    @computed get selectedRow(): IRegion[] {
-        const frame = this.props.appStore.activeFrame;
-        if (frame && frame.regionSet.selectedRegion) {
-            const index = frame.regionSet.regions.indexOf(frame.regionSet.selectedRegion);
-            return [{rows: [index, index]}];
-        }
-        return [];
-    }
+    @observable width: number;
+    @observable height: number;
 
     public static get WIDGET_CONFIG(): WidgetConfig {
         return {
@@ -37,37 +32,9 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         };
     }
 
-    private renderName = (rowIndex: number) => {
-        const region = this.validRegions[rowIndex];
-        return <Cell className={region.editing ? "region-editing" : ""}>{region.regionId === 0 ? "Cursor" : `Region ${region.regionId}`}</Cell>;
-    };
-
-    private renderType = (rowIndex: number) => {
-        const region = this.validRegions[rowIndex];
-        return <Cell className={region.editing ? "region-editing" : ""}>{RegionStore.RegionTypeString(region.regionType)}</Cell>;
-    };
-
-    private renderCenter = (rowIndex: number) => {
-        const region = this.validRegions[rowIndex];
-        if (region.controlPoints.length) {
-            const point = region.controlPoints[0];
-            if (isFinite(point.x) && isFinite(point.y)) {
-                return <Cell className={region.editing ? "region-editing" : ""}>{`(${point.x.toFixed(0)}, ${point.y.toFixed(0)})`}</Cell>;
-            }
-        }
-        return <Cell>Invalid</Cell>;
-    };
-
-    private renderRotation = (rowIndex: number) => {
-        const region = this.validRegions[rowIndex];
-        return <Cell className={region.editing ? "region-editing" : ""}>{region.rotation.toFixed(1)}</Cell>;
-    };
-
-    private handleSelection = (selectedRegions: IRegion[]) => {
-        const frame = this.props.appStore.activeFrame;
-        if (frame && frame.regionSet.regions.length && selectedRegions.length) {
-            frame.regionSet.selectRegionByIndex(selectedRegions[0].rows[0]);
-        }
+    private onResize = (width: number, height: number) => {
+        this.width = width;
+        this.height = height;
     };
 
     render() {
@@ -77,27 +44,59 @@ export class RegionListComponent extends React.Component<WidgetProps> {
             return <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"}/>;
         }
 
-        // dummy
-        const x = this.validRegions.map(r => r.controlPoints.length);
-        const y = this.validRegions.map(r => r.rotation);
+        const padding = 5;
+        const rowSize = 41;
+        const requiredTableHeight = 1 + padding * 2 + rowSize * (this.validRegions.length + 1);
+        const tableHeight = Math.min(requiredTableHeight, this.height);
+
+        let nameWidth = 160;
+        const typeWidth = 100;
+        const centerWidth = 120;
+        const rotationWidth = 80;
+
+        const availableWidth = this.width - 2 * padding;
+        const fixedWidth = typeWidth + centerWidth + rotationWidth;
+        nameWidth = availableWidth - fixedWidth;
+        const selectedRegion = frame.regionSet.selectedRegion;
+
+        const rows = this.validRegions.map(region => {
+            const point = region.controlPoints[0];
+            let pixelCenterEntry;
+            if (isFinite(point.x) && isFinite(point.y)) {
+                pixelCenterEntry = <td style={{width: centerWidth}}>{`(${point.x.toFixed(0)}, ${point.y.toFixed(0)})`}</td>;
+            } else {
+                pixelCenterEntry = <td style={{width: centerWidth}}>Invalid</td>;
+            }
+            return (
+                <tr
+                    className={(selectedRegion && selectedRegion.regionId === region.regionId) ? "selected" : ""}
+                    key={region.regionId}
+                    onClick={() => frame.regionSet.selectRegion(region)}
+                >
+                    <td style={{width: nameWidth}}>{region.regionId === 0 ? "Cursor" : `Region ${region.regionId}`}</td>
+                    <td style={{width: typeWidth}}>{RegionStore.RegionTypeString(region.regionType)}</td>
+                    {pixelCenterEntry}
+                    <td style={{width: rotationWidth}}>{region.rotation.toFixed(1)}</td>
+                </tr>
+            );
+        });
 
         return (
             <div className="region-list-widget">
-                <Table
-                    numRows={this.validRegions.length}
-                    defaultRowHeight={25}
-                    selectionModes={SelectionModes.ROWS_AND_CELLS}
-                    onSelection={this.handleSelection}
-                    selectedRegions={this.selectedRow}
-                    enableMultipleSelection={false}
-                    enableRowHeader={false}
-                    renderMode={RenderMode.NONE}
-                >
-                    <Column name="Name" cellRenderer={this.renderName}/>
-                    <Column name="Type" cellRenderer={this.renderType}/>
-                    <Column name="Pixel Center" cellRenderer={this.renderCenter}/>
-                    <Column name="Rotation (Deg)" cellRenderer={this.renderRotation}/>
-                </Table>
+                <HTMLTable style={{height: tableHeight}}>
+                    <thead>
+                    <tr>
+                        <th style={{width: nameWidth}}>Name</th>
+                        <th style={{width: typeWidth}}>Type</th>
+                        <th style={{width: centerWidth}}>Pixel Center</th>
+                        <th style={{width: rotationWidth}}>Rotation</th>
+                    </tr>
+                    </thead>
+                    <tbody className={this.props.appStore.darkTheme ? "dark-theme" : ""}>
+                    {rows}
+                    </tbody>
+                </HTMLTable>
+                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize}/>
             </div>
         );
     }

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -41,13 +41,18 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         const frame = this.props.appStore.activeFrame;
 
         if (!frame) {
-            return <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"}/>;
+            return (
+                <div className="region-list-widget">
+                    <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"}/>;
+                    <ReactResizeDetector handleWidth handleHeight onResize={this.onResize}/>
+                </div>
+            );
         }
 
         const padding = 5;
         const rowSize = 41;
         const requiredTableHeight = 1 + padding * 2 + rowSize * (this.validRegions.length + 1);
-        const tableHeight = Math.min(requiredTableHeight, this.height);
+        const tableHeight = isFinite(this.height) ? Math.min(requiredTableHeight, this.height) : requiredTableHeight;
 
         let nameWidth = 160;
         const typeWidth = 90;
@@ -57,7 +62,9 @@ export class RegionListComponent extends React.Component<WidgetProps> {
 
         const availableWidth = this.width - 2 * padding;
         const fixedWidth = typeWidth + centerWidth + sizeWidth + rotationWidth;
-        nameWidth = availableWidth - fixedWidth;
+        if (availableWidth > fixedWidth) {
+            nameWidth = availableWidth - fixedWidth;
+        }
         const selectedRegion = frame.regionSet.selectedRegion;
 
         const rows = this.validRegions.map(region => {

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import {computed} from "mobx";
+import {observer} from "mobx-react";
+import {NonIdealState} from "@blueprintjs/core";
+import {Cell, Column, IRegion, RenderMode, SelectionModes, Table} from "@blueprintjs/table";
+import {RegionStore, WidgetConfig, WidgetProps} from "stores";
+import "./RegionListComponent.css";
+
+@observer
+export class RegionListComponent extends React.Component<WidgetProps> {
+    @computed get validRegions(): RegionStore[] {
+        if (this.props.appStore.activeFrame) {
+            return this.props.appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary);
+        }
+        return [];
+    }
+
+    @computed get selectedRow(): IRegion[] {
+        const frame = this.props.appStore.activeFrame;
+        if (frame && frame.regionSet.selectedRegion) {
+            const index = frame.regionSet.regions.indexOf(frame.regionSet.selectedRegion);
+            return [{rows: [index, index]}];
+        }
+        return [];
+    }
+
+    public static get WIDGET_CONFIG(): WidgetConfig {
+        return {
+            id: "region-list",
+            type: "region-list",
+            minWidth: 350,
+            minHeight: 180,
+            defaultWidth: 650,
+            defaultHeight: 180,
+            title: "Region List",
+            isCloseable: true
+        };
+    }
+
+    private renderName = (rowIndex: number) => {
+        const region = this.validRegions[rowIndex];
+        return <Cell className={region.editing ? "region-editing" : ""}>{region.regionId === 0 ? "Cursor" : `Region ${region.regionId}`}</Cell>;
+    };
+
+    private renderType = (rowIndex: number) => {
+        const region = this.validRegions[rowIndex];
+        return <Cell className={region.editing ? "region-editing" : ""}>{RegionStore.RegionTypeString(region.regionType)}</Cell>;
+    };
+
+    private renderCenter = (rowIndex: number) => {
+        const region = this.validRegions[rowIndex];
+        if (region.controlPoints.length) {
+            const point = region.controlPoints[0];
+            if (isFinite(point.x) && isFinite(point.y)) {
+                return <Cell className={region.editing ? "region-editing" : ""}>{`(${point.x.toFixed(0)}, ${point.y.toFixed(0)})`}</Cell>;
+            }
+        }
+        return <Cell>Invalid</Cell>;
+    };
+
+    private renderRotation = (rowIndex: number) => {
+        const region = this.validRegions[rowIndex];
+        return <Cell className={region.editing ? "region-editing" : ""}>{region.rotation.toFixed(1)}</Cell>;
+    };
+
+    private handleSelection = (selectedRegions: IRegion[]) => {
+        const frame = this.props.appStore.activeFrame;
+        if (frame && frame.regionSet.regions.length && selectedRegions.length) {
+            frame.regionSet.selectRegionByIndex(selectedRegions[0].rows[0]);
+        }
+    };
+
+    render() {
+        const frame = this.props.appStore.activeFrame;
+
+        if (!frame) {
+            return <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"}/>;
+        }
+
+        // dummy
+        const x = this.validRegions.map(r => r.controlPoints.length);
+        const y = this.validRegions.map(r => r.rotation);
+
+        return (
+            <div className="region-list-widget">
+                <Table
+                    numRows={this.validRegions.length}
+                    defaultRowHeight={25}
+                    selectionModes={SelectionModes.ROWS_AND_CELLS}
+                    onSelection={this.handleSelection}
+                    selectedRegions={this.selectedRow}
+                    enableMultipleSelection={false}
+                    enableRowHeader={false}
+                    renderMode={RenderMode.NONE}
+                >
+                    <Column name="Name" cellRenderer={this.renderName}/>
+                    <Column name="Type" cellRenderer={this.renderType}/>
+                    <Column name="Pixel Center" cellRenderer={this.renderCenter}/>
+                    <Column name="Rotation (Deg)" cellRenderer={this.renderRotation}/>
+                </Table>
+            </div>
+        );
+    }
+}

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -3,9 +3,9 @@ import {computed, observable} from "mobx";
 import {observer} from "mobx-react";
 import {HTMLTable, NonIdealState} from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
+import {CARTA} from "carta-protobuf";
 import {RegionStore, WidgetConfig, WidgetProps} from "stores";
 import "./RegionListComponent.css";
-import {min} from "rxjs/operators";
 
 @observer
 export class RegionListComponent extends React.Component<WidgetProps> {
@@ -50,12 +50,13 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         const tableHeight = Math.min(requiredTableHeight, this.height);
 
         let nameWidth = 160;
-        const typeWidth = 100;
+        const typeWidth = 90;
         const centerWidth = 120;
+        const sizeWidth = 160;
         const rotationWidth = 80;
 
         const availableWidth = this.width - 2 * padding;
-        const fixedWidth = typeWidth + centerWidth + rotationWidth;
+        const fixedWidth = typeWidth + centerWidth + sizeWidth + rotationWidth;
         nameWidth = availableWidth - fixedWidth;
         const selectedRegion = frame.regionSet.selectedRegion;
 
@@ -67,15 +68,28 @@ export class RegionListComponent extends React.Component<WidgetProps> {
             } else {
                 pixelCenterEntry = <td style={{width: centerWidth}}>Invalid</td>;
             }
+
+            let pixelSizeEntry;
+            const sizePoint = region.controlPoints[0];
+            if (region.regionType === CARTA.RegionType.RECTANGLE) {
+                pixelSizeEntry = <td style={{width: sizeWidth}}>{`(${sizePoint.x.toFixed(0)} \u00D7 ${sizePoint.y.toFixed(0)})`}</td>;
+            } else if (region.regionType === CARTA.RegionType.ELLIPSE) {
+                pixelSizeEntry = <td style={{width: sizeWidth}}>{`maj: ${sizePoint.x.toFixed(0)}; min: ${sizePoint.y.toFixed(0)}`}</td>;
+            } else {
+                pixelSizeEntry = <td style={{width: sizeWidth}}/>;
+            }
+
             return (
                 <tr
                     className={(selectedRegion && selectedRegion.regionId === region.regionId) ? "selected" : ""}
                     key={region.regionId}
                     onClick={() => frame.regionSet.selectRegion(region)}
+                    onDoubleClick={this.props.appStore.showRegionDialog}
                 >
                     <td style={{width: nameWidth}}>{region.regionId === 0 ? "Cursor" : `Region ${region.regionId}`}</td>
                     <td style={{width: typeWidth}}>{RegionStore.RegionTypeString(region.regionType)}</td>
                     {pixelCenterEntry}
+                    {pixelSizeEntry}
                     <td style={{width: rotationWidth}}>{region.rotation.toFixed(1)}</td>
                 </tr>
             );
@@ -84,11 +98,12 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         return (
             <div className="region-list-widget">
                 <HTMLTable style={{height: tableHeight}}>
-                    <thead>
+                    <thead className={this.props.appStore.darkTheme ? "dark-theme" : ""}>
                     <tr>
                         <th style={{width: nameWidth}}>Name</th>
                         <th style={{width: typeWidth}}>Type</th>
                         <th style={{width: centerWidth}}>Pixel Center</th>
+                        <th style={{width: sizeWidth}}>Size</th>
                         <th style={{width: rotationWidth}}>Rotation</th>
                     </tr>
                     </thead>

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.scss
@@ -4,6 +4,9 @@
     display: flex;
     width: 100%;
     height: 100%;
+    border: 1px solid transparent;
+    border-radius: 2px;
+    transition: border 500ms linear;
 
     .profile-container {
         flex: 3 3 auto;
@@ -13,5 +16,10 @@
             height: 100%;
             position: relative;
         }
+    }
+
+    &.linked-to-selected {
+        border: 1px solid $red2;
+        transition: border 500ms linear;
     }
 }

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -172,7 +172,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
         autorun(() => {
             const appStore = this.props.appStore;
-            const linkedToSelectedRegion = appStore.activeFrame.regionSet.selectedRegion && this.widgetStore.regionId === appStore.activeFrame.regionSet.selectedRegion.regionId;
+            const linkedToSelectedRegion = appStore.activeFrame && appStore.activeFrame.regionSet.selectedRegion && this.widgetStore.regionId === appStore.activeFrame.regionSet.selectedRegion.regionId;
             if (linkedToSelectedRegion) {
                 clearTimeout(this.highlightHandle);
                 this.highlightHandle = setTimeout(() => this.showHighlight = false, 2000);

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -32,6 +32,9 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
     @observable width: number;
     @observable height: number;
+    @observable showHighlight: boolean;
+
+    private highlightHandle;
 
     @computed get widgetStore(): SpectralProfileWidgetStore {
         if (this.props.appStore && this.props.appStore.widgetsStore.spectralProfileWidgets) {
@@ -166,6 +169,16 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `Z Profile: Cursor`);
             }
         });
+
+        autorun(() => {
+            const appStore = this.props.appStore;
+            const linkedToSelectedRegion = appStore.activeFrame.regionSet.selectedRegion && this.widgetStore.regionId === appStore.activeFrame.regionSet.selectedRegion.regionId;
+            if (linkedToSelectedRegion) {
+                clearTimeout(this.highlightHandle);
+                this.highlightHandle = setTimeout(() => this.showHighlight = false, 2000);
+                this.showHighlight = true;
+            }
+        });
     }
 
     onResize = (width: number, height: number) => {
@@ -177,8 +190,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         if (this.frame && this.frame.channelInfo) {
             let channelInfo = this.frame.channelInfo;
             let nearestIndex = (this.widgetStore.useWcsValues && channelInfo.getChannelIndexWCS) ?
-                            channelInfo.getChannelIndexWCS(x) :
-                            channelInfo.getChannelIndexSimple(x);
+                channelInfo.getChannelIndexWCS(x) :
+                channelInfo.getChannelIndexSimple(x);
             if (nearestIndex !== null && nearestIndex !== undefined) {
                 this.frame.setChannels(nearestIndex, this.frame.requiredStokes);
             }
@@ -360,8 +373,13 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             }
         }
 
+        let className = "spectral-profiler-widget";
+        if (this.showHighlight) {
+            className += " linked-to-selected";
+        }
+
         return (
-            <div className={"spectral-profiler-widget"}>
+            <div className={className}>
                 <div className="profile-container">
                     <div className="profile-plot">
                         <LinePlotComponent {...linePlotProps}/>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,5 +6,6 @@ export * from "./Log/LogComponent";
 export * from "./Menu/RootMenuComponent";
 export * from "./Placeholder/PlaceholderComponent";
 export * from "./RenderConfig/RenderConfigComponent";
+export * from "./RegionList/RegionListComponent";
 export * from "./SpatialProfiler/SpatialProfilerComponent";
 export * from "./SpectralProfiler/SpectralProfilerComponent";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import registerServiceWorker from "./registerServiceWorker";
 import "./index.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
+import "@blueprintjs/table/lib/css/table.css";
 import "./layout-base.css";
 
 // Pre-load static assets

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,6 @@ import registerServiceWorker from "./registerServiceWorker";
 import "./index.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
-import "@blueprintjs/table/lib/css/table.css";
 import "./layout-base.css";
 
 // Pre-load static assets

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -318,7 +318,11 @@ export class AppStore {
         }, 200);
 
         const debouncedSetCursor = _.debounce((fileId: number, x: number, y: number) => {
-            this.backendService.setCursor(fileId, x, y);
+            const frame = this.getFrame(fileId);
+            if (frame && frame.regionSet.regions[0]) {
+                frame.regionSet.regions[0].setControlPoint(0, {x, y});
+                this.backendService.setCursor(fileId, x, y);
+            }
         }, 200);
 
         // Update frame view

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -45,6 +45,16 @@ export class AppStore {
         this.imageToolbarVisible = false;
     };
 
+    // Region dialog
+    @observable regionDialogVisible: boolean;
+    @action showRegionDialog = () => {
+        console.log(`Showing dialog for ${this.activeFrame.regionSet.selectedRegion}`);
+        this.regionDialogVisible = true;
+    };
+    @action hideRegionDialog = () => {
+        this.regionDialogVisible = false;
+    };
+
     // Overlay
     @observable overlayStore: OverlayStore;
     // File Browser

--- a/src/stores/RegionSetStore.ts
+++ b/src/stores/RegionSetStore.ts
@@ -92,14 +92,21 @@ export class RegionSetStore {
         }
     };
 
+    @action selectRegionByIndex = (index: number) => {
+        if (index >= 0 && index < this.regions.length) {
+            this.selectedRegion = this.regions[index];
+        }
+    };
+
     @action deselectRegion = () => {
         this.selectedRegion = null;
     };
 
     @action deleteRegion = (region: RegionStore) => {
-        if (region && this.regions.length) {
+        // Cursor region cannot be deleted
+        if (region && region.regionId !== 0 && this.regions.length) {
             if (region === this.selectedRegion) {
-                this.selectedRegion = null;
+                this.selectedRegion = this.regions[0];
             }
             this.regions = this.regions.filter(r => r !== region);
             this.backendService.removeRegion(region.regionId);

--- a/src/stores/RegionSetStore.ts
+++ b/src/stores/RegionSetStore.ts
@@ -22,10 +22,10 @@ export class RegionSetStore {
         this.frame = frame;
         this.backendService = backendService;
         this.regions = [];
-        this.selectedRegion = null;
         this.newRegionType = CARTA.RegionType.RECTANGLE;
         this.mode = RegionMode.MOVING;
         this.addPointRegion({x: 0, y: 0}, true);
+        this.selectedRegion = this.regions[0];
     }
 
     // temporary region IDs are < 0 and used

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -17,6 +17,19 @@ export class RegionStore {
 
     private readonly backendService: BackendService;
 
+    public static RegionTypeString(regionType: CARTA.RegionType): string {
+        switch (regionType) {
+            case CARTA.RegionType.POINT:
+                return "Point";
+            case CARTA.RegionType.RECTANGLE:
+                return "Rectangle";
+            case CARTA.RegionType.ELLIPSE:
+                return "Ellipse";
+            default:
+                return "Not Implemented";
+        }
+    }
+
     @computed get isTemporary() {
         return this.regionId < 0;
     }
@@ -82,7 +95,7 @@ export class RegionStore {
     };
 
     @action setRotation = (angle: number) => {
-        this.rotation = angle;
+        this.rotation = (angle + 360) % 360;
         if (!this.editing) {
             this.updateRegion();
         }

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -34,6 +34,20 @@ export class RegionStore {
         return this.regionId < 0;
     }
 
+    @computed get boundingBoxArea(): number {
+        if (!this.isValid) {
+            return 0;
+        }
+        switch (this.regionType) {
+            case CARTA.RegionType.RECTANGLE:
+                return this.controlPoints[1].x * this.controlPoints[1].y;
+            case CARTA.RegionType.ELLIPSE:
+                return 4 * this.controlPoints[1].x * this.controlPoints[1].y;
+            default:
+                return 0;
+        }
+    }
+
     @computed get isClosedRegion() {
         switch (this.regionType) {
             case CARTA.RegionType.RECTANGLE:

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -1,7 +1,7 @@
 import * as GoldenLayout from "golden-layout";
 import * as $ from "jquery";
 import {action, observable} from "mobx";
-import {AnimatorComponent, ImageViewComponent, LogComponent, PlaceholderComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
+import {AnimatorComponent, ImageViewComponent, LogComponent, PlaceholderComponent, RegionListComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent} from "components";
 import {AppStore} from "./AppStore";
 import {RenderConfigWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore} from "./widgets";
 
@@ -58,6 +58,8 @@ export class WidgetsStore {
                 return SpatialProfilerComponent.WIDGET_CONFIG;
             case SpectralProfilerComponent.WIDGET_CONFIG.type:
                 return SpectralProfilerComponent.WIDGET_CONFIG;
+            case RegionListComponent.WIDGET_CONFIG.type:
+                return RegionListComponent.WIDGET_CONFIG;
             default:
                 return PlaceholderComponent.WIDGET_CONFIG;
         }
@@ -71,6 +73,7 @@ export class WidgetsStore {
         layout.registerComponent("spatial-profiler", SpatialProfilerComponent);
         layout.registerComponent("spectral-profiler", SpectralProfilerComponent);
         layout.registerComponent("render-config", RenderConfigComponent);
+        layout.registerComponent("region-list", RegionListComponent);
         layout.registerComponent("log", LogComponent);
         layout.registerComponent("animator", AnimatorComponent);
 
@@ -219,6 +222,10 @@ export class WidgetsStore {
 
     createFloatingAnimatorWidget = () => {
         this.addFloatingWidget(AnimatorComponent.WIDGET_CONFIG);
+    };
+
+    createFloatingRegionListWidget = () => {
+        this.addFloatingWidget(RegionListComponent.WIDGET_CONFIG);
     };
 
     // region Spatial Profile Widgets


### PR DESCRIPTION
This PR adds a region list widget, which displays some basic properties for each region. Clicking on a row in the list selects the associated region. In addtion: 
- double-clicking on the row brings up the region dialog (just a placeholder for now)
- pressing delete deletes the row
- selecting a region temporarily highlights all spectral profilers associated with that region

closes #173 