### PR TITLE
Angus/fix widget region selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
 
         widgetsStore.addSpatialProfileWidget("spatial-profiler-0", "x", -1, 0);
         widgetsStore.addSpatialProfileWidget("spatial-profiler-1", "y", -1, 0);
-        widgetsStore.addSpectralProfileWidget("spectral-profiler-0", "z", -1, 0);
+        widgetsStore.addSpectralProfileWidget("spectral-profiler-0", "z");
         widgetsStore.addRenderConfigWidget("render-config-0");
         widgetsStore.addAnimatorWidget("animator-0");
         widgetsStore.addRegionListWidget("region-list-0");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,7 +296,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
                 {fileHotkeys}
                 <Hotkey group="Appearance" global={true} combo="shift + D" label="Toggle light/dark theme" onKeyDown={this.toggleDarkTheme}/>
                 <Hotkey group="Cursor" global={true} combo="F" label="Freeze/unfreeze cursor position" onKeyDown={appStore.toggleCursorFrozen}/>
-                <Hotkey group="Regions" global={true} combo="del" label="Delete selected region" onKeyDown={this.deleteSelectedRegion}/>
+                <Hotkey group="Regions" global={true} combo="del" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion}/>
                 <Hotkey group="Regions" global={true} combo="backspace" label="Delete selected region" onKeyDown={this.deleteSelectedRegion}/>
                 <Hotkey group="Regions" global={true} combo="c" label="Toggle region creation mode" onKeyDown={this.toggleCreateMode}/>
             </Hotkeys>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,13 +250,6 @@ export class App extends React.Component<{ appStore: AppStore }> {
         }
     };
 
