### PR TITLE
fixes #864 by re-centering image before fitting zoom

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1091,6 +1091,7 @@ export class FrameStore {
     @action fitZoom = () => {
         if (this.spatialReference) {
             // Calculate midpoint of image
+            this.initCenter();
             const imageCenterReferenceSpace = getTransformedCoordinates(this.spatialTransformAST, this.center, true);
             this.spatialReference.setCenter(imageCenterReferenceSpace.x, imageCenterReferenceSpace.y);
             // Calculate bounding box for transformed image


### PR DESCRIPTION
simple fix to re-center images before fitting zoom.