### PR TITLE
Angus/profile optimisation

### DIFF
--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -166,8 +166,8 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
 
                         localCounter++;
                         if (localCounter === decimationFactor) {
-                            // Use the midpoint of the decimated data range as the x coordinate
-                            const x = coordinateData.start + i + xMin - decimationFactor / 2.0;
+                            // Use the midpoint of the decimated data range as the x coordinate (rounded down to nearest pixel)
+                            const x = Math.floor(coordinateData.start + i + xMin - decimationFactor / 2.0);
                             values[decimatedIndex * 2] = {x, y: localMin};
                             values[decimatedIndex * 2 + 1] = {x, y: localMax};
                             localMin = NaN;
@@ -182,14 +182,6 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                         values[values.length - 2] = {x, y: localMin};
                         values[values.length - 1] = {x, y: localMax};
                     }
-                }
-            }
-
-            for (let i = 0; i < values.length; i++) {
-                if (!values[i]) {
-                    console.log(`missing value entry ${i}`);
-                    console.log(values);
-                    break;
                 }
             }
 

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -10,7 +10,7 @@ import {SpectralProfilerSettingsPanelComponent} from "./SpectralProfilerSettings
 import {SpectralProfilerToolbarComponent} from "./SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent";
 import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps} from "stores";
 import {SpectralProfileWidgetStore} from "stores/widgets";
-import {Point2D} from "models";
+import {Point2D, ProcessedSpectralProfile} from "models";
 import {clamp} from "utilities";
 import "./SpectralProfilerComponent.css";
 
@@ -69,7 +69,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         }
 
         const fileId = frame.frameInfo.fileId;
-        let coordinateData: CARTA.ISpectralProfile;
+        let coordinateData: ProcessedSpectralProfile;
         let regionId = this.widgetStore.regionIdMap.get(fileId) || 0;
         if (frame.regionSet) {
             const region = frame.regionSet.regions.find(r => r.regionId === regionId);
@@ -79,7 +79,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         }
 
         let channelInfo = frame.channelInfo;