-    deleteSelectedRegion = () => {
-        const appStore = this.props.appStore;
-        if (appStore.activeFrame) {
-            appStore.activeFrame.regionSet.deleteRegion(appStore.activeFrame.regionSet.selectedRegion);
-        }
-    };
-
     toggleCreateMode = () => {
         const appStore = this.props.appStore;
         if (appStore.activeFrame) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,7 +297,7 @@ export class App extends React.Component<{ appStore: AppStore }> {
                 <Hotkey group="Appearance" global={true} combo="shift + D" label="Toggle light/dark theme" onKeyDown={this.toggleDarkTheme}/>
                 <Hotkey group="Cursor" global={true} combo="F" label="Freeze/unfreeze cursor position" onKeyDown={appStore.toggleCursorFrozen}/>
                 <Hotkey group="Regions" global={true} combo="del" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion}/>
-                <Hotkey group="Regions" global={true} combo="backspace" label="Delete selected region" onKeyDown={this.deleteSelectedRegion}/>
+                <Hotkey group="Regions" global={true} combo="backspace" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion}/>
                 <Hotkey group="Regions" global={true} combo="c" label="Toggle region creation mode" onKeyDown={this.toggleCreateMode}/>
             </Hotkeys>
         );

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -15,9 +15,7 @@ export class RegionDialogComponent extends React.Component<{ appStore: AppStore 
     private handleDeleteClicked = () => {
         const appStore = this.props.appStore;
         appStore.hideRegionDialog();
-        if (appStore.activeFrame && appStore.activeFrame.regionSet.selectedRegion) {
-            appStore.activeFrame.regionSet.deleteRegion(appStore.activeFrame.regionSet.selectedRegion);
-        }
+        appStore.deleteSelectedRegion();
     };
 
     public render() {

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -56,12 +56,8 @@ export class HistogramComponent extends React.Component<WidgetProps> {
         const appStore = this.props.appStore;
 
         if (appStore.activeFrame) {
-            let fileId = this.widgetStore.fileId;
-            let regionId = this.widgetStore.regionId;
-            // Replace "current file" fileId with active frame's fileId
-            if (this.widgetStore.fileId === -1) {
-                fileId = appStore.activeFrame.frameInfo.fileId;
-            }
+            let fileId = appStore.activeFrame.frameInfo.fileId;
+            let regionId = this.widgetStore.regionIdMap.get(fileId) || -1;
 
             // // Image histograms handled slightly differently
             // if (regionId === -1) {
@@ -136,11 +132,12 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             const appStore = this.props.appStore;
             if (this.widgetStore) {
                 let regionString = "Unknown";
+                const regionId = this.widgetStore.regionIdMap.get(appStore.activeFrame.frameInfo.fileId) || -1;
 
-                if (this.widgetStore.regionId === -1) {
+                if (regionId === -1) {
                     regionString = "Image";
                 } else if (appStore.activeFrame && appStore.activeFrame.regionSet) {
-                    const region = appStore.activeFrame.regionSet.regions.find(r => r.regionId === this.widgetStore.regionId);
+                    const region = appStore.activeFrame.regionSet.regions.find(r => r.regionId === regionId);
                     if (region) {
                         regionString = region.nameString;
                     }

--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -14,16 +14,23 @@ export class HistogramSettingsPanelComponent extends React.Component<{ appStore:
     };
 
     private handleRegionChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
-        this.props.widgetStore.setRegionId(parseInt(changeEvent.target.value));
+        const appStore = this.props.appStore;
+        if (appStore.activeFrame) {
+            this.props.widgetStore.setRegionId(appStore.activeFrame.frameInfo.fileId, parseInt(changeEvent.target.value));
+        }
     };
 
     render() {
         const widgetStore = this.props.widgetStore;
         const appStore = this.props.appStore;
 
+        let regionId = -1;
+
         // Fill region select options with all non-temporary regions that are closed
         let profileRegionOptions: IOptionProps[] = [{value: -1, label: "Image"}];
         if (appStore.activeFrame && appStore.activeFrame.regionSet) {
+            let fileId = appStore.activeFrame.frameInfo.fileId;
+            regionId = widgetStore.regionIdMap.get(fileId) || -1;
             profileRegionOptions = profileRegionOptions.concat(this.props.appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary && r.isClosedRegion).map(r => {
                 return {
                     value: r.regionId,
@@ -37,7 +44,7 @@ export class HistogramSettingsPanelComponent extends React.Component<{ appStore:
                 <FormGroup className={"histogram-settings-panel-form"}>
                     <ControlGroup fill={true} vertical={true}>
                         <FormGroup label={"Region"} inline={true}>
-                            <HTMLSelect value={widgetStore.regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
+                            <HTMLSelect value={regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
                         </FormGroup>
                         <Switch label={"Log Scale"} checked={widgetStore.logScaleY} onChange={this.handleLogScaleChanged}/>
                         <PlotTypeSelectorComponent value={widgetStore.plotType} onValueChanged={widgetStore.setPlotType}/>

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -23,7 +23,10 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
     };
 
     handleRegionChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
-        this.props.widgetStore.setRegionId(parseInt(changeEvent.target.value));
+        const appStore = this.props.appStore;
+        if (appStore.activeFrame) {
+            this.props.widgetStore.setRegionId(appStore.activeFrame.frameInfo.fileId, parseInt(changeEvent.target.value));
+        }
     };
 
     handleStatsChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
@@ -41,9 +44,13 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
             {value: "Vz", label: "V"}
         ];
 
+        let regionId = 0;
+
         // Fill region select options with all non-temporary regions that are closed or point type
         let profileRegionOptions: IOptionProps[];
         if (this.props.appStore.activeFrame && this.props.appStore.activeFrame.regionSet) {
+            let fileId = appStore.activeFrame.frameInfo.fileId;
+            regionId = widgetStore.regionIdMap.get(fileId) || 0;
             profileRegionOptions = this.props.appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary && (r.isClosedRegion || r.regionType === CARTA.RegionType.POINT)).map(r => {
                 return {
                     value: r.regionId,
@@ -54,7 +61,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
 
         let showStatsType = false;
         if (appStore.activeFrame) {
-            const selectedRegion = appStore.activeFrame.regionSet.regions.find(r => r.regionId === widgetStore.regionId);
+            const selectedRegion = appStore.activeFrame.regionSet.regions.find(r => r.regionId === regionId);
             showStatsType = (selectedRegion && selectedRegion.isClosedRegion);
         }
 
@@ -77,7 +84,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<{ ap
                             <HTMLSelect value={widgetStore.coordinate} options={profileCoordinateOptions} onChange={this.handleCoordinateChanged}/>
                         </FormGroup>
                         <FormGroup label={"Region"} inline={true}>
-                            <HTMLSelect value={widgetStore.regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
+                            <HTMLSelect value={regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
                         </FormGroup>
                         {showStatsType &&
                         <FormGroup label={"Stats"} inline={true}>

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -43,21 +43,14 @@ export class StatsComponent extends React.Component<WidgetProps> {
         const appStore = this.props.appStore;
 
         if (appStore.activeFrame) {
-            let fileId = this.widgetStore.fileId;
-            let regionId = this.widgetStore.regionId;
-            // Replace "current file" fileId with active frame's fileId
-            if (this.widgetStore.fileId === -1) {
-                fileId = appStore.activeFrame.frameInfo.fileId;
-            }
+            let fileId = appStore.activeFrame.frameInfo.fileId;
+            let regionId = this.widgetStore.regionIdMap.get(fileId) || -1;
 
             const frameMap = appStore.regionStats.get(fileId);
             if (!frameMap) {
                 return null;
             }
-            const data = frameMap.get(regionId);
-            if (data) {
-                return data;
-            }
+            return frameMap.get(regionId);
         }
         return null;
     }
@@ -91,13 +84,14 @@ export class StatsComponent extends React.Component<WidgetProps> {
         // Update widget title when region or coordinate changes
         autorun(() => {
             const appStore = this.props.appStore;
-            if (this.widgetStore) {
+            if (this.widgetStore && appStore.activeFrame) {
                 let regionString = "Unknown";
 
-                if (this.widgetStore.regionId === -1) {
+                const regionId = this.widgetStore.regionIdMap.get(appStore.activeFrame.frameInfo.fileId) || -1;
+                if (regionId ===  -1) {
                     regionString = "Image";
                 } else if (appStore.activeFrame && appStore.activeFrame.regionSet) {
-                    const region = appStore.activeFrame.regionSet.regions.find(r => r.regionId === this.widgetStore.regionId);
+                    const region = appStore.activeFrame.regionSet.regions.find(r => r.regionId === regionId);
                     if (region) {
                         regionString = region.nameString;
                     }
@@ -110,7 +104,10 @@ export class StatsComponent extends React.Component<WidgetProps> {
     }
 
     private handleRegionChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
-        this.widgetStore.setRegionId(parseInt(changeEvent.target.value));
+        const appStore = this.props.appStore;
+        if (appStore.activeFrame) {
+            this.widgetStore.setRegionId(appStore.activeFrame.frameInfo.fileId, parseInt(changeEvent.target.value));
+        }
     };
 
     private onResize = (width: number, height: number) => {
@@ -124,7 +121,10 @@ export class StatsComponent extends React.Component<WidgetProps> {
 
         // Fill region select options with all non-temporary regions that are closed
         let profileRegionOptions: IOptionProps[] = [{value: -1, label: "Image"}];
+        let regionId = -1;
         if (appStore.activeFrame && appStore.activeFrame.regionSet) {
+            let fileId = appStore.activeFrame.frameInfo.fileId;
+            regionId = this.widgetStore.regionIdMap.get(fileId) || -1;
             profileRegionOptions = profileRegionOptions.concat(this.props.appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary && r.isClosedRegion).map(r => {
                 return {
                     value: r.regionId,
@@ -173,7 +173,7 @@ export class StatsComponent extends React.Component<WidgetProps> {
             <div className={"stats-widget"}>
                 <ControlGroup fill={true} vertical={true}>
                     <FormGroup label={"Region"} inline={true}>
-                        <HTMLSelect value={this.widgetStore.regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
+                        <HTMLSelect value={regionId} options={profileRegionOptions} onChange={this.handleRegionChanged}/>
                     </FormGroup>
                 </ControlGroup>
                 <div className="stats-display">

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -7,7 +7,6 @@ import {CARTA} from "carta-protobuf";
 import {WidgetConfig, WidgetProps} from "stores";
 import {StatsWidgetStore} from "stores/widgets";
 import "./StatsComponent.css";
-import {Stats} from "fs";
 
 @observer
 export class StatsComponent extends React.Component<WidgetProps> {

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -87,8 +87,8 @@ export class BackendService {
             EventNames.RegisterViewerAck,
             EventNames.OpenFile,
             EventNames.OpenFileAck,
-            EventNames.SetHistogramRequirements,
-            EventNames.RegionHistogramData
+            EventNames.SetStatsRequirements,
+            EventNames.RegionStatsData
         ];
 
         // Check local storage for a list of events to log to console

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -86,9 +86,7 @@ export class BackendService {
             EventNames.RegisterViewer,
             EventNames.RegisterViewerAck,
             EventNames.OpenFile,
-            EventNames.OpenFileAck,
-            EventNames.SetStatsRequirements,
-            EventNames.RegionStatsData
+            EventNames.OpenFileAck
         ];
 
         // Check local storage for a list of events to log to console

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -87,8 +87,8 @@ export class BackendService {
             EventNames.RegisterViewerAck,
             EventNames.OpenFile,
             EventNames.OpenFileAck,
-            EventNames.SetHistogramRequirements,
-            EventNames.RegionHistogramData
+            EventNames.SetSpectralRequirements,
+            EventNames.SpectralProfileData
         ];
 
         // Check local storage for a list of events to log to console

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -86,7 +86,9 @@ export class BackendService {
             EventNames.RegisterViewer,
             EventNames.RegisterViewerAck,
             EventNames.OpenFile,
-            EventNames.OpenFileAck
+            EventNames.OpenFileAck,
+            EventNames.SetHistogramRequirements,
+            EventNames.RegionHistogramData
         ];
 
         // Check local storage for a list of events to log to console

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -209,6 +209,10 @@ export class AppStore {
             this.widgetsStore.statsWidgets.forEach(widgetStore => {
                 widgetStore.clearFrameEntry(fileId);
             });
+            this.widgetsStore.histogramWidgets.forEach(widgetStore => {
+                widgetStore.clearFrameEntry(fileId);
+            });
+
             if (this.backendService.closeFile(fileId)) {
                 if (this.activeFrame.frameInfo.fileId === fileId) {
                     this.activeFrame = null;
@@ -223,6 +227,9 @@ export class AppStore {
             this.frames = [];
             // adjust requirements for stores
             this.widgetsStore.statsWidgets.forEach(widgetStore => {
+                widgetStore.clearRegionMap();
+            });
+            this.widgetsStore.histogramWidgets.forEach(widgetStore => {
                 widgetStore.clearRegionMap();
             });
         }
@@ -640,6 +647,14 @@ export class AppStore {
                         widgetStore.clearFrameEntry(fileId);
                     }
                 });
+                this.widgetsStore.histogramWidgets.forEach(widgetStore => {
+                    const selectedRegionId = widgetStore.regionIdMap.get(fileId);
+                    // remove entry from map if it matches the deleted region
+                    if (isFinite(selectedRegionId) && selectedRegionId === regionId) {
+                        widgetStore.clearFrameEntry(fileId);
+                    }
+                });
+
                 // delete region
                 this.activeFrame.regionSet.deleteRegion(region);
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -736,9 +736,9 @@ export class AppStore {
 
         const updatedRequirements = new Map<number, Array<number>>();
         this.widgetsStore.histogramWidgets.forEach(widgetStore => {
-            const frame = this.getFrame(widgetStore.fileId);
-            const regionId = widgetStore.regionId;
+            const frame = this.activeFrame;
             const fileId = frame.frameInfo.fileId;
+            const regionId = widgetStore.regionIdMap.get(fileId) || -1;
             if (!frame.regionSet) {
                 return;
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -832,9 +832,9 @@ export class AppStore {
 
         const updatedRequirements = new Map<number, Map<number, CARTA.SetSpectralRequirements>>();
         this.widgetsStore.spectralProfileWidgets.forEach(widgetStore => {
-            const frame = this.getFrame(widgetStore.fileId);
-            const regionId = widgetStore.regionId;
+            const frame = this.activeFrame;
             const fileId = frame.frameInfo.fileId;
+            const regionId = widgetStore.regionIdMap.get(fileId) || 0;
             const coordinate = widgetStore.coordinate;
             let statsType = widgetStore.statsType;
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -626,9 +626,9 @@ export class AppStore {
 
         const updatedRequirements = new Map<number, Array<number>>();
         this.widgetsStore.statsWidgets.forEach(widgetStore => {
-            const frame = this.getFrame(widgetStore.fileId);
-            const regionId = widgetStore.regionId;
+            const frame = this.activeFrame;
             const fileId = frame.frameInfo.fileId;
+            const regionId = widgetStore.regionIdMap.get(fileId) || -1;
             if (!frame.regionSet) {
                 return;
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -207,7 +207,7 @@ export class AppStore {
         if (this.frames.find(f => f.frameInfo.fileId === fileId)) {
             // adjust requirements for stores
             this.widgetsStore.statsWidgets.forEach(widgetStore => {
-                widgetStore.regionIdMap.delete(fileId);
+                widgetStore.clearFrameEntry(fileId);
             });
             if (this.backendService.closeFile(fileId)) {
                 if (this.activeFrame.frameInfo.fileId === fileId) {
@@ -221,6 +221,10 @@ export class AppStore {
         if (this.backendService.closeFile(-1)) {
             this.activeFrame = null;
             this.frames = [];
+            // adjust requirements for stores
+            this.widgetsStore.statsWidgets.forEach(widgetStore => {
+                widgetStore.clearRegionMap();
+            });
         }
     };
 

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -3,7 +3,7 @@ import * as $ from "jquery";
 import {action, observable} from "mobx";
 import {AnimatorComponent, HistogramComponent, ImageViewComponent, LogComponent, PlaceholderComponent, RegionListComponent, RenderConfigComponent, SpatialProfilerComponent, SpectralProfilerComponent, StatsComponent} from "components";
 import {AppStore} from "./AppStore";
-import {EmptyWidgetStore, HistogramWidgetStore, RenderConfigWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore} from "./widgets";
+import {EmptyWidgetStore, HistogramWidgetStore, RegionWidgetStore, RenderConfigWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore} from "./widgets";
 
 export class WidgetConfig {
     id: string;
@@ -42,6 +42,28 @@ export class WidgetsStore {
 
     private appStore: AppStore;
     private widgetsMap: Map<string, Map<string, any>>;
+
+    public static RemoveFrameFromRegionWidgets(storeMap: Map<string, RegionWidgetStore>, fileId: number = -1) {
+        if (fileId === -1) {
+            storeMap.forEach(widgetStore => {
+                widgetStore.clearRegionMap();
+            });
+        } else {
+            storeMap.forEach(widgetStore => {
+                widgetStore.clearFrameEntry(fileId);
+            });
+        }
+    }
+
+    public static RemoveRegionFromRegionWidgets = (storeMap: Map<string, RegionWidgetStore>, fileId, regionId: number) => {
+        storeMap.forEach(widgetStore => {
+            const selectedRegionId = widgetStore.regionIdMap.get(fileId);
+            // remove entry from map if it matches the deleted region
+            if (isFinite(selectedRegionId) && selectedRegionId === regionId) {
+                widgetStore.clearFrameEntry(fileId);
+            }
+        });
+    };
 
     constructor(appStore: AppStore) {
         this.appStore = appStore;

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -360,14 +360,14 @@ export class WidgetsStore {
         this.addFloatingWidget(config);
     };
 
-    @action addHistogramWidget(id: string = null, fileId: number = -1, regionId: number = -1) {
+    @action addHistogramWidget(id: string = null) {
         // Generate new id if none passed in
         if (!id) {
             id = this.getNextId(HistogramComponent.WIDGET_CONFIG.type);
         }
 
         if (id) {
-            this.histogramWidgets.set(id, new HistogramWidgetStore(fileId, regionId));
+            this.histogramWidgets.set(id, new HistogramWidgetStore());
         }
         return id;
     }

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -339,14 +339,14 @@ export class WidgetsStore {
         this.addFloatingWidget(config);
     };
 
-    @action addStatsWidget(id: string = null, fileId: number = -1, regionId: number = -1) {
+    @action addStatsWidget(id: string = null) {
         // Generate new id if none passed in
         if (!id) {
             id = this.getNextId(StatsComponent.WIDGET_CONFIG.type);
         }
 
         if (id) {
-            this.statsWidgets.set(id, new StatsWidgetStore(fileId, regionId));
+            this.statsWidgets.set(id, new StatsWidgetStore());
         }
         return id;
     }

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -318,14 +318,14 @@ export class WidgetsStore {
         this.addFloatingWidget(config);
     };
 
-    @action addSpectralProfileWidget(id: string = null, coordinate: string = "z", fileId: number = -1, regionId: number = 0) {
+    @action addSpectralProfileWidget(id: string = null, coordinate: string = "z") {
         // Generate new id if none passed in
         if (!id) {
             id = this.getNextId(SpectralProfilerComponent.WIDGET_CONFIG.type);
         }
 
         if (id) {
-            this.spectralProfileWidgets.set(id, new SpectralProfileWidgetStore(coordinate, fileId, regionId));
+            this.spectralProfileWidgets.set(id, new SpectralProfileWidgetStore(coordinate));
         }
         return id;
     }

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -1,8 +1,8 @@
 import {action, computed, observable} from "mobx";
 import {PlotType} from "components/Shared";
+import {RegionWidgetStore} from "./RegionWidgetStore";
 
-export class HistogramWidgetStore {
-    @observable regionIdMap: Map<number, number>;
+export class HistogramWidgetStore extends RegionWidgetStore {
     @observable minX: number;
     @observable maxX: number;
     @observable minY: number;
@@ -11,18 +11,6 @@ export class HistogramWidgetStore {
     @observable logScaleY: boolean;
     @observable plotType: PlotType;
     @observable settingsPanelVisible: boolean;
-
-    @action clearFrameEntry = (fileId: number) => {
-        this.regionIdMap.delete(fileId);
-    };
-
-    @action clearRegionMap = () => {
-        this.regionIdMap.clear();
-    };
-
-    @action setRegionId = (fileId: number, regionId: number) => {
-        this.regionIdMap.set(fileId, regionId);
-    };
 
     @action setXBounds = (minVal: number, maxVal: number) => {
         this.minX = minVal;
@@ -87,7 +75,7 @@ export class HistogramWidgetStore {
     }
 
     constructor() {
-        this.regionIdMap = new Map<number, number>();
+        super();
         this.logScaleY = true;
         this.plotType = PlotType.STEPS;
         this.settingsPanelVisible = false;

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -2,8 +2,7 @@ import {action, computed, observable} from "mobx";
 import {PlotType} from "components/Shared";
 
 export class HistogramWidgetStore {
-    @observable fileId: number;
-    @observable regionId: number;
+    @observable regionIdMap: Map<number, number>;
     @observable minX: number;
     @observable maxX: number;
     @observable minY: number;
@@ -13,13 +12,18 @@ export class HistogramWidgetStore {
     @observable plotType: PlotType;
     @observable settingsPanelVisible: boolean;
 
-    @action setFileId = (fileId: number) => {
-        this.fileId = fileId;
+    @action clearFrameEntry = (fileId: number) => {
+        this.regionIdMap.delete(fileId);
     };
 
-    @action setRegionId = (regionId: number) => {
-        this.regionId = regionId;
+    @action clearRegionMap = () => {
+        this.regionIdMap.clear();
     };
+
+    @action setRegionId = (fileId: number, regionId: number) => {
+        this.regionIdMap.set(fileId, regionId);
+    };
+
     @action setXBounds = (minVal: number, maxVal: number) => {
         this.minX = minVal;
         this.maxX = maxVal;
@@ -82,9 +86,8 @@ export class HistogramWidgetStore {
         return (this.minY === undefined || this.maxY === undefined);
     }
 
-    constructor(fileId: number = -1, regionId: number = -1) {
-        this.fileId = fileId;
-        this.regionId = regionId;
+    constructor() {
+        this.regionIdMap = new Map<number, number>();
         this.logScaleY = true;
         this.plotType = PlotType.STEPS;
         this.settingsPanelVisible = false;

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -1,4 +1,5 @@
 import {action, computed, observable} from "mobx";
+import {CARTA} from "carta-protobuf";
 import {PlotType} from "components/Shared";
 import {RegionWidgetStore} from "./RegionWidgetStore";
 
@@ -72,6 +73,51 @@ export class HistogramWidgetStore extends RegionWidgetStore {
 
     @computed get isAutoScaledY() {
         return (this.minY === undefined || this.maxY === undefined);
+    }
+
+    public static DiffRequirementsArray(originalRequirements: Map<number, Array<number>>, updatedRequirements: Map<number, Array<number>>) {
+        const diffList: CARTA.ISetHistogramRequirements[] = [];
+
+        // Three possible scenarios:
+        // 1. Existing array, no new array => diff should be empty stats requirements for each element of existing array
+        // 2. No existing array, new array => diff should be full stats requirements for each element of new array
+        // 3. Existing array and new array => diff should be empty stats for those missing in new array, full stats for those missing in old array
+
+        // (1) & (3) handled first
+        originalRequirements.forEach((statsArray, fileId) => {
+            const updatedStatsArray = updatedRequirements.get(fileId);
+            // If there's no new array, remove requirements for all existing regions
+            if (!updatedStatsArray) {
+                for (const regionId of statsArray) {
+                    diffList.push({fileId, regionId, histograms: []});
+                }
+            } else {
+                // If regions in the new array are missing, remove requirements for those regions
+                for (const regionId of statsArray) {
+                    if (updatedStatsArray.indexOf(regionId) === -1) {
+                        diffList.push({fileId, regionId, histograms: []});
+                    }
+                }
+                // If regions in the existing array are missing, add requirements for those regions
+                for (const regionId of updatedStatsArray) {
+                    if (statsArray.indexOf(regionId) === -1) {
+                        diffList.push({fileId, regionId, histograms: [{channel: -1, numBins: -1}]});
+                    }
+                }
+            }
+        });
+
+        updatedRequirements.forEach((updatedStatsArray, fileId) => {
+            const statsArray = originalRequirements.get(fileId);
+            // If there's no existing array, add requirements for all new regions
+            if (!statsArray) {
+                for (const regionId of updatedStatsArray) {
+                    diffList.push({fileId, regionId, histograms: [{channel: -1, numBins: -1}]});
+                }
+            }
+        });
+
+        return diffList;
     }
 
     constructor() {

--- a/src/stores/widgets/RegionWidgetStore.ts
+++ b/src/stores/widgets/RegionWidgetStore.ts
@@ -1,0 +1,21 @@
+import {action, observable} from "mobx";
+
+export class RegionWidgetStore {
+    @observable regionIdMap: Map<number, number>;
+
+    constructor() {
+        this.regionIdMap = new Map<number, number>();
+    }
+
+    @action clearFrameEntry = (fileId: number) => {
+        this.regionIdMap.delete(fileId);
+    };
+
+    @action clearRegionMap = () => {
+        this.regionIdMap.clear();
+    };
+
+    @action setRegionId = (fileId: number, regionId: number) => {
+        this.regionIdMap.set(fileId, regionId);
+    };
+}

--- a/src/stores/widgets/RegionWidgetStore.ts
+++ b/src/stores/widgets/RegionWidgetStore.ts
@@ -1,4 +1,5 @@
 import {action, observable} from "mobx";
+import {FrameStore} from "../FrameStore";
 
 export class RegionWidgetStore {
     @observable regionIdMap: Map<number, number>;
@@ -18,4 +19,28 @@ export class RegionWidgetStore {
     @action setRegionId = (fileId: number, regionId: number) => {
         this.regionIdMap.set(fileId, regionId);
     };
+
+    public static CalculateRequirementsArray(frame: FrameStore, widgetsMap: Map<string, RegionWidgetStore>) {
+        const updatedRequirements = new Map<number, Array<number>>();
+        const fileId = frame.frameInfo.fileId;
+
+        widgetsMap.forEach(widgetStore => {
+            const regionId = widgetStore.regionIdMap.get(fileId) || -1;
+            if (!frame.regionSet) {
+                return;
+            }
+            const region = frame.regionSet.regions.find(r => r.regionId === regionId);
+            if (regionId === -1 || region && region.isClosedRegion) {
+                let frameRequirementsArray = updatedRequirements.get(fileId);
+                if (!frameRequirementsArray) {
+                    frameRequirementsArray = [];
+                    updatedRequirements.set(fileId, frameRequirementsArray);
+                }
+                if (frameRequirementsArray.indexOf(regionId) === -1) {
+                    frameRequirementsArray.push(regionId);
+                }
+            }
+        });
+        return updatedRequirements;
+    }
 }

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -2,6 +2,7 @@ import {action, computed, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {PlotType} from "components/Shared";
 import {RegionWidgetStore} from "./RegionWidgetStore";
+import {FrameStore} from "../FrameStore";
 
 export class SpectralProfileWidgetStore extends RegionWidgetStore {
     @observable coordinate: string;
@@ -132,5 +133,144 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
 
     @computed get isAutoScaledY() {
         return (this.minY === undefined || this.maxY === undefined);
+    }
+
+    public static CalculateRequirementsMap(frame: FrameStore, widgetsMap: Map<string, SpectralProfileWidgetStore>) {
+        const updatedRequirements = new Map<number, Map<number, CARTA.SetSpectralRequirements>>();
+        widgetsMap.forEach(widgetStore => {
+            const fileId = frame.frameInfo.fileId;
+            const regionId = widgetStore.regionIdMap.get(fileId) || 0;
+            const coordinate = widgetStore.coordinate;
+            let statsType = widgetStore.statsType;
+
+            if (!frame.regionSet) {
+                return;
+            }
+            const region = frame.regionSet.regions.find(r => r.regionId === regionId);
+            if (region) {
+                // Point regions have no meaningful stats type
+                if (region.regionType === CARTA.RegionType.POINT) {
+                    statsType = CARTA.StatsType.None;
+                }
+
+                let frameRequirements = updatedRequirements.get(fileId);
+                if (!frameRequirements) {
+                    frameRequirements = new Map<number, CARTA.SetSpectralRequirements>();
+                    updatedRequirements.set(fileId, frameRequirements);
+                }
+
+                let regionRequirements = frameRequirements.get(regionId);
+                if (!regionRequirements) {
+                    regionRequirements = new CARTA.SetSpectralRequirements({regionId, fileId});
+                    frameRequirements.set(regionId, regionRequirements);
+                }
+
+                if (!regionRequirements.spectralProfiles) {
+                    regionRequirements.spectralProfiles = [];
+                }
+
+                let spectralConfig = regionRequirements.spectralProfiles.find(profiles => profiles.coordinate === coordinate);
+                if (!spectralConfig) {
+                    // create new spectral config
+                    regionRequirements.spectralProfiles.push({coordinate, statsTypes: [statsType]});
+                } else if (spectralConfig.statsTypes.indexOf(statsType) === -1) {
+                    // add to the stats type array
+                    spectralConfig.statsTypes.push(statsType);
+                }
+            }
+        });
+
+        return updatedRequirements;
+    }
+
+    // This function diffs the updated requirements map with the existing requirements map, and reacts to changes
+    // Three diff cases are checked:
+    // 1. The old map has an entry, but the new one does not => send an "empty" SetSpectralRequirements message
+    // 2. The old and new maps both have entries, but they are different => send the new SetSpectralRequirements message
+    // 3. The new map has an entry, but the old one does not => send the new SetSpectralRequirements message
+    // The easiest way to check all three is to first add any missing entries to the new map (as empty requirements), and then check the updated maps entries
+    public static DiffSpectralRequirements(originalRequirements: Map<number, Map<number, CARTA.SetSpectralRequirements>>, updatedRequirements: Map<number, Map<number, CARTA.SetSpectralRequirements>>) {
+        const diffList: CARTA.SetSpectralRequirements[] = [];
+
+        // Fill updated requirements with missing entries
+        originalRequirements.forEach((frameRequirements, fileId) => {
+            let updatedFrameRequirements = updatedRequirements.get(fileId);
+            if (!updatedFrameRequirements) {
+                updatedFrameRequirements = new Map<number, CARTA.SetSpectralRequirements>();
+                updatedRequirements.set(fileId, updatedFrameRequirements);
+            }
+            frameRequirements.forEach((regionRequirements, regionId) => {
+                let updatedRegionRequirements = updatedFrameRequirements.get(regionId);
+                if (!updatedRegionRequirements) {
+                    updatedRegionRequirements = new CARTA.SetSpectralRequirements({fileId, regionId, spectralProfiles: []});
+                    updatedFrameRequirements.set(regionId, updatedRegionRequirements);
+                }
+            });
+        });
+
+        // Go through updated requirements entries and find differences
+        updatedRequirements.forEach((updatedFrameRequirements, fileId) => {
+            let frameRequirements = originalRequirements.get(fileId);
+            if (!frameRequirements) {
+                // If there are no existing requirements for this fileId, all entries for this file are new
+                updatedFrameRequirements.forEach(regionRequirements => diffList.push(regionRequirements));
+            } else {
+                updatedFrameRequirements.forEach((updatedRegionRequirements, regionId) => {
+                    let regionRequirements = frameRequirements.get(regionId);
+                    if (!regionRequirements) {
+                        // If there are no existing requirements for this regionId, this is a new entry
+                        diffList.push(updatedRegionRequirements);
+                    } else {
+                        // Deep equality comparison with sorted arrays
+                        const configCount = regionRequirements.spectralProfiles ? regionRequirements.spectralProfiles.length : 0;
+                        const updatedConfigCount = updatedRegionRequirements.spectralProfiles ? updatedRegionRequirements.spectralProfiles.length : 0;
+
+                        if (configCount !== updatedConfigCount) {
+                            diffList.push(updatedRegionRequirements);
+                            return;
+                        }
+
+                        if (configCount === 0) {
+                            return;
+                        }
+                        const sortedUpdatedConfigs = updatedRegionRequirements.spectralProfiles.sort(((a, b) => a.coordinate > b.coordinate ? 1 : -1));
+                        const sortedConfigs = regionRequirements.spectralProfiles.sort(((a, b) => a.coordinate > b.coordinate ? 1 : -1));
+
+                        for (let i = 0; i < updatedConfigCount; i++) {
+                            const updatedConfig = sortedUpdatedConfigs[i];
+                            const config = sortedConfigs[i];
+                            if (updatedConfig.coordinate !== config.coordinate) {
+                                diffList.push(updatedRegionRequirements);
+                                return;
+                            }
+
+                            const statsCount = config.statsTypes ? config.statsTypes.length : 0;
+                            const updatedStatsCount = updatedConfig.statsTypes ? updatedConfig.statsTypes.length : 0;
+
+                            if (statsCount !== updatedStatsCount) {
+                                diffList.push(updatedRegionRequirements);
+                                return;
+                            }
+
+                            if (statsCount === 0) {
+                                return;
+                            }
+
+                            const sortedUpdatedStats = updatedConfig.statsTypes.sort();
+                            const sortedStats = config.statsTypes.sort();
+                            for (let j = 0; j < updatedStatsCount; j++) {
+                                if (sortedUpdatedStats[j] !== sortedStats[j]) {
+                                    diffList.push(updatedRegionRequirements);
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+        });
+        // Sort list so that requirements clearing occurs first
+        return diffList.sort((a, b) => a.spectralProfiles.length > b.spectralProfiles.length ? 1 : -1);
     }
 }

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -1,10 +1,9 @@
 import {action, computed, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {PlotType} from "components/Shared";
+import {RegionWidgetStore} from "./RegionWidgetStore";
 
-export class SpectralProfileWidgetStore {
-    @observable fileId: number;
-    @observable regionId: number;
+export class SpectralProfileWidgetStore extends RegionWidgetStore {
     @observable coordinate: string;
     @observable statsType: CARTA.StatsType;
     @observable minX: number;
@@ -25,16 +24,9 @@ export class SpectralProfileWidgetStore {
         CARTA.StatsType.None, CARTA.StatsType.Sum, CARTA.StatsType.FluxDensity, CARTA.StatsType.Mean, CARTA.StatsType.RMS,
         CARTA.StatsType.Sigma, CARTA.StatsType.SumSq, CARTA.StatsType.Min, CARTA.StatsType.Max];
 
-    @action setFileId = (fileId: number) => {
-        // Reset zoom when changing between files
+    @action setRegionId = (fileId: number, regionId: number) => {
+        this.regionIdMap.set(fileId, regionId);
         this.clearXYBounds();
-        this.fileId = fileId;
-    };
-
-    @action setRegionId = (regionId: number) => {
-        // Reset zoom when changing between regions
-        this.clearXYBounds();
-        this.regionId = regionId;
     };
 
     @action setStatsType = (statsType: CARTA.StatsType) => {
@@ -121,10 +113,8 @@ export class SpectralProfileWidgetStore {
         this.cursorX = cursorVal;
     };
 
-    constructor(coordinate: string = "z", fileId: number = -1, regionId: number = 0) {
-        // Describes which data is being visualised
-        this.fileId = fileId;
-        this.regionId = regionId;
+    constructor(coordinate: string = "z") {
+        super();
         this.coordinate = coordinate;
         this.statsType = CARTA.StatsType.Mean;
 

--- a/src/stores/widgets/StatsWidgetStore.ts
+++ b/src/stores/widgets/StatsWidgetStore.ts
@@ -1,19 +1,22 @@
 import {action, observable} from "mobx";
 
 export class StatsWidgetStore {
-    @observable fileId: number;
-    @observable regionId: number;
+    @observable regionIdMap: Map<number, number>;
 
-    constructor(fileId: number = -1, regionId: number = -1) {
-        this.fileId = fileId;
-        this.regionId = regionId;
+    constructor() {
+        this.regionIdMap = new Map<number, number>();
     }
 
-    @action setFileId = (fileId: number) => {
-        this.fileId = fileId;
+    @action clearFrameEntry = (fileId: number) => {
+        this.regionIdMap.delete(fileId);
     };
 
-    @action setRegionId = (regionId: number) => {
-        this.regionId = regionId;
+    @action clearRegionMap = () => {
+        this.regionIdMap.clear();
     };
+
+    @action setRegionId = (fileId: number, regionId: number) => {
+        this.regionIdMap.set(fileId, regionId);
+    };
+
 }

--- a/src/stores/widgets/StatsWidgetStore.ts
+++ b/src/stores/widgets/StatsWidgetStore.ts
@@ -1,5 +1,50 @@
-import {RegionWidgetStore} from "./RegionWidgetStore";
+import {CARTA} from "carta-protobuf";
+import {AppStore} from "stores";
+import {RegionWidgetStore} from "stores/widgets";
 
 export class StatsWidgetStore extends RegionWidgetStore {
+    public static DiffRequirementsArray(originalRequirements: Map<number, Array<number>>, updatedRequirements: Map<number, Array<number>>) {
+        const diffList: CARTA.SetStatsRequirements[] = [];
 
+        // Three possible scenarios:
+        // 1. Existing array, no new array => diff should be empty stats requirements for each element of existing array
+        // 2. No existing array, new array => diff should be full stats requirements for each element of new array
+        // 3. Existing array and new array => diff should be empty stats for those missing in new array, full stats for those missing in old array
+
+        // (1) & (3) handled first
+        originalRequirements.forEach((statsArray, fileId) => {
+            const updatedStatsArray = updatedRequirements.get(fileId);
+            // If there's no new array, remove requirements for all existing regions
+            if (!updatedStatsArray) {
+                for (const regionId of statsArray) {
+                    diffList.push(CARTA.SetStatsRequirements.create({fileId, regionId, stats: []}));
+                }
+            } else {
+                // If regions in the new array are missing, remove requirements for those regions
+                for (const regionId of statsArray) {
+                    if (updatedStatsArray.indexOf(regionId) === -1) {
+                        diffList.push(CARTA.SetStatsRequirements.create({fileId, regionId, stats: []}));
+                    }
+                }
+                // If regions in the existing array are missing, add requirements for those regions
+                for (const regionId of updatedStatsArray) {
+                    if (statsArray.indexOf(regionId) === -1) {
+                        diffList.push(CARTA.SetStatsRequirements.create({fileId, regionId, stats: AppStore.DEFAULT_STATS_TYPES}));
+                    }
+                }
+            }
+        });
+
+        updatedRequirements.forEach((updatedStatsArray, fileId) => {
+            const statsArray = originalRequirements.get(fileId);
+            // If there's no existing array, add requirements for all new regions
+            if (!statsArray) {
+                for (const regionId of updatedStatsArray) {
+                    diffList.push(CARTA.SetStatsRequirements.create({fileId, regionId, stats: AppStore.DEFAULT_STATS_TYPES}));
+                }
+            }
+        });
+
+        return diffList;
+    }
 }

--- a/src/stores/widgets/StatsWidgetStore.ts
+++ b/src/stores/widgets/StatsWidgetStore.ts
@@ -1,22 +1,5 @@
-import {action, observable} from "mobx";
+import {RegionWidgetStore} from "./RegionWidgetStore";
 
-export class StatsWidgetStore {
-    @observable regionIdMap: Map<number, number>;
-
-    constructor() {
-        this.regionIdMap = new Map<number, number>();
-    }
-
-    @action clearFrameEntry = (fileId: number) => {
-        this.regionIdMap.delete(fileId);
-    };
-
-    @action clearRegionMap = () => {
-        this.regionIdMap.clear();
-    };
-
-    @action setRegionId = (fileId: number, regionId: number) => {
-        this.regionIdMap.set(fileId, regionId);
-    };
+export class StatsWidgetStore extends RegionWidgetStore {
 
 }

--- a/src/stores/widgets/index.ts
+++ b/src/stores/widgets/index.ts
@@ -1,6 +1,7 @@
 export * from "./RenderConfigWidgetStore";
 export * from "./SpatialProfileWidgetStore";
 export * from "./SpectralProfileWidgetStore";
+export * from "./RegionWidgetStore";
 export * from "./StatsWidgetStore";
 export * from "./HistogramWidgetStore";
 export * from "./EmptyWidgetStore";


### PR DESCRIPTION
quite a large refactoring, moved most of the requirements recalculations into their appropriate store classes as static functions, meaning `AppStore` is below 700 lines again (still needs more refactoring in future!)

Main change is that each widget now has a `regionId` for each open frame, rather than one `regionId`. 

Fixes #213 and #206 