### PR TITLE
shader changes to improve floating point errors

### DIFF
--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -20,7 +20,6 @@ interface ShaderUniforms {
     RotationOrigin: WebGLUniformLocation;
     RotationAngle: WebGLUniformLocation;
     ScaleAdjustment: WebGLUniformLocation;
-    Offset: WebGLUniformLocation;
     DashLength: WebGLUniformLocation;
     LineColor: WebGLUniformLocation;
     LineThickness: WebGLUniformLocation;
@@ -60,13 +59,13 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             } catch (e) {
                 console.log(e);
             }
-            if (!this.gl) {
-                console.log("Could not initialise WebGL");
-            }
 
             const extTextureFloat = this.gl.getExtension("OES_texture_float");
-            // TODO: manual bilinear or bicubic sampling to avoid this extension
             const extTextureFloatLinear = this.gl.getExtension("OES_texture_float_linear");
+
+            if (!this.gl || !extTextureFloat || !extTextureFloatLinear) {
+                console.error("Could not initialise WebGL");
+            }
 
             this.initShaders();
             loadImageTexture(this.gl, allMaps, WebGLRenderingContext.TEXTURE0).then(texture => {
@@ -167,7 +166,6 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
                 this.gl.uniform2f(this.shaderUniforms.RangeOffset, rangeOffset.x, rangeOffset.y);
                 this.gl.uniform1f(this.shaderUniforms.RotationAngle, 0.0);
                 this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, 1.0);
-                this.gl.uniform2f(this.shaderUniforms.Offset, 0, 0);
             }
         } else {
             const controlMap = frame.controlMaps.get(frame.spatialReference);
@@ -191,11 +189,9 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
 
             this.gl.uniform2f(this.shaderUniforms.RangeOffset, rangeOffset.x, rangeOffset.y);
             this.gl.uniform2f(this.shaderUniforms.RangeScale, rangeScale.x, rangeScale.y);
-
             this.gl.uniform1f(this.shaderUniforms.LineThickness, devicePixelRatio * frame.contourConfig.thickness / frame.spatialReference.zoomLevel);
             this.gl.uniform1f(this.shaderUniforms.RotationAngle, 0.0);
             this.gl.uniform1f(this.shaderUniforms.ScaleAdjustment, 1.0);
-            this.gl.uniform2f(this.shaderUniforms.Offset, 0, 0);
         }
 
         // Calculates ceiling power-of-three value as a dash factor.
@@ -267,7 +263,6 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             ScaleAdjustment: this.gl.getUniformLocation(shaderProgram, "uScaleAdjustment"),
             RotationOrigin: this.gl.getUniformLocation(shaderProgram, "uRotationOrigin"),
             RotationAngle: this.gl.getUniformLocation(shaderProgram, "uRotationAngle"),
-            Offset: this.gl.getUniformLocation(shaderProgram, "uOffset"),
             DashLength: this.gl.getUniformLocation(shaderProgram, "uDashLength"),
             LineColor: this.gl.getUniformLocation(shaderProgram, "uLineColor"),
             LineThickness: this.gl.getUniformLocation(shaderProgram, "uLineThickness"),

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -9,7 +9,6 @@ uniform vec2 uRangeOffset;
 uniform vec2 uRotationOrigin;
 uniform float uRotationAngle;
 uniform float uScaleAdjustment;
-uniform vec2 uOffset;
 uniform float uLineThickness;
 
 // Control-map based transformation

--- a/src/components/ImageView/ContourView/GLSL/vert_line.glsl
+++ b/src/components/ImageView/ContourView/GLSL/vert_line.glsl
@@ -93,7 +93,9 @@ void main(void) {
     // If there's a control map, use it to look up location using bilinear filtering
     if (uControlMapEnabled > 0) {
         // Use an offset of 10% of the grid spacing to estimate the direction of the normal
-        float delta = 0.1 * (uControlMapMax.x - uControlMapMin.x) / uControlMapSize.x;
+        vec2 deltaVec = 0.1 * (uControlMapMax - uControlMapMin) / uControlMapSize;
+        // Use a minimum of 10% in X and 10% in Y directions
+        float delta = min(deltaVec.x, deltaVec.y);
         vec2 extrudedPoint = controlMapLookup(posImageSpace + normalize(extrudeOffet) * delta);
         posImageSpace = controlMapLookup(posImageSpace);
         vec2 transformedNormal = extrudedPoint - posImageSpace;


### PR DESCRIPTION
There were two root causes for #704:
* When using spatial matching, but viewing the contours on top of the same image, there was an accumulation of floating point errors that caused the thickness of lines to be very inconsistent (sometimes less than zero, rendering the lines invisible)
* When using spatial matching and a control map to view the contours on top of the reference image, using a "delta" of 0.1 pixels to estimate the transformed normal of the line segment was not an appropriate size, as the image was 48K in width, and thus control points were 190 pixels apart (when using a 256x256 grid)

I've implemented two fixes:
* Rearranged the shader so that more of the floating point calculations that are independent of the vertex positions are done outside of the shader. This has two advantages: Firstly, the accumulated floating point error from these calculations is now independent of vertex position, so any errors are _consistent_, and will just result in a tiny offset for all pixels rendered. Secondly, the calculations are done using double-precision, so the floating point errors are dramatically reduced. Unfortunately, this makes the shader code and the accompanying javascript code a little less readable.
* Instead of using a fixed delta of 0.1 pixels, I now use 10% of the grid size. For the image mentioned above, that would mean a delta of 19 pixels. 

The lines now look much better. They look a little wonky when zooming far in on the reference image, but at that point, the zoom level on the reference image is about 1600x, so I think it's an acceptable solution. Switching the control map resolution to 1024x1024 helps a little bit in this case, so perhaps it's just something users need to be aware of, when comparing images with huge differences in pixel sizes. 

![lines_fixed](https://user-images.githubusercontent.com/592504/73631324-503a6e00-4661-11ea-9a3e-b2894412fc88.gif)
