### PR TITLE
Angus/spectral matching

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -49,3 +49,7 @@ body {
     z-index: 999 !important;
 }
 
+// Workaround for BlueprintJS bug
+.bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-popover-wrapper:not(:last-child) .bp3-button, .bp3-dark .bp3-button-group:not(.bp3-minimal) > .bp3-button:not(:last-child) {
+    margin-right: -1px !important;
+}

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -38,7 +38,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             if (val >= this.props.appStore.activeFrame.frameInfo.fileInfoExtended.depth) {
                 val = 0;
             }
-            this.props.appStore.activeFrame.setChannels(val, this.props.appStore.activeFrame.requiredStokes);
+            this.props.appStore.activeFrame.setChannels(val, this.props.appStore.activeFrame.requiredStokes, true);
         }
     };
 
@@ -59,7 +59,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             if (val >= this.props.appStore.activeFrame.frameInfo.fileInfoExtended.stokes) {
                 val = 0;
             }
-            this.props.appStore.activeFrame.setChannels(this.props.appStore.activeFrame.requiredChannel, val);
+            this.props.appStore.activeFrame.setChannels(this.props.appStore.activeFrame.requiredChannel, val, true);
         }
     };
 
@@ -91,10 +91,10 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 appStore.setActiveFrameByIndex(0);
                 break;
             case AnimationMode.CHANNEL:
-                frame.setChannels(0, frame.stokes);
+                frame.setChannels(0, frame.stokes, true);
                 break;
             case AnimationMode.STOKES:
-                frame.setChannels(frame.channel, 0);
+                frame.setChannels(frame.channel, 0, true);
                 break;
             default:
                 break;
@@ -114,10 +114,10 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 appStore.setActiveFrameByIndex(appStore.frames.length - 1);
                 break;
             case AnimationMode.CHANNEL:
-                frame.setChannels(frame.frameInfo.fileInfoExtended.depth - 1, frame.stokes);
+                frame.setChannels(frame.frameInfo.fileInfoExtended.depth - 1, frame.stokes, true);
                 break;
             case AnimationMode.STOKES:
-                frame.setChannels(frame.channel, frame.frameInfo.fileInfoExtended.stokes - 1);
+                frame.setChannels(frame.channel, frame.frameInfo.fileInfoExtended.stokes - 1, true);
                 break;
             default:
                 break;

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -2,21 +2,16 @@ import * as React from "react";
 import * as _ from "lodash";
 import {observable} from "mobx";
 import {observer} from "mobx-react";
-import {
-    Button, IDialogProps, Intent, Tab, Tabs,
-    FormGroup, TabId, MenuItem, Switch, RadioGroup,
-    Radio, HTMLSelect, AnchorButton, NumericInput, Tooltip,
-    Position, Checkbox
-} from "@blueprintjs/core";
+import {AnchorButton, Button, Checkbox, FormGroup, HTMLSelect, IDialogProps, Intent, MenuItem, NumericInput, Position, Radio, RadioGroup, Switch, Tab, TabId, Tabs, Tooltip} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import {ColorResult} from "react-color";
 import {CARTA} from "carta-protobuf";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {ScalingSelectComponent} from "components/Shared/ScalingSelectComponent/ScalingSelectComponent";
 import {ColorComponent} from "components/Dialogs/OverlaySettings/ColorComponent";
-import {ColorPickerComponent, ColormapComponent} from "components/Shared";
-import {Theme, CursorPosition, Zoom, ZoomPoint, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event} from "models";
-import {AppStore, BeamType, ContourGeneratorType, FrameScaling, PreferenceKeys, RegionStore, RenderConfigStore, HelpType} from "stores";
+import {ColormapComponent, ColorPickerComponent} from "components/Shared";
+import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, SpectralType, Theme, TileCache, WCSType, Zoom, ZoomPoint} from "models";
+import {AppStore, BeamType, ContourGeneratorType, FrameScaling, HelpType, PreferenceKeys, RegionStore, RenderConfigStore} from "stores";
 import {hexStringToRgba, SWATCH_COLORS} from "utilities";
 import "./PreferenceDialogComponent.css";
 
@@ -143,6 +138,11 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                 </FormGroup>
                 <FormGroup inline={true} label="Enable drag-to-pan">
                     <Switch checked={preference.dragPanning} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_DRAG_PANNING, ev.currentTarget.checked)}/>
