### PR TITLE
Angus/layer widget improvements

### DIFF
--- a/src/components/LayerList/LayerListComponent.scss
+++ b/src/components/LayerList/LayerListComponent.scss
@@ -13,4 +13,8 @@
     .spectral-matching-button {
         margin-left: 3px;
     }
+
+    .name-cell {
+        cursor: pointer;
+    }
 }

--- a/src/components/LayerList/LayerListComponent.scss
+++ b/src/components/LayerList/LayerListComponent.scss
@@ -9,4 +9,8 @@
     .active-row-cell {
         font-weight: bold;
     }
+
+    .spectral-matching-button {
+        margin-left: 3px;
+    }
 }

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -60,11 +60,13 @@ export class LayerListComponent extends React.Component<WidgetProps> {
 
         const frame = appStore.frames[rowIndex];
 
-        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
-            <div onDoubleClick={() => appStore.setActiveFrame(frame.frameInfo.fileId)}>
-                {frame.frameInfo.fileInfo.name}
-            </div>
-        </Cell>;
+        return (
+            <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
+                <div className="name-cell" onClick={() => appStore.setActiveFrame(frame.frameInfo.fileId)}>
+                    {frame.frameInfo.fileInfo.name}
+                </div>
+            </Cell>
+        );
     };
 
     private channelRenderer = (rowIndex: number) => {

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -12,7 +12,7 @@ import "./LayerListComponent.css";
 export class LayerListComponent extends React.Component<WidgetProps> {
     @observable width: number = 0;
     @observable height: number = 0;
-    @observable columnWidths = [150, 80, 80, 70];
+    @observable columnWidths = [150, 70, 85, 80, 70];
 
     public static get WIDGET_CONFIG(): WidgetConfig {
         return {
@@ -58,7 +58,13 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             return <Cell/>;
         }
 
-        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>{appStore.frames[rowIndex].frameInfo.fileInfo.name}</Cell>;
+        const frame = appStore.frames[rowIndex];
+
+        return <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
+            <div onDoubleClick={() => appStore.setActiveFrame(frame.frameInfo.fileId)}>
+                {frame.frameInfo.fileInfo.name}
+            </div>
+        </Cell>;
     };
 
     private channelRenderer = (rowIndex: number) => {
@@ -101,6 +107,63 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         );
     };
 
+    private matchingRenderer = (rowIndex: number) => {
+        const appStore = this.props.appStore;
+        if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
+            return <Cell/>;
+        }
+
+        const frame = appStore.frames[rowIndex];
+
+        let spatialMatchingButton: React.ReactNode;
+        if (appStore.spatialReference) {
+            let tooltipSubtitle: string;
+            if (frame === appStore.spatialReference) {
+                tooltipSubtitle = `${frame.frameInfo.fileInfo.name} is the current spatial reference`;
+            } else {
+                tooltipSubtitle = `Click to ${frame.spatialReference ? "disable" : "enable"} matching to ${appStore.spatialReference.frameInfo.fileInfo.name}`;
+            }
+            spatialMatchingButton = (
+                <Tooltip content={<span>Spatial matching<br/><i><small>{tooltipSubtitle}</small></i></span>}>
+                    <AnchorButton minimal={true} small={true} active={frame === appStore.spatialReference} intent={frame.spatialReference ? "primary" : "none"} onClick={() => appStore.toggleSpatialMatching(frame)}>XY</AnchorButton>
+                </Tooltip>
+            );
+        }
+
+        let spectralMatchingButton: React.ReactNode;
+        if (frame.frameInfo.fileInfoExtended.depth > 1 && appStore.spectralReference) {
+            let tooltipSubtitle: string;
+            if (frame === appStore.spectralReference) {
+                tooltipSubtitle = `${frame.frameInfo.fileInfo.name} is the current spectral reference`;
+            } else {
+                tooltipSubtitle = `Click to ${frame.spectralReference ? "disable" : "enable"} matching to ${appStore.spectralReference.frameInfo.fileInfo.name}`;
+            }
+            spectralMatchingButton = (
+                <Tooltip content={<span>Spectral matching<br/><i><small>{tooltipSubtitle}</small></i></span>}>
+                    <AnchorButton
+                        className="spectral-matching-button"
+                        minimal={true}
+                        small={true}
+                        active={frame === appStore.spectralReference}
+                        intent={frame.spectralReference ? "primary" : "none"}
+                        onClick={() => appStore.toggleSpectralMatching(frame)}
+                    >
+                        Z
+                    </AnchorButton>
+                </Tooltip>
+            );
+        }
+
+        return (
+            <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
+                <div className="matching-cell">
+                    {spatialMatchingButton}
+                    {spectralMatchingButton}
+                </div>
+            </Cell>
+        );
+    };
+
     private columnHeaderRenderer = (columnIndex: number) => {
         let name: string;
         switch (columnIndex) {
@@ -111,9 +174,12 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                 name = "Type";
                 break;
             case 2:
-                name = "Channel";
+                name = "Matching";
                 break;
             case 3:
+                name = "Channel";
+                break;
+            case 4:
                 name = "Stokes";
                 break;
             default:
@@ -148,6 +214,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         const activeFrameIndex = this.props.appStore.activeFrameIndex;
         const visibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
+        const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference);
 
         return (
             <div className="layer-list-widget">
@@ -164,23 +231,13 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     columnWidths={this.columnWidths}
                     enableColumnResizing={true}
                     onColumnWidthChanged={this.onColumnWidthsChange}
+                    onSelection={r => console.log(r)}
                 >
-                    <Column
-                        columnHeaderCellRenderer={this.columnHeaderRenderer}
-                        cellRenderer={this.fileNameRenderer}
-                    />
-                    <Column
-                        columnHeaderCellRenderer={this.columnHeaderRenderer}
-                        cellRenderer={this.typeRenderer}
-                    />
-                    <Column
-                        columnHeaderCellRenderer={this.columnHeaderRenderer}
-                        cellRenderer={this.channelRenderer}
-                    />
-                    <Column
-                        columnHeaderCellRenderer={this.columnHeaderRenderer}
-                        cellRenderer={this.stokesRenderer}
-                    />
+                    <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.fileNameRenderer}/>
+                    <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.typeRenderer}/>
+                    <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.matchingRenderer}/>
+                    <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.channelRenderer}/>
+                    <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.stokesRenderer}/>
                 </Table>
                 }
                 <ReactResizeDetector handleWidth handleHeight onResize={this.onResize}/>

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -62,9 +62,11 @@ export class LayerListComponent extends React.Component<WidgetProps> {
 
         return (
             <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
-                <div className="name-cell" onClick={() => appStore.setActiveFrame(frame.frameInfo.fileId)}>
-                    {frame.frameInfo.fileInfo.name}
-                </div>
+                <React.Fragment>
+                    <div className="name-cell" onClick={() => appStore.setActiveFrame(frame.frameInfo.fileId)}>
+                        {frame.frameInfo.fileInfo.name}
+                    </div>
+                </React.Fragment>
             </Cell>
         );
     };
