### PR TITLE
replace splice with filter operation to trigger component re-render

### DIFF
--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -227,7 +227,7 @@ export class ContourDialogComponent extends React.Component<{ appStore: AppStore
 
         // remove it from the array
         if (closestIndex >= 0) {
-            this.levels.splice(closestIndex, 1);
+            this.levels = this.levels.filter((v, i) => i !== closestIndex);
         }
     };
 
@@ -245,7 +245,7 @@ export class ContourDialogComponent extends React.Component<{ appStore: AppStore
     };
 
     @action private handleLevelRemoved = (value: string, index: number) => {
-        this.levels.splice(index, 1);
+        this.levels = this.levels.filter((v, i) => i !== index);
     };
 
     @action private handleLevelDragged = (index: number) => (val: number) => {

--- a/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
@@ -292,7 +292,7 @@ export class ContourGeneratorPanelComponent extends React.Component<{ frame: Fra
     };
 
     @action private handleLevelRemoved = (value: string, index: number) => {
-        this.sigmaLevels.splice(index, 1);
+        this.sigmaLevels = this.sigmaLevels.filter((v, i) => i !== index);
     };
 
     private renderMeanSigmaParameterRow() {


### PR DESCRIPTION
Filtering instead of splicing `@observable` array seems to solve the issue. I wonder if its because the levels are only used in a private function _called_ by render, and not inside render itself.