### PR TITLE
adds checks and warnings when enabling spatial matching

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1029,7 +1029,13 @@ export class AppStore {
         if (frame.spatialReference) {
             frame.clearSpatialReference();
         } else {
-            frame.setSpatialReference(this.spatialReference);
+            if (!frame.setSpatialReference(this.spatialReference)) {
+                AppToaster.show({
+                    icon: "warning-sign",
+                    message: `Could not enable spatial matching of ${frame.frameInfo.fileInfo.name} to reference image ${this.spatialReference.frameInfo.fileInfo.name}. No valid transform was found`,
+                    intent: "warning",
+                    timeout: 3000});
+            }
         }
     };
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1034,7 +1034,8 @@ export class AppStore {
                     icon: "warning-sign",
                     message: `Could not enable spatial matching of ${frame.frameInfo.fileInfo.name} to reference image ${this.spatialReference.frameInfo.fileInfo.name}. No valid transform was found`,
                     intent: "warning",
-                    timeout: 3000});
+                    timeout: 3000
+                });
             }
         }
     };

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -893,12 +893,16 @@ export class FrameStore {
     // Spatial WCS Matching
     @action setSpatialReference = (frame: FrameStore) => {
         if (frame === this) {
-            this.clearSpatialReference();
             console.log(`Skipping spatial self-reference`);
+            this.clearSpatialReference();
+            return false;
         }
-        console.log(`Setting spatial reference for file ${this.frameInfo.fileId} to ${frame.frameInfo.fileId}`);
-        this.spatialReference = frame;
-        this.spatialReference.addSecondaryImage(this);
+
+        if (this.validWcs !== frame.validWcs) {
+            console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
+            this.spatialReference = null;
+            return false;
+        }
 
         const copySrc = AST.copy(this.wcsInfo);
         const copyDest = AST.copy(frame.wcsInfo);
@@ -909,7 +913,22 @@ export class FrameStore {
         AST.delete(copyDest);
         if (!this.spatialTransformAST) {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
+            this.spatialReference = null;
+            return false;
         }
+        this.spatialReference = frame;
+        const currentTransform = this.spatialTransform;
+        if (!isFinite(currentTransform.rotation) || !isFinite(currentTransform.scale) || !isFinite(currentTransform.translation.x) || !isFinite(currentTransform.translation.y)
+            || !isFinite(currentTransform.origin.x) || !isFinite(currentTransform.origin.y)) {
+            console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
+            this.spatialReference = null;
+            AST.delete(this.spatialTransformAST);
+            this.spatialTransformAST = null;
+            return false;
+        }
+
+        this.spatialReference.addSecondaryImage(this);
+        return true;
     };
 
     @action clearSpatialReference = () => {


### PR DESCRIPTION
This PR adds basic checks in to handle situations where no valid transform between images can be found. If this occurs, then the image is _not_ spatially matched, and a warning is shown