### PR TITLE
jump to start of animation range when starting outside

### DIFF
--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -43,7 +43,6 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
 
     onRangeChanged = (range: NumberRange) => {
         const frame = this.props.appStore.activeFrame;
-        console.log(range);
         if (range && range.length === 2 && frame) {
             if (range[0] >= 0 && range[0] < range[1] && range[1] < frame.frameInfo.fileInfoExtended.depth) {
                 frame.setAnimationRange(range);

--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -64,6 +64,10 @@ export class AnimatorStore {
                 channel: 1,
                 stokes: 0
             };
+
+            // Skip to the start of the animation range if below it.
+            // The first frame delivered by the animation should be the one after the current one
+            startFrame.channel = Math.max((startFrame.channel + 1) % frame.frameInfo.fileInfoExtended.depth, firstFrame.channel);
         } else if (this.animationMode === AnimationMode.STOKES) {
             firstFrame = {
                 channel: frame.channel,
@@ -79,6 +83,9 @@ export class AnimatorStore {
                 channel: 0,
                 stokes: 1
             };
+            // Skip to the start of the animation range if below it
+            // The first frame delivered by the animation should be the one after the current one
+            startFrame.stokes = Math.max((startFrame.stokes + 1) % frame.frameInfo.fileInfoExtended.stokes, firstFrame.stokes);
         }
 
         const reqView = frame.requiredFrameView;


### PR DESCRIPTION
This PR fixes #389, and also ensures that the first frame sent by the animation is in fact the _next_ frame required (rather than a duplicate of the current frame)