### PR TITLE
Angus/delay tile requests zooming

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -436,6 +436,9 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                         <option key={5} value={1000000}>1M</option>
                     </HTMLSelect>
                 </FormGroup>
+                <FormGroup inline={true} label="Stream image tiles while zooming">
+                    <Switch checked={preference.streamTilesWhileZooming} onChange={(ev) => preference.setStreamContoursWhileZooming(ev.currentTarget.checked)}/>
+                </FormGroup>
             </React.Fragment>
         );
 
@@ -472,7 +475,7 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} minWidth={450} minHeight={300} defaultWidth={775} defaultHeight={450} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} minWidth={450} minHeight={300} defaultWidth={775} defaultHeight={500} enableResizing={true}>
                 <div className="bp3-dialog-body">
                     <Tabs
                         id="preferenceTabs"

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -218,7 +218,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     <ToolbarComponent
                         appStore={appStore}
                         docked={this.props.docked}
-                        visible={appStore.activeFrame.zooming}
+                        visible={appStore.imageToolbarVisible}
                         vertical={false}
                     />
                     <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -218,7 +218,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     <ToolbarComponent
                         appStore={appStore}
                         docked={this.props.docked}
-                        visible={appStore.imageToolbarVisible}
+                        visible={appStore.activeFrame.zooming}
                         vertical={false}
                     />
                     <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -534,7 +534,7 @@ export class AppStore {
 
         // Update frame view outside of animation
         autorun(() => {
-            if (this.activeFrame && (this.animatorStore.animationState === AnimationState.STOPPED || this.animatorStore.animationMode === AnimationMode.FRAME)) {
+            if (this.activeFrame && !this.activeFrame.zooming && (this.animatorStore.animationState === AnimationState.STOPPED || this.animatorStore.animationMode === AnimationMode.FRAME)) {
                 // Trigger update raster view/title when switching layout
                 const layout = this.layoutStore.dockedLayout;
                 this.widgetsStore.updateImageWidgetTitle();

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -76,11 +76,11 @@ export class AppStore {
         this.appContainer = container;
     };
 
-    public get ContourContext () {
+    public get ContourContext() {
         return this.contourWebGLContext;
     }
 
-    public set ContourContext (gl: WebGLRenderingContext) {
+    public set ContourContext(gl: WebGLRenderingContext) {
         this.contourWebGLContext = gl;
     }
 
@@ -534,7 +534,9 @@ export class AppStore {
 
         // Update frame view outside of animation
         autorun(() => {
-            if (this.activeFrame && !this.activeFrame.zooming && (this.animatorStore.animationState === AnimationState.STOPPED || this.animatorStore.animationMode === AnimationMode.FRAME)) {
+            if (this.activeFrame &&
+                (this.preferenceStore.streamTilesWhileZooming || !this.activeFrame.zooming) &&
+                (this.animatorStore.animationState === AnimationState.STOPPED || this.animatorStore.animationMode === AnimationMode.FRAME)) {
                 // Trigger update raster view/title when switching layout
                 const layout = this.layoutStore.dockedLayout;
                 this.widgetsStore.updateImageWidgetTitle();

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -48,6 +48,7 @@ export class FrameStore {
     @observable overviewRasterView: FrameView;
     @observable valid: boolean;
     @observable moving: boolean;
+    @observable zooming: boolean;
     @observable regionSet: RegionSetStore;
 
     @computed get requiredFrameView(): FrameView {
@@ -342,8 +343,10 @@ export class FrameStore {
     private readonly preference: PreferenceStore;
     private readonly backendService: BackendService;
     private readonly contourContext: WebGLRenderingContext;
+    private zoomHandler;
 
     private static readonly CursorInfoMaxPrecision = 25;
+    private static readonly ZoomInertiaDuration = 50;
 
     constructor(preference: PreferenceStore, overlay: OverlayStore, logStore: LogStore, frameInfo: FrameInfo, backendService: BackendService, gl: WebGLRenderingContext) {
         this.overlayStore = overlay;
@@ -662,11 +665,23 @@ export class FrameStore {
         };
         this.zoomLevel = zoom;
         this.center = newCenter;
+        this.addZoomHandler();
+        this.zooming = true;
     }
 
     @action zoomToSelection(xMin: number, xMax: number, yMin: number, yMax: number) {
         // TODO
     }
+
+    private addZoomHandler = () => {
+        if (this.zoomHandler) {
+            clearTimeout(this.zoomHandler);
+        }
+
+        this.zoomHandler = setTimeout(() => {
+            this.zooming = false;
+        }, FrameStore.ZoomInertiaDuration);
+    };
 
     @action private initCenter = () => {
         this.center.x = this.frameInfo.fileInfoExtended.width / 2.0 + 0.5;

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -346,7 +346,7 @@ export class FrameStore {
     private zoomHandler;
 
     private static readonly CursorInfoMaxPrecision = 25;
-    private static readonly ZoomInertiaDuration = 50;
+    private static readonly ZoomInertiaDuration = 250;
 
     constructor(preference: PreferenceStore, overlay: OverlayStore, logStore: LogStore, frameInfo: FrameInfo, backendService: BackendService, gl: WebGLRenderingContext) {
         this.overlayStore = overlay;

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -343,7 +343,7 @@ export class FrameStore {
     private readonly preference: PreferenceStore;
     private readonly backendService: BackendService;
     private readonly contourContext: WebGLRenderingContext;
-    private zoomHandler;
+    private zoomTimeoutHandler;
 
     private static readonly CursorInfoMaxPrecision = 25;
     private static readonly ZoomInertiaDuration = 250;
@@ -367,6 +367,7 @@ export class FrameStore {
         this.contourStores = new Map<number, ContourStore>();
         this.renderType = RasterRenderType.NONE;
         this.moving = false;
+        this.zooming = false;
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preference.astColor;
@@ -405,7 +406,7 @@ export class FrameStore {
         autorun(() => {
             // update zoomLevel when image viewer is available for drawing
             if (this.isRenderable && this.zoomLevel <= 0) {
-                this.zoomLevel = this.zoomLevelForFit;
+                this.setZoom(this.zoomLevelForFit);
             }
         });
     }
@@ -641,6 +642,8 @@ export class FrameStore {
 
     @action setZoom(zoom: number) {
         this.zoomLevel = zoom;
+        this.replaceZoomTimeoutHandler();
+        this.zooming = true;
     }
 
     @action setCenter(x: number, y: number) {
@@ -663,22 +666,16 @@ export class FrameStore {
             x: x + this.zoomLevel / zoom * (this.center.x - x),
             y: y + this.zoomLevel / zoom * (this.center.y - y)
         };
-        this.zoomLevel = zoom;
+        this.setZoom(zoom);
         this.center = newCenter;
-        this.addZoomHandler();
-        this.zooming = true;
     }
 
-    @action zoomToSelection(xMin: number, xMax: number, yMin: number, yMax: number) {
-        // TODO
-    }
-
-    private addZoomHandler = () => {
-        if (this.zoomHandler) {
-            clearTimeout(this.zoomHandler);
+    private replaceZoomTimeoutHandler = () => {
+        if (this.zoomTimeoutHandler) {
+            clearTimeout(this.zoomTimeoutHandler);
         }
 
-        this.zoomHandler = setTimeout(() => {
+        this.zoomTimeoutHandler = setTimeout(() => {
             this.zooming = false;
         }, FrameStore.ZoomInertiaDuration);
     };

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -44,6 +44,7 @@ const PREFERENCE_KEYS = {
     contourDecimation: "contourDecimation",
     contourCompressionLevel: "contourCompressionLevel",
     contourChunkSize: "contourChunkSize",
+    streamContoursWhileZooming: "streamContoursWhileZooming",
     logEventList: "logEventList"
 };
 
@@ -84,6 +85,7 @@ const DEFAULTS = {
     contourDecimation: 4,
     contourCompressionLevel: 8,
     contourChunkSize: 100000,
+    streamContoursWhileZooming: false,
     eventLoggingEnabled: false
 };
 
@@ -124,6 +126,7 @@ export class PreferenceStore {
     @observable contourDecimation: number;
     @observable contourCompressionLevel: number;
     @observable contourChunkSize: number;
+    @observable streamTilesWhileZooming: boolean;
     @observable eventsLoggingEnabled: Map<CARTA.EventType, boolean>;
 
     // getters for global settings
@@ -406,6 +409,11 @@ export class PreferenceStore {
         return isFinite(value) && TileCache.isSystemTileCacheValid(value) ? value : DEFAULTS.systemTileCache;
     };
 
+    private getStreamTilesWhileZooming = (): boolean => {
+        const val = localStorage.getItem(PREFERENCE_KEYS.streamContoursWhileZooming);
+        return parseBoolean(val, DEFAULTS.streamContoursWhileZooming);
+    };
+
     // getters for log event, the list saved in local storage should be a string array like ["REGISTER_VIEWER", "OPEN_FILE_ACK", ...]
     private getLogEvents = (): Map<CARTA.EventType, boolean> => {
         let events = new Map<CARTA.EventType, boolean>();
@@ -643,6 +651,11 @@ export class PreferenceStore {
         localStorage.setItem(PREFERENCE_KEYS.systemTileCache, systemTileCache.toString(10));
     };
 
+    @action setStreamContoursWhileZooming = (val: boolean) => {
+        this.streamTilesWhileZooming = val;
+        localStorage.setItem(PREFERENCE_KEYS.streamContoursWhileZooming, String(val));
+    };
+
     // reset functions
     @action resetGlobalSettings = () => {
         this.setTheme(DEFAULTS.theme);
@@ -695,6 +708,7 @@ export class PreferenceStore {
         this.setContourDecimation(DEFAULTS.contourDecimation);
         this.setContourCompressionLevel(DEFAULTS.contourCompressionLevel);
         this.setContourChunkSize(DEFAULTS.contourChunkSize);
+        this.setStreamContoursWhileZooming(DEFAULTS.streamContoursWhileZooming);
     };
 
     @action resetLogEventSettings = () => {
@@ -736,6 +750,7 @@ export class PreferenceStore {
         this.contourDecimation = this.getContourDecimation();
         this.contourCompressionLevel = this.getContourCompressionLevel();
         this.contourChunkSize = this.getContourChunkSize();
+        this.streamTilesWhileZooming = this.getStreamTilesWhileZooming();
         this.eventsLoggingEnabled = this.getLogEvents();
 
         // setup region settings container (for AppearanceForm in PreferenceDialogComponent)


### PR DESCRIPTION
Closes #367 and improves the situation describes in #544.

Instead of requesting tiles while the user zooms in, we wait until the zoom level has not changed for a specified amount of time (250 ms) before requesting tiles. This means that if a user zooms continuously  through a number of zoom levels, only the _last_ zoom level will result in tiles being requested. This is a much better approach in situations where:
- the tiles take a long time to calculate (e.g. very large images that need to be downsampled) 
- the tiles take a long time to be delivered (e.g. slow network connection)

The downside of this approach is that higher-resolution tiles do not appear while the user is zooming in. As this may be important to some users, I've added a new preference entry in the "Performance" tab, which allows them to always request tiles by selecting "Stream image tiles while zooming".

![zoom_delay_tiles-opt](https://user-images.githubusercontent.com/592504/67713897-6932e380-f9cf-11e9-8d6e-b8eaac97f9f0.gif)

