### PR TITLE
Widget code cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,8 +103,8 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         type: "react-component",
                         component: "log",
                         title: "Log",
-                        id: "log-docked",
-                        props: {appStore: this.props.appStore, id: "log-docked", docked: true}
+                        id: "log-0",
+                        props: {appStore: this.props.appStore, id: "log-0", docked: true}
                     }]
                 }]
             }, {
@@ -136,17 +136,20 @@ export class App extends React.Component<{ appStore: AppStore }> {
                         type: "react-component",
                         component: "region-list",
                         title: "Region List",
-                        id: "region-list-docked",
-                        props: {appStore: this.props.appStore, id: "region-list-docked", docked: true}
+                        id: "region-list-0",
+                        props: {appStore: this.props.appStore, id: "region-list-0", docked: true}
                     }]
                 }]
             }]
         }];
 
-        widgetsStore.addSpatialProfileWidget("spatial-profiler-0", -1, 0, "x");
-        widgetsStore.addSpatialProfileWidget("spatial-profiler-1", -1, 0, "y");
-        widgetsStore.addSpectralProfileWidget("spectral-profiler-0", -1, 0, "z");
+        widgetsStore.addSpatialProfileWidget("spatial-profiler-0", "x", -1, 0);
+        widgetsStore.addSpatialProfileWidget("spatial-profiler-1", "y", -1, 0);
+        widgetsStore.addSpectralProfileWidget("spectral-profiler-0", "z", -1, 0);
         widgetsStore.addRenderConfigWidget("render-config-0");
