### PR TITLE
adds a render type to FrameStore to determine which mode of rendering is used

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -245,7 +245,6 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                 <RasterViewComponent
                     frame={appStore.activeFrame}
                     docked={this.props.docked}
-                    tiledRendering={appStore.animatorStore.animationState === AnimationState.STOPPED || appStore.animatorStore.animationMode === AnimationMode.FRAME}
                     overlaySettings={appStore.overlayStore}
                     tileService={appStore.tileService}
                 />

--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -70,7 +70,7 @@ export class AnimatorStore {
             startFrame.channel = Math.max((startFrame.channel + 1) % frame.frameInfo.fileInfoExtended.depth, firstFrame.channel);
             // Jump back to start if outside the range
             if (startFrame.channel > lastFrame.channel) {
-                startFrame.channel = firstFrame.channel
+                startFrame.channel = firstFrame.channel;
             }
         } else if (this.animationMode === AnimationMode.STOKES) {
             firstFrame = {
@@ -92,7 +92,7 @@ export class AnimatorStore {
             startFrame.stokes = Math.max((startFrame.stokes + 1) % frame.frameInfo.fileInfoExtended.stokes, firstFrame.stokes);
             // Jump back to start if outside the range
             if (startFrame.stokes > lastFrame.stokes) {
-                startFrame.stokes = firstFrame.stokes
+                startFrame.stokes = firstFrame.stokes;
             }
         }
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -3,14 +3,28 @@ import * as AST from "ast_wrapper";
 import {action, autorun, computed, observable, ObservableMap} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {
-    AlertStore, AnimationState, AnimatorStore, dayPalette, FileBrowserStore,
-    FrameInfo, FrameStore, LogEntry, LogStore, nightPalette,
-    OverlayStore, RegionStore, SpatialProfileStore, SpectralProfileStore, WidgetsStore,
-    PreferenceStore, AnimationMode
+    AlertStore,
+    AnimationMode,
+    AnimationState,
+    AnimatorStore,
+    dayPalette,
+    FileBrowserStore,
+    FrameInfo,
+    FrameStore,
+    LogEntry,
+    LogStore,
+    nightPalette,
+    OverlayStore,
+    PreferenceStore,
+    RasterRenderType,
+    RegionStore,
+    SpatialProfileStore,
+    SpectralProfileStore,
+    WidgetsStore
 } from ".";
 import {GetRequiredTiles} from "utilities";
 import {BackendService, TileService} from "services";
-import {CursorInfo, FrameView, Theme, Point2D, ProcessedSpatialProfile, ProtobufProcessing} from "models";
+import {CursorInfo, FrameView, Point2D, ProcessedSpatialProfile, ProtobufProcessing, Theme} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore} from "./widgets";
 
 const CURSOR_THROTTLE_TIME = 200;
@@ -645,6 +659,11 @@ export class AppStore {
                 this.pendingHistogram = null;
             }
         }
+
+        // Switch to tiled rendering. TODO: ensure that the correct frame gets set to tiled
+        if (this.activeFrame) {
+            this.activeFrame.renderType = RasterRenderType.TILED;
+        }
     };
 
     handleRegionStatsStream = (regionStatsData: CARTA.RegionStatsData) => {
@@ -669,6 +688,7 @@ export class AppStore {
                 updatedFrame.updateFromRasterData(rasterImageData);
                 updatedFrame.requiredChannel = rasterImageData.channel;
                 updatedFrame.requiredStokes = rasterImageData.stokes;
+                updatedFrame.renderType = RasterRenderType.ANIMATION;
                 this.animatorStore.incrementFlowCounter(updatedFrame.frameInfo.fileId, updatedFrame.channel, updatedFrame.stokes);
             }
         }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -14,6 +14,12 @@ export interface FrameInfo {
     renderMode: CARTA.RenderMode;
 }
 
+export enum RasterRenderType {
+    NONE,
+    ANIMATION,
+    TILED
+}
+
 export class FrameStore {
     @observable frameInfo: FrameInfo;
     @observable renderHiDPI: boolean;
@@ -27,6 +33,7 @@ export class FrameStore {
     @observable requiredStokes: number;
     @observable requiredChannel: number;
     @observable animationChannelRange: NumberRange;
+    @observable renderType: RasterRenderType;
     @observable currentFrameView: FrameView;
     @observable currentCompressionQuality: number;
     @observable renderConfig: RenderConfigStore;
@@ -48,8 +55,9 @@ export class FrameStore {
         this.requiredStokes = 0;
         this.requiredChannel = 0;
         this.renderConfig = new RenderConfigStore(preference);
+        this.renderType = RasterRenderType.TILED;
 
-        // synchornize AST overlay's color/grid/label with perference when frame is created
+        // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preference.astColor;
         if (astColor !== overlay.global.color) {
             overlay.global.setColor(astColor);
@@ -431,6 +439,10 @@ export class FrameStore {
 
     @action setAnimationRange = (range: NumberRange) => {
         this.animationChannelRange = range;
+    };
+
+    @action setRasterRenderType = (renderType: RasterRenderType) => {
+        this.renderType = renderType;
     };
 
     private calculateZoomX() {


### PR DESCRIPTION
This PR adds a render type property to the `FrameStore`, which is either `ANIMATION` or `TILED`. This is used to determine which render path to use. The render type is only switched to `ANIMATION` when the first valid `RASTER_IMAGE_DATA` arrives, and only switches back to `TILED` when the first set of tiles arrives, rather than when "Play" or "Stop" is pressed. 

This should fix the weird behaviour when starting and stopping an animation, as well as the flashing seen in #371  (although the Play/Stop adjustments mentioned in that issue still need to be made)