### PR TITLE
use -FLT_MAX as a placeholder for NAN values on GPU

### DIFF
--- a/src/components/ImageView/RasterView/GLSL/pixel_shader_float_rgb.glsl
+++ b/src/components/ImageView/RasterView/GLSL/pixel_shader_float_rgb.glsl
@@ -9,6 +9,8 @@ precision highp float;
 #define EXP 6
 #define CUSTOM 7
 
+#define FLT_MAX 3.402823466e+38
+
 varying vec2 vUV;
 uniform bool uTiledRendering;
 // Textures
@@ -33,8 +35,9 @@ uniform vec2 uTileTextureOffset;
 uniform float uTextureSize;
 uniform float uTileTextureSize;
 
+// Some shader compilers have trouble with NaN checks, so we instead use a dummy value of -FLT_MAX
 bool isnan(float val) {
-    return (val < 0.0 || 0.0 < val || val == 0.0) ? false : true;
+    return val <= -FLT_MAX;
 }
 
 void main(void) {

--- a/wasm_src/zfp_wrapper/post.ts
+++ b/wasm_src/zfp_wrapper/post.ts
@@ -1,7 +1,7 @@
 declare var Module: any;
 declare var addOnPostRun: any;
 const ctx: Worker = self as any;
-
+const FLT_MAX = 3.402823466e+38;
 // Allocate a 4 MB uncompressed buffer and 1 MB uncompressed buffer
 Module.nDataBytes = 4e6;
 Module.nDataBytesCompressed = 1e6;
@@ -93,7 +93,8 @@ ctx.onmessage = (event => {
 
             for (let L of eventArgs.nanEncodings) {
                 if (fillVal) {
-                    outputView.fill(NaN, decodedIndex, decodedIndex + L);
+                    // Some shader compilers have trouble with NaN checks, so we instead use a dummy value of -FLT_MAX
+                    outputView.fill(-FLT_MAX, decodedIndex, decodedIndex + L);
                 }
                 fillVal = !fillVal;
                 decodedIndex += L;


### PR DESCRIPTION
closes #708 

(needs testing to make sure it doesn't break _other_ implementations)