### PR TITLE
build adjustments for llvm-based emscripten build systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,10 +176,10 @@ wasm_src/zfp_wrapper/post.js
 public/zfp_wrapper.wasm
 # ZSTD
 wasm_libs/zstd/*
-wasm_libs/zstd-dev.zip
+wasm_libs/zstd-1.4.4.tar.gz
 wasm_src/carta_computation/build/*
 wasm_src/carta_computation/post.js
-public/carta_contouring.wasm
+public/carta_computation.wasm
 
 # Protocol buffers
 protobuf/build/*
@@ -188,5 +188,4 @@ protobuf/build/*
 src/static/gitInfo.ts
 # NPM package lock (ignored while in active development)
 /package-lock.json
-/wasm_libs/zstd-dev.tar.gz
-/public/carta_computation.wasm
+

--- a/wasm_libs/build_ast.sh
+++ b/wasm_libs/build_ast.sh
@@ -14,8 +14,8 @@ cd ast
 patch -i ../0001-New-attribute-TextGapType-for-the-plot-class.patch
 
 echo "Building AST using Emscripten"
-CFLAGS="-g0 -O3 -s WASM=1" CC=emcc ./configure --without-pthreads --without-fortran --without-stardocs --enable-shared=no
-make -j 4
+CFLAGS="-g0 -O3 -s WASM=1" emconfigure ./configure --without-pthreads --without-fortran --without-stardocs --enable-shared=no
+emmake make -j 4
 echo "Checking for AST static lib..."
 if [[ $(find .libs/libast.a -type f -size +1000000c 2>/dev/null) ]]; then
     echo "Found"

--- a/wasm_libs/build_zfp.sh
+++ b/wasm_libs/build_zfp.sh
@@ -12,8 +12,8 @@ cd zfp
 mkdir -p build
 cd build
 echo "Building ZFP using Emscripten"
-CC=emcc CXX=emcc cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s WASM=1" -DZFP_WITH_OPENMP=OFF -DBUILD_UTILITIES=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DZFP_ENABLE_PIC=OFF ../
-make -j4
+emconfigure cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s WASM=1" -DZFP_WITH_OPENMP=OFF -DBUILD_UTILITIES=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DZFP_ENABLE_PIC=OFF ../
+emmake make -j4
 echo "Checking for ZFP static lib..."
 if [[ $(find -L ./lib/libzfp.a -type f -size +192000c 2>/dev/null) ]]; then
     echo "Found"

--- a/wasm_libs/build_zstd.sh
+++ b/wasm_libs/build_zstd.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not installed or in PATH.Aborting." >&2; exit 1; }
 
-wget -O zstd-dev.tar.gz https://github.com/facebook/zstd/tarball/dev
-mkdir -p zstd; tar -xf zstd-dev.tar.gz --directory ./zstd --strip-components=1
+if ! [[ $(find zstd-1.4.4.tar.gz -type f 2>/dev/null && md5sum -c zstd.md5 &>/dev/null) ]]; then
+  echo "Fetching Zstd 0.4.4"
+  wget https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz
+fi
+
+mkdir -p zstd; tar -xf zstd-1.4.4.tar.gz --directory ./zstd --strip-components=1
 
 echo "Creating single file decoder source"
 cd zstd/contrib/single_file_decoder
@@ -12,9 +16,9 @@ echo "Compiling to LLVM bitcode"
 cd ../../
 mkdir -p build
 cd build
-emcc -O3 -g0 -s WASM=1 ../contrib/single_file_decoder/zstddeclib.c -o ./standalone_zstd.bc
+emcc -O3 -g0 -s WASM=1 ../contrib/single_file_decoder/zstddeclib.c -c -o ./standalone_zstd.bc
 echo "Checking for Zstd bitcode..."
-if [[ $(find -L ./standalone_zstd.bc -type f -size +177000c 2>/dev/null) ]]; then
+if [[ $(find -L ./standalone_zstd.bc -type f -size +10000c 2>/dev/null) ]]; then
     echo "Found"
 else
     echo "Not found!"

--- a/wasm_libs/zstd.md5
+++ b/wasm_libs/zstd.md5
@@ -1,0 +1,1 @@
+487f7ee1562dee7c1c8adf85e2a63df9  zstd-1.4.4.tar.gz

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -1,8 +1,9 @@
-extern "C" {
-#include "ast.h"
 #include <string.h>
 #include <emscripten.h>
-    
+
+extern "C" {
+#include "ast.h"
+
 char lastErrorMessage[256];
 
 EMSCRIPTEN_KEEPALIVE const char * getLastErrorMessage() {

--- a/wasm_src/ast_wrapper/grf_debug.cc
+++ b/wasm_src/ast_wrapper/grf_debug.cc
@@ -1,10 +1,11 @@
-extern "C" {
-#include "grf.h"
-#include "ast.h"
 #include <stdio.h>
 #include <string.h>
 #include <emscripten.h>
 #include <math.h>
+
+extern "C" {
+#include "grf.h"
+#include "ast.h"
 
 #define LOG printf
 #define PI 3.14159265

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -10,7 +10,6 @@ emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js bui
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
     -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance"]'
 
-
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then
     echo "Found"
@@ -21,7 +20,6 @@ if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then
     cd ../../node_modules
     rm -f ast_wrapper
     ln -s ../wasm_src/ast_wrapper/build ast_wrapper
-
 else
     echo "Not found!"
     exit

--- a/wasm_src/build_carta_computation.sh
+++ b/wasm_src/build_carta_computation.sh
@@ -13,7 +13,7 @@ cp typings.d.ts build/index.d.ts
 emcc -o build/carta_computation.js carta_computation.cc Point2D.cc ../../wasm_libs/zstd/build/standalone_zstd.bc \
   --pre-js build/pre.js --post-js build/post.js -std=c++11 -g0 -O3 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
   -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS='["_ZSTD_decompress", "_decodeArray", "_generateVertexData", "_malloc", "_free"]' \
-  -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "calledRun"]' -s "BINARYEN_TRAP_MODE='clamp'"
+  -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "calledRun"]'
 
 printf "Checking for CARTA computation WASM..."
 if [[ $(find build/carta_computation.js -type f -size +10000c 2>/dev/null) ]]; then


### PR DESCRIPTION
This PR updates the WebAssembly components to be compatible with new versions of Emscripten (tested on 1.39.4), which use an LLVM backend (rather than compiling to asm.js and then to wasm). 

It also switches to a fixed version of Zstd, rather than the `dev` branch.