-        if (coordinateData && channelInfo && coordinateData.vals && coordinateData.vals.length && coordinateData.vals.length === channelInfo.values.length) {
+        if (coordinateData && channelInfo && coordinateData.values && coordinateData.values.length && coordinateData.values.length === channelInfo.values.length) {
             let channelValues = this.widgetStore.useWcsValues ? channelInfo.values : channelInfo.indexes;
             let xMin = Math.min(channelValues[0], channelValues[channelValues.length - 1]);
             let xMax = Math.max(channelValues[0], channelValues[channelValues.length - 1]);
@@ -106,7 +106,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             for (let i = 0; i < channelValues.length; i++) {
                 let index = isIncremental ? i : channelValues.length - 1 - i;
                 const x = channelValues[index];
-                const y = coordinateData.vals[index];
+                const y = coordinateData.values[index];
 
                 // Skip values outside of range. If array already contains elements, we've reached the end of the range, and can break
                 if (x < xMin || x > xMax) {

--- a/src/models/Processed.ts
+++ b/src/models/Processed.ts
@@ -1,0 +1,51 @@
+import {CARTA} from "carta-protobuf";
+
+export interface ProcessedSpatialProfile extends CARTA.ISpatialProfile {
+    values: Float32Array;
+}
+
+export interface ProcessedSpectralProfile extends CARTA.ISpectralProfile {
+    values: Float32Array | Float64Array;
+}
+
+export class ProtobufProcessing {
+    static ProcessSpatialProfile(profile: CARTA.ISpatialProfile): ProcessedSpatialProfile {
+        if (profile.rawValuesFp32 && profile.rawValuesFp32.length && profile.rawValuesFp32.length % 4 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                start: profile.start,
+                end: profile.end,
+                values: new Float32Array(profile.rawValuesFp32.slice().buffer)
+            };
+        }
+
+        return {
+            coordinate: profile.coordinate,
+            start: profile.start,
+            end: profile.end,
+            values: null
+        };
+    }
+
+    static ProcessSpectralProfile(profile: CARTA.ISpectralProfile): ProcessedSpectralProfile {
+        if (profile.rawValuesFp64 && profile.rawValuesFp64.length && profile.rawValuesFp64.length % 8 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                statsType: profile.statsType,
+                values: new Float64Array(profile.rawValuesFp64.slice().buffer)
+            };
+        } else if (profile.rawValuesFp32 && profile.rawValuesFp32.length && profile.rawValuesFp32.length % 4 === 0) {
+            return {
+                coordinate: profile.coordinate,
+                statsType: profile.statsType,
+                values: new Float32Array(profile.rawValuesFp32.slice().buffer)
+            };
+        }
+
+        return {
+            coordinate: profile.coordinate,
+            statsType: profile.statsType,
+            values: null
+        };
+    }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -13,3 +13,4 @@ export * from "./WCSType";
 export * from "./RegionCreationMode";
 export * from "./CompressionQuality";
 export * from "./TileCache";
+export * from "./Processed";

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -14,7 +14,7 @@ import {CursorInfo, FrameView, Theme, Point2D} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore} from "./widgets";
 
 const CURSOR_DEBOUNCE_TIME = 200;
-const CURSOR_THROTTLE_TIME = 200;
+const CURSOR_THROTTLE_TIME = 100;
 const IMAGE_THROTTLE_TIME = 50;
 const IMAGE_CHANNEL_THROTTLE_TIME = 500;
 const REQUIREMENTS_CHECK_INTERVAL = 200;
@@ -500,14 +500,6 @@ export class AppStore {
                         throttledSetCursor(this.activeFrame.frameInfo.fileId, pos.x, pos.y);
                     } else {
                         debouncedSetCursor(this.activeFrame.frameInfo.fileId, pos.x, pos.y);
-                        let keyStruct = {fileId: this.activeFrame.frameInfo.fileId, regionId: 0};
-                        const key = `${keyStruct.fileId}-${keyStruct.regionId}`;
-                        const profileStore = this.spatialProfiles.get(key);
-                        if (profileStore) {
-                            profileStore.x = pos.x;
-                            profileStore.y = pos.y;
-                            profileStore.approximate = true;
-                        }
                     }
                 }
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -554,7 +554,7 @@ export class AppStore {
     }
 
     // region Subscription handlers
-    handleSpatialProfileStream = (spatialProfileData: CARTA.SpatialProfileData) => {
+    @action handleSpatialProfileStream = (spatialProfileData: CARTA.SpatialProfileData) => {
         if (this.frames.find(frame => frame.frameInfo.fileId === spatialProfileData.fileId)) {
             const key = `${spatialProfileData.fileId}-${spatialProfileData.regionId}`;
             let profileStore = this.spatialProfiles.get(key);
@@ -568,9 +568,9 @@ export class AppStore {
             profileStore.x = spatialProfileData.x;
             profileStore.y = spatialProfileData.y;
             profileStore.approximate = false;
-            const profileMap = new Map<string, CARTA.SpatialProfile>();
+            const profileMap = new Map<string, CARTA.ISpatialProfile>();
             for (let profile of spatialProfileData.profiles) {
-                profileMap.set(profile.coordinate, profile as CARTA.SpatialProfile);
+                profileMap.set(profile.coordinate, profile);
             }
             profileStore.setProfiles(profileMap);
         }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -10,6 +10,7 @@ export interface FrameInfo {
     fileId: number;
     fileInfo: CARTA.FileInfo;
     fileInfoExtended: CARTA.FileInfoExtended;
+    fileFeatureFlags: number;
     renderMode: CARTA.RenderMode;
 }
 

--- a/src/stores/SpatialProfileStore.ts
+++ b/src/stores/SpatialProfileStore.ts
@@ -9,20 +9,20 @@ export class SpatialProfileStore {
     @observable x: number;
     @observable y: number;
     @observable approximate: boolean;
-    @observable profiles: Map<string, CARTA.SpatialProfile>;
+    @observable profiles: Map<string, CARTA.ISpatialProfile>;
 
     constructor(fileId: number = 0, regionId: number = 0) {
         this.fileId = fileId;
         this.regionId = regionId;
         this.approximate = true;
-        this.profiles = new Map<string, CARTA.SpatialProfile>();
+        this.profiles = new Map<string, CARTA.ISpatialProfile>();
     }
 
-    @action setProfile(coordinate: string, profile: CARTA.SpatialProfile) {
+    @action setProfile(coordinate: string, profile: CARTA.ISpatialProfile) {
         this.profiles.set(coordinate, profile);
     }
 
-    @action setProfiles(profiles: Map<string, CARTA.SpatialProfile>) {
+    @action setProfiles(profiles: Map<string, CARTA.ISpatialProfile>) {
         this.profiles = profiles;
     }
 }

--- a/src/stores/SpatialProfileStore.ts
+++ b/src/stores/SpatialProfileStore.ts
@@ -1,5 +1,5 @@
 import {action, observable} from "mobx";
-import {CARTA} from "carta-protobuf";
+import {ProcessedSpatialProfile} from "models";
 
 export class SpatialProfileStore {
     @observable regionId: number;
@@ -8,21 +8,19 @@ export class SpatialProfileStore {
     @observable channel: number;
     @observable x: number;
     @observable y: number;
-    @observable approximate: boolean;
-    @observable profiles: Map<string, CARTA.ISpatialProfile>;
+    @observable profiles: Map<string, ProcessedSpatialProfile>;
 
     constructor(fileId: number = 0, regionId: number = 0) {
         this.fileId = fileId;
         this.regionId = regionId;
-        this.approximate = true;
-        this.profiles = new Map<string, CARTA.ISpatialProfile>();
+        this.profiles = new Map<string, ProcessedSpatialProfile>();
     }
 
-    @action setProfile(coordinate: string, profile: CARTA.ISpatialProfile) {
+    @action setProfile(coordinate: string, profile: ProcessedSpatialProfile) {
         this.profiles.set(coordinate, profile);
     }
 
-    @action setProfiles(profiles: Map<string, CARTA.ISpatialProfile>) {
+    @action setProfiles(profiles: Map<string, ProcessedSpatialProfile>) {
         this.profiles = profiles;
     }
 }

--- a/src/stores/SpectralProfileStore.ts
+++ b/src/stores/SpectralProfileStore.ts
@@ -1,5 +1,6 @@
 import {action, observable, ObservableMap} from "mobx";
 import {CARTA} from "carta-protobuf";
+import {ProcessedSpectralProfile} from "models";
 
 export class SpectralProfileStore {
     @observable regionId: number;
@@ -7,12 +8,12 @@ export class SpectralProfileStore {
     @observable stokes: number;
     @observable x: number;
     @observable y: number;
-    @observable profiles: Map<string, ObservableMap<CARTA.StatsType, CARTA.ISpectralProfile>>;
+    @observable profiles: Map<string, ObservableMap<CARTA.StatsType, ProcessedSpectralProfile>>;
 
     constructor(fileId: number = 0, regionId: number = 0) {
         this.fileId = fileId;
         this.regionId = regionId;
-        this.profiles = new Map<string, ObservableMap<CARTA.StatsType, CARTA.ISpectralProfile>>();
+        this.profiles = new Map<string, ObservableMap<CARTA.StatsType, ProcessedSpectralProfile>>();
     }
 
     getProfile(coordinate: string, statsType: CARTA.StatsType) {
@@ -24,13 +25,13 @@ export class SpectralProfileStore {
     }
 
     @action clearProfiles() {
-        this.profiles = new Map<string, ObservableMap<CARTA.StatsType, CARTA.ISpectralProfile>>();
+        this.profiles = new Map<string, ObservableMap<CARTA.StatsType, ProcessedSpectralProfile>>();
     }
 
-    @action setProfile(profile: CARTA.ISpectralProfile) {
+    @action setProfile(profile: ProcessedSpectralProfile) {
         let coordinateMap = this.profiles.get(profile.coordinate);
         if (!coordinateMap) {
-            coordinateMap = new ObservableMap<CARTA.StatsType, CARTA.ISpectralProfile>();
+            coordinateMap = new ObservableMap<CARTA.StatsType, ProcessedSpectralProfile>();
             this.profiles.set(profile.coordinate, coordinateMap);
         }
         coordinateMap.set(profile.statsType, profile);


### PR DESCRIPTION
Note: Companion PR of [#262](https://github.com/CARTAvis/carta-backend/pull/262). This PR should not be merged until the companion PR is approved.

This PR adds decimation to spatial profiles, to ensure that performance is smooth when viewing large images. See #366 for details and some benchmarks. 

This PR also adapts the backend to the changes in ICD version 5.0.0 (described in the google doc). Specifically, it makes use of `bytes` fields instead of `repeated float` and `repeated double` for spatial and spectral profiles. This is done to avoid the overhead incurred when decoding these messages, particularly in the case when the profiles are very large. This overhead was up to 2 ms for large (48K profiles). The decode time has now decreased to below 0.25 ms. 

Finally, it makes use of the `fileFeatureFlags` value returned by `OPEN_FILE_ACK` to determine whether swizzled datasets are present, and then adjusts the throttled cursor update performance accordingly. This should enable _up to_ 5 fps spatial and spectral profile updates for FITS/CASA files, and up to 10 fps for HDF5 files. 