### PR TITLE
fix 451: prevent frontend frozen when setting the tolerance of AST grid line in overlay dialog

### DIFF
--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -108,7 +108,7 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
                         placeholder="Tolerance"
                         min={0.1}
                         value={global.tolerance}
-                        stepSize={1}
+                        stepSize={0.1}
                         minorStepSize={null}
                         majorStepSize={10}
                         onValueChange={(value: number) => global.setTolerance(value)}


### PR DESCRIPTION
This one line quick fix is to prevent accidentally setting the tolerance to 0.1% from 1% by a _single_ click on the spinner. When viewing small field image, 0.1% works fine. However for wide field image (e.g., full sky survey), 0.1% will make the frontend frozen completely. To prevent this, now the step is set from 1 to 0.1, so the chance to trigger #451 is significantly lower (but still can by typing in a small value). 

A possible better solution is to use the size of the current field of view to dynamically determine the minimum tolerance. As for the scaling function, some experiments are needed. This may be considered for future improvement. 

Just as a note here: when the tolerance is 0.5%, the frontend is still responsive. When it is <= 0.4%, the frontend will freeze. The test machine is MBP 13" (2016).