### PR TITLE
Confluence/downsampled region dims rounding fix

### DIFF
--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -149,8 +149,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
     private updateTexture() {
         const frame = this.props.frame;
-        const w = Math.floor((frame.currentFrameView.xMax - frame.currentFrameView.xMin) / frame.currentFrameView.mip);
-        const h = Math.floor((frame.currentFrameView.yMax - frame.currentFrameView.yMin) / frame.currentFrameView.mip);
+        const w = Math.ceil((frame.currentFrameView.xMax - frame.currentFrameView.xMin) / frame.currentFrameView.mip);
+        const h = Math.ceil((frame.currentFrameView.yMax - frame.currentFrameView.yMin) / frame.currentFrameView.mip);
         if (!frame.rasterData || frame.rasterData.length !== w * h) {
             console.log(`Data mismatch! L=${frame.rasterData ? frame.rasterData.length : "null"}, WxH = ${w}x${h}=${w * h}`);
             return;
@@ -216,8 +216,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const fullHeight = full.yMax - full.yMin;
 
         // Bounds need to be adjusted because of MIP level
-        const adjustedXMax = current.xMin + Math.floor((current.xMax - current.xMin) / current.mip) * current.mip;
-        const adjustedYMax = current.yMin + Math.floor((current.yMax - current.yMin) / current.mip) * current.mip;
+        const adjustedXMax = current.xMin + Math.ceil((current.xMax - current.xMin) / current.mip) * current.mip;
+        const adjustedYMax = current.yMin + Math.ceil((current.yMax - current.yMin) / current.mip) * current.mip;
 
         const LT = {x: (0.5 + current.xMin - full.xMin) / fullWidth, y: (0.5 + current.yMin - full.yMin) / fullHeight};
         const RB = {x: (0.5 + adjustedXMax - full.xMin) / fullWidth, y: (0.5 + adjustedYMax - full.yMin) / fullHeight};

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -315,8 +315,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 if (tile.layer > 0 && renderLowRes) {
                     const lowResTile = {
                         layer: tile.layer - 1,
-                        x: Math.ceil(tile.x / 2.0),
-                        y: Math.ceil(tile.y / 2.0),
+                        x: Math.floor(tile.x / 2.0),
+                        y: Math.floor(tile.y / 2.0),
                     };
                     placeholderTileMap.set(TileCoordinate.EncodeCoordinate(lowResTile), true);
                 }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -315,8 +315,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 if (tile.layer > 0 && renderLowRes) {
                     const lowResTile = {
                         layer: tile.layer - 1,
-                        x: Math.floor(tile.x / 2.0),
-                        y: Math.floor(tile.y / 2.0),
+                        x: Math.ceil(tile.x / 2.0),
+                        y: Math.ceil(tile.y / 2.0),
                     };
                     placeholderTileMap.set(TileCoordinate.EncodeCoordinate(lowResTile), true);
                 }

--- a/src/services/DecompressionService.ts
+++ b/src/services/DecompressionService.ts
@@ -87,8 +87,8 @@ export class DecompressionService {
                 reject("Unsupported compression type");
             }
 
-            const w = Math.floor((message.imageBounds.xMax - message.imageBounds.xMin) / message.mip);
-            const h = Math.floor((message.imageBounds.yMax - message.imageBounds.yMin) / message.mip);
+            const w = Math.ceil((message.imageBounds.xMax - message.imageBounds.xMin) / message.mip);
+            const h = Math.ceil((message.imageBounds.yMax - message.imageBounds.yMin) / message.mip);
             this.submitWork(message.imageData, message.nanEncodings, message.compressionQuality, w, h).then(() => {
                 const promise = new Promise<Float32Array>(resolveWork => {
                     this.decompressedData = resolveWork;


### PR DESCRIPTION
This is a fix for the off-by-one rounding error in the downsampled tile dimensions. It should be merged at the same time as [the corresponding back-end PR](https://github.com/CARTAvis/carta-backend/pull/386). This needs more thorough testing.