### PR TITLE
fixes issue with Chart.js library >= 2.9.0

### DIFF
--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -817,6 +817,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                 tabIndex={0}
             >
                 <ReactResizeDetector handleWidth handleHeight onResize={this.resize} refreshMode={"throttle"} refreshRate={33}/>
+                {this.width > 0 && this.height > 0 &&
                 <PlotContainerComponent
                     {...this.props}
                     plotRefUpdated={this.onPlotRefUpdated}
@@ -824,6 +825,8 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     width={this.width}
                     height={this.height}
                 />
+                }
+                {this.width > 0 && this.height > 0 &&
                 <Stage
                     className={"annotation-stage"}
                     ref={ref => this.stageRef = ref}
@@ -841,6 +844,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                         {this.genBorderRect()}
                     </Layer>
                 </Stage>
+                }
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
                     visible={this.isMouseEntered && (this.props.data !== undefined || (this.props.multiPlotData && this.props.multiPlotData.size > 0))}

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -587,6 +587,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
                 tabIndex={0}
             >
                 <ReactResizeDetector handleWidth handleHeight onResize={this.resize} refreshMode={"throttle"} refreshRate={33}/>
+                {this.width > 0 && this.height > 0 &&
                 <PlotContainerComponent
                     {...this.props}
                     plotRefUpdated={this.onPlotRefUpdated}
@@ -594,6 +595,8 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
                     width={this.width}
                     height={this.height}
                 />
+                }
+                {this.width > 0 && this.height > 0 &&
                 <Stage
                     className={"annotation-stage"}
                     width={this.width}
@@ -609,6 +612,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
                         {this.genSelectionRect()}
                     </Layer>
                 </Stage>
+                }
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
                     visible={this.isMouseEntered && (this.props.data !== undefined || this.props.multiPlotData !== undefined)}


### PR DESCRIPTION
closes #584 

This PR prevents chart components from being displayed when they have zero width or height. This fixes the issue with docking widgets when using Chart.js >= 2.9.0