### PR TITLE
Adding a script to temporarily patch the production build's breadcrumb issue

### DIFF
--- a/crumbs-fix.sh
+++ b/crumbs-fix.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This script is intended as a temporary fix for the missing ">" breadcrumb symbols in the file browser that only occurs when we build the frontend in production mode.
+# CARTAvis/carta-frontend issue #698
+# It seems to be a sass-loader bug. The problem may eventually go away, but meanwhile this script will fix it. 
+# This script will be run automatically at the last step of "npm run build".
+
+if [ "$(uname)" == "Darwin" ]; then
+
+  sed -i '' "s/M10.71 7.29l-4-4a1.003 1.003 0 0-1.42 1.42 NaNl.46 NaNL5.3 NaNC5.11 NaN 5 NaN 5 NaNa1.003 1.003 0 1.71.71 NaN NaNlNaN NaNcNaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaNz/M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z/w patch.txt" build/static/css/main*.css
+  if [ -s patch.txt ]; then
+    echo "The production build css file has been patched for the breadcrumbs fix."
+  else
+    echo "The css file has NOT been patched. Maybe the sass-loader/breadcrumbs problem is gone?"
+  fi
+
+fi
+
+if [ "$(uname)" == "Linux" ]; then
+
+  sed -i "s/M10.71 7.29l-4-4a1.003 1.003 0 0-1.42 1.42 NaNl.46 NaNL5.3 NaNC5.11 NaN 5 NaN 5 NaNa1.003 1.003 0 1.71.71 NaN NaNlNaN NaNcNaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaNz/M10.71 7.29l-4-4a1.003 1.003 0 00-1.42 1.42L8.59 8 5.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l4-4c.18-.18.29-.43.29-.71 0-.28-.11-.53-.29-.71z/w patch.txt" build/static/css/main*.css
+  if [ -s patch.txt ]; then
+    echo "The production build css file has been patched for the breadcrumbs fix."
+  else
+    echo "The css file has NOT been patched. Maybe the sass-loader/breadcrumbs problem is gone?"
+  fi
+
+fi

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "start-js": "react-scripts-ts start",
         "start": "npm run git-info; npm-run-all -p watch-css start-js",
         "build-js": "react-scripts-ts --max_old_space_size=4096 build",
-        "build": "npm run git-info; npm-run-all build-wrappers build-protobuf build-css build-js",
+        "build": "npm run git-info; npm-run-all build-wrappers build-protobuf build-css build-js; ./crumbs-fix.sh",
         "test": "react-scripts-ts test --env=jsdom",
         "eject": "react-scripts-ts eject"
     },


### PR DESCRIPTION
Here is a simple script to fix the bad string of NaNs in the css file of the production build related to issue [#698](https://github.com/CARTAvis/carta-frontend/issues/698)

The script is called in package.json file at the last stage of the "build" script.
```
"build": "npm run git-info; npm-run-all build-wrappers build-protobuf build-css build-js; ./crumbs-fix.sh",
```
The script uses **sed** to find the bad string and replace it with the correct string. It uses a slightly different **sed** command between MacOS and Linux (MacOS sed requires an extra two apostrophes in the command).

The script uses sed "w" so that we can get an "echo" feedback as to whether or not the command ran successfully. Hopefully, if/when the sass-loader bug is fixed, we will see that the script will no longer run, and then we can remove it.