### PR TITLE
Fixed a warning whenever browsing file

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -31,8 +31,9 @@ export class FileListComponent extends React.Component<{
         const fileEntries = [];
         const fileList = this.props.files;
         if (fileList) {
-            let sortedDirectories = fileList.subdirectories.slice();
-            if (sortedDirectories) {
+            let sortedDirectories = [];
+            if (fileList.subdirectories && fileList.subdirectories.length) {
+                sortedDirectories = fileList.subdirectories.slice();
                 if (this.state.sortColumn === "name") {
                     sortedDirectories.sort((a, b) => this.state.sortDirection * (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
                 } else {
@@ -50,10 +51,10 @@ export class FileListComponent extends React.Component<{
                     </tr>
                 );
             }));
-
-            let sortedFiles = fileList.files.slice();
-
-            if (sortedFiles) {
+            
+            let sortedFiles = [];
+            if (fileList.files && fileList.files.length) {
+                sortedFiles = fileList.files.slice();
                 switch (this.state.sortColumn) {
                     case "name":
                         sortedFiles.sort((a, b) => this.state.sortDirection * (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1));

--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -31,12 +31,12 @@ export class FileListComponent extends React.Component<{
         const fileEntries = [];
         const fileList = this.props.files;
         if (fileList) {
-            let sortedDirectories: string[] = [];
-            if (fileList.subdirectories && fileList.subdirectories.length) {
+            let sortedDirectories = fileList.subdirectories.slice();
+            if (sortedDirectories) {
                 if (this.state.sortColumn === "name") {
-                    sortedDirectories = fileList.subdirectories.sort((a, b) => this.state.sortDirection * (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+                    sortedDirectories.sort((a, b) => this.state.sortDirection * (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
                 } else {
-                    sortedDirectories = fileList.subdirectories.sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+                    sortedDirectories.sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
                 }
             }
 
@@ -51,19 +51,19 @@ export class FileListComponent extends React.Component<{
                 );
             }));
 
-            let sortedFiles = [];
+            let sortedFiles = fileList.files.slice();
 
-            if (fileList.files && fileList.files.length) {
+            if (sortedFiles) {
                 switch (this.state.sortColumn) {
                     case "name":
-                        sortedFiles = fileList.files.sort((a, b) => this.state.sortDirection * (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1));
+                        sortedFiles.sort((a, b) => this.state.sortDirection * (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1));
                         break;
                     case "type":
-                        sortedFiles = fileList.files.sort((a, b) => this.state.sortDirection * (a.type > b.type ? -1 : 1));
+                        sortedFiles.sort((a, b) => this.state.sortDirection * (a.type > b.type ? -1 : 1));
                         break;
                     case "size":
                     default:
-                        sortedFiles = fileList.files.sort((a, b) => this.state.sortDirection * (a.size < b.size ? -1 : 1));
+                        sortedFiles.sort((a, b) => this.state.sortDirection * (a.size < b.size ? -1 : 1));
                         break;
                 }
             }


### PR DESCRIPTION
A warning:

> [mobx] `observableArray.sort()` will not update the array in place. Use `observableArray.slice().sort()` to supress this warning and perform the operation on a copy, or `observableArray.replace(observableArray.slice().sort())` to sort & update in place

will happen when file browser executes. Fixed the copied data by using .slice() such as the advice from warning.