### PR TITLE
Fix file size column width not big enough(#325)

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -144,7 +144,7 @@ export class FileListComponent extends React.Component<{
         } else if (sizeInBytes >= 1e6) {
             return `${toFixed(sizeInBytes / 1e6, 1)} MB`;
         } else if (sizeInBytes >= 1e3) {
-            return `${toFixed(sizeInBytes / 1e3, 1)} <b>kB</b>`;
+            return `${toFixed(sizeInBytes / 1e3, 1)} kB`;
         } else {
             return `${sizeInBytes} B`;
         }

--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -83,7 +83,7 @@ export class FileListComponent extends React.Component<{
                             <td><Icon icon="document"/></td>
                             <td>{file.HDUList.length > 1 ? `${file.name}: HDU ${hdu}` : file.name}</td>
                             <td><Tooltip content={typeInfo.description}>{typeInfo.type}</Tooltip></td>
-                            <td>{this.getFileSizeDisplay(file.size as number)}</td>
+                            <td style={{whiteSpace: "nowrap"}}>{this.getFileSizeDisplay(file.size as number)}</td>
                         </tr>
                     );
                 });
@@ -144,7 +144,7 @@ export class FileListComponent extends React.Component<{
         } else if (sizeInBytes >= 1e6) {
             return `${toFixed(sizeInBytes / 1e6, 1)} MB`;
         } else if (sizeInBytes >= 1e3) {
-            return `${toFixed(sizeInBytes / 1e3, 1)} kB`;
+            return `${toFixed(sizeInBytes / 1e3, 1)} <b>kB</b>`;
         } else {
             return `${sizeInBytes} B`;
         }

--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -137,7 +137,9 @@ export class FileListComponent extends React.Component<{
     }
 
     private getFileSizeDisplay(sizeInBytes: number): string {
-        if (sizeInBytes >= 1e9) {
+        if (sizeInBytes >= 1e12) {
+            return `${toFixed(sizeInBytes / 1e12, 2)} TB`;
+        } else if (sizeInBytes >= 1e9) {
             return `${toFixed(sizeInBytes / 1e9, 1)} GB`;
         } else if (sizeInBytes >= 1e6) {
             return `${toFixed(sizeInBytes / 1e6, 1)} MB`;

--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -83,7 +83,7 @@ export class FileListComponent extends React.Component<{
                             <td><Icon icon="document"/></td>
                             <td>{file.HDUList.length > 1 ? `${file.name}: HDU ${hdu}` : file.name}</td>
                             <td><Tooltip content={typeInfo.description}>{typeInfo.type}</Tooltip></td>
-                            <td>{this.getFileSizeDisplay(file.size as number)}</td>
+                            <td style={{whiteSpace: "nowrap"}}>{this.getFileSizeDisplay(file.size as number)}</td>
                         </tr>
                     );
                 });


### PR DESCRIPTION
Add TB into file size column (column is not enough when the file size is over 1000 GB). Set TB with 2 decimals for clear information.