### PR TITLE
adding U. Alberta in license section

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -48,7 +48,7 @@ export class AboutDialogComponent extends React.Component<{ appStore: AppStore }
                     </ul>
                     <h3>License</h3>
                     <p>
-                        Copyright (C) 2018-2019 ASIAA, IDIA, and NRAO. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
+                        Copyright (C) 2018-2019 ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
                         <a href="http://www.gnu.org/copyleft/gpl.html" target="_blank">GNU General Public License version 3</a>&#160;
                         as published by the Free Software Foundation.
                     </p>


### PR DESCRIPTION
Issue #476 
Adding "Department of Physics, University of Alberta" in the license section of the about dialog.