### PR TITLE
Patch for issue #126

### DIFF
--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -271,7 +271,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         this.gl.uniform1f(this.ContrastUniform, 1);
         this.gl.uniform1f(this.GammaUniform, 1);
         this.gl.uniform1f(this.AlphaUniform, 1000);
-        this.gl.uniform4f(this.NaNColor, 0, 0, 1, 1);
+        this.gl.uniform4f(this.NaNColor, 0, 0, 0, 0);
     }
 
     private initBuffers() {


### PR DESCRIPTION
Set opacity of uNaNColor and NaNColor to be 0 so that a non-finite pixel is transparent.