### PR TITLE
Angus/spectral profile indicator

### DIFF
--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -57,6 +57,7 @@ export class LinePlotComponentProps {
     yLabel?: string;
     logY?: boolean;
     lineColor?: string;
+    opacity?: number;
     darkMode?: boolean;
     imageName?: string;
     plotName?: string;

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -182,7 +182,6 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         const opacity = clamp(this.props.opacity || 1.0, 0, 1);
         if (opacity < 1.0) {
             lineColor = hexStringToRgba(lineColor, opacity);
-            console.log(lineColor);
         }
         // ChartJS plot
         let plotOptions: ChartOptions = {

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -3,6 +3,7 @@ import * as _ from "lodash";
 import {Chart, ChartArea, ChartData, ChartDataSets, ChartOptions} from "chart.js";
 import {Scatter} from "react-chartjs-2";
 import {Colors} from "@blueprintjs/core";
+import {clamp, hexStringToRgba} from "utilities";
 
 export class PlotContainerProps {
     width?: number;
@@ -16,6 +17,7 @@ export class PlotContainerProps {
     yLabel?: string;
     logY?: boolean;
     lineColor?: string;
+    opacity?: number;
     darkMode?: boolean;
     usePointSymbols?: boolean;
     forceScientificNotationTicksX?: boolean;
@@ -114,6 +116,9 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         else if (props.lineColor !== nextProps.lineColor) {
             return true;
         }
+        else if (props.opacity !== nextProps.opacity) {
+            return true;
+        }
         else if (props.usePointSymbols !== nextProps.usePointSymbols) {
             return true;
         }
@@ -173,7 +178,12 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
     render() {
         const labelColor = this.props.darkMode ? Colors.LIGHT_GRAY4 : Colors.GRAY1;
         const gridColor = this.props.darkMode ? Colors.DARK_GRAY5 : Colors.LIGHT_GRAY1;
-        const lineColor = this.props.lineColor || (this.props.darkMode ? Colors.BLUE4 : Colors.BLUE2);
+        let lineColor = this.props.lineColor || (this.props.darkMode ? Colors.BLUE4 : Colors.BLUE2);
+        const opacity = clamp(this.props.opacity || 1.0, 0, 1);
+        if (opacity < 1.0) {
+            lineColor = hexStringToRgba(lineColor, opacity);
+            console.log(lineColor);
+        }
         // ChartJS plot
         let plotOptions: ChartOptions = {
             maintainAspectRatio: false,

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -17,6 +17,8 @@ import "./SpectralProfilerComponent.css";
 // The fixed size of the settings panel popover (excluding the show/hide button)
 const PANEL_CONTENT_WIDTH = 180;
 
+type PlotData = { values: Array<Point2D>, xMin: number, xMax: number, yMin: number, yMax: number, yMean: number, yRms: number, progress: number };
+
 @observer
 export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     public static get WIDGET_CONFIG(): WidgetConfig {
@@ -62,7 +64,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return 20 + (this.widgetStore.settingsPanelVisible ? PANEL_CONTENT_WIDTH : 0);
     }
 
-    @computed get plotData(): { values: Array<Point2D>, xMin: number, xMax: number, yMin: number, yMax: number, yMean: number, yRms: number } {
+    @computed get plotData(): PlotData {
         const frame = this.props.appStore.activeFrame;
         if (!frame) {
             return null;
@@ -102,7 +104,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
             // values are needed to be sorted in incremental order for binary search
             let values: Array<{ x: number, y: number }> = [];
-            let isIncremental = channelValues[0] <= channelValues[channelValues.length - 1] ? true : false;
+            let isIncremental = channelValues[0] <= channelValues[channelValues.length - 1];
             for (let i = 0; i < channelValues.length; i++) {
                 let index = isIncremental ? i : channelValues.length - 1 - i;
                 const x = channelValues[index];
@@ -136,7 +138,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 yMin = undefined;
                 yMax = undefined;
             }
-            return {values: values, xMin, xMax, yMin, yMax, yMean, yRms};
+            return {values, xMin, xMax, yMin, yMax, yMean, yRms, progress: coordinateData.progress};
         }
         return null;
     }
@@ -191,6 +193,11 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 const coordinate = this.widgetStore.coordinate;
                 const appStore = this.props.appStore;
                 const frame = appStore.activeFrame;
+                let progressString = "";
+                const currentData = this.plotData;
+                if (currentData && isFinite(currentData.progress) && currentData.progress < 1.0) {
+                    progressString = `[${(currentData.progress * 100).toFixed(0)}% complete]`;
+                }
                 if (frame && coordinate) {
                     let coordinateString: string;
                     if (coordinate.length === 2) {
@@ -201,7 +208,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                     const regionId = this.widgetStore.regionIdMap.get(frame.frameInfo.fileId) || 0;
                     const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
                     const selectedString = this.matchesSelectedRegion ? "(Selected)" : "";
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `${coordinateString}: ${regionString} ${selectedString}`);
+                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `${coordinateString}: ${regionString} ${selectedString} ${progressString}`);
                 }
             } else {
                 this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `Z Profile: Cursor`);
@@ -317,6 +324,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             const currentPlotData = this.plotData;
             if (currentPlotData) {
                 linePlotProps.data = currentPlotData.values;
+                // Opacity ranges from 0.15 to 0.40 when data is in progress, and is 1.0 when finished
+                linePlotProps.opacity = currentPlotData.progress < 1.0 ? 0.15 + currentPlotData.progress / 4.0 : 1.0;
                 // Determine scale in X and Y directions. If auto-scaling, use the bounds of the current data
                 if (this.widgetStore.isAutoScaledX) {
                     linePlotProps.xMin = currentPlotData.xMin;

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -75,7 +75,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         let regionId = this.widgetStore.regionIdMap.get(fileId) || 0;
         if (frame.regionSet) {
             const region = frame.regionSet.regions.find(r => r.regionId === regionId);
-            if (region) {
+            if (region && this.profileStore) {
                 coordinateData = this.profileStore.getProfile(this.widgetStore.coordinate, region.isClosedRegion ? this.widgetStore.statsType : CARTA.StatsType.Sum);
             }
         }

--- a/src/models/Processed.ts
+++ b/src/models/Processed.ts
@@ -6,6 +6,7 @@ export interface ProcessedSpatialProfile extends CARTA.ISpatialProfile {
 
 export interface ProcessedSpectralProfile extends CARTA.ISpectralProfile {
     values: Float32Array | Float64Array;
+    progress: number;
 }
 
 export class ProtobufProcessing {
@@ -27,25 +28,28 @@ export class ProtobufProcessing {
         };
     }
 
-    static ProcessSpectralProfile(profile: CARTA.ISpectralProfile): ProcessedSpectralProfile {
+    static ProcessSpectralProfile(profile: CARTA.ISpectralProfile, progress: number): ProcessedSpectralProfile {
         if (profile.rawValuesFp64 && profile.rawValuesFp64.length && profile.rawValuesFp64.length % 8 === 0) {
             return {
                 coordinate: profile.coordinate,
                 statsType: profile.statsType,
-                values: new Float64Array(profile.rawValuesFp64.slice().buffer)
+                values: new Float64Array(profile.rawValuesFp64.slice().buffer),
+                progress
             };
         } else if (profile.rawValuesFp32 && profile.rawValuesFp32.length && profile.rawValuesFp32.length % 4 === 0) {
             return {
                 coordinate: profile.coordinate,
                 statsType: profile.statsType,
-                values: new Float32Array(profile.rawValuesFp32.slice().buffer)
+                values: new Float32Array(profile.rawValuesFp32.slice().buffer),
+                progress
             };
         }
 
         return {
             coordinate: profile.coordinate,
             statsType: profile.statsType,
-            values: null
+            values: null,
+            progress: 0
         };
     }
 }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -614,7 +614,7 @@ export class AppStore {
 
             profileStore.stokes = spectralProfileData.stokes;
             for (let profile of spectralProfileData.profiles) {
-                profileStore.setProfile(ProtobufProcessing.ProcessSpectralProfile(profile));
+                profileStore.setProfile(ProtobufProcessing.ProcessSpectralProfile(profile, spectralProfileData.progress));
             }
         }
     };

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -4,6 +4,7 @@ import {CARTA} from "carta-protobuf";
 import {FrameScaling, RenderConfigStore, RegionStore} from "stores";
 import {Theme, Layout, CursorPosition, Zoom, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event} from "models";
 import {AppStore} from "./AppStore";
+import {isColorValid} from "../utilities";
 
 const PREFERENCE_KEYS = {
     theme: "CARTA_theme",
@@ -158,7 +159,7 @@ export class PreferenceStore {
     // getters for region
     private getRegionColor = (): string => {
         const regionColor = localStorage.getItem(PREFERENCE_KEYS.regionColor);
-        return regionColor && RegionStore.IsRegionColorValid(regionColor) ? regionColor : DEFAULTS.regionColor;
+        return regionColor && isColorValid(regionColor) ? regionColor : DEFAULTS.regionColor;
     };
 
     private getRegionLineWidth = (): number => {

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -64,12 +64,7 @@ export class RegionStore {
     ]);
 
     public static IsRegionTypeValid(regionType: CARTA.RegionType): boolean {
-        return RegionStore.AVAILABLE_REGION_TYPES.has(regionType) ? true : false;
-    }
-
-    public static IsRegionColorValid(regionColor: string): boolean {
-        const colorHex: RegExp = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
-        return colorHex.test(regionColor);
+        return RegionStore.AVAILABLE_REGION_TYPES.has(regionType);
     }
 
     public static IsRegionLineWidthValid(regionLineWidth: number): boolean {

--- a/src/utilities/color.ts
+++ b/src/utilities/color.ts
@@ -1,0 +1,20 @@
+export function isColorValid(colorString: string): boolean {
+    const colorHex: RegExp = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+    return colorHex.test(colorString);
+}
+
+// adapted from https://stackoverflow.com/questions/21646738/convert-hex-to-rgba
+export function hexStringToRgba(colorString: string, opacity: number) {
+    let c;
+    if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(colorString)) {
+        c = colorString.substring(1).split("");
+        if (c.length === 3) {
+            c = [c[0], c[0], c[1], c[1], c[2], c[2]];
+        }
+        c = "0x" + c.join("");
+        return `rgba(${(c >> 16) & 255}, ${(c >> 8) & 255}, ${c & 255}, ${opacity})`;
+    }
+    return null;
+}
+
+// end stolen from https://stackoverflow.com/questions/21646738/convert-hex-to-rgba

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,3 +3,4 @@ export * from "./units";
 export * from "./array";
 export * from "./tiling";
 export * from "./webgl";
+export * from "./color";


### PR DESCRIPTION
fixes #382 

This PR adds the `opacity` property to the `LinePlotComponent`, and makes use of it when a partial spectral profile is delivered. It also adds the partial profile's progress percentage to the widget title. 

There was a minor bug with `SpectralProfilerComponent::profileStore` returning null, so I've added an extra guard when attempting to access the result. 

![partial_profile_progress_light](https://user-images.githubusercontent.com/592504/61734665-a8bfb300-ad82-11e9-8f6a-82699e27349f.gif)