+        widgetsStore.addAnimatorWidget("animator-0");
+        widgetsStore.addRegionListWidget("region-list-0");
+        widgetsStore.addLogWidget("log-0");
 
         const layout = new GoldenLayout({
             settings: {

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -100,7 +100,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
             >
                 <div className={titleClass}>
                     <div className={"floating-title"}>
-                        {`${widgetConfig.title}: id='${widgetConfig.id}' type='${widgetConfig.type}'`}
+                        {widgetConfig.title}
                     </div>
                     {this.props.showPinButton &&
                     <div className="floating-header-button" ref={ref => this.pinElementRef = ref} onClick={() => console.log("pin!")}>

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -100,7 +100,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
             >
                 <div className={titleClass}>
                     <div className={"floating-title"}>
-                        {widgetConfig.title}
+                        {`${widgetConfig.title}: id='${widgetConfig.id}' type='${widgetConfig.type}'`}
                     </div>
                     {this.props.showPinButton &&
                     <div className="floating-header-button" ref={ref => this.pinElementRef = ref} onClick={() => console.log("pin!")}>

--- a/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
+++ b/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
@@ -48,7 +48,7 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
                         <FloatingWidgetComponent
                             isSelected={index === widgetConfigs.length - 1}
                             appStore={appStore}
-                            key={`${w.type}-${w.id}-${index}`}
+                            key={w.id}
                             widgetConfig={w}
                             zIndex={index}
                             showPinButton={true}

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -16,8 +16,8 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         return [];
     }
 
-    @observable width: number;
-    @observable height: number;
+    @observable width: number = 0;
+    @observable height: number = 0;
 
     private static readonly NAME_COLUMN_MIN_WIDTH = 50;
     private static readonly NAME_COLUMN_DEFAULT_WIDTH = 160;

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -45,7 +45,7 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                 return widgetStore;
             }
         }
-        console.error("can't find store for widget");
+        console.log("can't find store for widget");
         return new RenderConfigWidgetStore();
     }
 
@@ -94,11 +94,11 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
         // Check if this widget hasn't been assigned an ID yet
         if (!props.docked && props.id === RenderConfigComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
-            const id = props.appStore.widgetsStore.addNewRenderConfigWidget();
+            const id = props.appStore.widgetsStore.addRenderConfigWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);
         } else {
             if (!this.props.appStore.widgetsStore.renderConfigWidgets.has(this.props.id)) {
-                console.error(`can't find store for widget with id=${this.props.id}`);
+                console.log(`can't find store for widget with id=${this.props.id}`);
                 this.props.appStore.widgetsStore.renderConfigWidgets.set(this.props.id, new RenderConfigWidgetStore());
             }
         }

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -92,7 +92,7 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
     constructor(props: WidgetProps) {
         super(props);
         // Check if this widget hasn't been assigned an ID yet
-        if (!props.docked && props.id === RenderConfigComponent.WIDGET_CONFIG.id) {
+        if (!props.docked && props.id === RenderConfigComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
             const id = props.appStore.widgetsStore.addNewRenderConfigWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -246,7 +246,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
     constructor(props: WidgetProps) {
         super(props);
         // Check if this widget hasn't been assigned an ID yet
-        if (!props.docked && props.id === SpatialProfilerComponent.WIDGET_CONFIG.id) {
+        if (!props.docked && props.id === SpatialProfilerComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
             const id = props.appStore.widgetsStore.addNewSpatialProfileWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -43,7 +43,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                 return widgetStore;
             }
         }
-        console.error("can't find store for widget");
+        console.log("can't find store for widget");
         return new SpatialProfileWidgetStore();
     }
 
@@ -248,11 +248,11 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         // Check if this widget hasn't been assigned an ID yet
         if (!props.docked && props.id === SpatialProfilerComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
-            const id = props.appStore.widgetsStore.addNewSpatialProfileWidget();
+            const id = props.appStore.widgetsStore.addSpatialProfileWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);
         } else {
             if (!this.props.appStore.widgetsStore.spatialProfileWidgets.has(this.props.id)) {
-                console.error(`can't find store for widget with id=${this.props.id}`);
+                console.log(`can't find store for widget with id=${this.props.id}`);
                 this.props.appStore.widgetsStore.spatialProfileWidgets.set(this.props.id, new SpatialProfileWidgetStore());
             }
         }

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -145,7 +145,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     constructor(props: WidgetProps) {
         super(props);
         // Check if this widget hasn't been assigned an ID yet
-        if (!props.docked && props.id === SpectralProfilerComponent.WIDGET_CONFIG.id) {
+        if (!props.docked && props.id === SpectralProfilerComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
             const id = props.appStore.widgetsStore.addNewSpectralProfileWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -43,7 +43,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 return widgetStore;
             }
         }
-        console.error("can't find store for widget");
+        console.log("can't find store for widget");
         return new SpectralProfileWidgetStore();
     }
 
@@ -147,12 +147,12 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         // Check if this widget hasn't been assigned an ID yet
         if (!props.docked && props.id === SpectralProfilerComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
-            const id = props.appStore.widgetsStore.addNewSpectralProfileWidget();
+            const id = props.appStore.widgetsStore.addSpectralProfileWidget();
             props.appStore.widgetsStore.changeWidgetId(props.id, id);
         } else {
             if (!this.props.appStore.widgetsStore.spectralProfileWidgets.has(this.props.id)) {
-                console.error(`can't find store for widget with id=${this.props.id}`);
-                this.props.appStore.widgetsStore.spectralProfileWidgets.set(this.props.id, new SpectralProfileWidgetStore());
+                console.log(`can't find store for widget with id=${this.props.id}`);
+                this.props.appStore.widgetsStore.addSpectralProfileWidget(this.props.id);
             }
         }
         // Update widget title when region or coordinate changes

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -170,22 +170,22 @@ export class WidgetsStore {
         // Check if it's an uninitialised widget
         switch (id) {
             case RenderConfigComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewRenderConfigWidget();
+                itemId = this.addRenderConfigWidget();
                 break;
             case SpatialProfilerComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewSpatialProfileWidget();
+                itemId = this.addSpatialProfileWidget();
                 break;
             case SpectralProfilerComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewSpectralProfileWidget();
+                itemId = this.addSpectralProfileWidget();
                 break;
             case AnimatorComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewAnimatorWidget();
+                itemId = this.addAnimatorWidget();
                 break;
             case LogComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewLogWidget();
+                itemId = this.addLogWidget();
                 break;
             case RegionListComponent.WIDGET_CONFIG.type:
-                itemId = this.addNewRegionListWidget();
+                itemId = this.addRegionListWidget();
                 break;
             default:
                 // Remove it from the floating widget array, while preserving its store
@@ -194,8 +194,10 @@ export class WidgetsStore {
                 }
         }
 
-        config.id = itemId;
-        config.props.id = itemId;
+        if (itemId) {
+            config.id = itemId;
+            config.props.id = itemId;
+        }
     };
 
     @action handleItemRemoval = (item: GoldenLayout.ContentItem) => {
@@ -273,20 +275,20 @@ export class WidgetsStore {
     // region Spatial Profile Widgets
     createFloatingSpatialProfilerWidget = () => {
         let config = SpatialProfilerComponent.WIDGET_CONFIG;
-        config.id = this.addNewSpatialProfileWidget();
+        config.id = this.addSpatialProfileWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewSpatialProfileWidget() {
-        const id = this.getNextId(SpatialProfilerComponent.WIDGET_CONFIG.type);
+    @action addSpatialProfileWidget(id: string = null, coordinate: string = "x", fileId: number = -1, regionId: number = 0) {
+        // Generate new id if none passed in
+        if (!id) {
+            id = this.getNextId(SpatialProfilerComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
-            this.spatialProfileWidgets.set(id, new SpatialProfileWidgetStore());
+            this.spatialProfileWidgets.set(id, new SpatialProfileWidgetStore(coordinate, fileId, regionId));
         }
         return id;
-    }
-
-    @action addSpatialProfileWidget(id: string, fileId: number, regionId: number, coordinate: string) {
-        this.spatialProfileWidgets.set(id, new SpatialProfileWidgetStore(coordinate, fileId, regionId));
     }
 
     // endregion
@@ -294,20 +296,20 @@ export class WidgetsStore {
     // region Spectral Profile Widgets
     createFloatingSpectralProfilerWidget = () => {
         let config = SpectralProfilerComponent.WIDGET_CONFIG;
-        config.id = this.addNewSpectralProfileWidget();
+        config.id = this.addSpectralProfileWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewSpectralProfileWidget() {
-        const id = this.getNextId(SpectralProfilerComponent.WIDGET_CONFIG.type);
+    @action addSpectralProfileWidget(id: string = null, coordinate: string = "z", fileId: number = -1, regionId: number = 0) {
+        // Generate new id if none passed in
+        if (!id) {
+            id = this.getNextId(SpectralProfilerComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
-            this.spatialProfileWidgets.set(id, new SpatialProfileWidgetStore());
+            this.spectralProfileWidgets.set(id, new SpectralProfileWidgetStore(coordinate, fileId, regionId));
         }
         return id;
-    }
-
-    @action addSpectralProfileWidget(id: string, fileId: number, regionId: number, coordinate: string) {
-        this.spectralProfileWidgets.set(id, new SpectralProfileWidgetStore(coordinate, fileId, regionId));
     }
 
     // endregion
@@ -315,20 +317,19 @@ export class WidgetsStore {
     // region Render Config Widgets
     createFloatingRenderWidget = () => {
         let config = RenderConfigComponent.WIDGET_CONFIG;
-        config.id = this.addNewRenderConfigWidget();
+        config.id = this.addRenderConfigWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewRenderConfigWidget() {
-        const id = this.getNextId(RenderConfigComponent.WIDGET_CONFIG.type);
+    @action addRenderConfigWidget(id: string = null) {
+        if (!id) {
+            id = this.getNextId(RenderConfigComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
             this.renderConfigWidgets.set(id, new RenderConfigWidgetStore());
         }
         return id;
-    }
-
-    @action addRenderConfigWidget(id: string) {
-        this.renderConfigWidgets.set(id, new RenderConfigWidgetStore());
     }
 
     // endregion
@@ -337,56 +338,53 @@ export class WidgetsStore {
 
     createFloatingLogWidget = () => {
         const config = LogComponent.WIDGET_CONFIG;
-        config.id = this.addNewSpatialProfileWidget();
+        config.id = this.addLogWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewLogWidget = () => {
-        const id = this.getNextId(LogComponent.WIDGET_CONFIG.type);
+    @action addLogWidget(id: string = null) {
+        if (!id) {
+            id = this.getNextId(LogComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
             this.logWidgets.set(id, new EmptyWidgetStore());
         }
         return id;
-    };
-
-    @action addLogWidget(id: string) {
-        this.logWidgets.set(id, new EmptyWidgetStore());
     }
 
     createFloatingAnimatorWidget = () => {
         const config = AnimatorComponent.WIDGET_CONFIG;
-        config.id = this.addNewAnimatorWidget();
+        config.id = this.addAnimatorWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewAnimatorWidget = () => {
-        const id = this.getNextId(AnimatorComponent.WIDGET_CONFIG.type);
+    @action addAnimatorWidget(id: string = null) {
+        if (!id) {
+            id = this.getNextId(AnimatorComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
             this.animatorWidgets.set(id, new EmptyWidgetStore());
         }
         return id;
-    };
-
-    @action addAnimationWidget(id: string) {
-        this.animatorWidgets.set(id, new EmptyWidgetStore());
     }
 
     createFloatingRegionListWidget = () => {
         const config = RegionListComponent.WIDGET_CONFIG;
-        config.id = this.addNewRegionListWidget();
+        config.id = this.addRegionListWidget();
         this.addFloatingWidget(config);
     };
 
-    @action addNewRegionListWidget = () => {
-        const id = this.getNextId(RegionListComponent.WIDGET_CONFIG.type);
+    @action addRegionListWidget(id: string = null) {
+        if (!id) {
+            id = this.getNextId(RegionListComponent.WIDGET_CONFIG.type);
+        }
+
         if (id) {
             this.regionListWidgets.set(id, new EmptyWidgetStore());
         }
         return id;
-    };
-
-    @action addRegionListWidget(id: string) {
-        this.regionListWidgets.set(id, new EmptyWidgetStore());
     }
 
     // endregion

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -217,15 +217,32 @@ export class WidgetsStore {
     }
 
     createFloatingLogWidget = () => {
-        this.addFloatingWidget(LogComponent.WIDGET_CONFIG);
+        const config = LogComponent.WIDGET_CONFIG;
+        config.id = this.getNextId(config.id);
+        this.addFloatingWidget(config);
     };
 
     createFloatingAnimatorWidget = () => {
-        this.addFloatingWidget(AnimatorComponent.WIDGET_CONFIG);
+        const config = AnimatorComponent.WIDGET_CONFIG;
+        config.id = this.getNextId(config.id);
+        this.addFloatingWidget(config);
     };
 
     createFloatingRegionListWidget = () => {
-        this.addFloatingWidget(RegionListComponent.WIDGET_CONFIG);
+        const config = RegionListComponent.WIDGET_CONFIG;
+        config.id = this.getNextId(config.id);
+        this.addFloatingWidget(config);
+    };
+
+    private getNextId = (defaultId: string) => {
+        let nextIndex = 0;
+        while (true) {
+            const nextId = `${defaultId}-${nextIndex}`;
+            if (!this.floatingWidgets.find(w=>w.id === nextId)) {
+                return nextId;
+            }
+            nextIndex++;
+        }
     };
 
     // region Spatial Profile Widgets

--- a/src/stores/widgets/EmptyWidgetStore.ts
+++ b/src/stores/widgets/EmptyWidgetStore.ts
@@ -1,0 +1,3 @@
+export class EmptyWidgetStore {
+
+}

--- a/src/stores/widgets/index.ts
+++ b/src/stores/widgets/index.ts
@@ -1,3 +1,4 @@
 export * from "./RenderConfigWidgetStore";
 export * from "./SpatialProfileWidgetStore";
 export * from "./SpectralProfileWidgetStore";
+export * from "./EmptyWidgetStore";


### PR DESCRIPTION
This PR cleans up the widget store code a bit and introduces "empty" widget stores for widgets that do not yet have per-widget settings. This simplifies the code a bit and ensures that all widgets (except the image view widget) are handled in a similar fashion. 

As a side effect, it fixes #180 