### PR TITLE
fix help drawer of docked widgets not working in FireFox #854

### DIFF
--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -495,7 +495,7 @@ export class WidgetsStore {
             const container = item["container"] as GoldenLayout.Container;
             let centerX = 0;
             if (container && container.width) {
-                centerX = ev.toElement.getBoundingClientRect().right + 36 - container.width * 0.5; // 36(px) is the length between help button and right border of widget
+                centerX = ev.target.getBoundingClientRect().right + 36 - container.width * 0.5; // 36(px) is the length between help button and right border of widget
             }
             this.appStore.helpStore.showHelpDrawer(widgetConfig.helpType, centerX);
         }


### PR DESCRIPTION
Fix #854. This was caused by `toElement`(a legacy method) of `@type/jquery` acting differently in different browsers(returning `undefined` in FireFox). 