### PR TITLE
Angus/mean sigma calcs

### DIFF
--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -80,6 +80,10 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
         this.widgetStore.setLogScale(changeEvent.target.checked);
     };
 
+    handleMeanRmsChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
+        this.widgetStore.setMeanRmsVisible(changeEvent.target.checked);
+    };
+
     handleXMinChange = (ev: React.KeyboardEvent<HTMLInputElement>) => {
         if (ev.type === "keydown" && ev.keyCode !== KEYCODE_ENTER) {
             return;
@@ -162,6 +166,8 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
             clearXYBounds: widgetStore.clearXYBounds,
             logScaleY: widgetStore.logScaleY,
             handleLogScaleChanged: this.handleLogScaleChanged,
+            meanRmsVisible: widgetStore.meanRmsVisible,
+            handleMeanRmsChanged: this.handleMeanRmsChanged,
             xMinVal: parseNumber(widgetStore.minX, widgetStore.linePlotInitXYBoundaries.minXVal),
             handleXMinChange: this.handleXMinChange,
             xMaxVal: parseNumber(widgetStore.maxX, widgetStore.linePlotInitXYBoundaries.maxXVal),

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -352,7 +352,7 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                 horizontal: false,
             }];
 
-            if (frame.renderConfig.histogram && frame.renderConfig.histogram.stdDev > 0) {
+            if (this.widgetStore.meanRmsVisible && frame.renderConfig.histogram && frame.renderConfig.histogram.stdDev > 0) {
                 linePlotProps.markers.push({
                     value: frame.renderConfig.histogram.mean,
                     id: "marker-mean",

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -351,6 +351,27 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                 dragMove: this.onMaxMoved,
                 horizontal: false,
             }];
+
+            if (frame.renderConfig.histogram && frame.renderConfig.histogram.stdDev > 0) {
+                linePlotProps.markers.push({
+                    value: frame.renderConfig.histogram.mean,
+                    id: "marker-mean",
+                    draggable: false,
+                    horizontal: false,
+                    color: appStore.darkTheme ? Colors.GREEN4 : Colors.GREEN2,
+                    dash: [5]
+                });
+
+                linePlotProps.markers.push({
+                    value: frame.renderConfig.histogram.mean,
+                    id: "marker-rms",
+                    draggable: false,
+                    horizontal: false,
+                    width: frame.renderConfig.histogram.stdDev,
+                    opacity: 0.2,
+                    color: appStore.darkTheme ? Colors.GREEN4 : Colors.GREEN2
+                });
+            }
         }
 
         const percentileButtonCutoff = 600;

--- a/src/components/RenderConfig/RenderConfigSettingsPanelComponent/RenderConfigSettingsPanelComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigSettingsPanelComponent/RenderConfigSettingsPanelComponent.tsx
@@ -46,6 +46,10 @@ export class RenderConfigSettingsPanelComponent extends React.Component<WidgetPr
         this.widgetStore.setMarkerTextVisible(changeEvent.target.checked);
     };
 
