### PR TITLE
Jason/fix 73

### DIFF
--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -33,7 +33,6 @@ export const renderColor: ItemRenderer<Color> = (color, {handleClick, modifiers,
 };
 
 // Font selector
-
 export class Font {
     name: string;
     id: number;

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import * as AST from "ast_wrapper";
 import * as _ from "lodash";
 import {observer} from "mobx-react";
-import {ASTSettingsString, FrameStore, OverlayStore} from "stores";
-import {CursorInfo, Point2D} from "models";
+import {FrameStore, OverlayStore} from "stores";
+import {CursorInfo} from "models";
 import "./OverlayComponent.css";
 
 export class OverlayComponentProps {
@@ -72,10 +72,6 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
     render() {
         const styleString = this.props.overlaySettings.styleString;
-        const frameView = this.props.frame.requiredFrameView;
-        const framePadding = this.props.overlaySettings.padding;
-        const w = this.props.overlaySettings.viewWidth;
-        const h = this.props.overlaySettings.viewHeight;
 
         let className = "overlay-canvas";
         if (this.props.docked) {

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -73,6 +73,12 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     render() {
         const styleString = this.props.overlaySettings.styleString;
 
+        // changing the frame view, padding or width/height triggers a re-render
+        const frameView = this.props.frame.requiredFrameView;
+        const framePadding = this.props.overlaySettings.padding;
+        const w = this.props.overlaySettings.viewWidth;
+        const h = this.props.overlaySettings.viewHeight;
+
         let className = "overlay-canvas";
         if (this.props.docked) {
             className += " docked";

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -80,7 +80,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                 let astString = new ASTSettingsString();
                 astString.add("Format(1)", this.props.overlaySettings.numbers.cursorFormatStringX(precisionX));
                 astString.add("Format(2)", this.props.overlaySettings.numbers.cursorFormatStringY(precisionY));
-                astString.add("System", this.props.overlaySettings.global.implicitSystem);
+                astString.add("System", this.props.overlaySettings.global.explicitSystem);
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map((pos) => AST.getFormattedCoordinates(this.props.frame.wcsInfo, pos.x, pos.y, astString.toString()));
                 let [p, n1, n2] = formattedNeighbourhood;

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -287,7 +287,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         const isXProfile = this.widgetStore.coordinate.indexOf("x") >= 0;
 
         let astString = new ASTSettingsString();
-        astString.add("System", this.props.appStore.overlayStore.global.implicitSystem);
+        astString.add("System", this.props.appStore.overlayStore.global.explicitSystem);
 
         if (isXProfile) {
             for (let i = 0; i < values.length; i++) {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -33,7 +33,7 @@ export enum LabelType {
 }
 
 export enum SystemType {
-    Native = "",
+    Native = "NATIVE",
     Ecliptic = "ECLIPTIC",
     FK4 = "FK4",
     FK5 = "FK5",
@@ -88,17 +88,8 @@ export class OverlayGlobalSettings {
         astString.add("Labelling", this.labelType);
         astString.add("Color", this.color);
         astString.add("Tol", (this.tolerance / 100).toFixed(2), (this.tolerance >= 0.001)); // convert to fraction
-        astString.add("System", this.implicitSystem);
+        astString.add("System", this.explicitSystem);
         return astString.toString();
-    }
-
-    // Get the current manually overridden system or nothing if system is set to native
-    @computed get implicitSystem() {
-        if (!this.validWcs || this.system === SystemType.Native) {
-            return undefined;
-        }
-
-        return this.system;
     }
 
     // Get the current manually overridden system or the default saved from file if system is set to native

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -260,7 +260,6 @@ export class OverlayGridSettings {
     @action setGapY(gap: number) {
         this.gapY = gap;
     }
-
 }
 
 export class OverlayBorderSettings {
@@ -637,7 +636,6 @@ export class OverlayStore {
     @observable ticks: OverlayTickSettings;
 
     // Dialog
-
     @observable overlaySettingsDialogVisible = false;
 
     @action showOverlaySettings = () => {
@@ -672,7 +670,6 @@ export class OverlayStore {
     }
 
     @action setFormatsFromSystem() {
-
         if (!this.global.validWcs) {
             // TODO: check if degrees would work
             this.numbers.setDefaultFormatX(undefined);


### PR DESCRIPTION
we use implicit system(parameter system="") in overlay store in order to provide native option for users,  however current logic will not append "system" parameter when its value is an empty string, then the AST just use previous coordinate system to render. The solution is to set explicit system (saved in defaultSystem) to AST.

closes #73 