+                </FormGroup>
+                <FormGroup inline={true} label="Spectral Matching">
+                    <HTMLSelect value={preference.spectralMatchingType} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, ev.currentTarget.value)}>
+                        {SPECTRAL_MATCHING_TYPES.map(type => <option key={type} value={type}>{SPECTRAL_TYPE_STRING.get(type)}</option>)}
+                    </HTMLSelect>
                 </FormGroup>
             </React.Fragment>
         );

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -280,7 +280,6 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         const frame = this.props.appStore.activeFrame;
         if (frame) {
             const view = frame.requiredFrameView;
-            const contourData = frame.contourStores;
             const config = frame.contourConfig;
             const thickness = config.thickness;
             const color = config.colormapEnabled ? config.colormap : config.color;
@@ -289,10 +288,9 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             const contrast = config.colormapContrast;
 
             const contourFrames = this.props.appStore.contourFrames;
-
-            contourData.forEach(contourStore => {
+            contourFrames.forEach(f => f.contourStores.forEach(contourStore => {
                 const numVertices = contourStore.vertexCount;
-            });
+            }));
         }
         const padding = this.props.overlaySettings.padding;
         let className = "contour-div";

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -4,7 +4,7 @@
     position: absolute;
     margin: 5px;
     transition: opacity 400ms;
-   
+
     &.docked {
         z-index: 4;
     }
@@ -14,6 +14,7 @@
         padding-right: 0;
         font-weight: bold;
         font-size: smaller;
+
         span {
             color: $gray1;
         }
@@ -37,7 +38,13 @@
 
     &.bp3-dark {
         .full-zoom-button {
-            span {
+            .bp3-button-text {
+                color: $gray5;
+            }
+        }
+
+        .link-button {
+            .bp3-button-text {
                 color: $gray5;
             }
         }

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -29,6 +29,10 @@
             font-size: smaller;
             color: $gray1;
         }
+
+        .bp3-icon {
+            transform: scale(-1, 1);
+        }
     }
 
     &.bp3-dark {

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -19,6 +19,18 @@
         }
     }
 
