### PR TITLE
recursively render up to 3 layers of placeholder tiles

### DIFF
--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -65,7 +65,6 @@ export class BackendService {
             CARTA.EventType.OPEN_FILE,
             CARTA.EventType.OPEN_FILE_ACK,
             CARTA.EventType.RASTER_IMAGE_DATA,
-            CARTA.EventType.REGION_HISTOGRAM_DATA
         ];
 
         // Check local storage for a list of events to log to console


### PR DESCRIPTION
This solves #363 by recursively calling `renderTiles` (up to 3 times) for higher resolution tiles (it's already done for lower-resolution tiles). 

The higher-resolution tiles are attempted first, since by writing to the z-buffer, they'll appear on top of any lower-resolution tiles. 