### PR TITLE
Angus/test canvas rendering

### DIFF
--- a/src/components/ImageView/CatalogView/CatalogViewComponent.scss
+++ b/src/components/ImageView/CatalogView/CatalogViewComponent.scss
@@ -1,12 +1,12 @@
 .catalog-div {
     position: absolute;
-    // left: 0;
+    left: 0;
 
     &.docked {
         z-index: 3;
     }
 
-    .catalog-layer {
+    .catalog-canvas {
         position: absolute;
         z-index: 0;
     }


### PR DESCRIPTION
Uses native canvas rendering to accelerate rendering of catalogs. 

This provides a large speedup, and should be able to handle ~ 10K catalog points reasonably well. If we want to support more points, we will need to implement #814