### PR TITLE
Angus/fix offscreen load

### DIFF
--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -72,8 +72,8 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             return;
         }
 
-        const reqWidth = frame.renderWidth * devicePixelRatio;
-        const reqHeight = frame.renderHeight * devicePixelRatio;
+        const reqWidth = Math.max(1, frame.renderWidth * devicePixelRatio);
+        const reqHeight = Math.max(1, frame.renderHeight * devicePixelRatio);
         // Resize canvas if necessary
         if (this.canvas.width !== reqWidth || this.canvas.height !== reqHeight) {
             this.canvas.width = reqWidth;
@@ -206,8 +206,8 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
                     style={{
                         top: padding.top,
                         left: padding.left,
-                        width: frame ? frame.renderWidth : 1,
-                        height: frame ? frame.renderHeight : 1
+                        width: frame ? frame.renderWidth || 1 : 1,
+                        height: frame ? frame.renderHeight || 1 : 1
                     }}
                 />
             </div>);

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -21,7 +21,6 @@ class CursorOverlayProps {
     showWCS?: boolean;
     showImage?: boolean;
     showValue?: boolean;
-    showCanvas?: boolean;
     showChannel?: boolean;
     showSpectral?: boolean;
 }
@@ -34,9 +33,6 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
         let infoStrings: string[] = [];
         if (this.props.showWCS && cursorInfo.infoWCS) {
             infoStrings.push(`WCS:\u00a0(${cursorInfo.infoWCS.x},\u00a0${cursorInfo.infoWCS.y})`);
-        }
-        if (this.props.showCanvas) {
-            infoStrings.push(`Canvas:\u00a0(${toFixed(cursorInfo.posCanvasSpace.x)},\u00a0${toFixed(cursorInfo.posCanvasSpace.y)})`);
         }
         if (this.props.showImage) {
             infoStrings.push(`Image:\u00a0(${toFixed(cursorInfo.posImageSpace.x)},\u00a0${toFixed(cursorInfo.posImageSpace.y)})`);

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -62,7 +62,6 @@ export const exportImage = (padding, darkTheme, imageName) => {
 
 @observer
 export class ImageViewComponent extends React.Component<WidgetProps> {
-    private containerDiv: HTMLDivElement;
     private ratioIndicatorTimeoutHandle;
     private cachedImageSize: Point2D;
 
@@ -102,6 +101,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     }
 
     onResize = (width: number, height: number) => {
+        console.log(`Image view component: WxH = ${width}x${height}`);
         if (width > 0 && height > 0) {
             this.props.appStore.setImageViewDimensions(width, height);
         }
@@ -235,7 +235,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         }
 
         return (
-            <div className="image-view-div" ref={(ref) => this.containerDiv = ref} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+            <div className="image-view-div" onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <RasterViewComponent
                     frame={appStore.activeFrame}
                     docked={this.props.docked}

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -101,7 +101,6 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     }
 
     onResize = (width: number, height: number) => {
-        console.log(`Image view component: WxH = ${width}x${height}`);
         if (width > 0 && height > 0) {
             this.props.appStore.setImageViewDimensions(width, height);
         }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -496,8 +496,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                     style={{
                         top: padding.top,
                         left: padding.left,
-                        width: frame && frame.isRenderable ? frame.renderWidth : 1,
-                        height: frame && frame.isRenderable ? frame.renderHeight : 1
+                        width: frame && frame.isRenderable ? (frame.renderWidth || 1) : 1,
+                        height: frame && frame.isRenderable ? (frame.renderHeight || 1) : 1
                     }}
                 />
             </div>);

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -48,7 +48,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
     updateCursorPos = _.throttle((x: number, y: number) => {
         if (this.props.frame.wcsInfo) {
-            this.props.frame.setCursorInfo(this.props.frame.getCursorInfo({x, y}));
+            this.props.frame.setCursorInfo(this.props.frame.getCursorInfoCanvasSpace({x, y}));
         }
     }, 100);
 
@@ -274,7 +274,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         const cursorPosCanvasSpace = {x: mouseEvent.offsetX, y: mouseEvent.offsetY};
         if (this.props.frame.wcsInfo && this.props.onClicked && (!this.props.dragPanningEnabled || isSecondaryClick)) {
-            this.props.onClicked(this.props.frame.getCursorInfo(cursorPosCanvasSpace));
+            this.props.onClicked(this.props.frame.getCursorInfoCanvasSpace(cursorPosCanvasSpace));
         }
     };
 
@@ -284,7 +284,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         const delta = mouseEvent.deltaMode === WheelEvent.DOM_DELTA_PIXEL ? mouseEvent.deltaY : mouseEvent.deltaY * lineHeight;
         const cursorPosCanvasSpace = {x: mouseEvent.offsetX, y: mouseEvent.offsetY};
         if (this.props.frame.wcsInfo && this.props.onZoomed) {
-            this.props.onZoomed(this.props.frame.getCursorInfo(cursorPosCanvasSpace), -delta);
+            this.props.onZoomed(this.props.frame.getCursorInfoCanvasSpace(cursorPosCanvasSpace), -delta);
         }
     };
 

