### PR TITLE
fixed stokes line plot bugs with chartjs 2.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "@blueprintjs/core": "^3.19.1",
         "@blueprintjs/icons": "^3.11.0",
         "@blueprintjs/select": "^3.11.1",
-        "chart.js": "~2.8.0",
+        "chart.js": "^2.9.3",
         "chartjs-plugin-annotation": "^0.5.7",
         "golden-layout": "^1.5.9",
         "konva": "^3.4.1",
@@ -45,7 +45,7 @@
         "eject": "react-scripts-ts eject"
     },
     "devDependencies": {
-        "@types/chart.js": "^2.8.7",
+        "@types/chart.js": "^2.9.3",
         "@types/jest": "^24.0.19",
         "@types/jquery": "^3.3.30",
         "@types/lodash": "^4.14.144",

--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -16,7 +16,7 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
             minWidth: 280,
             minHeight: 225,
             defaultWidth: 300,
-            defaultHeight: 350,
+            defaultHeight: 320,
             title: "histogram-settings",
             isCloseable: true,
             parentId: "histogram",

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -111,6 +111,8 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
             xScale.left = 85;
             xScale.right = currentWidth - 1;
             xScale.width = xScale.right - xScale.left;
+            xScale._startPixel = xScale.left;
+            xScale._length = xScale.width;
 
             chart.chartArea.left = 85;
             chart.chartArea.right = currentWidth - 1;
@@ -470,6 +472,8 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
                 if (this.props.multiColorMultiLinesColors && this.props.multiColorMultiLinesColors.size) {
                     if (this.props.usePointSymbols) {
                         multiPlotDatasetConfig.pointBackgroundColor = this.props.multiColorMultiLinesColors.get(key);
+                        multiPlotDatasetConfig.borderColor = currentLineColor;
+                        multiPlotDatasetConfig.pointBorderColor = "rgba(0, 0, 0, 0)";
                     } else {
                         multiPlotDatasetConfig.multicolorLineColors = this.props.multiColorMultiLinesColors.get(key);
                     }

--- a/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.scss
+++ b/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.scss
@@ -1,6 +1,6 @@
 .line-settings-panel {
     width: 100%;
-    margin: 5px;
+    margin-top: 10px;
     
     .bp3-tab-panel {
         height: 22em;

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -16,7 +16,7 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
             minWidth: 280,
             minHeight: 225,
             defaultWidth: 300,
-            defaultHeight: 390,
+            defaultHeight: 410,
             title: "spatial-profiler-settings",
             isCloseable: true,
             parentId: "spatial-profiler",

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.scss
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.scss
@@ -1,7 +1,7 @@
 
 .stokes-settings {
-    width: 98%;
-    height: 98%;
+    width: calc(100% - 10px);
+    height: calc(100% - 10px);
     margin: 5px;
 
     .stokes-line-settings {

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
@@ -17,7 +17,7 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
             minWidth: 350,
             minHeight: 300,
             defaultWidth: 350,
-            defaultHeight: 530,
+            defaultHeight: 550,
             title: "stokes-settings",
             isCloseable: true,
             parentId: "stokes",


### PR DESCRIPTION
1. fixed stokes widget bug (line plots draw line out of chart area) under chartjs 2.9.3
2. fixed stokes widget legend color disappear bug when user choose point style under chartjs 2.9.3 