### PR TITLE
use numeric values from header entries if the entry type is numeric

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import * as AST from "ast_wrapper";
 import {ASTSettingsString, PreferenceStore, OverlayBeamStore, OverlayStore, LogStore, RegionSetStore, RenderConfigStore, ContourConfigStore, ContourStore} from "stores";
 import {CursorInfo, Point2D, FrameView, SpectralInfo, ChannelInfo, CHANNEL_TYPES, ProtobufProcessing} from "models";
-import {clamp, frequencyStringFromVelocity, velocityStringFromFrequency, toFixed, hexStringToRgba, trimFitsComment} from "utilities";
+import {clamp, frequencyStringFromVelocity, velocityStringFromFrequency, toFixed, hexStringToRgba, trimFitsComment, getHeaderNumericValue} from "utilities";
 import {BackendService} from "services";
 
 export interface FrameInfo {
@@ -119,11 +119,11 @@ export class FrameStore {
         const deltaHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf("CDELT1") !== -1);
 
         if (bMajHeader && bMinHeader && bpaHeader && unitHeader && deltaHeader) {
-            let bMaj = parseFloat(bMajHeader.value);
-            let bMin = parseFloat(bMinHeader.value);
-            const bpa = parseFloat(bpaHeader.value);
+            let bMaj = getHeaderNumericValue(bMajHeader);
+            let bMin = getHeaderNumericValue(bMinHeader);
+            const bpa = getHeaderNumericValue(bpaHeader);
             const unit = unitHeader.value.trim();
-            const delta = parseFloat(deltaHeader.value);
+            const delta = getHeaderNumericValue(deltaHeader);
 
             if (isFinite(bMaj) && bMaj > 0 && isFinite(bMin) && bMin > 0 && isFinite(bpa) && isFinite(delta) && unit === "deg" || unit === "rad") {
                 return {
@@ -144,7 +144,7 @@ export class FrameStore {
         }
         const restFreqHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`RESTFRQ`) !== -1);
         if (restFreqHeader) {
-            const restFreqVal = parseFloat(restFreqHeader.value);
+            const restFreqVal = getHeaderNumericValue(restFreqHeader);
             if (isFinite(restFreqVal)) {
                 return restFreqVal;
             }
@@ -187,9 +187,9 @@ export class FrameStore {
             const unitHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CUNIT${channelTypeInfo.dimension}`) !== -1);
 
             if (refPixHeader && refValHeader && deltaHeader) {
-                const refPix = parseFloat(refPixHeader.value);
-                const refVal = parseFloat(refValHeader.value);
-                const delta = parseFloat(deltaHeader.value);
+                const refPix = getHeaderNumericValue(refPixHeader);
+                const refVal = getHeaderNumericValue(refValHeader);
+                const delta = getHeaderNumericValue(deltaHeader);
                 const unit = unitHeader ? unitHeader.value.trim() : "";
                 if (isFinite(refPix) && isFinite(refVal) && isFinite(delta)) {
                     // Override unit if it's specified by a header

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -70,6 +70,10 @@ export function formattedExponential(val: number, digits: number, unit: string =
 }
 
 export function getHeaderNumericValue(headerEntry: CARTA.IHeaderEntry): number {
+    if (!headerEntry) {
+        return NaN;
+    }
+
     if (headerEntry.entryType === CARTA.EntryType.FLOAT || headerEntry.entryType === CARTA.EntryType.INT) {
         return headerEntry.numericValue;
     } else {

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -1,3 +1,5 @@
+import {CARTA} from "carta-protobuf";
+
 export function velocityFromFrequency(freq: number, refFreq: number): number {
     const c = 299792458;
     return c * (1.0 - freq / refFreq);
@@ -26,7 +28,7 @@ export function frequencyStringFromVelocity(velocity: number, refFreq: number): 
 
 export function toExponential(val: number, decimals: number = 0): string {
     if (isFinite(val) && isFinite(decimals) && decimals >= 0 && decimals <= 20) {
-      return val.toExponential(decimals);
+        return val.toExponential(decimals);
     }
     // leave undefined or non-finite values as is (+- INF, NaN and undefined will still appear properly)
     return String(val);
@@ -35,7 +37,7 @@ export function toExponential(val: number, decimals: number = 0): string {
 // According to MDN, toFixed only works for up to 20 decimals
 export function toFixed(val: number, decimals: number = 0): string {
     if (isFinite(val) && isFinite(decimals) && decimals >= 0 && decimals <= 20) {
-      return val.toFixed(decimals);
+        return val.toFixed(decimals);
     }
     // leave undefined or non-finite values as is (+- INF, NaN and undefined will still appear properly)
     return String(val);
@@ -65,4 +67,12 @@ export function formattedExponential(val: number, digits: number, unit: string =
         valString = `${valString} ${unit}`;
     }
     return valString;
+}
+
+export function getHeaderNumericValue(headerEntry: CARTA.IHeaderEntry): number {
+    if (headerEntry.entryType === CARTA.EntryType.FLOAT || headerEntry.entryType === CARTA.EntryType.INT) {
+        return headerEntry.numericValue;
+    } else {
+        return parseFloat(headerEntry.value);
+    }
 }


### PR DESCRIPTION
This is a quick fix for #653, by adding a `getHeaderNumericValue` utility function, which returns the header's `numericValue` if the header type is set to a numeric type, otherwise it attempts to parse the string. 