### PR TITLE
show tooltip in file browser

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -17,7 +17,7 @@ export class FileListComponent extends React.Component<{
     private static readonly FileTypeMap = new Map<CARTA.FileType, { type: string, description: string }>([
         [CARTA.FileType.FITS, {type: "FITS", description: "Flexible Image Transport System"}],
         [CARTA.FileType.CASA, {type: "CASA", description: "CASA Image"}],
-        [CARTA.FileType.MIRIAD, {type: "Miriad", description: "ATNF Miriad Image"}],
+        [CARTA.FileType.MIRIAD, {type: "Miriad", description: "Miriad Image"}],
         [CARTA.FileType.HDF5, {type: "HDF5", description: "HDF5 File (IDIA Schema)"}],
         [CARTA.FileType.CRTF, {type: "CRTF", description: "CASA Region Text Format"}],
         [CARTA.FileType.REG, {type: "DS9", description: "DS9 Region Format"}],

--- a/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileList/FileListComponent.tsx
@@ -52,7 +52,7 @@ export class FileListComponent extends React.Component<{
                     </tr>
                 );
             }));
-            
+
             let sortedFiles = [];
             if (fileList.files && fileList.files.length) {
                 sortedFiles = fileList.files.slice();
@@ -78,11 +78,12 @@ export class FileListComponent extends React.Component<{
                     }
 
                     const typeInfo = this.getFileTypeDisplay(file.type);
+                    const fileName = file.HDUList.length > 1 ? `${file.name}: HDU ${hdu}` : file.name;
                     return (
                         <tr key={`${file.name}:${hdu}`} onDoubleClick={() => this.props.onFileDoubleClicked(file, hdu)} onClick={() => this.props.onFileClicked(file, hdu)} className={className}>
                             <td><Icon icon="document"/></td>
-                            <td>{file.HDUList.length > 1 ? `${file.name}: HDU ${hdu}` : file.name}</td>
-                            <td><Tooltip content={typeInfo.description}>{typeInfo.type}</Tooltip></td>
+                            <td><Tooltip hoverOpenDelay={1000} content={fileName}>{fileName}</Tooltip></td>
+                            <td><Tooltip hoverOpenDelay={1000} content={typeInfo.description}>{typeInfo.type}</Tooltip></td>
                             <td style={{whiteSpace: "nowrap"}}>{this.getFileSizeDisplay(file.size as number)}</td>
                         </tr>
                     );

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -35,7 +35,7 @@ export class FileInfoComponent extends React.Component<{
                 {tabEntries}
             </Tabs>
         );
-    }
+    };
 
     private renderInfoPanel = () => {
         if (this.props.isLoading) {
@@ -56,7 +56,7 @@ export class FileInfoComponent extends React.Component<{
             default:
                 return "";
         }
-    }
+    };
 
     render() {
         return (


### PR DESCRIPTION
PR adds the file name as a tooltip for situations where the file name is too long to fit in the file column. Temporary fix until #692 is implemented.