### PR TITLE
Angus/wcs translation

### DIFF
--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -274,7 +274,7 @@ export class ContourDialogComponent extends React.Component<{ appStore: AppStore
             isOpen: appStore.dialogStore.contourDialogVisible,
             onClose: appStore.dialogStore.hideContourDialog,
             className: "contour-dialog",
-            canEscapeKeyClose: false,
+            canEscapeKeyClose: true,
             title: "Contour Configuration",
         };
 

--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -100,7 +100,7 @@ export class EllipticalRegionForm extends React.Component<{ region: RegionStore,
 
     private getFormattedString(wcsInfo: number, pixelCoords: Point2D) {
         if (wcsInfo) {
-            const pointWCS = AST.pixToWCS(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
+            const pointWCS = AST.transformPoint(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
             const normVals = AST.normalizeCoordinates(this.props.wcsInfo, pointWCS.x, pointWCS.y);
             const wcsCoords = AST.getFormattedCoordinates(this.props.wcsInfo, normVals.x, normVals.y);
             if (wcsCoords) {
@@ -112,9 +112,9 @@ export class EllipticalRegionForm extends React.Component<{ region: RegionStore,
 
     private getSizeString(wcsInfo: number, centerPixel: Point2D, cornerPixel: Point2D) {
         if (wcsInfo) {
-            const centerWCS = AST.pixToWCS(this.props.wcsInfo, centerPixel.x, centerPixel.y);
-            const horizontalEdgeWCS = AST.pixToWCS(this.props.wcsInfo, cornerPixel.x, centerPixel.y);
-            const verticalEdgeWCS = AST.pixToWCS(this.props.wcsInfo, centerPixel.x, cornerPixel.y);
+            const centerWCS = AST.transformPoint(this.props.wcsInfo, centerPixel.x, centerPixel.y);
+            const horizontalEdgeWCS = AST.transformPoint(this.props.wcsInfo, cornerPixel.x, centerPixel.y);
+            const verticalEdgeWCS = AST.transformPoint(this.props.wcsInfo, centerPixel.x, cornerPixel.y);
             const hDist = Math.abs(AST.axDistance(this.props.wcsInfo, 1, centerWCS.x, horizontalEdgeWCS.x));
             const vDist = Math.abs(AST.axDistance(this.props.wcsInfo, 2, centerWCS.y, verticalEdgeWCS.y));
             const wcsDistStrings = AST.getFormattedCoordinates(this.props.wcsInfo, hDist, vDist, "Format(1)=m.5, Format(2)=m.5", true);

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -52,7 +52,7 @@ export class PointRegionForm extends React.Component<{ region: RegionStore, wcsI
 
     private getFormattedString(wcsInfo: number, pixelCoords: Point2D) {
         if (wcsInfo) {
-            const pointWCS = AST.pixToWCS(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
+            const pointWCS = AST.transformPoint(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
             const normVals = AST.normalizeCoordinates(this.props.wcsInfo, pointWCS.x, pointWCS.y);
             const wcsCoords = AST.getFormattedCoordinates(this.props.wcsInfo, normVals.x, normVals.y);
             if (wcsCoords) {

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -47,7 +47,7 @@ export class PolygonRegionForm extends React.Component<{ region: RegionStore, wc
 
     private getFormattedString(wcsInfo: number, pixelCoords: Point2D) {
         if (wcsInfo) {
-            const pointWCS = AST.pixToWCS(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
+            const pointWCS = AST.transformPoint(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
             const normVals = AST.normalizeCoordinates(this.props.wcsInfo, pointWCS.x, pointWCS.y);
             const wcsCoords = AST.getFormattedCoordinates(this.props.wcsInfo, normVals.x, normVals.y);
             if (wcsCoords) {

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -219,7 +219,7 @@ export class RectangularRegionForm extends React.Component<{ region: RegionStore
 
     private getFormattedString(wcsInfo: number, pixelCoords: Point2D) {
         if (wcsInfo) {
-            const pointWCS = AST.pixToWCS(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
+            const pointWCS = AST.transformPoint(this.props.wcsInfo, pixelCoords.x, pixelCoords.y);
             const normVals = AST.normalizeCoordinates(this.props.wcsInfo, pointWCS.x, pointWCS.y);
             const wcsCoords = AST.getFormattedCoordinates(this.props.wcsInfo, normVals.x, normVals.y);
             if (wcsCoords) {
@@ -231,9 +231,9 @@ export class RectangularRegionForm extends React.Component<{ region: RegionStore
 
     private getSizeString(wcsInfo: number, centerPixel: Point2D, cornerPixel: Point2D) {
         if (wcsInfo) {
-            const centerWCS = AST.pixToWCS(this.props.wcsInfo, centerPixel.x, centerPixel.y);
-            const horizontalEdgeWCS = AST.pixToWCS(this.props.wcsInfo, cornerPixel.x, centerPixel.y);
-            const verticalEdgeWCS = AST.pixToWCS(this.props.wcsInfo, centerPixel.x, cornerPixel.y);
+            const centerWCS = AST.transformPoint(this.props.wcsInfo, centerPixel.x, centerPixel.y);
+            const horizontalEdgeWCS = AST.transformPoint(this.props.wcsInfo, cornerPixel.x, centerPixel.y);
+            const verticalEdgeWCS = AST.transformPoint(this.props.wcsInfo, centerPixel.x, cornerPixel.y);
             const hDist = Math.abs(2 * AST.axDistance(this.props.wcsInfo, 1, centerWCS.x, horizontalEdgeWCS.x));
             const vDist = Math.abs(2 * AST.axDistance(this.props.wcsInfo, 2, centerWCS.y, verticalEdgeWCS.y));
             const wcsDistStrings = AST.getFormattedCoordinates(this.props.wcsInfo, hDist, vDist, "Format(1)=m.5, Format(2)=m.5", true);

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -91,6 +91,8 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         if (frame && this.canvas && this.gl && this.shaderUniforms) {
             this.resizeAndClearCanvas();
 
+            const zoomLevel = frame.spatialReference ? frame.spatialReference.zoomLevel / frame.spatialTransform.scale.x : frame.zoomLevel;
+
             const fullWidth = frame.requiredFrameView.xMax - frame.requiredFrameView.xMin;
             const fullHeight = frame.requiredFrameView.yMax - frame.requiredFrameView.yMin;
             const scale = {x: 2.0 / fullWidth, y: 2.0 / fullHeight};
@@ -98,7 +100,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             // update uniforms
             this.gl.uniform2f(this.shaderUniforms.Scale, scale.x, scale.y);
             this.gl.uniform2f(this.shaderUniforms.Offset, offset.x, offset.y);
-            this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / frame.zoomLevel);
+            this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / zoomLevel);
 
             this.gl.uniform1i(this.shaderUniforms.CmapEnabled, frame.contourConfig.colormapEnabled ? 1 : 0);
             if (frame.contourConfig.colormapEnabled) {
@@ -108,7 +110,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             }
 
             // Calculates ceiling power-of-three value as a dash factor.
-            const dashFactor = Math.pow(3.0, Math.ceil(Math.log(1.0 / frame.zoomLevel) / Math.log(3)));
+            const dashFactor = Math.pow(3.0, Math.ceil(Math.log(1.0 / zoomLevel) / Math.log(3)));
             if (frame.contourStores) {
                 const levels = [];
                 frame.contourStores.forEach((v, level) => levels.push(level));

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -91,7 +91,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         if (frame && this.canvas && this.gl && this.shaderUniforms) {
             this.resizeAndClearCanvas();
 
-            const zoomLevel = frame.spatialReference ? frame.spatialReference.zoomLevel / frame.spatialTransform.scale.x : frame.zoomLevel;
+            const zoomLevel = frame.spatialReference ? frame.spatialReference.zoomLevel * frame.spatialTransform.scale.x : frame.zoomLevel;
 
             const fullWidth = frame.requiredFrameView.xMax - frame.requiredFrameView.xMin;
             const fullHeight = frame.requiredFrameView.yMax - frame.requiredFrameView.yMin;

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -10,7 +10,6 @@ uniform vec2 uRotationOrigin;
 uniform float uRotationAngle;
 uniform float uScaleAdjustment;
 uniform vec2 uOffset;
-
 uniform float uLineThickness;
 
 varying float vLinePosition;
@@ -34,13 +33,11 @@ void main(void) {
     // Extrude point along normal
     vec2 posImageSpace = (aVertexPosition.xy + (aVertexNormal / 16384.0) * uLineThickness * 0.5);
     // Scale and rotate
-    vec2 posRefSpace = scaleAboutPoint2D(rotateAboutPoint2D(posImageSpace, uRotationOrigin, uRotationAngle), uRotationOrigin, uScaleAdjustment);
-    // Shift
-    vec2 pos = posRefSpace + uOffset;
+    vec2 posRefSpace = scaleAboutPoint2D(rotateAboutPoint2D(posImageSpace, uRotationOrigin, uRotationAngle), uRotationOrigin, uScaleAdjustment) + uOffset;
 
     // Convert from image space to GL space [-1, 1]
     vec2 range = uFrameMax - uFrameMin;
-    vec2 adjustedPosition = vec2((pos.x - uFrameMin.x) / range.x, (pos.y - uFrameMin.y) / range.y) * 2.0 - 1.0;
+    vec2 adjustedPosition = vec2((posRefSpace.x - uFrameMin.x) / range.x, (posRefSpace.y - uFrameMin.y) / range.y) * 2.0 - 1.0;
 
     vLineSide = sign(aVertexPosition.z);
     vLinePosition = abs(aVertexPosition.z);

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -6,14 +6,33 @@ attribute vec2 aVertexNormal;
 
 uniform vec2 uScale;
 uniform vec2 uOffset;
+uniform vec2 uRotationOrigin;
+uniform float uRotationAngle;
 uniform float uLineThickness;
+uniform float uScaleAdjustment;
 
 varying float vLinePosition;
 varying float vLineSide;
 
+vec2 rotate2D(vec2 vector, float theta) {
+    float sinTheta = sin(theta);
+    float cosTheta = cos(theta);
+    return mat2(cosTheta, -sinTheta, sinTheta, cosTheta) * vector;
+}
+
+vec2 rotateAboutPoint2D(vec2 vector, vec2 origin, float theta) {
+    return rotate2D(vector - origin, theta) + origin;
+}
+
+vec2 scaleAboutPoint2D(vec2 vector, vec2 origin, float scale) {
+    return (vector - origin) * scale + origin;
+}
+
 void main(void) {
     // Convert position to GL space
-    vec2 pos = (aVertexPosition.xy + (aVertexNormal / 16384.0) * uLineThickness * 0.5) * uScale + uOffset;
+    vec2 posImageSpace = (aVertexPosition.xy + (aVertexNormal / 16384.0) * uLineThickness * 0.5);
+    vec2 posRefSpace = scaleAboutPoint2D(rotateAboutPoint2D(posImageSpace, uRotationOrigin, uRotationAngle), uRotationOrigin, uScaleAdjustment);
+    vec2 pos = posRefSpace * uScale + uOffset;
     vLineSide = sign(aVertexPosition.z);
     vLinePosition = abs(aVertexPosition.z);
     gl_Position =  vec4(pos.x, pos.y, 0.0, 1.0);

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -121,9 +121,18 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         const appStore = this.props.appStore;
         if (appStore.activeFrame) {
             const zoomSpeed = 1 + Math.abs(delta / 750.0);
-            const newZoom = appStore.activeFrame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
-            // Shift from one-indexed image space position to zero-indexed
-            appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom);
+
+            // If frame is spatially matched, apply zoom to the reference frame, rather than the active frame
+            if (appStore.activeFrame.spatialReference) {
+                const newZoom = appStore.activeFrame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+                // Shift from one-indexed image space position to zero-indexed
+                // TODO: apply zoom point properly based on rotated, scaled and translated cursor location
+                appStore.activeFrame.spatialReference.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom);
+            } else {
+                const newZoom = appStore.activeFrame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+                // Shift from one-indexed image space position to zero-indexed
+                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom);
+            }
         }
     };
 

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -108,10 +108,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
     onClicked = (cursorInfo: CursorInfo) => {
         const appStore = this.props.appStore;
-        if (appStore.activeFrame
-            && 0 < cursorInfo.posImageSpace.x && cursorInfo.posImageSpace.x < appStore.activeFrame.frameInfo.fileInfoExtended.width
-            && 0 < cursorInfo.posImageSpace.y && cursorInfo.posImageSpace.y < appStore.activeFrame.frameInfo.fileInfoExtended.height
-        ) {
+        if (appStore.activeFrame) {
             // Shift from one-indexed image space position to zero-indexed
             appStore.activeFrame.setCenter(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1);
         }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -126,12 +126,11 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             if (appStore.activeFrame.spatialReference) {
                 const newZoom = appStore.activeFrame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
                 // Shift from one-indexed image space position to zero-indexed
-                // TODO: apply zoom point properly based on rotated, scaled and translated cursor location
-                appStore.activeFrame.spatialReference.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom);
+                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
             } else {
                 const newZoom = appStore.activeFrame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
                 // Shift from one-indexed image space position to zero-indexed
-                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom);
+                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
             }
         }
     };

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -41,14 +41,17 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         const pixelRatio = devicePixelRatio;
 
         if (frame.wcsInfo) {
+            const wcsInfo = frame.spatialReference ? frame.transformedWcsInfo : frame.wcsInfo;
+            const frameView = frame.spatialReference ? frame.spatialReference.requiredFrameView : frame.requiredFrameView;
+
             this.updateImageDimensions();
             AST.setCanvas(this.canvas);
 
             const plot = (styleString: string) => {
                 AST.plot(
-                    frame.wcsInfo,
-                    frame.requiredFrameView.xMin, frame.requiredFrameView.xMax,
-                    frame.requiredFrameView.yMin, frame.requiredFrameView.yMax,
+                    wcsInfo,
+                    frameView.xMin, frameView.xMax,
+                    frameView.yMin, frameView.yMax,
                     settings.viewWidth * pixelRatio, settings.viewHeight * pixelRatio,
                     settings.padding.left * pixelRatio, settings.padding.right * pixelRatio, settings.padding.top * pixelRatio, settings.padding.bottom * pixelRatio,
                     styleString);
@@ -75,8 +78,10 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     render() {
         const styleString = this.props.overlaySettings.styleString;
 
+        const refFrame = this.props.frame.spatialReference || this.props.frame;
         // changing the frame view, padding or width/height triggers a re-render
-        const frameView = this.props.frame.requiredFrameView;
+        const frameView = refFrame.requiredFrameView;
+
         const framePadding = this.props.overlaySettings.padding;
         const w = this.props.overlaySettings.viewWidth;
         const h = this.props.overlaySettings.viewHeight;

--- a/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
+++ b/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
@@ -6,6 +6,9 @@ attribute vec2 aVertexUV;
 varying vec2 vUV;
 uniform float uCanvasWidth;
 uniform float uCanvasHeight;
+uniform vec2 uRotationOrigin;
+uniform float uRotationAngle;
+uniform float uScaleAdjustment;
 // Tiling parameters
 uniform bool uTiledRendering;
 uniform vec2 uTileSize;
@@ -13,9 +16,27 @@ uniform vec2 uTileScaling;
 uniform vec2 uTileOffset;
 uniform float uTileTextureSize;
 
+vec2 rotate2D(vec2 vector, float theta) {
+    float sinTheta = sin(theta);
+    float cosTheta = cos(theta);
+    return mat2(cosTheta, -sinTheta, sinTheta, cosTheta) * vector;
+}
+
+vec2 rotateAboutPoint2D(vec2 vector, vec2 origin, float theta) {
+    return rotate2D(vector - origin, theta) + origin;
+}
+
+vec2 scaleAboutPoint2D(vec2 vector, vec2 origin, float scale) {
+    return (vector - origin) * scale + origin;
+}
+
 void main(void) {
     if (uTiledRendering) {
-        vec2 tilePosition = aVertexPosition.xy * uTileScaling * uTileSize + uTileOffset;
+        vec2 tilePosition = rotateAboutPoint2D(aVertexPosition.xy * uTileScaling * uTileSize + uTileOffset, uRotationOrigin, uRotationAngle);
+
+        // adjust based on pixel scales
+        tilePosition = scaleAboutPoint2D(tilePosition, uRotationOrigin, uScaleAdjustment);
+
         // convert XY from canvas space to [-1, 1]
         vec2 adjustedPosition = vec2(tilePosition.x / uCanvasWidth, tilePosition.y / uCanvasHeight) * 2.0 - 1.0;
         gl_Position = vec4(adjustedPosition.x, adjustedPosition.y, aVertexPosition.z, 1.0);

--- a/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
+++ b/src/components/ImageView/RasterView/GLSL/vertex_shader.glsl
@@ -4,19 +4,22 @@ precision highp float;
 attribute vec3 aVertexPosition;
 attribute vec2 aVertexUV;
 varying vec2 vUV;
+uniform float uCanvasWidth;
+uniform float uCanvasHeight;
 // Tiling parameters
 uniform bool uTiledRendering;
 uniform vec2 uTileSize;
 uniform vec2 uTileScaling;
 uniform vec2 uTileOffset;
+uniform float uTileTextureSize;
 
 void main(void) {
     if (uTiledRendering) {
         vec2 tilePosition = aVertexPosition.xy * uTileScaling * uTileSize + uTileOffset;
-        // Convert XY from [0, 1] -> [-1, 1]
-        vec2 adjustedPosition = tilePosition * 2.0 - 1.0;
+        // convert XY from canvas space to [-1, 1]
+        vec2 adjustedPosition = vec2(tilePosition.x / uCanvasWidth, tilePosition.y / uCanvasHeight) * 2.0 - 1.0;
         gl_Position = vec4(adjustedPosition.x, adjustedPosition.y, aVertexPosition.z, 1.0);
-        vUV = aVertexUV * uTileSize;
+        vUV = aVertexUV * uTileSize / uTileTextureSize;
     } else {
         gl_Position =  vec4(aVertexPosition, 1.0);
         vUV = aVertexUV;

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -376,7 +376,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         // TODO: Extremely experimental!
         console.log(bottomLeft);
         if (frame.spatialReference && frame.spatialTranslation) {
-            bottomLeft = add2D(bottomLeft, scale2D(frame.spatialTranslation, 1.0 / fullWidth));
+            bottomLeft = add2D(bottomLeft, {x: frame.spatialTranslation.x / fullWidth, y: frame.spatialTranslation.y / fullHeight});
         }
 
         console.log({bottomLeft, trans: frame.spatialTranslation});

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -390,7 +390,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             };
             this.gl.uniform2f(this.shaderUniforms.RotationOrigin, rotationOriginCanvasSpace.x, rotationOriginCanvasSpace.y);
             this.gl.uniform1f(this.shaderUniforms.RotationAngle, -frame.spatialTransform.rotation);
-            this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, frame.spatialTransform.scale.x);
+            this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, frame.spatialTransform.scale);
         } else {
             this.gl.uniform1f(this.shaderUniforms.RotationAngle, 0);
             this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, 1);

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -392,7 +392,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 y: spatialRef.zoomLevel * (rotationOriginImageSpace.y - full.yMin),
             };
             this.gl.uniform2f(this.shaderUniforms.RotationOrigin, rotationOriginCanvasSpace.x, rotationOriginCanvasSpace.y);
-            this.gl.uniform1f(this.shaderUniforms.RotationAngle, frame.spatialTransform.rotation);
+            this.gl.uniform1f(this.shaderUniforms.RotationAngle, -frame.spatialTransform.rotation);
             this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, frame.spatialTransform.scale.x);
         } else {
             this.gl.uniform1f(this.shaderUniforms.RotationAngle, 0);

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -356,7 +356,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.uniform2f(this.shaderUniforms.TileTextureOffset, textureParameters.offset.x, textureParameters.offset.y);
         }
 
-        const full = frame.requiredFrameView;
+        const spatialRef = frame.spatialReference || frame;
+        const full = spatialRef.requiredFrameView;
 
         const fullWidth = full.xMax - full.xMin;
         const fullHeight = full.yMax - full.yMin;
@@ -373,13 +374,16 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         let bottomLeft = {x: (0.5 + tileImageView.xMin - full.xMin) / fullWidth, y: (0.5 + tileImageView.yMin - full.yMin) / fullHeight};
 
         // TODO: Extremely experimental!
+        console.log(bottomLeft);
         if (frame.spatialReference && frame.spatialTranslation) {
             bottomLeft = add2D(bottomLeft, scale2D(frame.spatialTranslation, 1.0 / fullWidth));
         }
 
+        console.log({bottomLeft, trans: frame.spatialTranslation});
+
         this.gl.uniform2f(this.shaderUniforms.TileSize, rasterTile.width / TILE_SIZE, rasterTile.height / TILE_SIZE);
         this.gl.uniform2f(this.shaderUniforms.TileOffset, bottomLeft.x, bottomLeft.y);
-        this.gl.uniform2f(this.shaderUniforms.TileScaling, (mip * TILE_SIZE * frame.zoomLevel) / (frame.renderWidth * devicePixelRatio), (mip * TILE_SIZE * frame.zoomLevel) / (frame.renderHeight * devicePixelRatio));
+        this.gl.uniform2f(this.shaderUniforms.TileScaling, (mip * TILE_SIZE * spatialRef.zoomLevel) / (spatialRef.renderWidth * devicePixelRatio), (mip * TILE_SIZE * spatialRef.zoomLevel) / (spatialRef.renderHeight * devicePixelRatio));
         this.gl.drawArrays(WebGLRenderingContext.TRIANGLE_STRIP, 0, 4);
     }
 

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -373,13 +373,10 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
         let bottomLeft = {x: (0.5 + tileImageView.xMin - full.xMin) / fullWidth, y: (0.5 + tileImageView.yMin - full.yMin) / fullHeight};
 
-        // TODO: Extremely experimental!
-        console.log(bottomLeft);
+        // TODO: Experimental code to handle WCS translations
         if (frame.spatialReference && frame.spatialTranslation) {
             bottomLeft = add2D(bottomLeft, {x: frame.spatialTranslation.x / fullWidth, y: frame.spatialTranslation.y / fullHeight});
         }
-
-        console.log({bottomLeft, trans: frame.spatialTranslation});
 
         this.gl.uniform2f(this.shaderUniforms.TileSize, rasterTile.width / TILE_SIZE, rasterTile.height / TILE_SIZE);
         this.gl.uniform2f(this.shaderUniforms.TileOffset, bottomLeft.x, bottomLeft.y);

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -367,9 +367,6 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const spatialRef = frame.spatialReference || frame;
         const full = spatialRef.requiredFrameView;
 
-        const fullWidth = full.xMax - full.xMin;
-        const fullHeight = full.yMax - full.yMin;
-
         const tileSizeAdjusted = mip * TILE_SIZE;
         const tileImageView: FrameView = {
             xMin: tile.x * tileSizeAdjusted,

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -386,7 +386,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         if (frame.spatialReference && frame.spatialTransform) {
             bottomLeft = add2D(bottomLeft, frame.spatialTransform.translation);
             // set origin of rotation to image center
-            const rotationOriginImageSpace: Point2D = add2D(frame.referencePixel, frame.spatialTransform.translation);
+            const rotationOriginImageSpace: Point2D = add2D(frame.spatialTransform.origin, frame.spatialTransform.translation);
             const rotationOriginCanvasSpace: Point2D = {
                 x: spatialRef.zoomLevel * (rotationOriginImageSpace.x - full.xMin),
                 y: spatialRef.zoomLevel * (rotationOriginImageSpace.y - full.yMin),

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -498,10 +498,13 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     render() {
         // dummy values to trigger React's componentDidUpdate()
         const frame = this.props.frame;
-        const frameView = frame ? frame.requiredFrameView : null;
-        const currentView = frame ? frame.currentFrameView : null;
         const preference = this.props.preference;
         if (frame) {
+            const spatialReference = frame.spatialReference || frame;
+            const frameView = spatialReference.requiredFrameView;
+            const currentView = spatialReference.currentFrameView;
+            const renderType = frame.renderType;
+
             const colorMapping = {
                 min: frame.renderConfig.scaleMinVal,
                 max: frame.renderConfig.scaleMaxVal,
@@ -515,8 +518,6 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 nanColorHex: preference.nanColorHex,
                 nanAlpha: preference.nanAlpha
             };
-            const renderType = frame.renderType;
-            const spatialReference = frame.spatialReference;
         }
         const padding = this.props.overlaySettings.padding;
         let className = "raster-div";

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -123,8 +123,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                 this.dragPanning = true;
 
                 let cursorPoint = konvaEvent.target.getStage().getPointerPosition();
-                const frame = this.props.frame;
-                if (frame) {
+                if (this.props.frame) {
+                    const frame = this.props.frame.spatialReference || this.props.frame;
                     this.initialDragPointCanvasSpace = cursorPoint;
                     this.initialDragCenter = frame.center;
                     frame.startMoving();
@@ -206,8 +206,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         if (!offset || !isFinite(offset.x) || !isFinite(offset.y)) {
             return;
         }
-        const frame = this.props.frame;
-        if (frame) {
+        if (this.props.frame) {
+            const frame = this.props.frame.spatialReference || this.props.frame;
             if (!this.dragOffset) {
                 this.dragOffset = {x: 0, y: 0};
             } else {
@@ -375,7 +375,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             // Ignore the double click distance longer than DOUBLE_CLICK_DISTANCE
             return;
         }
-        if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion && 
+        if (frame.regionSet.mode === RegionMode.CREATING && this.creatingRegion &&
             this.creatingRegion.regionType === CARTA.RegionType.POLYGON) {
             // Handle region completion
             if (this.creatingRegion.isValid && this.creatingRegion.controlPoints.length > 2) {

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -84,7 +84,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             className += " docked";
         }
 
-        const zoomLevel = (frame.spatialReference && frame.spatialTransform) ? frame.spatialReference.zoomLevel * frame.spatialTransform.scale.x : frame.zoomLevel;
+        const zoomLevel = (frame.spatialReference && frame.spatialTransform) ? frame.spatialReference.zoomLevel * frame.spatialTransform.scale : frame.zoomLevel;
         const currentZoomSpan = <span><br/><i><small>Current: {toFixed(zoomLevel, 2)}x</small></i></span>;
         const tooltipPosition: PopoverPosition = this.props.vertical ? "left" : "bottom";
 

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -82,7 +82,8 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             className += " docked";
         }
 
-        const currentZoomSpan = <span><br/><i><small>Current: {toFixed(frame.zoomLevel, 2)}x</small></i></span>;
+        const zoomLevel = (frame.spatialReference && frame.spatialTransform) ? frame.spatialReference.zoomLevel * frame.spatialTransform.scale.x : frame.zoomLevel;
+        const currentZoomSpan = <span><br/><i><small>Current: {toFixed(zoomLevel, 2)}x</small></i></span>;
         const tooltipPosition: PopoverPosition = this.props.vertical ? "left" : "bottom";
 
         const regionMenu = (
@@ -156,7 +157,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
-                    <AnchorButton icon="link" active={!!frame.spatialReference} disabled={frame === appStore.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
+                    <Button icon="link" active={!!frame.spatialReference} disabled={frame === appStore.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {CSSProperties} from "react";
 import {observer} from "mobx-react";
-import {Button, ButtonGroup, IconName, Menu, MenuItem, Popover, PopoverPosition, Position, Tooltip} from "@blueprintjs/core";
+import {AnchorButton, Button, ButtonGroup, IconName, Menu, MenuItem, Popover, PopoverPosition, Position, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {exportImage} from "components";
 import {AppStore, RegionMode, SystemType} from "stores";
@@ -17,23 +17,6 @@ export class ToolbarComponentProps {
 
 @observer
 export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
-    handleZoomToActualSizeClicked = () => {
-        this.props.appStore.activeFrame.setZoom(1.0);
-    };
-
-    handleZoomInClicked = () => {
-        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel * 2.0);
-    };
-
-    handleZoomOutClicked = () => {
-        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel / 2.0);
-    };
-
-    handleRegionTypeClicked = (type: CARTA.RegionType) => {
-        this.props.appStore.activeFrame.regionSet.setNewRegionType(type);
-        this.props.appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
-    };
-
     private static readonly CoordinateSystemName = new Map<SystemType, string>([
         [SystemType.Auto, "AUTO"],
         [SystemType.FK5, "FK5"],
@@ -52,8 +35,29 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         [SystemType.ICRS, "International Celestial Reference System"],
     ]);
 
+    handleZoomToActualSizeClicked = () => {
+        this.props.appStore.activeFrame.setZoom(1.0);
+    };
+
+    handleZoomInClicked = () => {
+        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel * 2.0);
+    };
+
+    handleZoomOutClicked = () => {
+        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel / 2.0);
+    };
+
+    handleRegionTypeClicked = (type: CARTA.RegionType) => {
+        this.props.appStore.activeFrame.regionSet.setNewRegionType(type);
+        this.props.appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
+    };
+
     handleCoordinateSystemClicked = (coordinateSystem: SystemType) => {
         this.props.appStore.overlayStore.global.setSystem(coordinateSystem);
+    };
+
+    handleSpatialReferenceToggled = () => {
+        this.props.appStore.toggleSpatialMatching(this.props.appStore.activeFrame);
     };
 
     render() {
@@ -152,7 +156,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
-                    <Button icon="zoom-to-fit" active={frame.spatialReference !== null}/>
+                    <AnchorButton icon="link" active={!!frame.spatialReference} disabled={frame === appStore.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -157,7 +157,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
-                    <Button icon="link" active={!!frame.spatialReference} disabled={frame === appStore.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
+                    <Button icon="link" active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -40,11 +40,13 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
     };
 
     handleZoomInClicked = () => {
-        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel * 2.0);
+        const frame = this.props.appStore.activeFrame.spatialReference || this.props.appStore.activeFrame;
+        frame.setZoom(frame.zoomLevel * 2.0, true);
     };
 
     handleZoomOutClicked = () => {
-        this.props.appStore.activeFrame.setZoom(this.props.appStore.activeFrame.zoomLevel / 2.0);
+        const frame = this.props.appStore.activeFrame.spatialReference || this.props.appStore.activeFrame;
+        frame.setZoom(frame.zoomLevel / 2.0, true);
     };
 
     handleRegionTypeClicked = (type: CARTA.RegionType) => {

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -43,7 +43,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         [SystemType.ICRS, "ICRS"],
     ]);
 
-    private static readonly  CoordinateSystemTooltip = new Map<SystemType, string>([
+    private static readonly CoordinateSystemTooltip = new Map<SystemType, string>([
         [SystemType.Auto, "Automatically select the coordinate system based on file headers"],
         [SystemType.FK5, "FK5 coordinates, J2000.0 equinox"],
         [SystemType.FK4, "FK4 coordinates, B1950.0 equinox"],
@@ -91,7 +91,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         );
 
         let coordinateSystem = this.props.appStore.overlayStore.global.system;
-        
+
         const coordinateSystemMenu = (
             <Menu>
                 <MenuItem text={ToolbarComponent.CoordinateSystemName.get(SystemType.Auto)} onClick={() => this.handleCoordinateSystemClicked(SystemType.Auto)}/>
@@ -151,9 +151,12 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 <Tooltip position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
+                <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
+                    <Button icon="zoom-to-fit" active={frame.spatialReference !== null}/>
+                </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>
-                        <Button text={ToolbarComponent.CoordinateSystemName.get(coordinateSystem)} />
+                        <Button text={ToolbarComponent.CoordinateSystemName.get(coordinateSystem)}/>
                     </Popover>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content="Toggle grid">

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -279,13 +279,13 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
 
         if (isXProfile) {
             for (let i = 0; i < values.length; i++) {
-                const pointWCS = AST.pixToWCS(this.frame.wcsInfo, values[i] + 1, this.profileStore.y + 1);
+                const pointWCS = AST.transformPoint(this.frame.wcsInfo, values[i] + 1, this.profileStore.y + 1);
                 const normVals = AST.normalizeCoordinates(this.frame.wcsInfo, pointWCS.x, pointWCS.y);
                 this.cachedFormattedCoordinates[i] = AST.getFormattedCoordinates(this.frame.wcsInfo, normVals.x, undefined, astString.toString(), true).x;
             }
         } else {
             for (let i = 0; i < values.length; i++) {
-                const pointWCS = AST.pixToWCS(this.frame.wcsInfo, this.profileStore.x + 1, values[i] + 1);
+                const pointWCS = AST.transformPoint(this.frame.wcsInfo, this.profileStore.x + 1, values[i] + 1);
                 const normVals = AST.normalizeCoordinates(this.frame.wcsInfo, pointWCS.x, pointWCS.y);
                 this.cachedFormattedCoordinates[i] = AST.getFormattedCoordinates(this.frame.wcsInfo, undefined, normVals.y, astString.toString(), true).y;
             }

--- a/src/models/Transform2D.ts
+++ b/src/models/Transform2D.ts
@@ -1,0 +1,7 @@
+import {Point2D} from "./Point2D";
+
+export interface Transform2D {
+    translation: Point2D;
+    rotation: number;
+    scale: Point2D;
+}

--- a/src/models/Transform2D.ts
+++ b/src/models/Transform2D.ts
@@ -3,5 +3,6 @@ import {Point2D} from "./Point2D";
 export interface Transform2D {
     translation: Point2D;
     rotation: number;
+    origin: Point2D;
     scale: Point2D;
 }

--- a/src/models/Transform2D.ts
+++ b/src/models/Transform2D.ts
@@ -3,6 +3,6 @@ import {Point2D} from "./Point2D";
 export interface Transform2D {
     translation: Point2D;
     rotation: number;
+    scale: number;
     origin: Point2D;
-    scale: Point2D;
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,6 +3,7 @@ export * from "./ChannelInfo";
 export * from "./ChannelType";
 export * from "./FrameView";
 export * from "./Point2D";
+export * from "./Transform2D";
 export * from "./SpectralInfo";
 export * from "./TileCoordinate";
 export * from "./Theme";

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -544,42 +544,7 @@ export class AppStore {
                 const layout = this.layoutStore.dockedLayout;
                 this.widgetsStore.updateImageWidgetTitle();
 
-                let reqView: FrameView;
-
-                if (this.activeFrame.spatialReference) {
-                    const frame = this.activeFrame;
-                    const refFrame = frame.spatialReference;
-                    // Required view of reference frame
-                    const refView = refFrame.requiredFrameView;
-
-                    // Get the position of the ref frame's corners in the secondary frame's pixel space
-                    const corners = [
-                        getApproximateCoordinates(frame.spatialTransform, {x: 0, y: 0}, false),
-                        getApproximateCoordinates(frame.spatialTransform, {x: 0, y: refFrame.frameInfo.fileInfoExtended.height}, false),
-                        getApproximateCoordinates(frame.spatialTransform, {x: refFrame.frameInfo.fileInfoExtended.width, y: refFrame.frameInfo.fileInfoExtended.height}, false),
-                        getApproximateCoordinates(frame.spatialTransform, {x: refFrame.frameInfo.fileInfoExtended.width, y: 0}, false)
-                    ];
-
-                    const {minPoint, maxPoint} = minMax2D(corners);
-
-                    // Manually get adjusted zoom level
-                    const mipAdjustment = frame.spatialTransform.scale.x * (this.preferenceStore.lowBandwidthMode ? 2.0 : 1.0);
-                    const mipExact = Math.max(1.0, mipAdjustment / refFrame.zoomLevel);
-                    const mipLog2 = Math.log2(mipExact);
-                    const mipLog2Rounded = Math.round(mipLog2);
-
-                    reqView = {
-                        xMin: minPoint.x,
-                        xMax: maxPoint.x,
-                        yMin: minPoint.y,
-                        yMax: maxPoint.y,
-                        mip: Math.pow(2, mipLog2Rounded)
-                    };
-                } else {
-                    // Calculate new required frame view (cropped to file size)
-                    reqView = this.activeFrame.requiredFrameView;
-                }
-
+                const reqView = this.activeFrame.requiredFrameView;
                 let croppedReq: FrameView = {
                     xMin: Math.max(0, reqView.xMin),
                     xMax: Math.min(this.activeFrame.frameInfo.fileInfoExtended.width, reqView.xMax),

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -68,6 +68,9 @@ export class AppStore {
     @observable regionStats: Map<number, ObservableMap<number, CARTA.RegionStatsData>>;
     @observable regionHistograms: Map<number, ObservableMap<number, CARTA.IRegionHistogramData>>;
 
+    // Spatial WCS reference
+    @observable referenceFrame: FrameStore;
+
     private appContainer: HTMLElement;
     private contourWebGLContext: WebGLRenderingContext;
 
@@ -265,6 +268,10 @@ export class AppStore {
                 this.frames[existingFrameIndex] = newFrame;
             } else {
                 this.frames.push(newFrame);
+                // TODO: remove this debug bit
+                if (this.frames.length > 1) {
+                    newFrame.setSpatialReference(this.frames[0]);
+                }
             }
             this.setActiveFrame(newFrame.frameInfo.fileId);
             this.fileBrowserStore.hideFileBrowser();
@@ -879,6 +886,19 @@ export class AppStore {
         const frame = this.getFrame(fileId);
         if (frame && frame.regionSet.regions[0]) {
             frame.regionSet.regions[0].setControlPoint(0, {x, y});
+        }
+    };
+
+    @action setSpatialReference = (frame: FrameStore) => {
+        this.referenceFrame = frame;
+
+        for (const f of this.frames) {
+            // The reference image can't reference itself
+            if (f === frame) {
+                f.clearSpatialReference();
+            } else if (f.spatialReference) {
+                f.setSpatialReference(frame);
+            }
         }
     };
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -905,7 +905,7 @@ export class AppStore {
     };
 
     @action toggleSpatialMatching = (frame: FrameStore) => {
-        if (!frame) {
+        if (!frame || frame === this.spatialReference) {
             return;
         }
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -69,7 +69,7 @@ export class AppStore {
     @observable regionHistograms: Map<number, ObservableMap<number, CARTA.IRegionHistogramData>>;
 
     // Spatial WCS reference
-    @observable referenceFrame: FrameStore;
+    @observable spatialReference: FrameStore;
 
     private appContainer: HTMLElement;
     private contourWebGLContext: WebGLRenderingContext;
@@ -268,11 +268,13 @@ export class AppStore {
                 this.frames[existingFrameIndex] = newFrame;
             } else {
                 this.frames.push(newFrame);
-                // TODO: remove this debug bit
-                if (this.frames.length > 1) {
-                    newFrame.setSpatialReference(this.frames[0]);
-                }
             }
+
+            // First image defaults to spatial reference
+            if (this.frames.length === 1) {
+                this.setSpatialReference(this.frames[0]);
+            }
+
             this.setActiveFrame(newFrame.frameInfo.fileId);
             this.fileBrowserStore.hideFileBrowser();
         }, err => {
@@ -890,7 +892,7 @@ export class AppStore {
     };
 
     @action setSpatialReference = (frame: FrameStore) => {
-        this.referenceFrame = frame;
+        this.spatialReference = frame;
 
         for (const f of this.frames) {
             // The reference image can't reference itself
@@ -899,6 +901,18 @@ export class AppStore {
             } else if (f.spatialReference) {
                 f.setSpatialReference(frame);
             }
+        }
+    };
+
+    @action toggleSpatialMatching = (frame: FrameStore) => {
+        if (!frame) {
+            return;
+        }
+
+        if (frame.spatialReference) {
+            frame.clearSpatialReference();
+        } else {
+            frame.setSpatialReference(this.spatialReference);
         }
     };
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -853,11 +853,10 @@ export class FrameStore {
         AST.delete(copySrc);
         AST.delete(copyDest);
         if (!this.spatialTransformAST) {
-            console.log("Error creating spatial transform between ");
+            console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
         }
 
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
-        console.log(toJS(this.spatialTransform));
         // Translation is applied after scaling / rotation matrix, so it needs to be adjusted by the inverse matrix
         let adjTranslation: Point2D = {
             x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -684,7 +684,7 @@ export class FrameStore {
     @action setZoom(zoom: number, absolute: boolean = false) {
         if (this.spatialReference) {
             // Adjust zoom by scaling factor if zoom level is not absolute
-            const adjustedZoom = absolute ? zoom: zoom/ this.spatialTransform.scale.x;
+            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale.x;
             this.spatialReference.setZoom(adjustedZoom);
         } else {
             this.zoomLevel = zoom;
@@ -716,7 +716,7 @@ export class FrameStore {
     @action zoomToPoint(x: number, y: number, zoom: number, absolute: boolean = false) {
         if (this.spatialReference) {
             // Adjust zoom by scaling factor if zoom level is not absolute
-            const adjustedZoom = absolute ? zoom: zoom/ this.spatialTransform.scale.x;
+            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale.x;
             const pointRefImage = getApproximateCoordinates(this.spatialTransform, {x, y}, true);
             this.spatialReference.zoomToPoint(pointRefImage.x, pointRefImage.y, adjustedZoom);
         } else {
@@ -838,11 +838,11 @@ export class FrameStore {
             x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,
             y: -this.spatialTransform.translation.y / this.spatialTransform.scale.y,
         };
-        adjTranslation = rotate2D(adjTranslation, this.spatialTransform.rotation);
+        adjTranslation = rotate2D(adjTranslation, -this.spatialTransform.rotation);
 
         this.transformedWcsInfo = AST.createTransformedFrameset(this.wcsInfo,
             adjTranslation.x, adjTranslation.y,
-            this.spatialTransform.rotation,
+            -this.spatialTransform.rotation,
             this.spatialTransform.origin.x, this.spatialTransform.origin.y,
             1.0 / this.spatialTransform.scale.x, 1.0 / this.spatialTransform.scale.y);
     };

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -70,9 +70,8 @@ export class FrameStore {
             ];
 
             const {minPoint, maxPoint} = minMax2D(corners);
-
             // Manually get adjusted zoom level
-            const mipAdjustment = this.spatialTransform.scale.x * (this.preference.lowBandwidthMode ? 2.0 : 1.0);
+            const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale.x;
             const mipExact = Math.max(1.0, mipAdjustment / refFrame.zoomLevel);
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
@@ -106,6 +105,7 @@ export class FrameStore {
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
             const mipRoundedPow2 = Math.pow(2, mipLog2Rounded);
+
             return {
                 xMin: this.center.x - imageWidth / 2.0,
                 xMax: this.center.x + imageWidth / 2.0,

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -827,7 +827,7 @@ export class FrameStore {
             y: -this.spatialTransform.translation.y / this.spatialTransform.scale.y,
         };
 
-        adjTranslation = rotate2D(adjTranslation, -this.spatialTransform.rotation);
+        adjTranslation = rotate2D(adjTranslation, this.spatialTransform.rotation);
 
         this.transformedWcsInfo = AST.createTransformedFrameset(this.wcsInfo,
             adjTranslation.x, adjTranslation.y,

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -821,16 +821,18 @@ export class FrameStore {
 
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
         console.log(toJS(this.spatialTransform));
+        // Translation is applied after scaling / rotation matrix, so it needs to be adjusted by the inverse matrix
         let adjTranslation: Point2D = {
-            x: (this.spatialTransform.scale.x - 1) * (this.referencePixel.x) - this.spatialTransform.translation.x,
-            y: (this.spatialTransform.scale.y - 1) * (this.referencePixel.y) - this.spatialTransform.translation.y,
+            x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,
+            y: -this.spatialTransform.translation.y / this.spatialTransform.scale.y,
         };
 
-        adjTranslation = rotate2D(adjTranslation, this.spatialTransform.rotation);
+        adjTranslation = rotate2D(adjTranslation, -this.spatialTransform.rotation);
 
         this.transformedWcsInfo = AST.createTransformedFrameset(this.wcsInfo,
             adjTranslation.x, adjTranslation.y,
             this.spatialTransform.rotation,
+            this.referencePixel.x, this.referencePixel.y,
             1.0 / this.spatialTransform.scale.x, 1.0 / this.spatialTransform.scale.y);
     };
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -872,7 +872,13 @@ export class FrameStore {
     };
 
     @action clearSpatialReference = () => {
-        this.spatialReference = null;
+        // Adjust center and zoom based on existing spatial reference
+        if (this.spatialReference) {
+            this.center = getApproximateCoordinates(this.spatialTransform, this.spatialReference.center, false);
+            this.zoomLevel = this.spatialReference.zoomLevel * this.spatialTransform.scale.x;
+            this.spatialReference = null;
+        }
+
         if (this.spatialTransformAST) {
             AST.delete(this.spatialTransformAST);
         }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -854,6 +854,12 @@ export class FrameStore {
         AST.delete(copyDest);
         if (!this.spatialTransformAST) {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
+        } else {
+            const tStart = performance.now();
+            const grid = AST.getTransformGrid(this.spatialTransformAST, 0.5, this.frameInfo.fileInfoExtended.width + 0.5, 200, 0.5, this.frameInfo.fileInfoExtended.height + 0.5, 200, 1);
+            const tEnd = performance.now();
+            const dt = tEnd - tStart;
+            console.log(`Created transform grid in ${dt} ms`);
         }
 
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -57,10 +57,10 @@ export class FrameStore {
     @observable transformedWcsInfo: number;
 
     @computed get requiredFrameView(): FrameView {
+        // use spatial reference frame to calculate frame view, if it exists
         if (this.spatialReference) {
-            const refFrame = this.spatialReference;
             // Required view of reference frame
-            const refView = refFrame.requiredFrameView;
+            const refView = this.spatialReference.requiredFrameView;
             // Get the position of the ref frame's view in the secondary frame's pixel space
             const corners = [
                 getApproximateCoordinates(this.spatialTransform, {x: refView.xMin, y: refView.yMin}, false),
@@ -70,9 +70,9 @@ export class FrameStore {
             ];
 
             const {minPoint, maxPoint} = minMax2D(corners);
-            // Manually get adjusted zoom level
+            // Manually get adjusted zoom level and round to a power of 2
             const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale.x;
-            const mipExact = Math.max(1.0, mipAdjustment / refFrame.zoomLevel);
+            const mipExact = Math.max(1.0, mipAdjustment / this.spatialReference.zoomLevel);
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -71,7 +71,7 @@ export class FrameStore {
 
             const {minPoint, maxPoint} = minMax2D(corners);
             // Manually get adjusted zoom level and round to a power of 2
-            const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale.x;
+            const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale;
             const mipExact = Math.max(1.0, mipAdjustment / this.spatialReference.zoomLevel);
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
@@ -696,7 +696,7 @@ export class FrameStore {
     @action setZoom(zoom: number, absolute: boolean = false) {
         if (this.spatialReference) {
             // Adjust zoom by scaling factor if zoom level is not absolute
-            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale.x;
+            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale;
             this.spatialReference.setZoom(adjustedZoom);
         } else {
             this.zoomLevel = zoom;
@@ -728,7 +728,7 @@ export class FrameStore {
     @action zoomToPoint(x: number, y: number, zoom: number, absolute: boolean = false) {
         if (this.spatialReference) {
             // Adjust zoom by scaling factor if zoom level is not absolute
-            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale.x;
+            const adjustedZoom = absolute ? zoom : zoom / this.spatialTransform.scale;
             const pointRefImage = getApproximateCoordinates(this.spatialTransform, {x, y}, true);
             this.spatialReference.zoomToPoint(pointRefImage.x, pointRefImage.y, adjustedZoom);
         } else {
@@ -865,8 +865,8 @@ export class FrameStore {
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
         // Translation is applied after scaling / rotation matrix, so it needs to be adjusted by the inverse matrix
         let adjTranslation: Point2D = {
-            x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,
-            y: -this.spatialTransform.translation.y / this.spatialTransform.scale.y,
+            x: -this.spatialTransform.translation.x / this.spatialTransform.scale,
+            y: -this.spatialTransform.translation.y / this.spatialTransform.scale,
         };
         adjTranslation = rotate2D(adjTranslation, -this.spatialTransform.rotation);
 
@@ -874,14 +874,14 @@ export class FrameStore {
             adjTranslation.x, adjTranslation.y,
             -this.spatialTransform.rotation,
             this.spatialTransform.origin.x, this.spatialTransform.origin.y,
-            1.0 / this.spatialTransform.scale.x, 1.0 / this.spatialTransform.scale.y);
+            1.0 / this.spatialTransform.scale, 1.0 / this.spatialTransform.scale);
     };
 
     @action clearSpatialReference = () => {
         // Adjust center and zoom based on existing spatial reference
         if (this.spatialReference) {
             this.center = getApproximateCoordinates(this.spatialTransform, this.spatialReference.center, false);
-            this.zoomLevel = this.spatialReference.zoomLevel * this.spatialTransform.scale.x;
+            this.zoomLevel = this.spatialReference.zoomLevel * this.spatialTransform.scale;
             this.spatialReference = null;
         }
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -759,7 +759,7 @@ export class FrameStore {
             const zoomX = this.spatialReference.renderWidth / rangeX;
             const zoomY = this.spatialReference.renderHeight / rangeY;
             this.spatialReference.setZoom(Math.min(zoomX, zoomY), true);
-            this.spatialReference.setCenter((maxPoint.x + minPoint.x) / 2.0, (maxPoint.y + minPoint.y) / 2.0);
+            this.spatialReference.setCenter((maxPoint.x + minPoint.x) / 2.0 + 0.5, (maxPoint.y + minPoint.y) / 2.0 + 0.5);
         } else {
             this.zoomLevel = this.zoomLevelForFit;
             this.initCenter();
@@ -845,6 +845,7 @@ export class FrameStore {
         }
 
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
+        console.log(toJS(this.spatialTransform));
         // Translation is applied after scaling / rotation matrix, so it needs to be adjusted by the inverse matrix
         let adjTranslation: Point2D = {
             x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -822,8 +822,8 @@ export class FrameStore {
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
         console.log(toJS(this.spatialTransform));
         let adjTranslation: Point2D = {
-            x: (this.spatialTransform.scale.x - 1) * (this.frameInfo.fileInfoExtended.width / 2.0 + 1) - this.spatialTransform.translation.x,
-            y: (this.spatialTransform.scale.y - 1) * (this.frameInfo.fileInfoExtended.height / 2.0 + 1) - this.spatialTransform.translation.y,
+            x: (this.spatialTransform.scale.x - 1) * (this.referencePixel.x) - this.spatialTransform.translation.x,
+            y: (this.spatialTransform.scale.y - 1) * (this.referencePixel.y) - this.spatialTransform.translation.y,
         };
 
         adjTranslation = rotate2D(adjTranslation, this.spatialTransform.rotation);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -820,13 +820,11 @@ export class FrameStore {
         }
 
         this.spatialTransform = getTransform(this.spatialTransformAST, this.referencePixel);
-        console.log(toJS(this.spatialTransform));
         // Translation is applied after scaling / rotation matrix, so it needs to be adjusted by the inverse matrix
         let adjTranslation: Point2D = {
             x: -this.spatialTransform.translation.x / this.spatialTransform.scale.x,
             y: -this.spatialTransform.translation.y / this.spatialTransform.scale.y,
         };
-
         adjTranslation = rotate2D(adjTranslation, this.spatialTransform.rotation);
 
         this.transformedWcsInfo = AST.createTransformedFrameset(this.wcsInfo,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -6,3 +6,4 @@ export * from "./parsing";
 export * from "./tiling";
 export * from "./units";
 export * from "./webgl";
+export * from "./wcs";

--- a/src/utilities/math2d.ts
+++ b/src/utilities/math2d.ts
@@ -64,6 +64,10 @@ export function scaleAboutPoint2D(point: Point2D, origin: Point2D, scale: number
     return add2D(scale2D(subtract2D(point, origin), scale), origin);
 }
 
+export function scaleAndRotateAboutPoint2D(point: Point2D, origin: Point2D, scale: number, theta: number) {
+    return add2D(scale2D(rotate2D(subtract2D(point, origin), theta), scale), origin);
+}
+
 export function minMax2D(points: Point2D[]): { maxPoint: Point2D, minPoint: Point2D } {
     let maxPoint = {x: -Number.MAX_VALUE, y: -Number.MAX_VALUE};
     let minPoint = {x: Number.MAX_VALUE, y: Number.MAX_VALUE};

--- a/src/utilities/math2d.ts
+++ b/src/utilities/math2d.ts
@@ -50,6 +50,12 @@ export function average2D(points: Point2D[]) {
     return scale2D(sum, 1.0 / points.length);
 }
 
+export function rotate2D(point: Point2D, theta: number) {
+    const sinTheta = Math.sin(theta);
+    const cosTheta = Math.cos(theta);
+    return {x: cosTheta * point.x - sinTheta * point.y, y: sinTheta * point.x + cosTheta * point.y};
+}
+
 export function minMax2D(points: Point2D[]): { maxPoint: Point2D, minPoint: Point2D } {
     let maxPoint = {x: -Number.MAX_VALUE, y: -Number.MAX_VALUE};
     let minPoint = {x: Number.MAX_VALUE, y: Number.MAX_VALUE};

--- a/src/utilities/math2d.ts
+++ b/src/utilities/math2d.ts
@@ -56,6 +56,14 @@ export function rotate2D(point: Point2D, theta: number) {
     return {x: cosTheta * point.x - sinTheta * point.y, y: sinTheta * point.x + cosTheta * point.y};
 }
 
+export function rotateAboutPoint2D(point: Point2D, origin: Point2D, theta: number) {
+    return add2D(rotate2D(subtract2D(point, origin), theta), origin);
+}
+
+export function scaleAboutPoint2D(point: Point2D, origin: Point2D, scale: number) {
+    return add2D(scale2D(subtract2D(point, origin), scale), origin);
+}
+
 export function minMax2D(points: Point2D[]): { maxPoint: Point2D, minPoint: Point2D } {
     let maxPoint = {x: -Number.MAX_VALUE, y: -Number.MAX_VALUE};
     let minPoint = {x: Number.MAX_VALUE, y: Number.MAX_VALUE};

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -68,15 +68,3 @@ export function formattedExponential(val: number, digits: number, unit: string =
     }
     return valString;
 }
-
-export function getHeaderNumericValue(headerEntry: CARTA.IHeaderEntry): number {
-    if (!headerEntry) {
-        return NaN;
-    }
-
-    if (headerEntry.entryType === CARTA.EntryType.FLOAT || headerEntry.entryType === CARTA.EntryType.INT) {
-        return headerEntry.numericValue;
-    } else {
-        return parseFloat(headerEntry.value);
-    }
-}

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -80,6 +80,19 @@ export function getTransform(astTransform: number, refPixel: Point2D): Transform
     return {
         translation: subtract2D(transformedRef, refPixel),
         scale: {x: scaling, y: scaling},
+        origin: {x: refPixel.x, y: refPixel.y},
         rotation: theta
     };
+}
+
+export function getApproximateCoordinates(transform: Transform2D, point: Point2D, forward: boolean = true) {
+    if (forward) {
+        // Move point from the original frame to the reference frame, using the supplied transform
+        // TODO: Scale and rotate
+        return add2D(point, transform.translation);
+    } else {
+        // Move point from the reference frame to the original frame, using the supplied transform
+        // TODO: Scale and rotate
+        return subtract2D(point, transform.translation);
+    }
 }

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -1,0 +1,85 @@
+import {CARTA} from "carta-protobuf";
+import * as AST from "ast_wrapper";
+import {CHANNEL_TYPES, Point2D, Transform2D} from "models";
+import {add2D, length2D, subtract2D} from "./math2d";
+
+export function getHeaderNumericValue(headerEntry: CARTA.IHeaderEntry): number {
+    if (!headerEntry) {
+        return NaN;
+    }
+
+    if (headerEntry.entryType === CARTA.EntryType.FLOAT || headerEntry.entryType === CARTA.EntryType.INT) {
+        return headerEntry.numericValue;
+    } else {
+        return parseFloat(headerEntry.value);
+    }
+}
+
+// Tests a list of headers for valid channel information in either 3rd or 4th axis
+export function findChannelType(entries: CARTA.IHeaderEntry[]) {
+    if (!entries || !entries.length) {
+        return undefined;
+    }
+
+    const typeHeader3 = entries.find(entry => entry.name.includes("CTYPE3"));
+    const typeHeader4 = entries.find(entry => entry.name.includes("CTYPE4"));
+    if (!typeHeader3 && !typeHeader4) {
+        return undefined;
+    }
+
+    // Test each header entry to see if it has a valid channel type
+    if (typeHeader3) {
+        const headerVal = typeHeader3.value.trim().toUpperCase();
+        const channelType = CHANNEL_TYPES.find(type => headerVal.indexOf(type.code) !== -1);
+        if (channelType) {
+            return {dimension: 3, type: {name: channelType.name, code: channelType.code, unit: channelType.unit}};
+        }
+    }
+
+    if (typeHeader4) {
+        const headerVal = typeHeader4.value.trim().toUpperCase();
+        const channelType = CHANNEL_TYPES.find(type => headerVal.indexOf(type.code) !== -1);
+        if (channelType) {
+            return {dimension: 4, type: {name: channelType.name, code: channelType.code, unit: channelType.unit}};
+        }
+    }
+
+    return undefined;
+}
+
+export function findRefPixel(entries: CARTA.IHeaderEntry[]) {
+    if (!entries || !entries.length) {
+        return undefined;
+    }
+
+    const pixVal1 = entries.find(entry => entry.name.includes("CRPIX1"));
+    const pixVal2 = entries.find(entry => entry.name.includes("CRPIX2"));
+    if (!pixVal1 && !pixVal2) {
+        return undefined;
+    }
+
+    return {x: getHeaderNumericValue(pixVal1), y: getHeaderNumericValue(pixVal2)};
+}
+
+export function getTransformedCoordinates(astTransform: number, point: Point2D, forward: boolean = true) {
+    const transformed: Point2D = AST.transformPoint(astTransform, point.x, point.y, forward);
+    return transformed;
+}
+
+export function getTransform(astTransform: number, refPixel: Point2D): Transform2D {
+    const transformedRef = getTransformedCoordinates(astTransform, refPixel, true);
+    const delta = 1.0;
+    const refTop = add2D(refPixel, {x: 0, y: delta / 2.0});
+    const refBottom = add2D(refPixel, {x: 0, y: -delta / 2.0});
+    const northVector = subtract2D(refTop, refBottom);
+    const transformedRefTop = getTransformedCoordinates(astTransform, refTop, true);
+    const transformedRefBottom = getTransformedCoordinates(astTransform, refBottom, true);
+    const transformedNorthVector = subtract2D(transformedRefTop, transformedRefBottom);
+    const scaling = length2D(transformedNorthVector) / length2D(northVector);
+    const theta = Math.atan2(northVector.y, northVector.x) - Math.atan2(transformedNorthVector.y, transformedNorthVector.x);
+    return {
+        translation: subtract2D(transformedRef, refPixel),
+        scale: {x: scaling, y: scaling},
+        rotation: theta
+    };
+}

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -79,8 +79,8 @@ export function getTransform(astTransform: number, refPixel: Point2D): Transform
     const theta = Math.atan2(transformedNorthVector.y, transformedNorthVector.x) - Math.atan2(northVector.y, northVector.x);
     return {
         translation: subtract2D(transformedRef, refPixel),
-        scale: {x: scaling, y: scaling},
         origin: {x: refPixel.x, y: refPixel.y},
+        scale: scaling,
         rotation: theta
     };
 }
@@ -88,11 +88,11 @@ export function getTransform(astTransform: number, refPixel: Point2D): Transform
 export function getApproximateCoordinates(transform: Transform2D, point: Point2D, forward: boolean = true) {
     if (forward) {
         // Move point from the original frame to the reference frame, using the supplied transform
-        const scaledPoint = scaleAndRotateAboutPoint2D(point, transform.origin, transform.scale.x, transform.rotation);
+        const scaledPoint = scaleAndRotateAboutPoint2D(point, transform.origin, transform.scale, transform.rotation);
         return add2D(scaledPoint, transform.translation);
     } else {
         // Move point from the reference frame to the original frame, using the supplied transform
         const shiftedPoint = subtract2D(point, transform.translation);
-        return scaleAndRotateAboutPoint2D(shiftedPoint, transform.origin, 1.0 / transform.scale.x, -transform.rotation);
+        return scaleAndRotateAboutPoint2D(shiftedPoint, transform.origin, 1.0 / transform.scale, -transform.rotation);
     }
 }

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -262,4 +262,55 @@ EMSCRIPTEN_KEEPALIVE double axDistance(AstFrameSet* wcsinfo, int axis, double v1
 {
     return astAxDistance(wcsinfo, axis, v1, v2);
 }
+
+EMSCRIPTEN_KEEPALIVE float* fillTransformGrid(AstFrameSet* wcsInfo, double xMin, double xMax, int nx, double yMin, double yMax, int ny, int forward)
+{
+    if (!wcsInfo)
+    {
+        return nullptr;
+    }
+    
+    int N = nx * ny;
+    double deltaX = (xMax - xMin) / nx;
+    double deltaY = (yMax - yMin) / ny;
+    double* pixAx = new double[N];
+    double* pixAy = new double[N];
+    double* pixBx = new double[N];
+    double* pixBy = new double[N];
+    float* out = new float[N * 2];
+
+    // Fill input array
+    for (auto i = 0; i < nx; i++) {
+        for (auto j = 0; j < ny; j++) {
+            pixAx[j * nx + i] = xMin + i * deltaX;
+            pixAy[j * nx + i] = yMin + j * deltaY;
+        }
+    }
+
+    // Debug: pass-through
+    if (forward < 0)
+    {
+        memcpy(pixBx, pixAx, N * sizeof(double));
+        memcpy(pixBy, pixAy, N * sizeof(double));
+    }
+    else
+    {
+        astTran2(wcsInfo, N, pixAx, pixAy, forward, pixBx, pixBy);
+    }
+
+    // Convert to float and fill output array
+    for (auto i = 0; i < N; i++)
+    {
+        out[i * 2] = pixBx[i];
+        out[i * 2 + 1] = pixBy[i];
+    }
+
+    // Clean up temp double precision pixels
+    delete[] pixAx;
+    delete[] pixAy;
+    delete[] pixBx;
+    delete[] pixBy;
+
+    return out;
+}
 }

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -197,6 +197,26 @@ EMSCRIPTEN_KEEPALIVE int transform(AstFrameSet* wcsinfo, int npoint, const doubl
     return 0;
 }
 
+EMSCRIPTEN_KEEPALIVE void deleteObject(AstFrameSet* src)
+{
+    astDelete(src);
+}
+
+EMSCRIPTEN_KEEPALIVE AstFrameSet* copy(AstFrameSet* src)
+{
+    return static_cast<AstFrameSet*> astCopy(src);
+}
+
+EMSCRIPTEN_KEEPALIVE void invert(AstFrameSet* src)
+{
+    astInvert(src);
+}
+
+EMSCRIPTEN_KEEPALIVE AstFrameSet* convert(AstFrameSet* from, AstFrameSet* to, const char* domainlist)
+{
+    return static_cast<AstFrameSet*> astConvert(from, to, domainlist);
+}
+
 EMSCRIPTEN_KEEPALIVE double axDistance(AstFrameSet* wcsinfo, int axis, double v1, double v2)
 {
     return astAxDistance(wcsinfo, axis, v1, v2);

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -92,7 +92,7 @@ EMSCRIPTEN_KEEPALIVE AstFrameSet* createTransformedFrameset(AstFrameSet* wcsinfo
     // 2D scale and rotation matrix
     double sinTheta = sin(angle);
     double cosTheta = cos(angle);
-    double matrixElements[] = {cosTheta * scaleX, -sinTheta, sinTheta, cosTheta * scaleY};
+    double matrixElements[] = {cosTheta * scaleX, -sinTheta * scaleX, sinTheta * scaleY, cosTheta * scaleY};
     AstMatrixMap* matrixMap = astMatrixMap(2, 2, 0, matrixElements, "");
 
     // 2D shifts

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -108,7 +108,6 @@ EMSCRIPTEN_KEEPALIVE AstFrameSet* createTransformedFrameset(AstFrameSet* wcsinfo
     astAddFrame(wcsInfoTransformed, 1, combinedMap2, pixFrameCopy);
     astAddFrame(wcsInfoTransformed, 2, pixToSkyMapping, skyFrame);
     astSetI(wcsInfoTransformed, "Current", 3);
-    astShow(wcsInfoTransformed);
     return wcsInfoTransformed;
 }
 

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -105,6 +105,8 @@ Module.copy = Module.cwrap("copy", null, ["number"]);
 Module.delete = Module.cwrap("deleteObject", null, ["number"]);
 Module.invert = Module.cwrap("invert", "number", ["number"]);
 Module.convert = Module.cwrap("convert", "number", ["number", "number", "string"]);
+Module.shiftMap2D = Module.cwrap("shiftMap2D", "number", ["number", "number"]);
+Module.createTransformedFrameset = Module.cwrap("createTransformedFrameset", "number", ["number", "number", "number", "number", "number", "number"]);
 
 Module.currentFormatStrings = [];
 
@@ -113,8 +115,7 @@ Module.getFormattedCoordinates = function (wcsInfo: number, x: number, y: number
     if (tempFormat) {
         prevString = Module.currentFormatStrings[wcsInfo];
         Module.set(wcsInfo, formatString);
-    }
-    else if (formatString && Module.currentFormatStrings[wcsInfo] !== formatString) {
+    } else if (formatString && Module.currentFormatStrings[wcsInfo] !== formatString) {
         Module.set(wcsInfo, formatString);
         Module.currentFormatStrings[wcsInfo] = formatString;
     }

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -106,7 +106,7 @@ Module.delete = Module.cwrap("deleteObject", null, ["number"]);
 Module.invert = Module.cwrap("invert", "number", ["number"]);
 Module.convert = Module.cwrap("convert", "number", ["number", "number", "string"]);
 Module.shiftMap2D = Module.cwrap("shiftMap2D", "number", ["number", "number"]);
-Module.createTransformedFrameset = Module.cwrap("createTransformedFrameset", "number", ["number", "number", "number", "number", "number", "number"]);
+Module.createTransformedFrameset = Module.cwrap("createTransformedFrameset", "number", ["number", "number", "number", "number", "number", "number", "number", "number"]);
 
 Module.currentFormatStrings = [];
 

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -107,6 +107,7 @@ Module.invert = Module.cwrap("invert", "number", ["number"]);
 Module.convert = Module.cwrap("convert", "number", ["number", "number", "string"]);
 Module.shiftMap2D = Module.cwrap("shiftMap2D", "number", ["number", "number"]);
 Module.createTransformedFrameset = Module.cwrap("createTransformedFrameset", "number", ["number", "number", "number", "number", "number", "number", "number", "number"]);
+Module.fillTransformGrid = Module.cwrap("fillTransformGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number"]);
 
 Module.currentFormatStrings = [];
 
@@ -177,6 +178,17 @@ Module.normalizeCoordinates = function (wcsInfo, xIn, yIn) {
     Module.norm(wcsInfo, Module.xIn);
     const xOut = new Float64Array(Module.HEAPF64.buffer, Module.xIn, 2);
     return {x: xOut[0], y: xOut[1]};
+};
+
+Module.getTransformGrid = function (transformFrameSet: number, xMin: number, xMax: number, nx: number, yMin: number, yMax: number, ny: number, forward: number) {
+    const out = Module.fillTransformGrid(transformFrameSet, xMin, xMax, nx, yMin, yMax, ny, forward);
+    if (out) {
+        const outArray = new Float32Array(Module.HEAPF32.buffer, out, nx * ny * 2).slice();
+        Module._free(out);
+        return outArray;
+    } else {
+        return null;
+    }
 };
 
 Module.onReady = new Promise(function (func) {

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -89,6 +89,9 @@ Module.setCanvas = function (canvas) {
     Module.gridContext.font = Module.font;
 };
 
+Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string"]);
+Module.initFrame = Module.cwrap("initFrame", "number", ["string"]);
+Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);
 Module.set = Module.cwrap("set", "number", ["number", "string"]);
 Module.getString = Module.cwrap("getString", "string", ["number", "string"]);
 Module.dump = Module.cwrap("dump", null, ["number"]);
@@ -98,6 +101,10 @@ Module.format = Module.cwrap("format", "string", ["number", "number", "number"])
 Module.transform = Module.cwrap("transform", "number", ["number", "number", "number", "number", "number", "number", "number"]);
 Module.getLastErrorMessage = Module.cwrap("getLastErrorMessage", "string");
 Module.clearLastErrorMessage = Module.cwrap("clearLastErrorMessage", null);
+Module.copy = Module.cwrap("copy", null, ["number"]);
+Module.celete = Module.cwrap("deleteObject", null, ["number"]);
+Module.invert = Module.cwrap("invert", "number", ["number"]);
+Module.convert = Module.cwrap("convert", "number", ["number", "number", "string"]);
 
 Module.currentFormatStrings = [];
 
@@ -153,12 +160,12 @@ Module.pixToWCSVector = function (wcsInfo, xIn, yIn) {
     return {x: xOut.slice(0), y: yOut.slice(0)};
 };
 
-Module.pixToWCS = function (wcsInfo, xIn, yIn) {
+Module.transformPoint = function (transformFrameSet: number, xIn: number, yIn: number, forward: boolean = true) {
     // Return empty array if arguments are invalid
     const N = 1;
     Module.HEAPF64.set(new Float64Array([xIn]), Module.xIn / 8);
     Module.HEAPF64.set(new Float64Array([yIn]), Module.yIn / 8);
-    Module.transform(wcsInfo, N, Module.xIn, Module.yIn, 1, Module.xOut, Module.yOut);
+    Module.transform(transformFrameSet, N, Module.xIn, Module.yIn, forward, Module.xOut, Module.yOut);
     const xOut = new Float64Array(Module.HEAPF64.buffer, Module.xOut, N);
     const yOut = new Float64Array(Module.HEAPF64.buffer, Module.yOut, N);
     return {x: xOut[0], y: yOut[0]};
@@ -170,11 +177,6 @@ Module.normalizeCoordinates = function (wcsInfo, xIn, yIn) {
     const xOut = new Float64Array(Module.HEAPF64.buffer, Module.xIn, 2);
     return {x: xOut[0], y: xOut[1]};
 };
-
-Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string"]);
-
-Module.initFrame = Module.cwrap("initFrame", "number", ["string"]);
-Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);
 
 Module.onReady = new Promise(function (func) {
     if (Module["calledRun"]) {

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -102,7 +102,7 @@ Module.transform = Module.cwrap("transform", "number", ["number", "number", "num
 Module.getLastErrorMessage = Module.cwrap("getLastErrorMessage", "string");
 Module.clearLastErrorMessage = Module.cwrap("clearLastErrorMessage", null);
 Module.copy = Module.cwrap("copy", null, ["number"]);
-Module.celete = Module.cwrap("deleteObject", null, ["number"]);
+Module.delete = Module.cwrap("deleteObject", null, ["number"]);
 Module.invert = Module.cwrap("invert", "number", ["number"]);
 Module.convert = Module.cwrap("convert", "number", ["number", "number", "string"]);
 

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset"]'
+    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert"]'
+    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance"]'
+    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then


### PR DESCRIPTION
Initial work on spatial reference matching. For now, there is a button on the image viewer toolbar that allows you to match the zoom, FoV and orientation of an image to the reference image. Current limitations:

- You currently can't change which image is the reference image. The first image loaded is the reference image. If you want to change to a new reference image, you have to open the image first (File->Open) and then append secondary images
- Regions are not displayed correctly when spatial matching is active. This will be fixed in a separate PR
- Some images can't be matched properly, and seem to generate an AST error. So far, I've found that it mostly happens with images that have no overlap, and are in completely different parts of the sky, _or_ images that have vastly different pixel sizes. 