### PR TITLE
fix missing tool buttons in image viewer

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -242,7 +242,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         }
 
         return (
-            <div className="image-view-div" onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+            <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <RasterViewComponent
                     frame={appStore.activeFrame}
                     docked={this.props.docked}


### PR DESCRIPTION
closes #700 

This PR simply changes the mouse handler from `onMouseEnter` to `onMouseOver` for the image viewer. 

@kswang1029 please test on mix 'n match and confirm it fixes #700 