### PR TITLE
inconsistent operator in (x,y) in if condition

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -577,7 +577,7 @@ export class AppStore {
         autorun(() => {
             if (this.activeFrame && this.activeFrame.cursorInfo && this.activeFrame.cursorInfo.posImageSpace) {
                 const pos = {x: Math.round(this.activeFrame.cursorInfo.posImageSpace.x), y: Math.round(this.activeFrame.cursorInfo.posImageSpace.y)};
-                if (pos.x >= 0 && pos.x <= this.activeFrame.frameInfo.fileInfoExtended.width - 1 && pos.y >= 0 && pos.y < this.activeFrame.frameInfo.fileInfoExtended.height - 1) {
+                if (pos.x >= 0 && pos.x <= this.activeFrame.frameInfo.fileInfoExtended.width - 1 && pos.y >= 0 && pos.y <= this.activeFrame.frameInfo.fileInfoExtended.height - 1) {
                     if (this.activeFrame.frameInfo.fileFeatureFlags & CARTA.FileFeatureFlags.ROTATED_DATASET) {
                         throttledSetCursorRotated(this.activeFrame.frameInfo.fileId, pos.x, pos.y);
                     } else {


### PR DESCRIPTION
When I test the codes together with src/stores/AppStore.ts, I found that y-condition has inconsistent operator to x-condition. It cause the Chrome Console cannot print the SetCursor for the raw at y=height-1.

I am not sure it is a small typo?... or is there any specific reason?, thus decide to ask it... 
If there was any reason to keep the inconsistency, please ignore this PR I requested.
Thank you very much!!!
