### PR TITLE
adds API key functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {smoothStepOffset} from "./utilities";
 import GitCommit from "./static/gitInfo";
 import "./App.css";
 import "./layout-theme.css";
+import {ApiKeyDialogComponent} from "./components/Dialogs/ApiKeyDialog/ApiKeyDialogComponent";
 
 @HotkeysTarget @observer
 export class App extends React.Component<{ appStore: AppStore }> {
@@ -60,7 +61,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
         // Log the frontend git commit hash
         appStore.logStore.addDebug(`Current frontend version: ${GitCommit.logMessage}`, ["version"]);
 
-        appStore.backendService.connect(wsURL, "1234").subscribe(sessionId => {
+        appStore.backendService.connect(wsURL, appStore.apiKey).subscribe(sessionId => {
             console.log(`Connected with session ID ${sessionId}`);
             connected = true;
             appStore.logStore.addInfo(`Connected to server ${wsURL}`, ["network"]);
@@ -189,6 +190,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
                 <RootMenuComponent appStore={appStore}/>
                 <OverlaySettingsDialogComponent appStore={appStore}/>
                 <URLConnectDialogComponent appStore={appStore}/>
+                <ApiKeyDialogComponent appStore={appStore}/>
                 <FileBrowserDialogComponent appStore={appStore}/>
                 <AboutDialogComponent appStore={appStore}/>
                 <RegionDialogComponent appStore={appStore}/>

--- a/src/components/Dialogs/ApiKeyDialog/ApiKeyDialogComponent.tsx
+++ b/src/components/Dialogs/ApiKeyDialog/ApiKeyDialogComponent.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import {observer} from "mobx-react";
+import {AnchorButton, Classes, IDialogProps, Intent, Tooltip} from "@blueprintjs/core";
+import {DraggableDialogComponent} from "components/Dialogs";
+import {AppStore} from "stores";
+import "./ApiKeyDialogComponent.css";
+import {observable} from "mobx";
+
+@observer
+export class ApiKeyDialogComponent extends React.Component<{ appStore: AppStore }> {
+    @observable key;
+
+    constructor(props: any) {
+        super(props);
+        this.key = this.props.appStore.apiKey;
+    }
+
+    public render() {
+        const appStore = this.props.appStore;
+        let className = "url-connect-dialog";
+        if (appStore.darkTheme) {
+            className += " bp3-dark";
+        }
+
+        const dialogProps: IDialogProps = {
+            icon: "key",
+            className: className,
+            backdropClassName: "minimal-dialog-backdrop",
+            canOutsideClickClose: true,
+            lazy: true,
+            isOpen: appStore.apiKeyDialogVisible,
+            onClose: appStore.hideApiKeyDialog,
+            title: "Edit API Key",
+        };
+
+        return (
+            <DraggableDialogComponent dialogProps={dialogProps} defaultWidth={400} defaultHeight={160} enableResizing={false}>
+                <div className={Classes.DIALOG_BODY}>
+                    <input className="bp3-input url-connect-input" type="text" placeholder="API Key" value={this.key} onChange={this.handleInput}/>
+                </div>
+                <div className={Classes.DIALOG_FOOTER}>
+                    <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                        <AnchorButton intent={Intent.NONE} onClick={appStore.hideApiKeyDialog} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={() => this.key = ""} disabled={!this.key} text="Clear"/>
+                        <AnchorButton intent={Intent.PRIMARY} onClick={this.onApplyKeyClicked} disabled={this.key === this.props.appStore.apiKey} text="Apply (Reload required)"/>
+                    </div>
+                </div>
+            </DraggableDialogComponent>
+        );
+    }
+
+    handleInput = (ev: React.FormEvent<HTMLInputElement>) => {
+        this.key = ev.currentTarget.value;
+    };
+
+    onApplyKeyClicked = () => {
+        const appStore = this.props.appStore;
+        appStore.applyApiKey(this.key);
+    };
+}

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -43,6 +43,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                 />
                 <Menu.Divider/>
                 <Menu.Item text="Preferences" icon={"cog"} label={`${modString}P`} disabled={true}/>
+                <Menu.Item text="Enter API Key" icon={"key"} onClick={appStore.showApiKeyDialog}/>
                 <Menu.Item text="Connect to URL" onClick={appStore.showURLConnect}/>
             </Menu>
         );

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -84,6 +84,26 @@ export class AppStore {
         this.aboutDialogVisible = false;
     };
 
+    @observable apiKey;
+    @action applyApiKey = (newKey: string, forceReload: boolean = true) => {
+        if (newKey) {
+            localStorage.setItem("API_KEY", newKey);
+            this.apiKey = newKey;
+        } else {
+            localStorage.removeItem("API_KEY");
+        }
+        if (forceReload) {
+            location.reload();
+        }
+    };
+    @observable apiKeyDialogVisible: boolean;
+    @action showApiKeyDialog = () => {
+        this.apiKeyDialogVisible = true;
+    };
+    @action hideApiKeyDialog = () => {
+        this.apiKeyDialogVisible = false;
+    };
+
     // Tasks
     @observable taskProgress: number;
     @observable taskStartTime: number;
@@ -303,6 +323,11 @@ export class AppStore {
     private existingRequirementsMap: Map<number, Map<number, CARTA.SetSpectralRequirements>>;
 
     constructor() {
+        const existingKey = localStorage.getItem("API_KEY");
+        if (existingKey) {
+            this.apiKey = existingKey;
+        }
+
         this.logStore = new LogStore();
         this.backendService = new BackendService(this.logStore);
         this.astReady = false;


### PR DESCRIPTION
Adds a dialog for editing the API key, which is stored in local storage and read when loading the frontend. This is required for our beta testers, in order to ensure that unauthenticated users can only view publicly available files on our server. 

(Requires a minor backend update before being useful)

closes #186 