### PR TITLE
fix half-pixel rendering artefacts at tile boundaries

### DIFF
--- a/src/components/ImageView/RasterView/GLSL/pixel_shader_float_rgb.glsl
+++ b/src/components/ImageView/RasterView/GLSL/pixel_shader_float_rgb.glsl
@@ -10,6 +10,7 @@ precision highp float;
 #define CUSTOM 7
 
 varying vec2 vUV;
+uniform bool uTiledRendering;
 // Textures
 uniform sampler2D
 uDataTexture;
@@ -27,8 +28,11 @@ uniform float uGamma;
 uniform float uAlpha;
 uniform vec4 uNaNColor;
 
-// Tile border
+// Tile texture parameters in pixels
 uniform float uTileBorder;
+uniform vec2 uTileTextureOffset;
+uniform float uTextureSize;
+uniform float uTileTextureSize;
 
 bool isnan(float val) {
     return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;
@@ -40,9 +44,21 @@ void main(void) {
         gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
         return;
     }
+    vec2 texCoords;
+
+    if (uTiledRendering) {
+        // Mimic texel fetch in WebGL1
+        vec2 tileCoordsPixel = vUV * uTileTextureSize;
+        // Prevent edge artefacts
+        vec2 texCoordsPixel = clamp(tileCoordsPixel, 0.5, uTileTextureSize - 0.5) + uTileTextureOffset;
+        texCoords = texCoordsPixel / uTextureSize;
+    }
+    else {
+        texCoords = vUV;
+    }
 
     float range = uMaxVal - uMinVal;
-    float rawVal = texture2D(uDataTexture, vUV).r;
+    float rawVal = texture2D(uDataTexture, texCoords).r;
 
     // Scaling types
     // LINEAR (Default: uScaleType == LINEAR)

--- a/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
+++ b/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
@@ -4,17 +4,11 @@ precision highp float;
 attribute vec3 aVertexPosition;
 attribute vec2 aVertexUV;
 varying vec2 vUV;
-
 // Tiling parameters
 uniform bool uTiledRendering;
 uniform vec2 uTileSize;
 uniform vec2 uTileScaling;
 uniform vec2 uTileOffset;
-
-// Tile texture parameters in pixels
-uniform vec2 uTileTextureOffset;
-uniform float uTextureSize;
-uniform float uTileTextureSize;
 
 void main(void) {
     if (uTiledRendering) {
@@ -22,10 +16,7 @@ void main(void) {
         // Convert XY from [0, 1] -> [-1, 1]
         vec2 adjustedPosition = tilePosition * 2.0 - 1.0;
         gl_Position = vec4(adjustedPosition.x, adjustedPosition.y, aVertexPosition.z, 1.0);
-        vec2 tilePixel = aVertexUV * uTileSize * uTileTextureSize;
-        // Prevent edge artifacts
-        tilePixel = uTileTextureOffset + clamp(tilePixel, 0.5, uTileTextureSize - 0.5);
-        vUV = tilePixel / uTextureSize;
+        vUV = aVertexUV * uTileSize;
     } else {
         gl_Position =  vec4(aVertexPosition, 1.0);
         vUV = aVertexUV;


### PR DESCRIPTION
Closes #350 

The previous half-pixel artefacts were due to an attempt to solve an existing tiling artefact. However, the fix was applied at the vertex shader level, and ended up cropping off the first and last half-pixels of every tile. The tile has now been moved to the pixel shader level, and fixes both artefacts.

![image](https://user-images.githubusercontent.com/592504/60536691-299d0900-9d07-11e9-852b-c82745777cb1.png)
