### PR TITLE
Angus/tile l2 cache changes

### DIFF
--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -139,8 +139,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 this.updateTexture();
             }
 
-            // TODO: is this needed
-            this.clearCanvas();
+            this.updateCanvasSize();
             this.updateUniforms();
             this.renderCanvas();
         }
@@ -174,15 +173,18 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         }
     }
 
-    private clearCanvas() {
+    private updateCanvasSize() {
         const frame = this.props.frame;
-        // Resize and/or clear the canvas
-        this.canvas.width = frame.renderWidth * devicePixelRatio;
-        this.canvas.height = frame.renderHeight * devicePixelRatio;
+        // Resize and clear the canvas if needed
+        if (this.canvas.width !== frame.renderWidth * devicePixelRatio || this.canvas.height !== frame.renderHeight * devicePixelRatio) {
+            this.canvas.width = frame.renderWidth * devicePixelRatio;
+            this.canvas.height = frame.renderHeight * devicePixelRatio;
+        }
     }
 
     private renderCanvas() {
         const frame = this.props.frame;
+        // Only clear and render if we're in animation or tiled mode
         if (frame && frame.renderType !== RasterRenderType.NONE) {
             this.gl.viewport(0, 0, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
             this.gl.enable(WebGLRenderingContext.DEPTH_TEST);

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -206,8 +206,8 @@ export class AppStore {
                 renderMode: CARTA.RenderMode.RASTER
             };
 
-            this.tileService.clearCache();
-            this.tileService.clearRequestQueue();
+            //this.tileService.clearCache();
+            //this.tileService.clearRequestQueue();
             let newFrame = new FrameStore(this.preferenceStore, this.overlayStore, frameInfo, this.backendService);
             this.loadWCS(newFrame);
 
@@ -710,6 +710,10 @@ export class AppStore {
     }
 
     private changeActiveFrame(frame: FrameStore) {
+        if (frame !== this.activeFrame) {
+            this.tileService.clearCache();
+            this.tileService.clearRequestQueue();
+        }
         this.activeFrame = frame;
         this.widgetsStore.updateImageWidgetTitle();
         this.setCursorFrozen(this.preferenceStore.isCursorFrozen);

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -417,26 +417,31 @@ export class AppStore {
         }, IMAGE_THROTTLE_TIME);
 
         const throttledSetChannels = _.throttle((fileId: number, channel: number, stokes: number) => {
-            this.activeFrame.channel = channel;
-            this.activeFrame.stokes = stokes;
+            const frame = this.getFrame(fileId);
+            if (!frame) {
+                return;
+            }
+
+            frame.channel = channel;
+            frame.stokes = stokes;
 
             // Calculate new required frame view (cropped to file size)
-            const reqView = this.activeFrame.requiredFrameView;
+            const reqView = frame.requiredFrameView;
 
             const croppedReq: FrameView = {
                 xMin: Math.max(0, reqView.xMin),
-                xMax: Math.min(this.activeFrame.frameInfo.fileInfoExtended.width, reqView.xMax),
+                xMax: Math.min(frame.frameInfo.fileInfoExtended.width, reqView.xMax),
                 yMin: Math.max(0, reqView.yMin),
-                yMax: Math.min(this.activeFrame.frameInfo.fileInfoExtended.height, reqView.yMax),
+                yMax: Math.min(frame.frameInfo.fileInfoExtended.height, reqView.yMax),
                 mip: reqView.mip
             };
-            const imageSize: Point2D = {x: this.activeFrame.frameInfo.fileInfoExtended.width, y: this.activeFrame.frameInfo.fileInfoExtended.height};
+            const imageSize: Point2D = {x: frame.frameInfo.fileInfoExtended.width, y: frame.frameInfo.fileInfoExtended.height};
             const tiles = GetRequiredTiles(croppedReq, imageSize, {x: 256, y: 256});
             const midPointImageCoords = {x: (reqView.xMax + reqView.xMin) / 2.0, y: (reqView.yMin + reqView.yMax) / 2.0};
             // TODO: dynamic tile size
             const tileSizeFullRes = reqView.mip * 256;
             const midPointTileCoords = {x: midPointImageCoords.x / tileSizeFullRes, y: midPointImageCoords.y / tileSizeFullRes};
-            this.tileService.requestTiles(tiles, this.activeFrame.frameInfo.fileId, this.activeFrame.channel, this.activeFrame.stokes, midPointTileCoords, this.compressionQuality);
+            this.tileService.requestTiles(tiles, frame.frameInfo.fileId, frame.channel, frame.stokes, midPointTileCoords, this.compressionQuality);
         }, IMAGE_CHANNEL_THROTTLE_TIME);
 
         const throttledSetCursorRotated = _.throttle((fileId: number, x: number, y: number) => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -720,6 +720,11 @@ export class AppStore {
     }
 
     @action setActiveFrame(fileId: number) {
+        // Disable rendering of old frame
+        if (this.activeFrame && this.activeFrame.frameInfo.fileId !== fileId) {
+            this.activeFrame.renderType = RasterRenderType.NONE;
+        }
+
         const requiredFrame = this.getFrame(fileId);
         if (requiredFrame) {
             this.changeActiveFrame(requiredFrame);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -55,7 +55,7 @@ export class FrameStore {
         this.requiredStokes = 0;
         this.requiredChannel = 0;
         this.renderConfig = new RenderConfigStore(preference);
-        this.renderType = RasterRenderType.TILED;
+        this.renderType = RasterRenderType.NONE;
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preference.astColor;

--- a/wasm_src/zfp_wrapper/post.ts
+++ b/wasm_src/zfp_wrapper/post.ts
@@ -106,6 +106,7 @@ ctx.onmessage = (event => {
                 requestId: eventArgs.requestId,
                 tileCoordinate: eventArgs.tileCoordinate,
                 layer: eventArgs.layer,
+                fileId: eventArgs.fileId
             }], [event.data[1]]);
 
             if (Module.debugOutput) {


### PR DESCRIPTION
Fixes #396 by assigning a compressed "L2" cache for each `fileId`. Clears this cache when loading a new file with the same ID, (or when closing a file), but this cache persists when switching between files. When switching between files, the compressed tiles in the cache are decompressed again and sent to the GPU