+    handleMeanRmsChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
+        this.widgetStore.setMeanRmsVisible(changeEvent.target.checked);
+    };
+
     handleXMinChange = (ev: React.KeyboardEvent<HTMLInputElement>) => {
         if (ev.type === "keydown" && ev.keyCode !== KEYCODE_ENTER) {
             return;
@@ -130,6 +134,8 @@ export class RenderConfigSettingsPanelComponent extends React.Component<WidgetPr
             handleLogScaleChanged: this.handleLogScaleChanged,
             markerTextVisible: widgetStore.markerTextVisible,
             handleMarkerTextChanged: this.handleMarkerTextChanged,
+            meanRmsVisible: widgetStore.meanRmsVisible,
+            handleMeanRmsChanged: this.handleMeanRmsChanged,
             xMinVal: parseNumber(widgetStore.minX, widgetStore.linePlotInitXYBoundaries.minXVal),
             handleXMinChange: this.handleXMinChange,
             xMaxVal: parseNumber(widgetStore.maxX, widgetStore.linePlotInitXYBoundaries.maxXVal),

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -666,7 +666,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     <Rect listening={false} key={0} x={lowerBound - valueCanvasSpace} y={chartArea.top} width={croppedThickness} height={lineHeight} fill={markerColor} opacity={markerOpacity}/>
                 )];
             } else {
-                lineSegments = [<Line listening={false} key={0} points={[0, chartArea.top, 0, chartArea.bottom]} strokeWidth={1} stroke={markerColor} opacity={markerOpacity}/>];
+                lineSegments = [<Line listening={false} key={0} points={[0, chartArea.top, 0, chartArea.bottom]} strokeWidth={1} stroke={markerColor} opacity={markerOpacity} dash={marker.dash}/>];
             }
         }
         if (marker.label) {

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -17,6 +17,7 @@ export class HistogramWidgetStore extends RegionWidgetStore {
     @observable primaryLineColor: { colorHex: string, fixed: boolean };
     @observable lineWidth: number;
     @observable linePlotPointSize: number;
+    @observable meanRmsVisible: boolean;
     @observable linePlotInitXYBoundaries: { minXVal: number, maxXVal: number, minYVal: number, maxYVal: number };
 
     @action setXBounds = (minVal: number, maxVal: number) => {
@@ -131,19 +132,23 @@ export class HistogramWidgetStore extends RegionWidgetStore {
     // settings
     @action setPrimaryLineColor = (colorHex: string, fixed: boolean) => {
         this.primaryLineColor = { colorHex: colorHex, fixed: fixed };
-    }
+    };
 
     @action setLineWidth = (val: number) => {
         if (val >= LineSettings.MIN_WIDTH && val <= LineSettings.MAX_WIDTH) {
             this.lineWidth = val;   
         }
-    }
+    };
 
     @action setLinePlotPointSize = (val: number) => {
         if (val >= LineSettings.MIN_POINT_SIZE && val <= LineSettings.MAX_POINT_SIZE) {
             this.linePlotPointSize = val;   
         }
-    }
+    };
+
+    @action setMeanRmsVisible = (val: boolean) => {
+        this.meanRmsVisible = val;
+    };
 
     @action initXYBoundaries (minXVal: number, maxXVal: number, minYVal: number, maxYVal: number) {
         this.linePlotInitXYBoundaries = { minXVal: minXVal, maxXVal: maxXVal, minYVal: minYVal, maxYVal: maxYVal };

--- a/src/stores/widgets/RenderConfigWidgetStore.ts
+++ b/src/stores/widgets/RenderConfigWidgetStore.ts
@@ -16,6 +16,7 @@ export class RenderConfigWidgetStore {
     @observable linePlotPointSize: number;
     @observable logScaleY: boolean;
     @observable markerTextVisible: boolean;
+    @observable meanRmsVisible: boolean;
     @observable linePlotInitXYBoundaries: { minXVal: number, maxXVal: number, minYVal: number, maxYVal: number };
 
     @action setXBounds = (minVal: number, maxVal: number) => {
@@ -56,6 +57,10 @@ export class RenderConfigWidgetStore {
         this.markerTextVisible = val;
     };
 
+    @action setMeanRmsVisible = (val: boolean) => {
+        this.meanRmsVisible = val;
+    };
+
     @action setLogScale = (logScale: boolean) => {
         this.logScaleY = logScale;
     };
@@ -72,6 +77,7 @@ export class RenderConfigWidgetStore {
         this.logScaleY = true;
         this.plotType = PlotType.STEPS;
         this.markerTextVisible = true;
+        this.meanRmsVisible = true;
         this.primaryLineColor = { colorHex: Colors.BLUE2, fixed: false };
         this.linePlotPointSize = 1.5;
         this.lineWidth = 1;
@@ -89,19 +95,19 @@ export class RenderConfigWidgetStore {
     // settings
     @action setPrimaryLineColor = (colorHex: string, fixed: boolean) => {
         this.primaryLineColor = { colorHex: colorHex, fixed: fixed };
-    }
+    };
 
     @action setLineWidth = (val: number) => {
         if (val >= LineSettings.MIN_WIDTH && val <= LineSettings.MAX_WIDTH) {
             this.lineWidth = val;   
         }
-    }
+    };
 
     @action setLinePlotPointSize = (val: number) => {
         if (val >= LineSettings.MIN_POINT_SIZE && val <= LineSettings.MAX_POINT_SIZE) {
             this.linePlotPointSize = val;   
         }
-    }
+    };
 
     @action initXYBoundaries (minXVal: number, maxXVal: number, minYVal: number, maxYVal: number) {
         this.linePlotInitXYBoundaries = { minXVal: minXVal, maxXVal: maxXVal, minYVal: minYVal, maxYVal: maxYVal };


### PR DESCRIPTION
Note: Companion PR of [carta-frontend/#398](https://github.com/CARTAvis/carta-backend/pull/398), The two need to be merged into `dev` simultaneously. 

This PR adds the ability to show or hide mean and std deviation quantities in histograms in the render config widget or histogram widgets. 
