### PR TITLE
Transparent backgrounds in exported images

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -34,7 +34,7 @@ export const exportImage = (padding, darkTheme, imageName) => {
     composedCanvas.height = overlayCanvas.height;
 
     const ctx = composedCanvas.getContext("2d");
-    ctx.fillStyle = darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5;
+    ctx.fillStyle = "rgba(255, 255, 255, 0.0)";
     ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
     ctx.drawImage(rasterCanvas, padding.left * devicePixelRatio, padding.top * devicePixelRatio);
     if (beamProfileCanvas) {

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -507,7 +507,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = this.props.darkMode ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5;
+        ctx.fillStyle = "rgba(255, 255, 255, 0.0)";
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -292,7 +292,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = this.props.darkMode ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5;
+        ctx.fillStyle = "rgba(255, 255, 255, 0.0)";
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 


### PR DESCRIPTION
Closes #549 

This PR changes the background colour for exported images to transparent white (`rgba(255, 255, 255, 0)` in CSS style). 

This means that PNG readers that support alpha channels (most of them) will simply see a transparent background, and those that _don't_ support alpha channels will just see a white background. This means that users can export images from CARTA and put them into a publication with any background theme.

Note that this does make plots exported in "dark theme" look a little odd unless they're placed on a dark background, but that seems sensible enough. The point is that after this PR, the choice of background is up to the user

Exported image placed on a white slide in powerpoint:
![image](https://user-images.githubusercontent.com/592504/66267159-1893f480-e82e-11e9-9ca0-cd3235e52b03.png)

Same image placed on a grey gradient background slide in powerpoint:
![image](https://user-images.githubusercontent.com/592504/66267178-4aa55680-e82e-11e9-8774-7d8a3ca79f34.png)
