### PR TITLE
Angus/contour control map

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -306,7 +306,7 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                 <FormGroup inline={true} label="Beam Visible">
                     <Switch
                         checked={preference.beamVisible}
-                        onChange={(ev) =>  preference.setBeamVisible(ev.currentTarget.checked)}
+                        onChange={(ev) => preference.setBeamVisible(ev.currentTarget.checked)}
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Beam Color">
@@ -327,14 +327,14 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                 </FormGroup>
                 <FormGroup inline={true} label="Beam Width" labelInfo="(px)">
                     <NumericInput
-                            placeholder="Beam Width"
-                            min={0.5}
-                            max={10}
-                            value={preference.beamWidth}
-                            stepSize={0.5}
-                            minorStepSize={0.1}
-                            majorStepSize={1}
-                            onValueChange={(value: number) => preference.setBeamWidth(value)}
+                        placeholder="Beam Width"
+                        min={0.5}
+                        max={10}
+                        value={preference.beamWidth}
+                        stepSize={0.5}
+                        minorStepSize={0.1}
+                        majorStepSize={1}
+                        onValueChange={(value: number) => preference.setBeamWidth(value)}
                     />
                 </FormGroup>
             </React.Fragment>
@@ -470,6 +470,14 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                         <option key={3} value={250000}>250K</option>
                         <option key={4} value={500000}>500K</option>
                         <option key={5} value={1000000}>1M</option>