@@ -158,10 +160,10 @@ export class LayerListComponent extends React.Component<WidgetProps> {
 
         return (
             <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
-                <div className="matching-cell">
+                <React.Fragment>
                     {spatialMatchingButton}
                     {spectralMatchingButton}
-                </div>
+                </React.Fragment>
             </Cell>
         );
     };
@@ -217,6 +219,8 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         const visibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
         const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference);
+        const currentSpectralReference = appStore.spectralReference;
+        const currentSpatialReference = appStore.spatialReference;
 
         return (
             <div className="layer-list-widget">
@@ -233,7 +237,6 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     columnWidths={this.columnWidths}
                     enableColumnResizing={true}
                     onColumnWidthChanged={this.onColumnWidthsChange}
-                    onSelection={r => console.log(r)}
                 >
                     <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.fileNameRenderer}/>
                     <Column columnHeaderCellRenderer={this.columnHeaderRenderer} cellRenderer={this.typeRenderer}/>

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1112,8 +1112,7 @@ export class AppStore {
         }
     };
 
-    @action setSpatialMatchingEnabled = (val: boolean) => {
-        const frame = this.activeFrame;
+    @action setSpatialMatchingEnabled = (frame: FrameStore, val: boolean) => {
         if (!frame || frame === this.spatialReference) {
             return;
         }
@@ -1130,6 +1129,14 @@ export class AppStore {
         } else {
             frame.clearSpatialReference();
         }
+    };
+
+    @action toggleSpatialMatching = (frame: FrameStore) => {
+        if (!frame || frame === this.spatialReference) {
+            return;
+        }
+
+        this.setSpatialMatchingEnabled(frame, !frame.spatialReference);
     };
 
     @action setSpectralReference = (frame: FrameStore) => {
@@ -1152,8 +1159,7 @@ export class AppStore {
         }
     };
 
-    @action setSpectralMatchingEnabled = (val: boolean) => {
-        const frame = this.activeFrame;
+    @action setSpectralMatchingEnabled = (frame: FrameStore, val: boolean) => {
         if (!frame || frame === this.spectralReference) {
             return;
         }
@@ -1172,9 +1178,17 @@ export class AppStore {
         }
     };
 
+    @action toggleSpectralMatching = (frame: FrameStore) => {
+        if (!frame || frame === this.spectralReference) {
+            return;
+        }
+
+        this.setSpectralMatchingEnabled(frame, !frame.spectralReference);
+    };
+
     @action setMatchingEnabled = (spatial: boolean, spectral: boolean) => {
-        this.setSpatialMatchingEnabled(spatial);
-        this.setSpectralMatchingEnabled(spectral);
+        this.setSpatialMatchingEnabled(this.activeFrame, spatial);
+        this.setSpectralMatchingEnabled(this.activeFrame, spectral);
     };
 
     // region requirements calculations

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -340,10 +340,10 @@ export class AppStore {
 
             if (this.frames.length > 1) {
                 if ((this.preferenceStore.autoWCSMatching & WCSMatchingType.SPATIAL) && this.spatialReference !== newFrame) {
-                    this.setSpatialMatchingEnabled(true);
+                    this.setSpatialMatchingEnabled(newFrame, true);
                 }
                 if ((this.preferenceStore.autoWCSMatching & WCSMatchingType.SPECTRAL) && this.spectralReference !== newFrame && newFrame.frameInfo.fileInfoExtended.depth > 1) {
-                    this.setSpectralMatchingEnabled(true);
+                    this.setSpectralMatchingEnabled(newFrame, true);
                 }
             }
 


### PR DESCRIPTION
Closes #682 (although a method for _changing_ the spectral and spatial references still needs to be added).

Adds ability to toggle WCS spectral and spatial matching from the layer widget, and the ability to change to a different image by clicking on the name

