### PR TITLE
Fix #443 unable to create polygon if clicking too fast

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -11,7 +11,7 @@ import {PolygonRegionComponent} from "./PolygonRegionComponent";
 import {PointRegionComponent} from "./PointRegionComponent";
 import {CursorInfo, Point2D} from "models";
 import "./RegionViewComponent.css";
-import {average2D, length2D, subtract2D, pointsDistance} from "utilities";
+import {average2D, length2D, subtract2D, pointDistanceSquared} from "utilities";
 import {canvasToImagePos, imageToCanvasPos} from "./shared";
 
 export interface RegionViewComponentProps {
@@ -37,11 +37,11 @@ const DOUBLE_CLICK_DISTANCE = 5;
 @observer
 export class RegionViewComponent extends React.Component<RegionViewComponentProps> {
     @observable creatingRegion: RegionStore;
-    private regionStartPoint: Point2D;
     @observable currentCursorPos: Point2D;
-    @observable mousePreviousClick: Point2D = {x: -1000, y: -1000};
-    @observable mouseClickDistance: number = 0;
 
+    private regionStartPoint: Point2D;
+    private mousePreviousClick: Point2D = {x: -1000, y: -1000};
+    private mouseClickDistance: number = 0;
     private dragPanning: boolean;
     private dragOffset: Point2D;
     private initialDragPointCanvasSpace: Point2D;
@@ -261,7 +261,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         const isSecondaryClick = mouseEvent.button !== 0 || mouseEvent.ctrlKey || mouseEvent.metaKey;
 
         // Record click position and distance
-        this.mouseClickDistance = pointsDistance(mouseEvent, this.mousePreviousClick);
+        this.mouseClickDistance = pointDistanceSquared(mouseEvent, this.mousePreviousClick);
         this.mousePreviousClick = {x: mouseEvent.x, y: mouseEvent.y};
 
         // Ignore clicks that aren't on the stage, unless it's a secondary click
@@ -371,7 +371,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
     private handleStageDoubleClick = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         const frame = this.props.frame;
-        if (this.mouseClickDistance > DOUBLE_CLICK_DISTANCE) {
+        if (this.mouseClickDistance > DOUBLE_CLICK_DISTANCE * DOUBLE_CLICK_DISTANCE) {
             // Ignore the double click distance longer than DOUBLE_CLICK_DISTANCE
             return;
         }

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -260,6 +260,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         const isSecondaryClick = mouseEvent.button !== 0 || mouseEvent.ctrlKey || mouseEvent.metaKey;
 
+        // Record click position and distance
         this.mouseClickDistance = {x: Math.abs(mouseEvent.x - this.mousePreviousClick.x), y: Math.abs(mouseEvent.y - this.mousePreviousClick.y)};
         this.mousePreviousClick = {x: mouseEvent.x, y: mouseEvent.y};
 
@@ -371,9 +372,9 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     private handleStageDoubleClick = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         const frame = this.props.frame;
         if (this.mouseClickDistance.x > DOUBLE_CLICK_DISTANCE || this.mouseClickDistance.y > DOUBLE_CLICK_DISTANCE) {
+            // Ignore the double click distance longer than DOUBLE_CLICK_DISTANCE
             return;
         }
-        console.log("Distance:" + this.mouseClickDistance.x);
         if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion && 
             this.creatingRegion.regionType === CARTA.RegionType.POLYGON) {
             // Handle region completion

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -32,12 +32,15 @@ export interface RegionViewComponentProps {
 }
 
 const DUPLICATE_POINT_THRESHOLD = 0.01;
+const DOUBLE_CLICK_DISTANCE = 5;
 
 @observer
 export class RegionViewComponent extends React.Component<RegionViewComponentProps> {
     @observable creatingRegion: RegionStore;
     private regionStartPoint: Point2D;
     @observable currentCursorPos: Point2D;
+    @observable mousePreviousPosition: Point2D = {x: -1000, y: -1000};
+    @observable mousePositionDistance: Point2D = {x: 0, y: 0};
 
     private dragPanning: boolean;
     private dragOffset: Point2D;
@@ -257,6 +260,9 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         const isSecondaryClick = mouseEvent.button !== 0 || mouseEvent.ctrlKey || mouseEvent.metaKey;
 
+        this.mousePositionDistance = {x: Math.abs(mouseEvent.x - this.mousePreviousPosition.x), y: Math.abs(mouseEvent.y - this.mousePreviousPosition.y)};
+        this.mousePreviousPosition = {x: mouseEvent.x, y: mouseEvent.y};
+
         // Ignore clicks that aren't on the stage, unless it's a secondary click
         if (konvaEvent.target !== konvaEvent.currentTarget && !isSecondaryClick) {
             return;
@@ -364,7 +370,12 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
     private handleStageDoubleClick = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         const frame = this.props.frame;
-        if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion && this.creatingRegion.regionType === CARTA.RegionType.POLYGON) {
+        if (this.mousePositionDistance.x > DOUBLE_CLICK_DISTANCE || this.mousePositionDistance.y > DOUBLE_CLICK_DISTANCE) {
+            return;
+        }
+        console.log("Distance:" + this.mousePositionDistance.x);
+        if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion && 
+            this.creatingRegion.regionType === CARTA.RegionType.POLYGON) {
             // Handle region completion
             if (this.creatingRegion.isValid && this.creatingRegion.controlPoints.length > 2) {
                 this.creatingRegion.endCreating();

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -11,7 +11,7 @@ import {PolygonRegionComponent} from "./PolygonRegionComponent";
 import {PointRegionComponent} from "./PointRegionComponent";
 import {CursorInfo, Point2D} from "models";
 import "./RegionViewComponent.css";
-import {add2D, average2D, length2D, subtract2D} from "../../../utilities";
+import {average2D, length2D, subtract2D, pointsDistance} from "utilities";
 import {canvasToImagePos, imageToCanvasPos} from "./shared";
 
 export interface RegionViewComponentProps {
@@ -40,7 +40,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     private regionStartPoint: Point2D;
     @observable currentCursorPos: Point2D;
     @observable mousePreviousClick: Point2D = {x: -1000, y: -1000};
-    @observable mouseClickDistance: Point2D = {x: 0, y: 0};
+    @observable mouseClickDistance: number = 0;
 
     private dragPanning: boolean;
     private dragOffset: Point2D;
@@ -261,7 +261,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         const isSecondaryClick = mouseEvent.button !== 0 || mouseEvent.ctrlKey || mouseEvent.metaKey;
 
         // Record click position and distance
-        this.mouseClickDistance = {x: Math.abs(mouseEvent.x - this.mousePreviousClick.x), y: Math.abs(mouseEvent.y - this.mousePreviousClick.y)};
+        this.mouseClickDistance = pointsDistance(mouseEvent, this.mousePreviousClick);
         this.mousePreviousClick = {x: mouseEvent.x, y: mouseEvent.y};
 
         // Ignore clicks that aren't on the stage, unless it's a secondary click
@@ -371,7 +371,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
     private handleStageDoubleClick = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         const frame = this.props.frame;
-        if (this.mouseClickDistance.x > DOUBLE_CLICK_DISTANCE || this.mouseClickDistance.y > DOUBLE_CLICK_DISTANCE) {
+        if (this.mouseClickDistance > DOUBLE_CLICK_DISTANCE) {
             // Ignore the double click distance longer than DOUBLE_CLICK_DISTANCE
             return;
         }

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -39,8 +39,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     @observable creatingRegion: RegionStore;
     private regionStartPoint: Point2D;
     @observable currentCursorPos: Point2D;
-    @observable mousePreviousPosition: Point2D = {x: -1000, y: -1000};
-    @observable mousePositionDistance: Point2D = {x: 0, y: 0};
+    @observable mousePreviousClick: Point2D = {x: -1000, y: -1000};
+    @observable mouseClickDistance: Point2D = {x: 0, y: 0};
 
     private dragPanning: boolean;
     private dragOffset: Point2D;
@@ -260,8 +260,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         const isSecondaryClick = mouseEvent.button !== 0 || mouseEvent.ctrlKey || mouseEvent.metaKey;
 
-        this.mousePositionDistance = {x: Math.abs(mouseEvent.x - this.mousePreviousPosition.x), y: Math.abs(mouseEvent.y - this.mousePreviousPosition.y)};
-        this.mousePreviousPosition = {x: mouseEvent.x, y: mouseEvent.y};
+        this.mouseClickDistance = {x: Math.abs(mouseEvent.x - this.mousePreviousClick.x), y: Math.abs(mouseEvent.y - this.mousePreviousClick.y)};
+        this.mousePreviousClick = {x: mouseEvent.x, y: mouseEvent.y};
 
         // Ignore clicks that aren't on the stage, unless it's a secondary click
         if (konvaEvent.target !== konvaEvent.currentTarget && !isSecondaryClick) {
@@ -370,10 +370,10 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
     private handleStageDoubleClick = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         const frame = this.props.frame;
-        if (this.mousePositionDistance.x > DOUBLE_CLICK_DISTANCE || this.mousePositionDistance.y > DOUBLE_CLICK_DISTANCE) {
+        if (this.mouseClickDistance.x > DOUBLE_CLICK_DISTANCE || this.mouseClickDistance.y > DOUBLE_CLICK_DISTANCE) {
             return;
         }
-        console.log("Distance:" + this.mousePositionDistance.x);
+        console.log("Distance:" + this.mouseClickDistance.x);
         if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion && 
             this.creatingRegion.regionType === CARTA.RegionType.POLYGON) {
             // Handle region completion

--- a/src/utilities/math2d.ts
+++ b/src/utilities/math2d.ts
@@ -184,7 +184,7 @@ export function simplePolygonPointTest(points: Point2D[], pointIndex: number) {
 type Point3D = { x: number, y: number, z?: number };
 
 // get distance between two points
-export function pointsDistance(p1: Point3D, p2: Point3D) {
+export function pointDistanceSquared(p1: Point3D, p2: Point3D) {
     const distance = subtract2D(p1, p2);
     return distance.x * distance.x + distance.y * distance.y;
 }
@@ -195,7 +195,7 @@ export function closestPointIndexToCursor(cursor: Point3D, points: readonly Poin
     let minIndex = 0;
     for (let index = 0; index < points.length; index++) {
         const point = points[index];
-        const distance = pointsDistance(cursor, point);
+        const distance = pointDistanceSquared(cursor, point);
         if (distance < minDistanceSquared) {
             minDistanceSquared = distance;
             minIndex = index;


### PR DESCRIPTION
Fix #443 by recording the click position to compute the click distance, which will disable double click while the distance is too long. The distance threshold is 5 px. After this fixing, the polygon creation can be fast and neat. 