### PR TITLE
added selection for Stokes coordinate in spectral profiler

### DIFF
--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -173,7 +173,13 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 const coordinate = this.widgetStore.coordinate;
                 const appStore = this.props.appStore;
                 if (appStore && coordinate) {
-                    const coordinateString = `${coordinate.toUpperCase()} Profile`;
+                    let coordinateString: string;
+                    if (coordinate.length == 2) {
+                        coordinateString = `Z Profile (Stokes ${coordinate[0]})`;
+                    }
+                    else {
+                        coordinateString = `Z Profile`;
+                    }
                     const regionString = this.widgetStore.regionId === 0 ? "Cursor" : `Region #${this.widgetStore.regionId}`;
                     this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `${coordinateString}: ${regionString}`);
                 }

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -33,9 +33,13 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
     render() {
         const widgetStore = this.props.widgetStore;
         const appStore = this.props.appStore;
-        const profileCoordinateOptions = [{
-            value: "z", label: "Z"
-        }];
+        const profileCoordinateOptions = [
+            {value: "z", label: "Current"},
+            {value: "Iz", label: "I"},
+            {value: "Qz", label: "Q"},
+            {value: "Uz", label: "U"},
+            {value: "Vz", label: "V"}
+        ];
 
         // Fill region select options with all non-temporary regions that are closed or point type
         let profileRegionOptions: IOptionProps[];
@@ -69,7 +73,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
             <React.Fragment>
                 <FormGroup className={"spectral-profile-settings-panel-form"}>
                     <ControlGroup fill={true} vertical={true}>
-                        <FormGroup label={"Coordinate"} inline={true}>
+                        <FormGroup label={"Stokes"} inline={true}>
                             <HTMLSelect value={widgetStore.coordinate} options={profileCoordinateOptions} onChange={this.handleCoordinateChanged}/>
                         </FormGroup>
                         <FormGroup label={"Region"} inline={true}>


### PR DESCRIPTION
minor addition to allow users to select a different Stokes value when viewing spectral profile. By default the current Stokes value is used. If a user explicitly selects a Stokes value, then only cubes that have this Stokes value will display a profile in that widget.

![stokes_cursor](https://user-images.githubusercontent.com/592504/55228294-75c94080-5222-11e9-9d35-3d4be8fb1ddc.gif)