+    .link-button {
+        width: 30px;
+
+        .bp3-button-text {
+            position: absolute;
+            top: 0;
+            left: 16px;
+            font-size: smaller;
+            color: $gray1;
+        }
+    }
+
     &.bp3-dark {
         .full-zoom-button {
             span {

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {CSSProperties} from "react";
 import {observer} from "mobx-react";
-import {AnchorButton, Button, ButtonGroup, IconName, Menu, MenuItem, Popover, PopoverPosition, Position, Tooltip} from "@blueprintjs/core";
+import {Button, ButtonGroup, IconName, Menu, MenuItem, Popover, PopoverPosition, Position, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {exportImage} from "components";
 import {AppStore, RegionMode, SystemType} from "stores";
@@ -128,13 +128,42 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const spectralMatchingEnabled = !!frame.spectralReference;
         const canEnableSpatialMatching = appStore.spatialReference !== frame;
         const canEnableSpectralMatching = appStore.spectralReference && appStore.spectralReference !== frame && frame.frameInfo.fileInfoExtended.depth > 1;
+        const wcsButtonSuperscript = (spatialMatchingEnabled ? "x" : "") + (spectralMatchingEnabled ? "z" : "");
+        const wcsButtonTooltipEntries = [];
+        if (spectralMatchingEnabled) {
+            wcsButtonTooltipEntries.push(`Spectral (${appStore.preferenceStore.spectralMatchingType})`);
+        }
+        if (spatialMatchingEnabled) {
+            wcsButtonTooltipEntries.push("Spatial");
+        }
+        const wcsButtonTooltip = wcsButtonTooltipEntries.join(" and ") || "None";
 
         const wcsMatchingMenu = (
             <Menu>
-                <MenuItem text="Spectral and Spatial" disabled={!canEnableSpatialMatching || !canEnableSpectralMatching} active={spectralMatchingEnabled && spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(true, true)}/>
-                <MenuItem text="Spectral only" disabled={!canEnableSpectralMatching} active={spectralMatchingEnabled && !spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(false, true)}/>
-                <MenuItem text="Spatial only" disabled={!canEnableSpatialMatching} active={!spectralMatchingEnabled && spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(true, false)}/>
-                <MenuItem text="None" disabled={!canEnableSpatialMatching} active={!spectralMatchingEnabled && !spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(false, false)}/>
+                <MenuItem
+                    text={`Spectral (${appStore.preferenceStore.spectralMatchingType}) and Spatial`}
+                    disabled={!canEnableSpatialMatching || !canEnableSpectralMatching}
+                    active={spectralMatchingEnabled && spatialMatchingEnabled}
+                    onClick={() => appStore.setMatchingEnabled(true, true)}
+                />
+                <MenuItem
+                    text={`Spectral (${appStore.preferenceStore.spectralMatchingType})  only`}
+                    disabled={!canEnableSpectralMatching}
+                    active={spectralMatchingEnabled && !spatialMatchingEnabled}
+                    onClick={() => appStore.setMatchingEnabled(false, true)}
+                />
+                <MenuItem
+                    text="Spatial only"
+                    disabled={!canEnableSpatialMatching}
+                    active={!spectralMatchingEnabled && spatialMatchingEnabled}
+                    onClick={() => appStore.setMatchingEnabled(true, false)}
+                />
+                <MenuItem
+                    text="None"
+                    disabled={!canEnableSpatialMatching}
+                    active={!spectralMatchingEnabled && !spatialMatchingEnabled}
+                    onClick={() => appStore.setMatchingEnabled(false, false)}
+                />
             </Menu>
         );
 
@@ -168,9 +197,11 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 <Tooltip position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
-                <Tooltip position={tooltipPosition} content={<span>WCS Matching <br/><small><i>Current: TODO</i></small></span>}>
+                <Tooltip position={tooltipPosition} content={<span>WCS Matching <br/><small><i>Current: {wcsButtonTooltip}</i></small></span>}>
                     <Popover content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
-                        <AnchorButton icon="link" disabled={!canEnableSpatialMatching && !canEnableSpectralMatching}/>
+                        <Button icon="link" className="link-button">
+                            {wcsButtonSuperscript}
+                        </Button>
                     </Popover>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -58,14 +58,6 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         this.props.appStore.overlayStore.global.setSystem(coordinateSystem);
     };
 
-    handleSpatialReferenceToggled = () => {
-        this.props.appStore.toggleSpatialMatching(this.props.appStore.activeFrame);
-    };
-
-    handleSpectralReferenceToggled = () => {
-        this.props.appStore.toggleSpectralMatching(this.props.appStore.activeFrame);
-    };
-
     render() {
         const appStore = this.props.appStore;
         const frame = appStore.activeFrame;
@@ -132,6 +124,20 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 regionIcon = "error";
         }
 
+        const spatialMatchingEnabled = !!frame.spatialReference;
+        const spectralMatchingEnabled = !!frame.spectralReference;
+        const canEnableSpatialMatching = appStore.spatialReference !== frame;
+        const canEnableSpectralMatching = appStore.spectralReference && appStore.spectralReference !== frame && frame.frameInfo.fileInfoExtended.depth > 1;
+
+        const wcsMatchingMenu = (
+            <Menu>
+                <MenuItem text="Spectral and Spatial" disabled={!canEnableSpatialMatching || !canEnableSpectralMatching} active={spectralMatchingEnabled && spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(true, true)}/>
+                <MenuItem text="Spectral only" disabled={!canEnableSpectralMatching} active={spectralMatchingEnabled && !spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(false, true)}/>
+                <MenuItem text="Spatial only" disabled={!canEnableSpatialMatching} active={!spectralMatchingEnabled && spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(true, false)}/>
+                <MenuItem text="None" disabled={!canEnableSpatialMatching} active={!spectralMatchingEnabled && !spatialMatchingEnabled} onClick={() => appStore.setMatchingEnabled(false, false)}/>
+            </Menu>
+        );
+
         return (
             <ButtonGroup className={className} style={styleProps} vertical={this.props.vertical}>
 
@@ -162,21 +168,10 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 <Tooltip position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
-                <Tooltip position={tooltipPosition} content={<span>Toggle spatial matching</span>}>
-                    <AnchorButton className={"link-button"} icon="link" disabled={appStore.spatialReference === frame} active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}>
-                        xy
-                    </AnchorButton>
-                </Tooltip>
-                <Tooltip position={tooltipPosition} content={<span>Toggle spectral matching</span>}>
-                    <AnchorButton
-                        className={"link-button"}
-                        icon="link"
-                        disabled={!appStore.spectralReference || appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1}
-                        active={!!frame.spectralReference}
-                        onClick={this.handleSpectralReferenceToggled}
-                    >
-                        &nbsp;z
-                    </AnchorButton>
+                <Tooltip position={tooltipPosition} content={<span>WCS Matching <br/><small><i>Current: TODO</i></small></span>}>
+                    <Popover content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
+                        <AnchorButton icon="link" disabled={!canEnableSpatialMatching && !canEnableSpectralMatching}/>
+                    </Popover>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -63,7 +63,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
     };
 
     handleSpectralReferenceToggled = () => {
-        this.props.appStore.toggleSpatialMatching(this.props.appStore.activeFrame);
+        this.props.appStore.toggleSpectralMatching(this.props.appStore.activeFrame);
     };
 
     render() {
@@ -168,7 +168,13 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     </AnchorButton>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Toggle spectral matching</span>}>
-                    <AnchorButton className={"link-button"} icon="link" disabled={appStore.spectralReference === frame} active={!!frame.spectralReference} onClick={this.handleSpectralReferenceToggled}>
+                    <AnchorButton
+                        className={"link-button"}
+                        icon="link"
+                        disabled={!appStore.spectralReference || appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1}
+                        active={!!frame.spectralReference}
+                        onClick={this.handleSpectralReferenceToggled}
+                    >
                         &nbsp;z
                     </AnchorButton>
                 </Tooltip>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -62,6 +62,10 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         this.props.appStore.toggleSpatialMatching(this.props.appStore.activeFrame);
     };
 
+    handleSpectralReferenceToggled = () => {
+        this.props.appStore.toggleSpatialMatching(this.props.appStore.activeFrame);
+    };
+
     render() {
         const appStore = this.props.appStore;
         const frame = appStore.activeFrame;
@@ -158,8 +162,15 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 <Tooltip position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
                     <Button icon="zoom-to-fit" onClick={frame.fitZoom}/>
                 </Tooltip>
-                <Tooltip position={tooltipPosition} content={<span>Debug: Toggle WCS ref</span>}>
-                    <AnchorButton icon="link" disabled={appStore.spatialReference === frame} active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}/>
+                <Tooltip position={tooltipPosition} content={<span>Toggle spatial matching</span>}>
+                    <AnchorButton className={"link-button"} icon="link" disabled={appStore.spatialReference === frame} active={!!frame.spatialReference} onClick={this.handleSpatialReferenceToggled}>
+                        xy
+                    </AnchorButton>
+                </Tooltip>
+                <Tooltip position={tooltipPosition} content={<span>Toggle spectral matching</span>}>
+                    <AnchorButton className={"link-button"} icon="link" disabled={appStore.spectralReference === frame} active={!!frame.spectralReference} onClick={this.handleSpectralReferenceToggled}>
+                        &nbsp;z
+                    </AnchorButton>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={<span>Overlay Coordinate <br/><small><i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i></small></span>}>
                     <Popover content={coordinateSystemMenu} position={Position.TOP} minimal={true}>

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -66,7 +66,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
-        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>{appStore.frames[rowIndex].channel}</Cell>;
+        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>{appStore.frames[rowIndex].requiredChannel}</Cell>;
     };
 
     private stokesRenderer = (rowIndex: number) => {
@@ -74,7 +74,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
-        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>{appStore.frames[rowIndex].stokes}</Cell>;
+        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>{appStore.frames[rowIndex].requiredStokes}</Cell>;
     };
 
     private typeRenderer = (rowIndex: number) => {

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -188,7 +188,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
         const userString = appStore.username ? ` as ${appStore.username}` : "";
         switch (connectionStatus) {
             case ConnectionStatus.PENDING:
-                connectivityTooltip = <span>Connecting to server${userString}</span>;
+                connectivityTooltip = <span>Connecting to server{userString}</span>;
                 connectivityClass += " warning";
                 break;
             case ConnectionStatus.ACTIVE:

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -234,7 +234,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 }
             }
             if (nearestIndex !== null && nearestIndex !== undefined) {
-                frame.setChannels(nearestIndex, frame.requiredStokes);
+                frame.setChannels(nearestIndex, frame.requiredStokes, true);
             }
         }
     };

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -178,7 +178,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 }
             }
             if (nearestIndex !== null && nearestIndex !== undefined) {
-                frame.setChannels(nearestIndex, frame.requiredStokes);
+                frame.setChannels(nearestIndex, frame.requiredStokes, true);
             }
         }
     };