+                    </HTMLSelect>
+                </FormGroup>
+                <FormGroup inline={true} label="Contour Control Map Resolution">
+                    <HTMLSelect value={preference.contourControlMapWidth} onChange={(ev) => preference.setContourControlMapWidth(parseInt(ev.currentTarget.value))}>
+                        <option key={0} value={128}>128&times;128 (128 KB)</option>
+                        <option key={1} value={256}>256&times;256 (512 KB)</option>
+                        <option key={2} value={512}>512&times;512 (2 MB)</option>
+                        <option key={3} value={1024}>1024&times;1024 (8 MB)</option>
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Stream image tiles while zooming">

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -101,7 +101,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / zoomLevel);
 
             if (frame.spatialReference) {
-                let rotationOrigin = frame.referencePixel;
+                let rotationOrigin = frame.spatialTransform.origin;
                 this.gl.uniform2f(this.shaderUniforms.FrameMin, frame.spatialReference.requiredFrameView.xMin, frame.spatialReference.requiredFrameView.yMin);
                 this.gl.uniform2f(this.shaderUniforms.FrameMax, frame.spatialReference.requiredFrameView.xMax, frame.spatialReference.requiredFrameView.yMax);
                 this.gl.uniform2f(this.shaderUniforms.RotationOrigin, rotationOrigin.x, rotationOrigin.y);

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -105,10 +105,14 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         const frame = this.props.appStore.activeFrame;
         if (frame && this.canvas && this.gl && this.shaderUniforms) {
             this.resizeAndClearCanvas();
-            this.renderFrameContours(frame, true);
+            if (frame.contourConfig.visible && frame.contourConfig.enabled) {
+                this.renderFrameContours(frame, true);
+            }
             if (frame.secondaryImages) {
                 for (const secondaryFrame of frame.secondaryImages) {
-                    this.renderFrameContours(secondaryFrame, false);
+                    if (secondaryFrame.contourConfig.visible && secondaryFrame.contourConfig.enabled) {
+                        this.renderFrameContours(secondaryFrame, false);
+                    }
                 }
             }
         }
@@ -271,6 +275,12 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             const dashMode = config.dashMode;
             const bias = config.colormapBias;
             const contrast = config.colormapContrast;
+
+            if (frame.secondaryImages) {
+                const visibleSecondaries = frame.secondaryImages.map(f => f.contourConfig.enabled && f.contourConfig.visible);
+            }
+
+            const visible = frame.contourConfig.enabled && frame.contourConfig.visible;
 
             contourData.forEach(contourStore => {
                 const numVertices = contourStore.vertexCount;

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -34,8 +34,7 @@ interface ShaderUniforms {
     Contrast: WebGLUniformLocation;
     ControlMapEnabled: WebGLUniformLocation;
     ControlMapSize: WebGLUniformLocation;
-    ControlMapTextureX: WebGLUniformLocation;
-    ControlMapTextureY: WebGLUniformLocation;
+    ControlMapTexture: WebGLUniformLocation;
     ControlMapMin: WebGLUniformLocation;
     ControlMapMax: WebGLUniformLocation;
 }
@@ -131,8 +130,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
 
         if (isActive) {
             this.gl.uniform1i(this.shaderUniforms.ControlMapEnabled, 0);
-            this.gl.uniform1i(this.shaderUniforms.ControlMapTextureX, 0);
-            this.gl.uniform1i(this.shaderUniforms.ControlMapTextureY, 0);
+            this.gl.uniform1i(this.shaderUniforms.ControlMapTexture, 0);
             this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / zoomLevel);
 
             if (frame.spatialReference) {
@@ -158,10 +156,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform2f(this.shaderUniforms.ControlMapSize, controlMap.width, controlMap.height);
             this.gl.activeTexture(GL.TEXTURE1);
             this.gl.bindTexture(GL.TEXTURE_2D, controlMap.getTextureX(this.gl));
-            this.gl.uniform1i(this.shaderUniforms.ControlMapTextureX, 1);
-            this.gl.activeTexture(GL.TEXTURE2);
-            this.gl.bindTexture(GL.TEXTURE_2D, controlMap.getTextureY(this.gl));
-            this.gl.uniform1i(this.shaderUniforms.ControlMapTextureY, 2);
+            this.gl.uniform1i(this.shaderUniforms.ControlMapTexture, 1);
 
             this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / frame.spatialReference.zoomLevel);
             this.gl.uniform2f(this.shaderUniforms.FrameMin, frame.spatialReference.requiredFrameView.xMin, frame.spatialReference.requiredFrameView.yMin);
@@ -255,8 +250,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             ControlMapSize: this.gl.getUniformLocation(shaderProgram, "uControlMapSize"),
             ControlMapMin: this.gl.getUniformLocation(shaderProgram, "uControlMapMin"),
             ControlMapMax: this.gl.getUniformLocation(shaderProgram, "uControlMapMax"),
-            ControlMapTextureX: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureX"),
-            ControlMapTextureY: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureY"),
+            ControlMapTexture: this.gl.getUniformLocation(shaderProgram, "uControlMapTexture"),
         };
 
         this.gl.uniform1i(this.shaderUniforms.NumCmaps, 79);

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -4,6 +4,7 @@ import {AppStore, ContourDashMode, FrameStore, OverlayStore, RenderConfigStore} 
 import {getShaderFromString, GL, loadImageTexture} from "utilities";
 import "./ContourViewComponent.css";
 import allMaps from "static/allmaps.png";
+import {observable} from "mobx";
 
 const vertexShaderLine = require("!raw-loader!./GLSL/vert_line.glsl");
 const pixelShaderDashed = require("!raw-loader!./GLSL/pixel_dashed.glsl");
@@ -250,7 +251,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             ControlMapMin: this.gl.getUniformLocation(shaderProgram, "uControlMapMin"),
             ControlMapMax: this.gl.getUniformLocation(shaderProgram, "uControlMapMax"),
             ControlMapTextureX: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureX"),
-            ControlMapTextureY: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureY")
+            ControlMapTextureY: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureY"),
         };
 
         this.gl.uniform1i(this.shaderUniforms.NumCmaps, 79);

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -32,6 +32,7 @@ interface ShaderUniforms {
     Bias: WebGLUniformLocation;
     Contrast: WebGLUniformLocation;
     ControlMapEnabled: WebGLUniformLocation;
+    ControlMapSize: WebGLUniformLocation;
     ControlMapTextureX: WebGLUniformLocation;
     ControlMapTextureY: WebGLUniformLocation;
     ControlMapMin: WebGLUniformLocation;
@@ -149,6 +150,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform1i(this.shaderUniforms.ControlMapEnabled, 1);
             this.gl.uniform2f(this.shaderUniforms.ControlMapMin, controlMap.minPoint.x, controlMap.minPoint.y);
             this.gl.uniform2f(this.shaderUniforms.ControlMapMax, controlMap.maxPoint.x, controlMap.maxPoint.y);
+            this.gl.uniform2f(this.shaderUniforms.ControlMapSize, controlMap.width, controlMap.height);
             this.gl.activeTexture(GL.TEXTURE1);
             this.gl.bindTexture(GL.TEXTURE_2D, controlMap.getTextureX(this.gl));
             this.gl.uniform1i(this.shaderUniforms.ControlMapTextureX, 1);
@@ -244,6 +246,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             Contrast: this.gl.getUniformLocation(shaderProgram, "uContrast"),
             Bias: this.gl.getUniformLocation(shaderProgram, "uBias"),
             ControlMapEnabled: this.gl.getUniformLocation(shaderProgram, "uControlMapEnabled"),
+            ControlMapSize: this.gl.getUniformLocation(shaderProgram, "uControlMapSize"),
             ControlMapMin: this.gl.getUniformLocation(shaderProgram, "uControlMapMin"),
             ControlMapMax: this.gl.getUniformLocation(shaderProgram, "uControlMapMax"),
             ControlMapTextureX: this.gl.getUniformLocation(shaderProgram, "uControlMapTextureX"),

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -118,7 +118,6 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         const zoomLevel = frame.spatialReference ? frame.spatialReference.zoomLevel * frame.spatialTransform.scale : frame.zoomLevel;
 
         // update uniforms
-        this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / zoomLevel);
         this.gl.uniform1i(this.shaderUniforms.CmapEnabled, frame.contourConfig.colormapEnabled ? 1 : 0);
         if (frame.contourConfig.colormapEnabled) {
             this.gl.uniform1i(this.shaderUniforms.CmapIndex, RenderConfigStore.COLOR_MAPS_ALL.indexOf(frame.contourConfig.colormap));
@@ -130,6 +129,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform1i(this.shaderUniforms.ControlMapEnabled, 0);
             this.gl.uniform1i(this.shaderUniforms.ControlMapTextureX, 0);
             this.gl.uniform1i(this.shaderUniforms.ControlMapTextureY, 0);
+            this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / zoomLevel);
 
             if (frame.spatialReference) {
                 let rotationOrigin = frame.spatialTransform.origin;
@@ -159,6 +159,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.bindTexture(GL.TEXTURE_2D, controlMap.getTextureY(this.gl));
             this.gl.uniform1i(this.shaderUniforms.ControlMapTextureY, 2);
 
+            this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / frame.spatialReference.zoomLevel);
             this.gl.uniform2f(this.shaderUniforms.FrameMin, frame.spatialReference.requiredFrameView.xMin, frame.spatialReference.requiredFrameView.yMin);
             this.gl.uniform2f(this.shaderUniforms.FrameMax, frame.spatialReference.requiredFrameView.xMax, frame.spatialReference.requiredFrameView.yMax);
             this.gl.uniform1f(this.shaderUniforms.RotationAngle, 0.0);

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -16,6 +16,7 @@ uniform float uLineThickness;
 uniform int uControlMapEnabled;
 uniform vec2 uControlMapMin;
 uniform vec2 uControlMapMax;
+uniform vec2 uControlMapSize;
 uniform sampler2D uControlMapTextureX;
 uniform sampler2D uControlMapTextureY;
 
@@ -39,12 +40,14 @@ vec2 scaleAboutPoint2D(vec2 vector, vec2 origin, float scale) {
 void main(void) {
     // Extrude point along normal
     vec2 posImageSpace = (aVertexPosition.xy + (aVertexNormal / 16384.0) * uLineThickness * 0.5);
+    // Shift by half a pixel to account for position of pixel center
+    posImageSpace += 0.5;
 
     // If there's a control map, use it to look up location using bilinear filtering
     if (uControlMapEnabled > 0) {
         vec2 range = uControlMapMax - uControlMapMin;
         vec2 shiftedPoint = posImageSpace - uControlMapMin;
-        vec2 index = shiftedPoint / range;
+        vec2 index = (shiftedPoint) / range + 0.5 / uControlMapSize;
         posImageSpace = vec2(texture2D(uControlMapTextureX, index).r, texture2D(uControlMapTextureY, index).r);
     }
 

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -12,6 +12,13 @@ uniform float uScaleAdjustment;
 uniform vec2 uOffset;
 uniform float uLineThickness;
 
+// Control-map based transformation
+uniform int uControlMapEnabled;
+uniform vec2 uControlMapMin;
+uniform vec2 uControlMapMax;
+uniform sampler2D uControlMapTextureX;
+uniform sampler2D uControlMapTextureY;
+
 varying float vLinePosition;
 varying float vLineSide;
 
@@ -32,6 +39,15 @@ vec2 scaleAboutPoint2D(vec2 vector, vec2 origin, float scale) {
 void main(void) {
     // Extrude point along normal
     vec2 posImageSpace = (aVertexPosition.xy + (aVertexNormal / 16384.0) * uLineThickness * 0.5);
+
+    // If there's a control map, use it to look up location using bilinear filtering
+    if (uControlMapEnabled > 0) {
+        vec2 range = uControlMapMax - uControlMapMin;
+        vec2 shiftedPoint = posImageSpace - uControlMapMin;
+        vec2 index = shiftedPoint / range;
+        posImageSpace = vec2(texture2D(uControlMapTextureX, index).r, texture2D(uControlMapTextureY, index).r);
+    }
+
     // Scale and rotate
     vec2 posRefSpace = scaleAboutPoint2D(rotateAboutPoint2D(posImageSpace, uRotationOrigin, uRotationAngle), uRotationOrigin, uScaleAdjustment) + uOffset;
 

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -36,6 +36,12 @@ vec2 rotateAboutPoint2D(vec2 vector, vec2 origin, float theta) {
 vec2 scaleAboutPoint2D(vec2 vector, vec2 origin, float scale) {
     return (vector - origin) * scale + origin;
 }
+
+// Based on NVIDIA GPU Gems 2 Chapter "Fast Third-Order Texture Filtering"
+// Adapted from GLSL code available at https://stackoverflow.com/questions/13501081/efficient-bicubic-filtering-code-in-glsl/13502446#13502446
+// The basic idea is to utilise the GPU's fixed-function bilinear filtering to perform four samples at once,
+// rather than sampling the texture 16 times. This should help GPU performance on lower-end hardware
+
 vec4 cubic(float x) {
     float x2 = x * x;
     float x3 = x2 * x;
@@ -46,6 +52,7 @@ vec4 cubic(float x) {
     w.w =  x3;
     return w / 6.0;
 }
+
 
 vec4 bicubicFilter(sampler2D texture, vec2 texcoord, vec2 texscale) {
     float fx = fract(texcoord.x);

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -17,8 +17,7 @@ uniform int uControlMapEnabled;
 uniform vec2 uControlMapMin;
 uniform vec2 uControlMapMax;
 uniform vec2 uControlMapSize;
-uniform sampler2D uControlMapTextureX;
-uniform sampler2D uControlMapTextureY;
+uniform sampler2D uControlMapTexture;
 
 varying float vLinePosition;
 varying float vLineSide;
@@ -46,13 +45,12 @@ vec4 cubic(float x) {
     float x2 = x * x;
     float x3 = x2 * x;
     vec4 w;
-    w.x =   -x3 + 3.0*x2 - 3.0*x + 1.0;
-    w.y =  3.0*x3 - 6.0*x2       + 4.0;
-    w.z = -3.0*x3 + 3.0*x2 + 3.0*x + 1.0;
-    w.w =  x3;
+    w.x = -x3 + 3.0 * x2 - 3.0 * x + 1.0;
+    w.y = 3.0 * x3 - 6.0 * x2 + 4.0;
+    w.z = -3.0 * x3 + 3.0 * x2 + 3.0 * x + 1.0;
+    w.w = x3;
     return w / 6.0;
 }
-
 
 vec4 bicubicFilter(sampler2D texture, vec2 texcoord, vec2 texscale) {
     float fx = fract(texcoord.x);
@@ -63,38 +61,29 @@ vec4 bicubicFilter(sampler2D texture, vec2 texcoord, vec2 texscale) {
     vec4 xcubic = cubic(fx);
     vec4 ycubic = cubic(fy);
 
-    vec4 c = vec4(texcoord.x - 0.5, texcoord.x + 1.5, texcoord.y -
-    0.5, texcoord.y + 1.5);
-    vec4 s = vec4(xcubic.x + xcubic.y, xcubic.z + xcubic.w, ycubic.x +
-    ycubic.y, ycubic.z + ycubic.w);
-    vec4 offset = c + vec4(xcubic.y, xcubic.w, ycubic.y, ycubic.w) /
-    s;
+    vec4 c = vec4(texcoord.x - 0.5, texcoord.x + 1.5, texcoord.y - 0.5, texcoord.y + 1.5);
+    vec4 s = vec4(xcubic.x + xcubic.y, xcubic.z + xcubic.w, ycubic.x + ycubic.y, ycubic.z + ycubic.w);
+    vec4 offset = c + vec4(xcubic.y, xcubic.w, ycubic.y, ycubic.w) / s;
 
-    vec4 sample0 = texture2D(texture, vec2(offset.x, offset.z) *
-    texscale);
-    vec4 sample1 = texture2D(texture, vec2(offset.y, offset.z) *
-    texscale);
-    vec4 sample2 = texture2D(texture, vec2(offset.x, offset.w) *
-    texscale);
-    vec4 sample3 = texture2D(texture, vec2(offset.y, offset.w) *
-    texscale);
+    vec4 sample0 = texture2D(texture, vec2(offset.x, offset.z) * texscale);
+    vec4 sample1 = texture2D(texture, vec2(offset.y, offset.z) * texscale);
+    vec4 sample2 = texture2D(texture, vec2(offset.x, offset.w) * texscale);
+    vec4 sample3 = texture2D(texture, vec2(offset.y, offset.w) * texscale);
 
     float sx = s.x / (s.x + s.y);
     float sy = s.z / (s.z + s.w);
 
-    return mix(
-    mix(sample3, sample2, sx),
-    mix(sample1, sample0, sx), sy);
+    return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
 }
 
-// end adaapted from NVIDIA GPU Gems
+// end adapted from NVIDIA GPU Gems 2
 
 vec2 controlMapLookup(vec2 pos) {
     vec2 texScale = 1.0 / uControlMapSize;
     vec2 range = uControlMapMax - uControlMapMin;
     vec2 shiftedPoint = pos - uControlMapMin;
     vec2 index = uControlMapSize * (shiftedPoint) / range;
-    return vec2(bicubicFilter(uControlMapTextureX, index, texScale).r, bicubicFilter(uControlMapTextureY, index, texScale).r);
+    return bicubicFilter(uControlMapTexture, index, texScale).ra;
 }
 
 void main(void) {
@@ -128,5 +117,5 @@ void main(void) {
 
     vLineSide = sign(aVertexPosition.z);
     vLinePosition = abs(aVertexPosition.z);
-    gl_Position =  vec4(adjustedPosition.x, adjustedPosition.y, 0.0, 1.0);
+    gl_Position = vec4(adjustedPosition.x, adjustedPosition.y, 0.0, 1.0);
 }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -207,6 +207,10 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.enable(WebGLRenderingContext.DEPTH_TEST);
             this.gl.clear(WebGLRenderingContext.COLOR_BUFFER_BIT | WebGLRenderingContext.DEPTH_BUFFER_BIT);
 
+            // Skip rendering if frame is hidden
+            if (!frame.renderConfig.visible) {
+                return;
+            }
             if (frame.renderType === RasterRenderType.TILED) {
                 this.renderTiledCanvas();
             } else {
@@ -512,6 +516,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 gamma: frame.renderConfig.gamma,
                 alpha: frame.renderConfig.alpha,
                 inverted: frame.renderConfig.inverted,
+                visibility: frame.renderConfig.visible,
                 nanColorHex: preference.nanColorHex,
                 nanAlpha: preference.nanAlpha
             };

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -159,7 +159,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
-                    <Button icon="link" active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
+                    <AnchorButton icon="link" disabled={appStore.spatialReference === frame} active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/LayerList/LayerListComponent.scss
+++ b/src/components/LayerList/LayerListComponent.scss
@@ -5,4 +5,8 @@
     height: 100%;
     user-select: none;
     padding: 5px;
+
+    .active-row-cell {
+        font-weight: bold;
+    }
 }

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -102,6 +102,11 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             fontWeight: "bold"
         };
 
+        // This is a necessary hack in order to trigger a re-rendering when values change, because the cell renderer is in its own function
+        // There is probably a neater way to do this, though
+        const dummyVisibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
+        const dummyVisibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
+
         return (
             <div className="layer-list-widget">
                 <Table

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -1,18 +1,18 @@
 import * as React from "react";
 import {CSSProperties} from "react";
-import { observable } from "mobx";
-import { observer } from "mobx-react";
-import { NonIdealState } from "@blueprintjs/core";
-import { Cell, Column, ColumnHeaderCell, RowHeaderCell, SelectionModes, Table } from "@blueprintjs/table";
+import {observable} from "mobx";
+import {observer} from "mobx-react";
+import {Button, NonIdealState} from "@blueprintjs/core";
+import {Cell, Column, ColumnHeaderCell, RowHeaderCell, SelectionModes, Table} from "@blueprintjs/table";
 import ReactResizeDetector from "react-resize-detector";
-import { WidgetConfig, WidgetProps } from "stores";
+import {WidgetConfig, WidgetProps} from "stores";
 import "./LayerListComponent.css";
 
 @observer
 export class LayerListComponent extends React.Component<WidgetProps> {
     @observable width: number = 0;
     @observable height: number = 0;
-    private columnWidths = [150, 60, 80, 70];
+    private columnWidths = [150, 80, 80, 70];
 
     public static get WIDGET_CONFIG(): WidgetConfig {
         return {
@@ -72,13 +72,29 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             return <RowHeaderCell name={rowIndex.toString()} style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}/>;
         };
         const fileNameRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameNames[rowIndex].label  : ""}</Cell>;
+            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameNames[rowIndex].label : ""}</Cell>;
         };
         const channelRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameChannels[rowIndex]  : ""}</Cell>;
+            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameChannels[rowIndex] : ""}</Cell>;
         };
         const stokesRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameStokes[rowIndex]  : ""}</Cell>;
+            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameStokes[rowIndex] : ""}</Cell>;
+        };
+        const typeRenderer = (rowIndex: number) => {
+            if (rowIndex < 0 || rowIndex >= frameNum) {
+                return null;
+            }
+
+            const frame = appStore.frames[rowIndex];
+
+            return (
+                <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>
+                    <Button minimal={true} small={true} intent={frame.renderConfig.visible ? "success" : "none"} onClick={frame.renderConfig.toggleVisibility}>R</Button>
+                    {frame.contourConfig.enabled &&
+                    <Button minimal={true} small={true} intent={frame.contourConfig.visible ? "success" : "none"} onClick={frame.contourConfig.toggleVisibility}>C</Button>
+                    }
+                </Cell>
+            );
         };
 
         const columnHeaderStyleProps: CSSProperties = {
@@ -107,6 +123,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     />
                     <Column
                         columnHeaderCellRenderer={(columnIndex: number) => <ColumnHeaderCell name="Type" style={columnHeaderStyleProps}/>}
+                        cellRenderer={typeRenderer}
                     />
                     <Column
                         columnHeaderCellRenderer={(columnIndex: number) => <ColumnHeaderCell name="Channel" style={columnHeaderStyleProps}/>}

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {CSSProperties} from "react";
 import {observable} from "mobx";
 import {observer} from "mobx-react";
-import {Button, NonIdealState} from "@blueprintjs/core";
+import {AnchorButton, NonIdealState, Tooltip} from "@blueprintjs/core";
 import {Cell, Column, ColumnHeaderCell, RowHeaderCell, SelectionModes, Table} from "@blueprintjs/table";
 import ReactResizeDetector from "react-resize-detector";
 import {WidgetConfig, WidgetProps} from "stores";
@@ -69,16 +69,16 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         };
 
         const rowHeaderCellRenderer = (rowIndex: number) => {
-            return <RowHeaderCell name={rowIndex.toString()} style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}/>;
+            return <RowHeaderCell name={rowIndex.toString()} className={rowIndex === activeFrameIndex ? "active-row-cell" : ""}/>;
         };
         const fileNameRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameNames[rowIndex].label : ""}</Cell>;
