### PR TITLE
update user manual url explicitly to v1.3

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -46,7 +46,7 @@ export class AboutDialogComponent extends React.Component<{ appStore: AppStore }
                     <ul>
                         <li>Source code for CARTA is available on <a href="https://github.com/cartavis" target="_blank">GitHub</a></li>
                         <li>Please report bugs or suggestions to <a href="mailto:carta_helpdesk@asiaa.sinica.edu.tw" target="_blank">carta_helpdesk@asiaa.sinica.edu.tw</a></li>
-                        <li>Documentation is available <a href="https://carta.readthedocs.io/en/latest" target="_blank">online</a></li>
+                        <li>Documentation is available <a href="https://carta.readthedocs.io/en/1.3" target="_blank">online</a></li>
                     </ul>
                     <h3>License</h3>
                     <p>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -279,7 +279,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
     }
 
     handleDocumentationClicked = () => {
-        window.open("https://carta.readthedocs.io/en/latest", "_blank", "width=1024");
+        window.open("https://carta.readthedocs.io/en/1.3", "_blank", "width=1024");
         if (process.env.REACT_APP_TARGET !== "linux" && process.env.REACT_APP_TARGET !== "darwin") {
             this.documentationAlertVisible = true;
             clearTimeout(this.documentationAlertTimeoutHandle);


### PR DESCRIPTION
In the past we point users to the "latest" version of the user manual. This works fine if users keep using the up-to-date version. However, users using older versions of CARTA will be pointed to still the "latest" version of user manual, which should not be the case. So, to prevent this in the future, we will need to update the url to explicit version. Now it is modified to
"https://carta.readthedocs.io/en/1.3"