--- a/src/models/CursorInfo.ts
+++ b/src/models/CursorInfo.ts
@@ -1,7 +1,6 @@
 import {Point2D} from "./Point2D";
 
 export interface CursorInfo {
-    posCanvasSpace: Point2D;
     posImageSpace: Point2D;
     posWCS: Point2D;
     infoWCS: { x: string, y: string };

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -27,7 +27,6 @@ export class FrameStore {
     @observable wcsInfo: number;
     @observable validWcs: boolean;
     @observable center: Point2D;
-    @observable centerY: number;
     @observable cursorInfo: CursorInfo;
     @observable cursorValue: number;
     @observable cursorFrozen: boolean;
@@ -399,7 +398,7 @@ export class FrameStore {
         this.zoomLevel = preference.isZoomRAWMode ? 1.0 : this.zoomLevelForFit;
 
         // need initialized wcs to get correct cursor info
-        this.cursorInfo = this.getCursorInfo({x: this.renderWidth / 2, y: this.renderHeight / 2});
+        this.cursorInfo = this.getCursorInfoImageSpace({x: 0, y: 0});
         this.cursorValue = 0;
         this.cursorFrozen = preference.isCursorFrozen;
 
@@ -470,9 +469,7 @@ export class FrameStore {
         };
     }
 
-    public getCursorInfo(cursorPosCanvasSpace: Point2D): CursorInfo {
-        const cursorPosImageSpace = this.getImagePos(cursorPosCanvasSpace.x, cursorPosCanvasSpace.y);
-
+    public getCursorInfoImageSpace(cursorPosImageSpace: Point2D) {
         let cursorPosWCS, cursorPosFormatted;
         if (this.validWcs) {
             // We need to compare X and Y coordinates in both directions
@@ -518,11 +515,15 @@ export class FrameStore {
         }
 
         return {
-            posCanvasSpace: cursorPosCanvasSpace,
             posImageSpace: cursorPosImageSpace,
             posWCS: cursorPosWCS,
             infoWCS: cursorPosFormatted,
         };
+    }
+
+    public getCursorInfoCanvasSpace(cursorPosCanvasSpace: Point2D): CursorInfo {
+        const cursorPosImageSpace = this.getImagePos(cursorPosCanvasSpace.x, cursorPosCanvasSpace.y);
+        return this.getCursorInfoImageSpace(cursorPosImageSpace);
     }
 
     @action updateFromRasterData(rasterImageData: CARTA.RasterImageData) {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -686,6 +686,8 @@ export class OverlayStore {
         this.numbers = new OverlayNumberSettings();
         this.labels = new OverlayLabelSettings(preference);
         this.ticks = new OverlayTickSettings();
+        this.viewHeight = 1;
+        this.viewWidth = 1;
 
         // if the system is manually selected, set new default formats
         autorun(() => {


### PR DESCRIPTION
closes #589 

This assigns a finite overlay width and height by default, so that `NaN` values don't pop up when calculating related properties, such as cursor positions and view widths. 

This also moves the default cursor position to _x=0_, _y=0_, which is a less invasive default cursor location (it doesn't put a big cross right in the middle of the image)