### PR TITLE
Angus/remaining tiles counter

### DIFF
--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -28,6 +28,12 @@
     .contour-loading-icon {
         padding-right: 8px;
         animation: pulse-green 2s infinite;
+        opacity: 0;
+        transition: opacity 0.5s;
+
+        &.icon-visible {
+            opacity: 1;
+        }
 
         @keyframes pulse-green {
             0% {

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -187,12 +187,11 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                 connectivityClass += " offline";
                 break;
         }
-        connectivityClass += " online";
-
-        let loadingIndicator: React.ReactNode;
 
         const tilesLoading = appStore.tileService.remainingTiles > 0;
         const contoursLoading = appStore.activeFrame && appStore.activeFrame.contourProgress >= 0 && appStore.activeFrame.contourProgress < 1;
+        let loadingTooltipFragment;
+        let loadingIndicatorClass = "contour-loading-icon";
 
         if (tilesLoading || contoursLoading) {
             let tilesTooltipContent;
@@ -204,7 +203,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                 contourTooltipContent = <span>Streaming contours. {toFixed(100 * appStore.activeFrame.contourProgress, 1)}% complete</span>;
             }
 
-            const tooltipFragment = (
+            loadingTooltipFragment = (
                 <React.Fragment>
                     {tilesTooltipContent}
                     {contoursLoading && tilesLoading && <br/>}
@@ -212,12 +211,14 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                 </React.Fragment>
             );
 
-            loadingIndicator = (
-                <Tooltip content={tooltipFragment}>
-                    <Icon icon={"cloud-download"} className="contour-loading-icon"/>
-                </Tooltip>
-            );
+            loadingIndicatorClass += " icon-visible";
         }
+
+        const loadingIndicator = (
+            <Tooltip content={loadingTooltipFragment}>
+                <Icon icon={"cloud-download"} className={loadingIndicatorClass}/>
+            </Tooltip>
+        );
 
         return (
             <div className="root-menu">

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -189,10 +189,31 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
         }
         connectivityClass += " online";
 
-        let contourLoadingNode: React.ReactNode;
-        if (appStore.activeFrame && appStore.activeFrame.contourProgress >= 0 && appStore.activeFrame.contourProgress < 1) {
-            contourLoadingNode = (
-                <Tooltip content={`Streaming contours. ${(100 * appStore.activeFrame.contourProgress).toFixed(1)}% complete`}>
+        let loadingIndicator: React.ReactNode;
+
+        const tilesLoading = appStore.tileService.remainingTiles > 0;
+        const contoursLoading = appStore.activeFrame && appStore.activeFrame.contourProgress >= 0 && appStore.activeFrame.contourProgress < 1;
+
+        if (tilesLoading || contoursLoading) {
+            let tilesTooltipContent;
+            if (tilesLoading) {
+                tilesTooltipContent = <span>Streaming image tiles. {appStore.tileService.remainingTiles} remaining</span>;
+            }
+            let contourTooltipContent;
+            if (contoursLoading) {
+                contourTooltipContent = <span>Streaming contours. {toFixed(100 * appStore.activeFrame.contourProgress, 1)}% complete</span>;
+            }
+
+            const tooltipFragment = (
+                <React.Fragment>
+                    {tilesTooltipContent}
+                    {contoursLoading && tilesLoading && <br/>}
+                    {contourTooltipContent}
+                </React.Fragment>
+            );
+
+            loadingIndicator = (
+                <Tooltip content={tooltipFragment}>
                     <Icon icon={"cloud-download"} className="contour-loading-icon"/>
                 </Tooltip>
             );
@@ -224,7 +245,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                 <Alert isOpen={this.documentationAlertVisible} onClose={this.handleAlertDismissed} canEscapeKeyCancel={true} canOutsideClickCancel={true} confirmButtonText={"Dismiss"}>
                     Documentation will open in a new tab. Please ensure any popup blockers are disabled.
                 </Alert>
-                {contourLoadingNode}
+                {loadingIndicator}
                 <Tooltip content={tooltip}>
                     <Icon icon={"symbol-circle"} className={connectivityClass}/>
                 </Tooltip>

--- a/src/models/Processed.ts
+++ b/src/models/Processed.ts
@@ -2,8 +2,6 @@ import {CARTA} from "carta-protobuf";
 // @ts-ignore
 import * as CARTACompute from "carta_computation";
 
-const ZstdMagicNumber = new Uint32Array([0xFD2FB528]);
-
 export interface ProcessedSpatialProfile extends CARTA.ISpatialProfile {
     values: Float32Array;
 }

--- a/src/stores/ContourStore.ts
+++ b/src/stores/ContourStore.ts
@@ -1,6 +1,5 @@
 import {action, computed, observable} from "mobx";
 import * as CARTACompute from "carta_computation";
-import TypedArray = NodeJS.TypedArray;
 
 export class ContourStore {
     @observable progress: number;

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -5,7 +5,7 @@ import * as AST from "ast_wrapper";
 import {ASTSettingsString, PreferenceStore, OverlayStore, LogStore, RegionSetStore, RenderConfigStore, ContourConfigStore, ContourStore} from "stores";
 import {CursorInfo, Point2D, FrameView, SpectralInfo, ChannelInfo, CHANNEL_TYPES, ProtobufProcessing} from "models";
 import {clamp, frequencyStringFromVelocity, velocityStringFromFrequency, toFixed, hexStringToRgba} from "utilities";
-import {BackendService} from "../services";
+import {BackendService} from "services";
 
 export interface FrameInfo {
     fileId: number;


### PR DESCRIPTION
closes #565 

A single indicator is used for streaming tiles and contours, with a tooltip used to provide information

![loading_indicator](https://user-images.githubusercontent.com/592504/67578328-83a45d00-f742-11e9-8bd0-15f675545fc3.gif)
