### PR TITLE
Angus/session resume

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,16 @@ import ReactResizeDetector from "react-resize-detector";
 import {Alert, Classes, Colors, Dialog, Hotkey, Hotkeys, HotkeysTarget, Intent} from "@blueprintjs/core";
 import {exportImage, FloatingWidgetManagerComponent, RootMenuComponent} from "./components";
 import {AppToaster} from "./components/Shared";
-import {AboutDialogComponent, AuthDialogComponent, FileBrowserDialogComponent, OverlaySettingsDialogComponent, PreferenceDialogComponent, RegionDialogComponent, SaveLayoutDialogComponent} from "./components/Dialogs";
+import {
+    AboutDialogComponent,
+    AuthDialogComponent,
+    FileBrowserDialogComponent,
+    OverlaySettingsDialogComponent,
+    PreferenceDialogComponent,
+    RegionDialogComponent,
+    SaveLayoutDialogComponent,
+    TaskProgressDialogComponent
+} from "./components/Dialogs";
 import {AppStore, BrowserMode, dayPalette, nightPalette, RegionMode} from "./stores";
 import {ConnectionStatus} from "./services";
 import {PresetLayout} from "models";
@@ -102,15 +111,12 @@ export class App extends React.Component<{ appStore: AppStore }> {
                     confirmButtonText="Yes"
                     cancelButtonText="Cancel"
                     intent={Intent.DANGER}
-                    onConfirm={() => {
-                        appStore.alertStore.dismissInteractiveAlert();
-                        appStore.layoutStore.saveLayout();
-                    }}
-                    onCancel={appStore.alertStore.dismissInteractiveAlert}
+                    onClose={appStore.alertStore.handleInteractiveAlertClosed}
                     canEscapeKeyCancel={true}
                 >
                     <p>{appStore.alertStore.interactiveAlertText}</p>
                 </Alert>
+                <TaskProgressDialogComponent progress={undefined} timeRemaining={0} isOpen={appStore.resumingSession} cancellable={false} text={"Resuming session..."}/>
                 <div className={glClassName} ref={ref => appStore.setAppContainer(ref)}>
                     <ReactResizeDetector handleWidth handleHeight onResize={this.onContainerResize} refreshMode={"throttle"} refreshRate={200}/>
                 </div>

--- a/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
@@ -35,9 +35,15 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
         appStore.hideSaveLayoutDialog();
         layoutStore.setLayoutToBeSaved(this.layoutName);
         if (layoutStore.layoutExist(this.layoutName)) {
-            PresetLayout.isValid(this.layoutName) ?
-            alertStore.showAlert("Layout name cannot be the same as system presets.") :
-            alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`);
+            if (PresetLayout.isValid(this.layoutName)) {
+                alertStore.showAlert("Layout name cannot be the same as system presets.");
+            } else {
+                alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`, (confirmed: boolean) => {
+                    if (confirmed) {
+                        layoutStore.saveLayout();
+                    }
+                });
+            }
         } else {
             layoutStore.saveLayout();
         }

--- a/src/components/Dialogs/TaskProgressDialog/TaskProgressDialogComponent.tsx
+++ b/src/components/Dialogs/TaskProgressDialog/TaskProgressDialogComponent.tsx
@@ -43,7 +43,7 @@ export class TaskProgressDialogComponent extends React.Component<TaskProgressDia
                 isOpen={this.props.isOpen}
             >
                 <div className={Classes.DIALOG_BODY}>
-                    <ProgressBar value={this.props.progress} animate={false} stripes={false} intent={"primary"}/>
+                    <ProgressBar value={this.props.progress} animate={!isFinite(this.props.progress)} stripes={!isFinite(this.props.progress)} intent={"primary"}/>
                 </div>
                 {this.props.cancellable &&
                 <div className={Classes.DIALOG_FOOTER}>

--- a/src/stores/AlertStore.ts
+++ b/src/stores/AlertStore.ts
@@ -5,6 +5,7 @@ export class AlertStore {
     @observable alertText;
     @observable interactiveAlertVisible;
     @observable interactiveAlertText;
+    interactiveAlertCallback: (confirmed: boolean) => void;
 
     @action("show_alert") showAlert = (text: string) => {
         this.alertText = text;
@@ -13,14 +14,22 @@ export class AlertStore {
 
     @action("dismiss_alert") dismissAlert = () => {
         this.alertVisible = false;
-    }
+    };
 
-    @action("show_alert") showInteractiveAlert = (text: string) => {
+    @action("show_alert") showInteractiveAlert = (text: string, onClose: (confirmed: boolean) => void) => {
         this.interactiveAlertText = text;
         this.interactiveAlertVisible = true;
+        this.interactiveAlertCallback = onClose;
     };
 
     @action("dismiss_alert") dismissInteractiveAlert = () => {
         this.interactiveAlertVisible = false;
+    };
+
+    @action handleInteractiveAlertClosed = (confirmed: boolean) => {
+        this.interactiveAlertVisible = false;
+        if (this.interactiveAlertCallback) {
+            this.interactiveAlertCallback(confirmed);
+        }
     }
 }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -636,6 +636,7 @@ export class AppStore {
         this.backendService.getContourStream().subscribe(this.handleContourImageStream);
         this.backendService.getErrorStream().subscribe(this.handleErrorStream);
         this.backendService.getRegionStatsStream().subscribe(this.handleRegionStatsStream);
+        this.backendService.getReconnectStream().subscribe(this.handleReconnectStream);
         this.tileService.GetTileStream().subscribe(this.handleTileStream);
 
         // Auth and connection
@@ -782,6 +783,27 @@ export class AppStore {
             };
             this.logStore.addLog(logEntry);
         }
+    };
+
+    handleReconnectStream = () => {
+        const images: CARTA.IImageProperties[] = [];
+        this.frames.forEach(frame => {
+            const info = frame.frameInfo;
+            images.push({
+                file: info.fileInfo.name,
+                directory: "",
+                hdu: "",
+                fileId: info.fileId,
+                renderMode: info.renderMode,
+                channel: frame.requiredChannel,
+                stokes: frame.requiredStokes,
+                regions: []
+            });
+        });
+        this.backendService.resumeSession({images}).subscribe(ack => {
+            console.log(ack);
+            console.log(`Resumed successfully`);
+        });
     };
 
     // endregion

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -9,6 +9,8 @@ import {BackendService} from "services";
 
 export interface FrameInfo {
     fileId: number;
+    directory: string;
+    hdu: string;
     fileInfo: CARTA.FileInfo;
     fileInfoExtended: CARTA.FileInfoExtended;
     fileFeatureFlags: number;


### PR DESCRIPTION
Note: this is a companion PR to [carta-backend/#375](https://github.com/CARTAvis/carta-backend/pull/375), and the two should be merged simultaneously (along with the ICD changes).

Initial resume support when the user's network is disconnected, or the backend crashes and is restarted.

Some work needs to be done to handle resuming sessions when running in authenticated mode, but this can happen at a later stage, once token-based authentication is supported.