### PR TITLE
Angus/animator timestamp

### DIFF
--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -122,7 +122,6 @@ export class AnimatorStore {
         });
 
         this.animationState = AnimationState.PLAYING;
-        this.flowControlCounter = 0;
     };
 
     @action stopAnimation = () => {
@@ -155,16 +154,7 @@ export class AnimatorStore {
         }
     };
 
-    @action incrementFlowCounter = (fileId: number, channel: number, stokes: number) => {
-        this.flowControlCounter++;
-        if (this.flowControlCounter >= this.frameRate) {
-            this.flowControlCounter = 0;
-            this.appStore.backendService.sendAnimationFlowControl({fileId, receivedFrame: {channel, stokes}});
-        }
-    };
-
     private readonly appStore: AppStore;
-    private flowControlCounter: number;
     private animateHandle;
 
     constructor(appStore: AppStore) {
@@ -173,7 +163,6 @@ export class AnimatorStore {
         this.minFrameRate = 1;
         this.animationMode = AnimationMode.CHANNEL;
         this.animationState = AnimationState.STOPPED;
-        this.flowControlCounter = 0;
         this.animateHandle = null;
         this.appStore = appStore;
     }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -669,7 +669,6 @@ export class AppStore {
                 updatedFrame.updateFromRasterData(rasterImageData);
                 updatedFrame.requiredChannel = rasterImageData.channel;
                 updatedFrame.requiredStokes = rasterImageData.stokes;
-                this.animatorStore.incrementFlowCounter(updatedFrame.frameInfo.fileId, updatedFrame.channel, updatedFrame.stokes);
             }
         }
     };

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -689,7 +689,6 @@ export class AppStore {
                 updatedFrame.requiredChannel = rasterImageData.channel;
                 updatedFrame.requiredStokes = rasterImageData.stokes;
                 updatedFrame.renderType = RasterRenderType.ANIMATION;
-                this.animatorStore.incrementFlowCounter(updatedFrame.frameInfo.fileId, updatedFrame.channel, updatedFrame.stokes);
             }
         }
     };


### PR DESCRIPTION
This PR adjusts the flow control approach to send timestamped flow control messages to the backend every frame, which allows the backend to control frame pacing correctly (#391)

This should not affect the behaviour of the frontend when using a backend that does not make use of the added timestamps, so this can be integrated into the frontend before the backend is updated. 