+            return <Cell className={rowIndex === activeFrameIndex ? "active-row-cell" : ""}>{rowIndex >= 0 && rowIndex < frameNum ? frameNames[rowIndex].label : ""}</Cell>;
         };
         const channelRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameChannels[rowIndex] : ""}</Cell>;
+            return <Cell className={rowIndex === activeFrameIndex ? "active-row-cell" : ""}>{rowIndex >= 0 && rowIndex < frameNum ? frameChannels[rowIndex] : ""}</Cell>;
         };
         const stokesRenderer = (rowIndex: number) => {
-            return <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>{rowIndex >= 0 && rowIndex < frameNum ? frameStokes[rowIndex] : ""}</Cell>;
+            return <Cell className={rowIndex === activeFrameIndex ? "active-row-cell" : ""}>{rowIndex >= 0 && rowIndex < frameNum ? frameStokes[rowIndex] : ""}</Cell>;
         };
         const typeRenderer = (rowIndex: number) => {
             if (rowIndex < 0 || rowIndex >= frameNum) {
@@ -88,11 +88,17 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             const frame = appStore.frames[rowIndex];
 
             return (
-                <Cell style={rowIndex === activeFrameIndex ? activeFrameStyleProps : null}>
-                    <Button minimal={true} small={true} intent={frame.renderConfig.visible ? "success" : "none"} onClick={frame.renderConfig.toggleVisibility}>R</Button>
-                    {frame.contourConfig.enabled &&
-                    <Button minimal={true} small={true} intent={frame.contourConfig.visible ? "success" : "none"} onClick={frame.contourConfig.toggleVisibility}>C</Button>
-                    }
+                <Cell className={rowIndex === activeFrameIndex ? "active-row-cell" : ""}>
+                    <React.Fragment>
+                        <Tooltip content={<span>Raster image<br/><i><small>Click to {frame.renderConfig.visible ? "hide" : "show"}</small></i></span>}>
+                            <AnchorButton minimal={true} small={true} intent={frame.renderConfig.visible ? "success" : "none"} onClick={frame.renderConfig.toggleVisibility}>R</AnchorButton>
+                        </Tooltip>
+                        {frame.contourConfig.enabled &&
+                        <Tooltip content={<span>Contour image<br/><i><small>Click to {frame.contourConfig.visible ? "hide" : "show"}</small></i></span>}>
+                            <AnchorButton minimal={true} small={true} intent={frame.contourConfig.visible ? "success" : "none"} onClick={frame.contourConfig.toggleVisibility}>C</AnchorButton>
+                        </Tooltip>
+                        }
+                    </React.Fragment>
                 </Cell>
             );
         };

--- a/src/models/ControlMap.ts
+++ b/src/models/ControlMap.ts
@@ -1,17 +1,21 @@
 import * as AST from "ast_wrapper";
 import {FrameStore} from "stores";
 import {Point2D} from "./Point2D";
-import {subtract2D} from "utilities";
+import {GL, subtract2D} from "utilities";
 
 export class ControlMap {
     readonly source: FrameStore;
     readonly destination: FrameStore;
-    texture: WebGLTexture;
     readonly width: number;
     readonly height: number;
     readonly minPoint: Point2D;
     readonly maxPoint: Point2D;
-    readonly grid: Float32Array;
+    private readonly grid: Float32Array;
+    private readonly gridX: Float32Array;
+    private readonly gridY: Float32Array;
+    private textureX: WebGLTexture;
+    private textureY: WebGLTexture;
+    private gl: WebGLRenderingContext;
 
     constructor(src: FrameStore, dst: FrameStore, astTransform: number, width: number, height: number) {
         this.source = src;
@@ -24,7 +28,42 @@ export class ControlMap {
         this.minPoint = {x: -paddingX, y: -paddingY};
         this.maxPoint = {x: paddingX + src.frameInfo.fileInfoExtended.width, y: paddingY + src.frameInfo.fileInfoExtended.height};
         this.grid = AST.getTransformGrid(astTransform, this.minPoint.x, this.maxPoint.x, width, this.minPoint.y, this.maxPoint.y, height, 1);
+        this.gridX = new Float32Array(this.grid.buffer, 0, this.width * this.height);
+        this.gridY = new Float32Array(this.grid.buffer, this.width * this.height * 4, this.width * this.height);
     }
+
+    getTextureX = (gl: WebGLRenderingContext) => {
+        if (gl !== this.gl || !this.textureX) {
+            // Context has changed, texture needs to be regenerated
+            this.gl = gl;
+            this.textureX = this.gl.createTexture();
+            this.gl.activeTexture(GL.TEXTURE1);
+            this.gl.bindTexture(GL.TEXTURE_2D, this.textureX);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+            this.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, this.width, this.height, 0, GL.LUMINANCE, GL.FLOAT, this.gridX);
+        }
+
+        return this.textureX;
+    };
+
+    getTextureY = (gl: WebGLRenderingContext) => {
+        if (gl !== this.gl || !this.textureY) {
+            // Context has changed, texture needs to be regenerated
+            this.gl = gl;
+            this.textureY = this.gl.createTexture();
+            this.gl.activeTexture(GL.TEXTURE2);
+            this.gl.bindTexture(GL.TEXTURE_2D, this.textureY);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+            this.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, this.width, this.height, 0, GL.LUMINANCE, GL.FLOAT, this.gridY);
+        }
+        return this.textureY;
+    };
 
     getTransformedCoordinate(point: Point2D) {
         const range = subtract2D(this.maxPoint, this.minPoint);
@@ -42,10 +81,10 @@ export class ControlMap {
         const index01 = (indexFloor.y + 1) * this.width + indexFloor.x;
         const index10 = indexFloor.y * this.width + indexFloor.x + 1;
         const index11 = (indexFloor.y + 1) * this.width + indexFloor.x + 1;
-        const f00 = {x: this.grid[2 * index00], y: this.grid[2 * index00 + 1]};
-        const f01 = {x: this.grid[2 * index01], y: this.grid[2 * index01 + 1]};
-        const f10 = {x: this.grid[2 * index10], y: this.grid[2 * index10 + 1]};
-        const f11 = {x: this.grid[2 * index11], y: this.grid[2 * index11 + 1]};
+        const f00 = {x: this.gridX[index00], y: this.gridY[index00]};
+        const f01 = {x: this.gridX[index01], y: this.gridY[index01]};
+        const f10 = {x: this.gridX[index10], y: this.gridY[index10]};
+        const f11 = {x: this.gridX[index11], y: this.gridY[index11]};
 
         return {
             x: f00.x * (1 - step.x) * (1 - step.y) + f10.x * step.x * (1 - step.y) + f01.x * (1 - step.x) * step.y + f11.x * step.x * step.y,

--- a/src/models/ControlMap.ts
+++ b/src/models/ControlMap.ts
@@ -11,10 +11,7 @@ export class ControlMap {
     readonly minPoint: Point2D;
     readonly maxPoint: Point2D;
     private readonly grid: Float32Array;
-    private readonly gridX: Float32Array;
-    private readonly gridY: Float32Array;
-    private textureX: WebGLTexture;
-    private textureY: WebGLTexture;
+    private texture: WebGLTexture;
     private gl: WebGLRenderingContext;
 
     constructor(src: FrameStore, dst: FrameStore, astTransform: number, width: number, height: number) {
@@ -28,41 +25,23 @@ export class ControlMap {
         this.minPoint = {x: -paddingX, y: -paddingY};
         this.maxPoint = {x: paddingX + src.frameInfo.fileInfoExtended.width, y: paddingY + src.frameInfo.fileInfoExtended.height};
         this.grid = AST.getTransformGrid(astTransform, this.minPoint.x, this.maxPoint.x, width, this.minPoint.y, this.maxPoint.y, height, 1);
-        this.gridX = new Float32Array(this.grid.buffer, 0, this.width * this.height);
-        this.gridY = new Float32Array(this.grid.buffer, this.width * this.height * 4, this.width * this.height);
     }
 
     getTextureX = (gl: WebGLRenderingContext) => {
-        if (gl !== this.gl || !this.textureX) {
+        if (gl !== this.gl || !this.texture) {
             // Context has changed, texture needs to be regenerated
             this.gl = gl;
-            this.textureX = this.gl.createTexture();
+            this.texture = this.gl.createTexture();
             this.gl.activeTexture(GL.TEXTURE1);
-            this.gl.bindTexture(GL.TEXTURE_2D, this.textureX);
+            this.gl.bindTexture(GL.TEXTURE_2D, this.texture);
             this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
             this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
             this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
             this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-            this.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, this.width, this.height, 0, GL.LUMINANCE, GL.FLOAT, this.gridX);
+            this.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE_ALPHA, this.width, this.height, 0, GL.LUMINANCE_ALPHA, GL.FLOAT, this.grid);
         }
 
-        return this.textureX;
-    };
-
-    getTextureY = (gl: WebGLRenderingContext) => {
-        if (gl !== this.gl || !this.textureY) {
-            // Context has changed, texture needs to be regenerated
-            this.gl = gl;
-            this.textureY = this.gl.createTexture();
-            this.gl.activeTexture(GL.TEXTURE2);
-            this.gl.bindTexture(GL.TEXTURE_2D, this.textureY);
-            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
-            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
-            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
-            this.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
-            this.gl.texImage2D(GL.TEXTURE_2D, 0, GL.LUMINANCE, this.width, this.height, 0, GL.LUMINANCE, GL.FLOAT, this.gridY);
-        }
-        return this.textureY;
+        return this.texture;
     };
 
     getTransformedCoordinate(point: Point2D) {
@@ -81,10 +60,10 @@ export class ControlMap {
         const index01 = (indexFloor.y + 1) * this.width + indexFloor.x;
         const index10 = indexFloor.y * this.width + indexFloor.x + 1;
         const index11 = (indexFloor.y + 1) * this.width + indexFloor.x + 1;
-        const f00 = {x: this.gridX[index00], y: this.gridY[index00]};
-        const f01 = {x: this.gridX[index01], y: this.gridY[index01]};
-        const f10 = {x: this.gridX[index10], y: this.gridY[index10]};
-        const f11 = {x: this.gridX[index11], y: this.gridY[index11]};
+        const f00 = {x: this.grid[index00 * 2], y: this.grid[index00 * 2 + 1]};
+        const f01 = {x: this.grid[index01 * 2], y: this.grid[index01 * 2 + 1]};
+        const f10 = {x: this.grid[index10 * 2], y: this.grid[index10 * 2 + 1]};
+        const f11 = {x: this.grid[index11 * 2], y: this.grid[index11 * 2 + 1]};
 
         return {
             x: f00.x * (1 - step.x) * (1 - step.y) + f10.x * step.x * (1 - step.y) + f01.x * (1 - step.x) * step.y + f11.x * step.x * step.y,

--- a/src/models/ControlMap.ts
+++ b/src/models/ControlMap.ts
@@ -1,0 +1,55 @@
+import * as AST from "ast_wrapper";
+import {FrameStore} from "stores";
+import {Point2D} from "./Point2D";
+import {subtract2D} from "utilities";
+
+export class ControlMap {
+    readonly source: FrameStore;
+    readonly destination: FrameStore;
+    texture: WebGLTexture;
+    readonly width: number;
+    readonly height: number;
+    readonly minPoint: Point2D;
+    readonly maxPoint: Point2D;
+    readonly grid: Float32Array;
+
+    constructor(src: FrameStore, dst: FrameStore, astTransform: number, width: number, height: number) {
+        this.source = src;
+        this.destination = dst;
+        this.width = width;
+        this.height = height;
+
+        const paddingX = Math.ceil(src.frameInfo.fileInfoExtended.width / width);
+        const paddingY = Math.ceil(src.frameInfo.fileInfoExtended.height / height);
+        this.minPoint = {x: -paddingX, y: -paddingY};
+        this.maxPoint = {x: paddingX + src.frameInfo.fileInfoExtended.width, y: paddingY + src.frameInfo.fileInfoExtended.height};
+        this.grid = AST.getTransformGrid(astTransform, this.minPoint.x, this.maxPoint.x, width, this.minPoint.y, this.maxPoint.y, height, 1);
+    }
+
+    getTransformedCoordinate(point: Point2D) {
+        const range = subtract2D(this.maxPoint, this.minPoint);
+        const shiftedPoint = subtract2D(point, this.minPoint);
+        const index2D: Point2D = {
+            x: this.width * shiftedPoint.x / range.x,
+            y: this.height * shiftedPoint.y / range.y,
+        };
+
+        const indexFloor = {x: Math.floor(index2D.x), y: Math.floor(index2D.y)};
+        const step = {x: index2D.x - indexFloor.x, y: index2D.y - indexFloor.y};
+
+        // Get the four samples for bilinear interpolation
+        const index00 = indexFloor.y * this.width + indexFloor.x;
+        const index01 = (indexFloor.y + 1) * this.width + indexFloor.x;
+        const index10 = indexFloor.y * this.width + indexFloor.x + 1;
+        const index11 = (indexFloor.y + 1) * this.width + indexFloor.x + 1;
+        const f00 = {x: this.grid[2 * index00], y: this.grid[2 * index00 + 1]};
+        const f01 = {x: this.grid[2 * index01], y: this.grid[2 * index01 + 1]};
+        const f10 = {x: this.grid[2 * index10], y: this.grid[2 * index10 + 1]};
+        const f11 = {x: this.grid[2 * index11], y: this.grid[2 * index11 + 1]};
+
+        return {
+            x: f00.x * (1 - step.x) * (1 - step.y) + f10.x * step.x * (1 - step.y) + f01.x * (1 - step.x) * step.y + f11.x * step.x * step.y,
+            y: f00.y * (1 - step.x) * (1 - step.y) + f10.y * step.x * (1 - step.y) + f01.y * (1 - step.x) * step.y + f11.y * step.x * step.y
+        };
+    }
+}

--- a/src/models/ControlMap.ts
+++ b/src/models/ControlMap.ts
@@ -70,4 +70,8 @@ export class ControlMap {
             y: f00.y * (1 - step.x) * (1 - step.y) + f10.y * step.x * (1 - step.y) + f01.y * (1 - step.x) * step.y + f11.y * step.x * step.y
         };
     }
+
+    static IsWidthValid(width: number) {
+        return (width >= 128 && width <= 1024);
+    }
 }

--- a/src/models/Transform2D.ts
+++ b/src/models/Transform2D.ts
@@ -1,8 +1,36 @@
 import {Point2D} from "./Point2D";
+import {add2D, getTransformedCoordinates, length2D, scaleAndRotateAboutPoint2D, subtract2D} from "utilities";
 
-export interface Transform2D {
+export class Transform2D {
     translation: Point2D;
     rotation: number;
     scale: number;
     origin: Point2D;
+
+    constructor(astTransform: number, refPixel: Point2D) {
+        const transformedRef = getTransformedCoordinates(astTransform, refPixel, true);
+        const delta = 1.0;
+        const refTop = add2D(refPixel, {x: 0, y: delta / 2.0});
+        const refBottom = add2D(refPixel, {x: 0, y: -delta / 2.0});
+        const northVector = subtract2D(refTop, refBottom);
+        const transformedRefTop = getTransformedCoordinates(astTransform, refTop, true);
+        const transformedRefBottom = getTransformedCoordinates(astTransform, refBottom, true);
+        const transformedNorthVector = subtract2D(transformedRefTop, transformedRefBottom);
+        this.scale = length2D(transformedNorthVector) / length2D(northVector);
+        this.rotation = Math.atan2(transformedNorthVector.y, transformedNorthVector.x) - Math.atan2(northVector.y, northVector.x);
+        this.translation = subtract2D(transformedRef, refPixel);
+        this.origin = {x: refPixel.x, y: refPixel.y};
+    }
+
+    transformCoordinate(point: Point2D, forward: boolean = true) {
+        if (forward) {
+            // Move point from the original frame to the reference frame, using the supplied transform
+            const scaledPoint = scaleAndRotateAboutPoint2D(point, this.origin, this.scale, this.rotation);
+            return add2D(scaledPoint, this.translation);
+        } else {
+            // Move point from the reference frame to the original frame, using the supplied transform
+            const shiftedPoint = subtract2D(point, this.translation);
+            return scaleAndRotateAboutPoint2D(shiftedPoint, this.origin, 1.0 / this.scale, -this.rotation);
+        }
+    }
 }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -29,7 +29,7 @@ import {
     SpectralProfileStore,
     WidgetsStore
 } from ".";
-import {getApproximateCoordinates, GetRequiredTiles, minMax2D} from "utilities";
+import {GetRequiredTiles} from "utilities";
 import {BackendService, ConnectionStatus, TileService} from "services";
 import {FrameView, Point2D, ProtobufProcessing, Theme} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore} from "./widgets";

--- a/src/stores/ContourConfigStore.ts
+++ b/src/stores/ContourConfigStore.ts
@@ -1,4 +1,4 @@
-import {action, computed, observable} from "mobx";
+import {action, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {PreferenceStore} from "./PreferenceStore";
 import {hexStringToRgba, RGBA} from "../utilities";
@@ -22,6 +22,7 @@ export class ContourConfigStore {
     @observable colormapBias: number;
     @observable dashMode: ContourDashMode;
     @observable thickness: number;
+    @observable visible: boolean;
 
     private readonly preferenceStore: PreferenceStore;
 
@@ -39,6 +40,7 @@ export class ContourConfigStore {
         this.colormapContrast = 1.0;
         this.thickness = 1.0;
         this.dashMode = ContourDashMode.NegativeOnly;
+        this.visible = true;
     }
 
     @action setEnabled(val: boolean) {
@@ -78,5 +80,13 @@ export class ContourConfigStore {
 
     @action setColormapContrast = (val: number) => {
         this.colormapContrast = val;
+    };
+
+    @action setVisible = (visible: boolean) => {
+        this.visible = visible;
+    };
+
+    @action toggleVisibility = () => {
+        this.visible = !this.visible;
     };
 }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -885,7 +885,7 @@ export class FrameStore {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
         } else {
             const tStart = performance.now();
-            this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, 200, 200));
+            this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, 256, 256));
             const tEnd = performance.now();
             const dt = tEnd - tStart;
             console.log(`Created transform grid in ${dt} ms`);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import * as AST from "ast_wrapper";
 import {ASTSettingsString, ContourConfigStore, ContourStore, LogStore, OverlayBeamStore, OverlayStore, PreferenceStore, RegionSetStore, RenderConfigStore} from "stores";
 import {ChannelInfo, CursorInfo, FrameView, Point2D, ProtobufProcessing, SpectralInfo, Transform2D} from "models";
-import {clamp, findChannelType, findRefPixel, frequencyStringFromVelocity, getHeaderNumericValue, getTransformedCoordinates, length2D, minMax2D, rotate2D, subtract2D, toFixed, trimFitsComment, velocityStringFromFrequency} from "utilities";
+import {clamp, findChannelType, frequencyStringFromVelocity, getHeaderNumericValue, getTransformedCoordinates, length2D, minMax2D, rotate2D, subtract2D, toFixed, trimFitsComment, velocityStringFromFrequency} from "utilities";
 import {BackendService} from "services";
 import {ControlMap} from "../models/ControlMap";
 
@@ -409,7 +409,6 @@ export class FrameStore {
     private spatialTransformAST: number;
     private cachedTransformedWcsInfo: number = -1;
     private zoomTimeoutHandler;
-    public readonly referencePixel: Point2D;
 
     private static readonly CursorInfoMaxPrecision = 25;
     private static readonly ZoomInertiaDuration = 250;
@@ -465,7 +464,6 @@ export class FrameStore {
         this.initWCS();
         this.initCenter();
         this.zoomLevel = preference.isZoomRAWMode ? 1.0 : this.zoomLevelForFit;
-        this.referencePixel = findRefPixel(this.frameInfo.fileInfoExtended.headerEntries) || {x: this.frameInfo.fileInfoExtended.width / 2.0, y: this.frameInfo.fileInfoExtended.height};
 
         // need initialized wcs to get correct cursor info
         this.cursorInfo = this.getCursorInfoImageSpace({x: 0, y: 0});

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -885,10 +885,10 @@ export class FrameStore {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
         } else {
             const tStart = performance.now();
-            this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, 256, 256));
+            this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, this.preference.contourControlMapWidth, this.preference.contourControlMapWidth));
             const tEnd = performance.now();
             const dt = tEnd - tStart;
-            console.log(`Created transform grid in ${dt} ms`);
+            console.log(`Created ${this.preference.contourControlMapWidth}x${this.preference.contourControlMapWidth} transform grid in ${dt} ms`);
         }
     };
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -54,6 +54,7 @@ export class FrameStore {
     @observable regionSet: RegionSetStore;
     @observable overlayBeamSettings: OverlayBeamStore;
     @observable spatialReference: FrameStore;
+    @observable controlMaps: Map<FrameStore, ControlMap>;
     @observable secondaryImages: FrameStore[];
 
     @computed get requiredFrameView(): FrameView {
@@ -435,6 +436,7 @@ export class FrameStore {
         this.zooming = false;
         this.overlayBeamSettings = new OverlayBeamStore(preference);
         this.spatialTransformAST = null;
+        this.controlMaps = new Map<FrameStore, ControlMap>();
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preference.astColor;
@@ -883,13 +885,15 @@ export class FrameStore {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
         } else {
             const tStart = performance.now();
-            const controlMap = new ControlMap(this, this.spatialReference, this.spatialTransformAST, 200, 200);
+            this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, 200, 200));
+
             const tEnd = performance.now();
             const dt = tEnd - tStart;
             console.log(`Created transform grid in ${dt} ms`);
 
             const numTrials = 1000;
             let maxError = 0;
+            const controlMap = this.controlMaps.get(this.spatialReference);
             for (let i = 0; i < numTrials; i++) {
                 const point = {x: Math.random() * this.frameInfo.fileInfoExtended.width, y: Math.random() * this.frameInfo.fileInfoExtended.height};
                 const actualCoords = getTransformedCoordinates(this.spatialTransformAST, point, true);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -886,26 +886,9 @@ export class FrameStore {
         } else {
             const tStart = performance.now();
             this.controlMaps.set(this.spatialReference, new ControlMap(this, this.spatialReference, this.spatialTransformAST, 200, 200));
-
             const tEnd = performance.now();
             const dt = tEnd - tStart;
             console.log(`Created transform grid in ${dt} ms`);
-
-            const numTrials = 1000;
-            let maxError = 0;
-            const controlMap = this.controlMaps.get(this.spatialReference);
-            for (let i = 0; i < numTrials; i++) {
-                const point = {x: Math.random() * this.frameInfo.fileInfoExtended.width, y: Math.random() * this.frameInfo.fileInfoExtended.height};
-                const actualCoords = getTransformedCoordinates(this.spatialTransformAST, point, true);
-                const mappedCoords = controlMap.getTransformedCoordinate(point);
-                const delta = subtract2D(actualCoords, mappedCoords);
-                const deltaLength = length2D(delta);
-                maxError = Math.max(maxError, deltaLength);
-                if (deltaLength > 0.05 || !isFinite(deltaLength)) {
-                    console.log(`Large error (${deltaLength.toFixed(2)} px) when transforming point (${point.x}, ${point.y}) => (${actualCoords.x}, ${actualCoords.y}). Mapped point: (${mappedCoords.x}, ${mappedCoords.y})`);
-                }
-            }
-            console.log(`Ran ${numTrials} of transforming points using control points. Maximum absolute error: ${maxError} px`);
         }
     };
 

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -5,6 +5,7 @@ import {CARTA} from "carta-protobuf";
 import {AppStore, BeamType, FrameScaling, LayoutStore, RenderConfigStore, RegionStore} from "stores";
 import {Theme, PresetLayout, CursorPosition, Zoom, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event} from "models";
 import {isColorValid, parseBoolean} from "utilities";
+import {ControlMap} from "../models/ControlMap";
 
 const PREFERENCE_KEYS = {
     theme: "theme",
@@ -47,6 +48,7 @@ const PREFERENCE_KEYS = {
     contourDecimation: "contourDecimation",
     contourCompressionLevel: "contourCompressionLevel",
     contourChunkSize: "contourChunkSize",
+    contourControlMapWidth: "contourControlMapWidth",
     streamContoursWhileZooming: "streamContoursWhileZooming",
     lowBandwidthMode: "lowBandwidthMode",
     logEventList: "logEventList"
@@ -93,6 +95,7 @@ const DEFAULTS = {
     contourDecimation: 4,
     contourCompressionLevel: 8,
     contourChunkSize: 100000,
+    contourControlMapWidth: 256,
     streamContoursWhileZooming: false,
     lowBandwidthMode: false,
     eventLoggingEnabled: false
@@ -138,6 +141,7 @@ export class PreferenceStore {
     @observable contourDecimation: number;
     @observable contourCompressionLevel: number;
     @observable contourChunkSize: number;
+    @observable contourControlMapWidth: number;
     @observable streamTilesWhileZooming: boolean;
     @observable lowBandwidthMode: boolean;
     @observable eventsLoggingEnabled: Map<CARTA.EventType, boolean>;
@@ -446,6 +450,16 @@ export class PreferenceStore {
         return isFinite(value) && TileCache.isSystemTileCacheValid(value) ? value : DEFAULTS.systemTileCache;
     };
 
+    private getContourControlMapWidth = (): number => {
+        const contourControlMapWidth = localStorage.getItem(PREFERENCE_KEYS.contourControlMapWidth);
+        if (!contourControlMapWidth) {
+            return DEFAULTS.contourControlMapWidth;
+        }
+
+        const value = Number(contourControlMapWidth);
+        return isFinite(value) && ControlMap.IsWidthValid(value) ? value : DEFAULTS.contourControlMapWidth;
+    };
+
     private getStreamTilesWhileZooming = (): boolean => {
         const val = localStorage.getItem(PREFERENCE_KEYS.streamContoursWhileZooming);
         return parseBoolean(val, DEFAULTS.streamContoursWhileZooming);
@@ -713,6 +727,11 @@ export class PreferenceStore {
         localStorage.setItem(PREFERENCE_KEYS.systemTileCache, systemTileCache.toString(10));
     };
 
+    @action setContourControlMapWidth = (contourControlMapWidth: number) => {
+        this.contourControlMapWidth = contourControlMapWidth;
+        localStorage.setItem(PREFERENCE_KEYS.contourControlMapWidth, contourControlMapWidth.toString(10));
+    };
+
     @action setStreamContoursWhileZooming = (val: boolean) => {
         this.streamTilesWhileZooming = val;
         localStorage.setItem(PREFERENCE_KEYS.streamContoursWhileZooming, String(val));
@@ -779,6 +798,7 @@ export class PreferenceStore {
         this.setContourDecimation(DEFAULTS.contourDecimation);
         this.setContourCompressionLevel(DEFAULTS.contourCompressionLevel);
         this.setContourChunkSize(DEFAULTS.contourChunkSize);
+        this.setContourControlMapWidth(DEFAULTS.contourControlMapWidth);
         this.setStreamContoursWhileZooming(DEFAULTS.streamContoursWhileZooming);
         this.setLowBandwidthMode(DEFAULTS.lowBandwidthMode);
     };
@@ -825,6 +845,7 @@ export class PreferenceStore {
         this.contourDecimation = this.getContourDecimation();
         this.contourCompressionLevel = this.getContourCompressionLevel();
         this.contourChunkSize = this.getContourChunkSize();
+        this.contourControlMapWidth = this.getContourControlMapWidth();
         this.streamTilesWhileZooming = this.getStreamTilesWhileZooming();
         this.lowBandwidthMode = this.getLowBandwidthMode();
         this.eventsLoggingEnabled = this.getLogEvents();

--- a/src/stores/RenderConfigStore.ts
+++ b/src/stores/RenderConfigStore.ts
@@ -71,6 +71,7 @@ export class RenderConfigStore {
     @observable stokes: number;
     @observable scaleMin: number[];
     @observable scaleMax: number[];
+    @observable visible: boolean;
 
     constructor(readonly preference: PreferenceStore) {
         const percentile = preference.percentile;
@@ -86,6 +87,7 @@ export class RenderConfigStore {
         this.stokes = 0;
         this.scaleMin = [0, 0, 0, 0];
         this.scaleMax = [1, 1, 1, 1];
+        this.visible = true;
     }
 
     public static IsScalingValid(scaling: FrameScaling): boolean {
@@ -252,5 +254,13 @@ export class RenderConfigStore {
 
     @action setInverted = (inverted: boolean) => {
         this.inverted = inverted;
+    };
+
+    @action setVisible = (visible: boolean) => {
+        this.visible = visible;
+    };
+
+    @action toggleVisibility = () => {
+        this.visible = !this.visible;
     };
 }

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -65,34 +65,3 @@ export function getTransformedCoordinates(astTransform: number, point: Point2D, 
     const transformed: Point2D = AST.transformPoint(astTransform, point.x, point.y, forward);
     return transformed;
 }
-
-export function getTransform(astTransform: number, refPixel: Point2D): Transform2D {
-    const transformedRef = getTransformedCoordinates(astTransform, refPixel, true);
-    const delta = 1.0;
-    const refTop = add2D(refPixel, {x: 0, y: delta / 2.0});
-    const refBottom = add2D(refPixel, {x: 0, y: -delta / 2.0});
-    const northVector = subtract2D(refTop, refBottom);
-    const transformedRefTop = getTransformedCoordinates(astTransform, refTop, true);
-    const transformedRefBottom = getTransformedCoordinates(astTransform, refBottom, true);
-    const transformedNorthVector = subtract2D(transformedRefTop, transformedRefBottom);
-    const scaling = length2D(transformedNorthVector) / length2D(northVector);
-    const theta = Math.atan2(transformedNorthVector.y, transformedNorthVector.x) - Math.atan2(northVector.y, northVector.x);
-    return {
-        translation: subtract2D(transformedRef, refPixel),
-        origin: {x: refPixel.x, y: refPixel.y},
-        scale: scaling,
-        rotation: theta
-    };
-}
-
-export function getApproximateCoordinates(transform: Transform2D, point: Point2D, forward: boolean = true) {
-    if (forward) {
-        // Move point from the original frame to the reference frame, using the supplied transform
-        const scaledPoint = scaleAndRotateAboutPoint2D(point, transform.origin, transform.scale, transform.rotation);
-        return add2D(scaledPoint, transform.translation);
-    } else {
-        // Move point from the reference frame to the original frame, using the supplied transform
-        const shiftedPoint = subtract2D(point, transform.translation);
-        return scaleAndRotateAboutPoint2D(shiftedPoint, transform.origin, 1.0 / transform.scale, -transform.rotation);
-    }
-}

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -47,20 +47,6 @@ export function findChannelType(entries: CARTA.IHeaderEntry[]) {
     return undefined;
 }
 
-export function findRefPixel(entries: CARTA.IHeaderEntry[]) {
-    if (!entries || !entries.length) {
-        return undefined;
-    }
-
-    const pixVal1 = entries.find(entry => entry.name.includes("CRPIX1"));
-    const pixVal2 = entries.find(entry => entry.name.includes("CRPIX2"));
-    if (!pixVal1 && !pixVal2) {
-        return undefined;
-    }
-
-    return {x: getHeaderNumericValue(pixVal1), y: getHeaderNumericValue(pixVal2)};
-}
-
 export function getTransformedCoordinates(astTransform: number, point: Point2D, forward: boolean = true) {
     const transformed: Point2D = AST.transformPoint(astTransform, point.x, point.y, forward);
     return transformed;

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -301,8 +301,8 @@ EMSCRIPTEN_KEEPALIVE float* fillTransformGrid(AstFrameSet* wcsInfo, double xMin,
     // Convert to float and fill output array
     for (auto i = 0; i < N; i++)
     {
-        out[i * 2] = pixBx[i];
-        out[i * 2 + 1] = pixBy[i];
+        out[i] = pixBx[i];
+        out[i + N] = pixBy[i];
     }
 
     // Clean up temp double precision pixels

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -301,8 +301,8 @@ EMSCRIPTEN_KEEPALIVE float* fillTransformGrid(AstFrameSet* wcsInfo, double xMin,
     // Convert to float and fill output array
     for (auto i = 0; i < N; i++)
     {
-        out[i] = pixBx[i];
-        out[i + N] = pixBy[i];
+        out[2* i] = pixBx[i];
+        out[2 * i + 1] = pixBy[i];
     }
 
     // Clean up temp double precision pixels


### PR DESCRIPTION
This PR adds the ability to show contours from secondary images overlaid on top of the reference image (The ability to show contours from other images on secondary images will be added in a separate PR). 

While raster images are rendered using an _approximate_ transformation (scaling, rotation and shifting to match a specific point in the image, which is now dynamically calculated from the centre of the current FoV), contours are rendered using a more accurate transformation.  

Using AST to translate every single contour vertex and regenerate the GPU buffers would dramatically increase memory usage and make switching between images pretty slow. Instead, when an image has "spatial matching" enabled, a control map is generated (currently of size 256x256). For each source vertex in the control map, AST is used to transform the vertex to the destination image's coordinate space. 

It is assumed that the exact transformation at any point on the image can be approximated by a cubic  spline interpolation of the nearest control points. Given that the default size of 256x256 means that control points are less than 0.4% of the image size away from each other, this is a fairly safe assumption. ~~In future, we can offer a preference for the desired control map size, if greater accuracy is required.~~ (edit: options of 128x128, 256x256, 512x512 and 1024x1024 have been added)

The control map is then loaded on to the GPU, and the vertex shader performs the cubic interpolation of the control map for each vertex, with no noticeable performance impact. Generating a 256x256 control map generally takes around 50 ms, but is a once-off operation when spatial matching is enabled, and occupies roughly 512 kB of GPU memory. The only downside of this approach is that the number of of control maps required for the full feature (showing contours on secondary images as well) scales like _O(N^2)_, where _N_ is the number of images in the WCS group.

This PR also adds the ability to show or hide the raster or contour images by clicking on the appropriate button in the layer widget. 