@@ -204,7 +204,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 }
             }
             if (nearestIndex !== null && nearestIndex !== undefined) {
-                frame.setChannels(nearestIndex, frame.requiredStokes);
+                frame.setChannels(nearestIndex, frame.requiredStokes, true);
             }
         }
     };

--- a/src/models/SpectralDefinition.ts
+++ b/src/models/SpectralDefinition.ts
@@ -23,11 +23,19 @@ export enum SpectralType {
     VOPT = "VOPT",
     FREQ = "FREQ",
     WAVE = "WAVE",
-    AWAV = "AWAV"
+    AWAV = "AWAV",
+    CHANNEL = "CHANNEL"
 }
+
+// Channel is not a valid standalone spectral type
 export const IsSpectralTypeValid = (type: string): boolean => {
-    return type && (<any> Object).values(SpectralType).includes(type);
+    return type && type !== SpectralType.CHANNEL && (<any> Object).values(SpectralType).includes(type);
 };
+
+export const SPECTRAL_MATCHING_TYPES: SpectralType[] = [SpectralType.VRAD, SpectralType.VOPT, SpectralType.FREQ, SpectralType.CHANNEL];
+export function IsSpectralMatchingTypeValid(type: SpectralType) {
+    return type && SPECTRAL_MATCHING_TYPES.includes(type);
+}
 
 export enum SpectralUnit {
     KMS = "km/s",
@@ -60,7 +68,8 @@ export const SPECTRAL_TYPE_STRING = new Map<SpectralType, string>([
     [SpectralType.VOPT, "Optical velocity"],
     [SpectralType.FREQ, "Frequency"],
     [SpectralType.WAVE, "Wavelength"],
-    [SpectralType.AWAV, "Air wavelength"]
+    [SpectralType.AWAV, "Air wavelength"],
+    [SpectralType.CHANNEL, "Channel"]
 ]);
 
 export const DEFAULT_UNIT = new Map<SpectralType, SpectralUnit>([

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -19,3 +19,4 @@ export * from "./Processed";
 export * from "./Event";
 export * from "./CARTAInfo";
 export * from "./LayoutConfig";
+export * from "./ControlMap";

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -225,6 +225,12 @@ export class TileService {
         }
     }
 
+    updateInactiveFileChannel(fileId: number, channel: number, stokes: number) {
+        this.clearCompressedCache(fileId);
+        this.channelMap.set(fileId, {channel, stokes});
+        this.backendService.setChannels(fileId, channel, stokes, {});
+    }
+
     clearGPUCache() {
         this.cachedTiles.forEach(this.clearTile);
         this.cachedTiles.clear();

--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -126,7 +126,7 @@ export class AnimatorStore {
                 endFrame
             };
             this.appStore.backendService.stopAnimation(stopMessage);
-            this.appStore.throttledSetChannels(frame.frameInfo.fileId, frame.requiredChannel, frame.requiredStokes);
+            this.appStore.throttledSetChannels([{frame, channel: frame.requiredChannel, stokes: frame.requiredStokes}]);
         }
     };
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -858,10 +858,12 @@ export class AppStore {
         const pendingHistogram = this.pendingChannelHistograms.get(key);
         if (pendingHistogram && pendingHistogram.histograms && pendingHistogram.histograms.length) {
             const updatedFrame = this.getFrame(pendingHistogram.fileId);
-            const channelHist = pendingHistogram.histograms.find(hist => hist.channel === updatedFrame.requiredChannel);
+            const channelHist = pendingHistogram.histograms.find(hist => hist.channel === updatedFrame.channel);
             if (updatedFrame && channelHist) {
                 updatedFrame.renderConfig.setStokes(pendingHistogram.stokes);
                 updatedFrame.renderConfig.updateChannelHistogram(channelHist);
+                updatedFrame.channel = tileStreamDetails.channel;
+                updatedFrame.stokes = tileStreamDetails.stokes;
             }
             this.pendingChannelHistograms.delete(key);
         }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1070,14 +1070,13 @@ export class AppStore {
         }
     };
 
-    @action toggleSpatialMatching = (frame: FrameStore) => {
+    @action setSpatialMatchingEnabled = (val: boolean) => {
+        const frame = this.activeFrame;
         if (!frame || frame === this.spatialReference) {
             return;
         }
 
-        if (frame.spatialReference) {
-            frame.clearSpatialReference();
-        } else {
+        if (val) {
             if (!frame.setSpatialReference(this.spatialReference)) {
                 AppToaster.show({
                     icon: "warning-sign",
@@ -1086,6 +1085,8 @@ export class AppStore {
                     timeout: 3000
                 });
             }
+        } else {
+            frame.clearSpatialReference();
         }
     };
 
@@ -1109,14 +1110,13 @@ export class AppStore {
         }
     };
 
-    @action toggleSpectralMatching = (frame: FrameStore) => {
+    @action setSpectralMatchingEnabled = (val: boolean) => {
+        const frame = this.activeFrame;
         if (!frame || frame === this.spectralReference) {
             return;
         }
 
-        if (frame.spectralReference) {
-            frame.clearSpectralReference();
-        } else {
+        if (val) {
             if (!frame.setSpectralReference(this.spectralReference)) {
                 AppToaster.show({
                     icon: "warning-sign",
@@ -1125,7 +1125,14 @@ export class AppStore {
                     timeout: 3000
                 });
             }
+        } else {
+            frame.clearSpectralReference();
         }
+    };
+
+    @action setMatchingEnabled = (spatial: boolean, spectral: boolean) => {
+        this.setSpatialMatchingEnabled(spatial);
+        this.setSpectralMatchingEnabled(spectral);
     };
 
     // region requirements calculations

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -608,8 +608,7 @@ export class AppStore {
                 const midPointTileCoords = {x: midPointImageCoords.x / tileSizeFullRes - 0.5, y: midPointImageCoords.y / tileSizeFullRes - 0.5};
                 this.tileService.requestTiles(tiles, frame.frameInfo.fileId, frame.channel, frame.stokes, midPointTileCoords, this.preferenceStore.imageCompressionQuality, true);
             } else {
-                // Update inactive channels
-                this.backendService.setChannels(frame.frameInfo.fileId, frame.channel, frame.stokes, {});
+                this.tileService.updateInactiveFileChannel(frame.frameInfo.fileId, frame.channel, frame.stokes);
             }
         });
     }, AppStore.ImageChannelThrottleTime);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -351,15 +351,11 @@ export class FrameStore {
         if (this.spectralReference) {
             let siblings = [];
             siblings.push(this.spectralReference);
-            if (this.spectralReference.secondarySpectralImages) {
-                siblings.push(...this.spectralReference.secondarySpectralImages.slice().filter(f => f !== this));
-            }
+            siblings.push(...this.spectralReference.secondarySpectralImages.slice().filter(f => f !== this));
             return siblings;
-        } else if (this.secondarySpectralImages) {
+        } else {
             return this.secondarySpectralImages.slice();
         }
-
-        return [];
     }
 
     @computed
@@ -448,6 +444,8 @@ export class FrameStore {
         this.overlayBeamSettings = new OverlayBeamStore(preference);
         this.spatialTransformAST = null;
         this.controlMaps = new Map<FrameStore, ControlMap>();
+        this.secondarySpatialImages = [];
+        this.secondarySpectralImages = [];
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preference.astColor;
@@ -1021,17 +1019,13 @@ export class FrameStore {
     };
 
     @action addSecondarySpatialImage = (frame: FrameStore) => {
-        if (!this.secondarySpatialImages) {
-            this.secondarySpatialImages = [frame];
-        } else if (!this.secondarySpatialImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
+        if (!this.secondarySpatialImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
             this.secondarySpatialImages.push(frame);
         }
     };
 
     @action removeSecondarySpatialImage = (frame: FrameStore) => {
-        if (this.secondarySpatialImages) {
-            this.secondarySpatialImages = this.secondarySpatialImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
-        }
+        this.secondarySpatialImages = this.secondarySpatialImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
     };
 
     // Spectral WCS matching
@@ -1095,16 +1089,12 @@ export class FrameStore {
     };
 
     @action addSecondarySpectralImage = (frame: FrameStore) => {
-        if (!this.secondarySpectralImages) {
-            this.secondarySpectralImages = [frame];
-        } else if (!this.secondarySpectralImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
+        if (!this.secondarySpectralImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
             this.secondarySpectralImages.push(frame);
         }
     };
 
     @action removeSecondarySpectralImage = (frame: FrameStore) => {
-        if (this.secondarySpectralImages) {
-            this.secondarySpectralImages = this.secondarySpectralImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
-        }
+        this.secondarySpectralImages = this.secondarySpectralImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
     };
 }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -3,7 +3,7 @@ import {NumberRange} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import * as AST from "ast_wrapper";
 import {ASTSettingsString, ContourConfigStore, ContourStore, LogStore, OverlayBeamStore, OverlayStore, PreferenceStore, RegionSetStore, RenderConfigStore} from "stores";
-import {ChannelInfo, CursorInfo, FrameView, Point2D, ProtobufProcessing, SpectralInfo, ControlMap, Transform2D, ZoomPoint} from "models";
+import {ChannelInfo, ControlMap, CursorInfo, FrameView, Point2D, ProtobufProcessing, SpectralInfo, SpectralType, Transform2D, ZoomPoint} from "models";
 import {clamp, findChannelType, frequencyStringFromVelocity, getHeaderNumericValue, getTransformedChannel, getTransformedCoordinates, minMax2D, rotate2D, toFixed, trimFitsComment, velocityStringFromFrequency} from "utilities";
 import {BackendService} from "services";
 
@@ -1052,8 +1052,12 @@ export class FrameStore {
         // For now, this is just done to ensure a mapping can be constructed
         const copySrc = AST.copy(this.fullWcsInfo);
         const copyDest = AST.copy(frame.fullWcsInfo);
-        AST.set(copySrc, `AlignSystem=${this.preference.spectralMatchingType}`);
-        AST.set(copyDest, `AlignSystem=${this.preference.spectralMatchingType}`);
+        const spectralMatchingType = this.preference.spectralMatchingType;
+        // Ensure that a mapping for the current alignment system is possible
+        if (spectralMatchingType !== SpectralType.CHANNEL) {
+            AST.set(copySrc, `AlignSystem=${this.preference.spectralMatchingType}`);
+            AST.set(copyDest, `AlignSystem=${this.preference.spectralMatchingType}`);
+        }
         AST.invert(copySrc);
         AST.invert(copyDest);
         this.spectralTransformAST = AST.convert(copySrc, copyDest, "");

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -3,9 +3,8 @@ import {Colors} from "@blueprintjs/core";
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 import {AppStore, BeamType, ContourGeneratorType, FrameScaling, RenderConfigStore, RegionStore} from "stores";
-import {Theme, PresetLayout, CursorPosition, Zoom, ZoomPoint, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event} from "models";
+import {Theme, PresetLayout, CursorPosition, Zoom, ZoomPoint, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event, ControlMap, SpectralType, IsSpectralMatchingTypeValid} from "models";
 import {isColorValid, parseBoolean} from "utilities";
-import {ControlMap} from "../models/ControlMap";
 
 export enum PreferenceKeys {
     GLOBAL_THEME = 1,
@@ -15,6 +14,7 @@ export enum PreferenceKeys {
     GLOBAL_ZOOM_MODE,
     GLOBAL_ZOOM_POINT,
     GLOBAL_DRAG_PANNING,
+    GLOBAL_SPECTRAL_MATCHING_TYPE,
 
     RENDER_CONFIG_SCALING,
     RENDER_CONFIG_COLORMAP,
@@ -71,6 +71,7 @@ const KEY_TO_STRING = new Map<PreferenceKeys, string>([
     [PreferenceKeys.GLOBAL_ZOOM_MODE, "zoomMode"],
     [PreferenceKeys.GLOBAL_ZOOM_POINT, "zoomPoint"],
     [PreferenceKeys.GLOBAL_DRAG_PANNING, "dragPanning"],
+    [PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, "spectralMatchingType"],
 
     [PreferenceKeys.RENDER_CONFIG_SCALING, "scaling"],
     [PreferenceKeys.RENDER_CONFIG_COLORMAP, "colormap"],
@@ -128,6 +129,7 @@ const DEFAULTS = {
         zoomMode: Zoom.FIT,
         zoomPoint: ZoomPoint.CURSOR,
         dragPanning: true,
+        spectralMatchingType: SpectralType.VRAD
     },
     RENDER_CONFIG: {
         scaling: FrameScaling.LINEAR,
@@ -197,6 +199,7 @@ export class PreferenceStore {
         [PreferenceKeys.GLOBAL_ZOOM_MODE, (value: string): string => { return value && Zoom.isValid(value) ? value : DEFAULTS.GLOBAL.zoomMode; }],
         [PreferenceKeys.GLOBAL_ZOOM_POINT, (value: string): string => { return value && ZoomPoint.isValid(value) ? value : DEFAULTS.GLOBAL.zoomPoint; }],
         [PreferenceKeys.GLOBAL_DRAG_PANNING, (value: string): boolean => { return value === "false" ? false : DEFAULTS.GLOBAL.dragPanning; }],
+        [PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, (value: SpectralType): string => { return IsSpectralMatchingTypeValid(value) ? value : DEFAULTS.GLOBAL.spectralMatchingType; }],
 
         [PreferenceKeys.RENDER_CONFIG_SCALING, (value: string): number => { return value && isFinite(Number(value)) && RenderConfigStore.IsScalingValid(Number(value)) ? Number(value) : DEFAULTS.RENDER_CONFIG.scaling; }],
         [PreferenceKeys.RENDER_CONFIG_COLORMAP, (value: string): string => { return value && RenderConfigStore.IsColormapValid(value) ? value : DEFAULTS.RENDER_CONFIG.colormap; }],
@@ -284,6 +287,10 @@ export class PreferenceStore {
 
     @computed get dragPanning(): boolean {
         return this.preferences.get(PreferenceKeys.GLOBAL_DRAG_PANNING);
+    }
+
+    @computed get spectralMatchingType(): SpectralType {
+        return this.preferences.get(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE);
     }
 
     // getters for render config
@@ -538,6 +545,7 @@ export class PreferenceStore {
         this.setPreference(PreferenceKeys.GLOBAL_ZOOM_MODE, DEFAULTS.GLOBAL.zoomMode);
         this.setPreference(PreferenceKeys.GLOBAL_ZOOM_POINT, DEFAULTS.GLOBAL.zoomPoint);
         this.setPreference(PreferenceKeys.GLOBAL_DRAG_PANNING, DEFAULTS.GLOBAL.dragPanning);
+        this.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, DEFAULTS.GLOBAL.spectralMatchingType);
     };
 
     @action resetRenderConfigSettings = () => {
@@ -621,6 +629,7 @@ export class PreferenceStore {
             [PreferenceKeys.GLOBAL_ZOOM_MODE, DEFAULTS.GLOBAL.zoomMode],
             [PreferenceKeys.GLOBAL_ZOOM_POINT, DEFAULTS.GLOBAL.zoomPoint],
             [PreferenceKeys.GLOBAL_DRAG_PANNING, DEFAULTS.GLOBAL.dragPanning],
+            [PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, DEFAULTS.GLOBAL.spectralMatchingType],
 
             [PreferenceKeys.RENDER_CONFIG_SCALING, DEFAULTS.RENDER_CONFIG.scaling],
             [PreferenceKeys.RENDER_CONFIG_COLORMAP, DEFAULTS.RENDER_CONFIG.colormap],

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -32,3 +32,7 @@ export function binarySearchByX(array: readonly Point2D[], x: number): {point: P
     const closer = ((array[start].x - x) < (x - array[end].x)) ? start : end;
     return {point: array[closer], index: closer};
 }
+
+export const distinct = (value: any, index: number, self: Array<any>) => {
+    return self.indexOf(value) === index;
+};

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -57,8 +57,8 @@ export function getTransformedChannel(srcTransform: number, destTransform: numbe
     }
 
     // Set spectral system for both transforms
-    AST.set(srcTransform, `System=${matchingType}`);
-    AST.set(destTransform, `System=${matchingType}`);
+    AST.set(srcTransform, `System=${matchingType}, StdOfRest=Helio`);
+    AST.set(destTransform, `System=${matchingType}, StdOfRest=Helio`);
     // Get spectral value from forward transform. Adjust for 1-based index
     const sourceSpectralValue = AST.transform3DPoint(srcTransform, 1, 1, srcChannel + 1, true);
     if (!sourceSpectralValue || !isFinite(sourceSpectralValue.z)) {

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -318,6 +318,22 @@ EMSCRIPTEN_KEEPALIVE int set(AstFrameSet* wcsinfo, const char* attrib)
     return 0;
 }
 
+EMSCRIPTEN_KEEPALIVE int clear(AstObject* obj, const char* attrib)
+{
+    if (!obj)
+    {
+        return 1;
+    }
+
+    astSet(obj, attrib);
+    if (!astOK)
+    {
+        astClearStatus;
+        return 1;
+    }
+    return 0;
+}
+
 EMSCRIPTEN_KEEPALIVE void dump(AstFrameSet* wcsinfo)
 {
     if (wcsinfo)

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -361,6 +361,23 @@ EMSCRIPTEN_KEEPALIVE int transform(AstFrameSet* wcsinfo, int npoint, const doubl
     return 0;
 }
 
+EMSCRIPTEN_KEEPALIVE int transform3D(AstSpecFrame* wcsinfo, double x, double y, double z, const int forward, double* out)
+{
+    if (!wcsinfo)
+    {
+        return 1;
+    }
+
+    double in[] ={x, y, z};
+    astTranN(wcsinfo, 1, 3, 1, in, forward, 3, 1, out);
+    if (!astOK)
+    {
+        astClearStatus;
+        return 1;
+    }
+    return 0;
+}
+
 EMSCRIPTEN_KEEPALIVE int spectralTransform(AstSpecFrame* specFrameFrom, const char* specTypeTo, const char* specUnitTo, const char* specSysTo, const int npoint, const double zIn[], const int forward, double zOut[])
 {
     if (!specFrameFrom || !specTypeTo ||!specUnitTo || !specSysTo)

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -102,6 +102,7 @@ Module.norm = Module.cwrap("norm", "number", ["number", "number"]);
 Module.axDistance = Module.cwrap("axDistance", "number", ["number", "number", "number", "number"]);
 Module.format = Module.cwrap("format", "string", ["number", "number", "number"]);
 Module.transform = Module.cwrap("transform", "number", ["number", "number", "number", "number", "number", "number", "number"]);
+Module.transform3D = Module.cwrap("transform3D", "number", ["number", "number", "number", "number", "number", "number"]);
 Module.spectralTransform = Module.cwrap("spectralTransform", "number", ["number", "string", "string", "string", "number", "number", "number", "number"]);
 Module.getLastErrorMessage = Module.cwrap("getLastErrorMessage", "string");
 Module.clearLastErrorMessage = Module.cwrap("clearLastErrorMessage", null);
@@ -167,7 +168,6 @@ Module.pixToWCSVector = function (wcsInfo, xIn, yIn) {
 };
 
 Module.transformPoint = function (transformFrameSet: number, xIn: number, yIn: number, forward: boolean = true) {
-    // Return empty array if arguments are invalid
     const N = 1;
     Module.HEAPF64.set(new Float64Array([xIn]), Module.xIn / 8);
     Module.HEAPF64.set(new Float64Array([yIn]), Module.yIn / 8);
@@ -175,6 +175,16 @@ Module.transformPoint = function (transformFrameSet: number, xIn: number, yIn: n
     const xOut = new Float64Array(Module.HEAPF64.buffer, Module.xOut, N);
     const yOut = new Float64Array(Module.HEAPF64.buffer, Module.yOut, N);
     return {x: xOut[0], y: yOut[0]};
+};
+
+Module.transform3DPoint = function (transformFrameSet: number, xIn: number, yIn: number, zIn: number, forward: boolean = true) {
+    const N = 1;
+    const outPtr = Module._malloc(24);
+    Module.transform3D(transformFrameSet, xIn, yIn, zIn, forward, outPtr);
+    const out = new Float64Array(Module.HEAPF64.buffer, outPtr, 3);
+    const res = {x: out[0], y: out[1], z: out[2]};
+    Module._free(outPtr);
+    return res;
 };
 
 Module.transformSpectralPoint = function (spectralFrameFrom: number, specType: string, specUnit: string, specSys: string, zIn: number, forward: boolean = true) {

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -96,6 +96,7 @@ Module.initFrame = Module.cwrap("initFrame", "number", ["string"]);
 Module.initSpectralFrame = Module.cwrap("initSpectralFrame", "number", ["string", "string", "string"]);
 Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);
 Module.set = Module.cwrap("set", "number", ["number", "string"]);
+Module.clear = Module.cwrap("clear", "number", ["number", "string"]);
 Module.getString = Module.cwrap("getString", "string", ["number", "string"]);
 Module.dump = Module.cwrap("dump", null, ["number"]);
 Module.norm = Module.cwrap("norm", "number", ["number", "number"]);

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
+    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
+    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then


### PR DESCRIPTION
Closes #769.

Spectral matching of images using AST. The user can choose to match images based on frequency, radio velocity (default), optical velocity or channel. 

This PR also implements a workaround for a minor BlueprintJS issue (button group entries are slightly larger in dark mode), and fixes some issues with channels not appearing when the required channel is changed quickly. 