### PR TITLE
Angus/code refactor singletons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {Alert, Classes, Colors, Dialog, Hotkey, Hotkeys, HotkeysTarget, Intent} 
 import {UIControllerComponent, exportImage, FloatingWidgetManagerComponent} from "./components";
 import {AppToaster} from "./components/Shared";
 import {TaskProgressDialogComponent} from "./components/Dialogs";
-import {AlertStore, AppStore, BrowserMode, dayPalette, DialogStore, FileBrowserStore, LogStore, nightPalette, RegionMode} from "./stores";
+import {AlertStore, AppStore, BrowserMode, dayPalette, DialogStore, FileBrowserStore, LogStore, nightPalette, OverlayStore, RegionMode} from "./stores";
 import {ConnectionStatus} from "./services";
 import GitCommit from "./static/gitInfo";
 import "./App.css";
@@ -228,7 +228,7 @@ export class App extends React.Component {
             <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File)}/>,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File, true)}/>,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}W`} label="Close image" onKeyDown={() => appStore.closeCurrentFile(true)}/>,
-            <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>,
+            <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => exportImage(OverlayStore.Instance.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>,
             <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}C`} label="Append catalog" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}/>
         ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,21 +23,20 @@ export class App extends React.Component {
         super(props);
 
         const appStore = AppStore.Instance;
-        const logStore = LogStore.Instance;
 
         AST.onReady.then(() => {
             AST.setPalette(appStore.darkTheme ? nightPalette : dayPalette);
             appStore.astReady = true;
-            logStore.addInfo("AST library loaded", ["ast"]);
+            appStore.logStore.addInfo("AST library loaded", ["ast"]);
         });
 
         CARTACompute.onReady.then(() => {
             appStore.cartaComputeReady = true;
-            logStore.addInfo("Compute module loaded", ["compute"]);
+            appStore.logStore.addInfo("Compute module loaded", ["compute"]);
         });
 
         // Log the frontend git commit hash
-        logStore.addDebug(`Current frontend version: ${GitCommit.logMessage}`, ["version"]);
+        appStore.logStore.addDebug(`Current frontend version: ${GitCommit.logMessage}`, ["version"]);
 
         this.previousConnectionStatus = ConnectionStatus.CLOSED;
         // Display toasts when connection status changes
@@ -74,7 +73,6 @@ export class App extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const alertStore = AlertStore.Instance;
         let className = "App";
         let glClassName = "gl-container-app";
         if (appStore.darkTheme) {
@@ -87,25 +85,25 @@ export class App extends React.Component {
         return (
             <div className={className}>
                 <UIControllerComponent appStore={appStore}/>
-                <Alert isOpen={alertStore.alertVisible} onClose={alertStore.dismissAlert} canEscapeKeyCancel={true}>
-                    <p>{alertStore.alertText}</p>
+                <Alert isOpen={appStore.alertStore.alertVisible} onClose={appStore.alertStore.dismissAlert} canEscapeKeyCancel={true}>
+                    <p>{appStore.alertStore.alertText}</p>
                 </Alert>
                 <Alert
-                    isOpen={alertStore.interactiveAlertVisible}
+                    isOpen={appStore.alertStore.interactiveAlertVisible}
                     confirmButtonText="OK"
                     cancelButtonText="Cancel"
                     intent={Intent.DANGER}
-                    onClose={alertStore.handleInteractiveAlertClosed}
+                    onClose={appStore.alertStore.handleInteractiveAlertClosed}
                     canEscapeKeyCancel={true}
                 >
-                    <p>{alertStore.interactiveAlertText}</p>
+                    <p>{appStore.alertStore.interactiveAlertText}</p>
                 </Alert>
                 <TaskProgressDialogComponent progress={undefined} timeRemaining={0} isOpen={appStore.resumingSession} cancellable={false} text={"Resuming session..."}/>
                 <div className={glClassName} ref={ref => appStore.setAppContainer(ref)}>
                     <ReactResizeDetector handleWidth handleHeight onResize={this.onContainerResize} refreshMode={"throttle"} refreshRate={200}/>
                 </div>
                 <FloatingWidgetManagerComponent appStore={appStore}/>
-                <Dialog isOpen={DialogStore.Instance.hotkeyDialogVisible} className={"bp3-hotkey-dialog"} canEscapeKeyClose={true} canOutsideClickClose={true} onClose={DialogStore.Instance.hideHotkeyDialog}>
+                <Dialog isOpen={appStore.dialogStore.hotkeyDialogVisible} className={"bp3-hotkey-dialog"} canEscapeKeyClose={true} canOutsideClickClose={true} onClose={appStore.dialogStore.hideHotkeyDialog}>
                     <div className={Classes.DIALOG_BODY}>
                         {this.renderHotkeys()}
                     </div>
@@ -187,7 +185,6 @@ export class App extends React.Component {
 
     public renderHotkeys() {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = FileBrowserStore.Instance;
         const modString = appStore.modifierString;
 
         const navigationGroupTitle = "1) Navigation";
@@ -225,11 +222,11 @@ export class App extends React.Component {
         ];
 
         const fileHotkeys = [
-            <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File)}/>,
-            <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File, true)}/>,
+            <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)}/>,
+            <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)}/>,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}W`} label="Close image" onKeyDown={() => appStore.closeCurrentFile(true)}/>,
-            <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => exportImage(OverlayStore.Instance.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>,
-            <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}C`} label="Append catalog" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}/>
+            <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>,
+            <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}C`} label="Append catalog" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}/>
         ];
 
         const otherHotKeys = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {Alert, Classes, Colors, Dialog, Hotkey, Hotkeys, HotkeysTarget, Intent} 
 import {UIControllerComponent, exportImage, FloatingWidgetManagerComponent} from "./components";
 import {AppToaster} from "./components/Shared";
 import {TaskProgressDialogComponent} from "./components/Dialogs";
-import {AlertStore, AppStore, BrowserMode, dayPalette, LogStore, nightPalette, RegionMode} from "./stores";
+import {AlertStore, AppStore, BrowserMode, dayPalette, DialogStore, LogStore, nightPalette, RegionMode} from "./stores";
 import {ConnectionStatus} from "./services";
 import GitCommit from "./static/gitInfo";
 import "./App.css";
@@ -105,7 +105,7 @@ export class App extends React.Component {
                     <ReactResizeDetector handleWidth handleHeight onResize={this.onContainerResize} refreshMode={"throttle"} refreshRate={200}/>
                 </div>
                 <FloatingWidgetManagerComponent appStore={appStore}/>
-                <Dialog isOpen={appStore.dialogStore.hotkeyDialogVisible} className={"bp3-hotkey-dialog"} canEscapeKeyClose={true} canOutsideClickClose={true} onClose={appStore.dialogStore.hideHotkeyDialog}>
+                <Dialog isOpen={DialogStore.Instance.hotkeyDialogVisible} className={"bp3-hotkey-dialog"} canEscapeKeyClose={true} canOutsideClickClose={true} onClose={DialogStore.Instance.hideHotkeyDialog}>
                     <div className={Classes.DIALOG_BODY}>
                         {this.renderHotkeys()}
                     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {Alert, Classes, Colors, Dialog, Hotkey, Hotkeys, HotkeysTarget, Intent} 
 import {UIControllerComponent, exportImage, FloatingWidgetManagerComponent} from "./components";
 import {AppToaster} from "./components/Shared";
 import {TaskProgressDialogComponent} from "./components/Dialogs";
-import {AlertStore, AppStore, BrowserMode, dayPalette, DialogStore, LogStore, nightPalette, RegionMode} from "./stores";
+import {AlertStore, AppStore, BrowserMode, dayPalette, DialogStore, FileBrowserStore, LogStore, nightPalette, RegionMode} from "./stores";
 import {ConnectionStatus} from "./services";
 import GitCommit from "./static/gitInfo";
 import "./App.css";
@@ -187,6 +187,7 @@ export class App extends React.Component {
 
     public renderHotkeys() {
         const appStore = AppStore.Instance;
+        const fileBrowserStore = FileBrowserStore.Instance;
         const modString = appStore.modifierString;
 
         const navigationGroupTitle = "1) Navigation";
@@ -224,11 +225,11 @@ export class App extends React.Component {
         ];
 
         const fileHotkeys = [
-            <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)}/>,
-            <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)}/>,
+            <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File)}/>,
+            <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.File, true)}/>,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}W`} label="Close image" onKeyDown={() => appStore.closeCurrentFile(true)}/>,
             <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>,
-            <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}C`} label="Append catalog" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}/>
+            <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}C`} label="Append catalog" onKeyDown={() => fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}/>
         ];
 
         const otherHotKeys = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ export class App extends React.Component {
 
         return (
             <div className={className}>
-                <UIControllerComponent appStore={appStore}/>
+                <UIControllerComponent/>
                 <Alert isOpen={appStore.alertStore.alertVisible} onClose={appStore.alertStore.dismissAlert} canEscapeKeyCancel={true}>
                     <p>{appStore.alertStore.alertText}</p>
                 </Alert>
@@ -102,7 +102,7 @@ export class App extends React.Component {
                 <div className={glClassName} ref={ref => appStore.setAppContainer(ref)}>
                     <ReactResizeDetector handleWidth handleHeight onResize={this.onContainerResize} refreshMode={"throttle"} refreshRate={200}/>
                 </div>
-                <FloatingWidgetManagerComponent appStore={appStore}/>
+                <FloatingWidgetManagerComponent/>
                 <Dialog isOpen={appStore.dialogStore.hotkeyDialogVisible} className={"bp3-hotkey-dialog"} canEscapeKeyClose={true} canOutsideClickClose={true} onClose={appStore.dialogStore.hideHotkeyDialog}>
                     <div className={Classes.DIALOG_BODY}>
                         {this.renderHotkeys()}

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -87,7 +87,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (AnimatorStore.Instance.animationMode) {
+        switch (appStore.animatorStore.animationMode) {
             case AnimationMode.FRAME:
                 appStore.setActiveFrameByIndex(0);
                 break;
@@ -110,7 +110,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (AnimatorStore.Instance.animationMode) {
+        switch (appStore.animatorStore.animationMode) {
             case AnimationMode.FRAME:
                 appStore.setActiveFrameByIndex(appStore.frames.length - 1);
                 break;
@@ -133,7 +133,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (AnimatorStore.Instance.animationMode) {
+        switch (appStore.animatorStore.animationMode) {
             case AnimationMode.FRAME:
                 appStore.nextFrame();
                 break;
@@ -156,7 +156,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (AnimatorStore.Instance.animationMode) {
+        switch (appStore.animatorStore.animationMode) {
             case AnimationMode.FRAME:
                 appStore.prevFrame();
                 break;
@@ -200,7 +200,6 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     public render() {
         const appStore = AppStore.Instance;
         const activeFrame = appStore.activeFrame;
-        const animatorStore = AnimatorStore.Instance;
         const dims = activeFrame ? activeFrame.frameInfo.fileInfoExtended.dimensions : 0;
         const numChannels = activeFrame ? activeFrame.frameInfo.fileInfoExtended.depth : 0;
         const numStokes = activeFrame ? activeFrame.frameInfo.fileInfoExtended.stokes : 0;
@@ -216,8 +215,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.FRAME}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
-                        checked={animatorStore.animationMode === AnimationMode.FRAME}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        checked={appStore.animatorStore.animationMode === AnimationMode.FRAME}
                         onChange={this.onAnimationModeChanged}
                         label="Frame"
                     />
@@ -229,7 +228,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         step={1}
                         onValueChange={this.onFrameChanged}
                         fill={true}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                     />
                     }
                     {!hideSliders &&
@@ -241,7 +240,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             showTrackFill={false}
                             stepSize={1}
                             onChange={this.onFrameChanged}
-                            disabled={animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {activeFrame.frameInfo.fileInfo.name}
@@ -260,8 +259,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.CHANNEL}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
-                        checked={animatorStore.animationMode === AnimationMode.CHANNEL}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL}
                         onChange={this.onAnimationModeChanged}
                         label="Channel"
                     />
@@ -273,7 +272,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         step={1}
                         onValueChange={this.onChannelChanged}
                         fill={true}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                     />
                     }
                     {!hideSliders &&
@@ -287,7 +286,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             labelPrecision={0}
                             showTrackFill={false}
                             onChange={this.onChannelChanged}
-                            disabled={animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {`Req: ${activeFrame.requiredChannel}; Current: ${activeFrame.channel}`}
@@ -308,7 +307,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             labelStepSize={channelStep}
                             labelPrecision={0}
                             onChange={this.onRangeChanged}
-                            disabled={animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info"/>
                     </React.Fragment>
@@ -323,8 +322,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.STOKES}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
-                        checked={animatorStore.animationMode === AnimationMode.STOKES}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        checked={appStore.animatorStore.animationMode === AnimationMode.STOKES}
                         onChange={this.onAnimationModeChanged}
                         label="Stokes"
                     />
@@ -335,7 +334,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         max={activeFrame.frameInfo.fileInfoExtended.stokes}
                         stepSize={1}
                         onValueChange={this.onStokesChanged}
-                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                         fill={true}
                     />
                     }
@@ -347,7 +346,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             showTrackFill={false}
                             max={activeFrame.frameInfo.fileInfoExtended.stokes - 1}
                             onChange={this.onStokesChanged}
-                            disabled={animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {`Req: ${activeFrame.requiredStokes}; Current: ${activeFrame.stokes}`}
@@ -368,16 +367,16 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 className="playback-mode"
                 content={
                     <Menu>
-                        <MenuItem icon="arrow-right" text="Play Forward" active={animatorStore.playMode === PlayMode.FORWARD} onClick={() => animatorStore.playMode = PlayMode.FORWARD}/>
-                        <MenuItem icon="arrow-left" text="Play Backwards" active={animatorStore.playMode === PlayMode.BACKWARD} onClick={() => animatorStore.playMode = PlayMode.BACKWARD}/>
-                        <MenuItem icon="swap-horizontal" text="Bouncing" active={animatorStore.playMode === PlayMode.BOUNCING} onClick={() => animatorStore.playMode = PlayMode.BOUNCING}/>
-                        <MenuItem icon="exchange" text="Blink" active={animatorStore.playMode === PlayMode.BLINK} onClick={() => animatorStore.playMode = PlayMode.BLINK}/>
+                        <MenuItem icon="arrow-right" text="Play Forward" active={appStore.animatorStore.playMode === PlayMode.FORWARD} onClick={() => appStore.animatorStore.playMode = PlayMode.FORWARD}/>
+                        <MenuItem icon="arrow-left" text="Play Backwards" active={appStore.animatorStore.playMode === PlayMode.BACKWARD} onClick={() => appStore.animatorStore.playMode = PlayMode.BACKWARD}/>
+                        <MenuItem icon="swap-horizontal" text="Bouncing" active={appStore.animatorStore.playMode === PlayMode.BOUNCING} onClick={() => appStore.animatorStore.playMode = PlayMode.BOUNCING}/>
+                        <MenuItem icon="exchange" text="Blink" active={appStore.animatorStore.playMode === PlayMode.BLINK} onClick={() => appStore.animatorStore.playMode = PlayMode.BLINK}/>
                     </Menu>
                 }
                 position={Position.TOP}
             >
                 <Tooltip content="Playback Mode" position={Position.TOP}>
-                    <Button icon={this.getPlayModeIcon()} disabled={animatorStore.animationState === AnimationState.PLAYING}>{!iconOnly && "Mode"}</Button>
+                    <Button icon={this.getPlayModeIcon()} disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}>{!iconOnly && "Mode"}</Button>
                 </Tooltip>
             </Popover>
         );
@@ -386,11 +385,11 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             <ButtonGroup fill={true} className="playback-buttons">
                 <Button icon={"chevron-backward"} onClick={this.onFirstClicked}>{!iconOnly && "First"}</Button>
                 <Button icon={"step-backward"} onClick={this.onPrevClicked}>{!iconOnly && "Prev"}</Button>
-                {animatorStore.animationState === AnimationState.PLAYING &&
-                <Button icon={"stop"} onClick={animatorStore.stopAnimation}>{!iconOnly && "Stop"}</Button>
+                {appStore.animatorStore.animationState === AnimationState.PLAYING &&
+                <Button icon={"stop"} onClick={appStore.animatorStore.stopAnimation}>{!iconOnly && "Stop"}</Button>
                 }
-                {animatorStore.animationState === AnimationState.STOPPED &&
-                <Button icon={"play"} onClick={animatorStore.startAnimation}>{!iconOnly && "Play"}</Button>
+                {appStore.animatorStore.animationState === AnimationState.STOPPED &&
+                <Button icon={"play"} onClick={appStore.animatorStore.startAnimation}>{!iconOnly && "Play"}</Button>
                 }
                 <Button icon={"step-forward"} onClick={this.onNextClicked}>{!iconOnly && "Next"}</Button>
                 <Button icon={"chevron-forward"} onClick={this.onLastClicked}>{!iconOnly && "Last"}</Button>
@@ -401,14 +400,14 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             <FormGroup label="Frame rate" inline={true} className="playback-framerate">
                 <SafeNumericInput
                     id="framerate-numeric"
-                    value={animatorStore.frameRate}
-                    min={animatorStore.minFrameRate}
-                    max={animatorStore.maxFrameRate}
+                    value={appStore.animatorStore.frameRate}
+                    min={appStore.animatorStore.minFrameRate}
+                    max={appStore.animatorStore.maxFrameRate}
                     stepSize={1}
                     minorStepSize={1}
                     majorStepSize={1}
-                    onValueChange={animatorStore.setFrameRate}
-                    disabled={animatorStore.animationState === AnimationState.PLAYING}
+                    onValueChange={appStore.animatorStore.setFrameRate}
+                    disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
                 />
             </FormGroup>
         );

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -32,19 +32,20 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onChannelChanged = (val: number) => {
-        if (this.props.appStore.activeFrame) {
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
             if (val < 0) {
-                val += this.props.appStore.activeFrame.frameInfo.fileInfoExtended.depth;
+                val += frame.frameInfo.fileInfoExtended.depth;
             }
-            if (val >= this.props.appStore.activeFrame.frameInfo.fileInfoExtended.depth) {
+            if (val >= frame.frameInfo.fileInfoExtended.depth) {
                 val = 0;
             }
-            this.props.appStore.activeFrame.setChannels(val, this.props.appStore.activeFrame.requiredStokes, true);
+            frame.setChannels(val, frame.requiredStokes, true);
         }
     };
 
     onRangeChanged = (range: NumberRange) => {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (range && range.length === 2 && frame) {
             if (range[0] >= 0 && range[0] < range[1] && range[1] < frame.frameInfo.fileInfoExtended.depth) {
                 frame.setAnimationRange(range);
@@ -53,25 +54,27 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onStokesChanged = (val: number) => {
-        if (this.props.appStore.activeFrame) {
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
             if (val < 0) {
-                val += this.props.appStore.activeFrame.frameInfo.fileInfoExtended.stokes;
+                val += frame.frameInfo.fileInfoExtended.stokes;
             }
-            if (val >= this.props.appStore.activeFrame.frameInfo.fileInfoExtended.stokes) {
+            if (val >= frame.frameInfo.fileInfoExtended.stokes) {
                 val = 0;
             }
-            this.props.appStore.activeFrame.setChannels(this.props.appStore.activeFrame.requiredChannel, val, true);
+            frame.setChannels(frame.requiredChannel, val, true);
         }
     };
 
     onFrameChanged = (val: number) => {
+        const appStore = AppStore.Instance;
         if (val < 0) {
-            val += this.props.appStore.frames.length;
+            val += appStore.frames.length;
         }
-        if (val >= this.props.appStore.frames.length) {
+        if (val >= appStore.frames.length) {
             val = 0;
         }
-        this.props.appStore.setActiveFrameByIndex(val);
+        appStore.setActiveFrameByIndex(val);
     };
 
     onAnimationModeChanged = (event: React.FormEvent<HTMLInputElement>) => {
@@ -80,7 +83,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onFirstClicked = () => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
 
         if (!frame) {
@@ -103,7 +106,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onLastClicked = () => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
 
         if (!frame) {
@@ -126,7 +129,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onNextClicked = () => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
 
         if (!frame) {
@@ -149,7 +152,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     onPrevClicked = () => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
 
         if (!frame) {

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import {action, observable} from "mobx";
 import {Button, ButtonGroup, FormGroup, IconName, Menu, MenuItem, NonIdealState, NumberRange, Popover, Position, Radio, RangeSlider, Slider, Tooltip} from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
-import {AnimationMode, AnimationState, PlayMode, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {AnimationMode, AnimationState, PlayMode, WidgetConfig, WidgetProps, HelpType, AnimatorStore, AppStore} from "stores";
 import {SafeNumericInput} from "components/Shared";
 import "./AnimatorComponent.css";
 
@@ -76,7 +76,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
 
     onAnimationModeChanged = (event: React.FormEvent<HTMLInputElement>) => {
         const newMode = parseInt(event.currentTarget.value) as AnimationMode;
-        this.props.appStore.animatorStore.setAnimationMode(newMode);
+        AnimatorStore.Instance.setAnimationMode(newMode);
     };
 
     onFirstClicked = () => {
@@ -87,7 +87,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (appStore.animatorStore.animationMode) {
+        switch (AnimatorStore.Instance.animationMode) {
             case AnimationMode.FRAME:
                 appStore.setActiveFrameByIndex(0);
                 break;
@@ -110,7 +110,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (appStore.animatorStore.animationMode) {
+        switch (AnimatorStore.Instance.animationMode) {
             case AnimationMode.FRAME:
                 appStore.setActiveFrameByIndex(appStore.frames.length - 1);
                 break;
@@ -133,7 +133,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (appStore.animatorStore.animationMode) {
+        switch (AnimatorStore.Instance.animationMode) {
             case AnimationMode.FRAME:
                 appStore.nextFrame();
                 break;
@@ -156,7 +156,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             return;
         }
 
-        switch (appStore.animatorStore.animationMode) {
+        switch (AnimatorStore.Instance.animationMode) {
             case AnimationMode.FRAME:
                 appStore.prevFrame();
                 break;
@@ -172,8 +172,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     };
 
     private getPlayModeIcon = (): IconName => {
-        const appStore = this.props.appStore;
-        switch (appStore.animatorStore.playMode) {
+        switch (AnimatorStore.Instance.playMode) {
             case PlayMode.FORWARD: default:
                 return "arrow-right";
             case PlayMode.BACKWARD:
@@ -199,8 +198,9 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
     }
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const activeFrame = appStore.activeFrame;
+        const animatorStore = AnimatorStore.Instance;
         const dims = activeFrame ? activeFrame.frameInfo.fileInfoExtended.dimensions : 0;
         const numChannels = activeFrame ? activeFrame.frameInfo.fileInfoExtended.depth : 0;
         const numStokes = activeFrame ? activeFrame.frameInfo.fileInfoExtended.stokes : 0;
@@ -216,8 +216,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.FRAME}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
-                        checked={appStore.animatorStore.animationMode === AnimationMode.FRAME}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        checked={animatorStore.animationMode === AnimationMode.FRAME}
                         onChange={this.onAnimationModeChanged}
                         label="Frame"
                     />
@@ -229,7 +229,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         step={1}
                         onValueChange={this.onFrameChanged}
                         fill={true}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
                     />
                     }
                     {!hideSliders &&
@@ -241,7 +241,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             showTrackFill={false}
                             stepSize={1}
                             onChange={this.onFrameChanged}
-                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {activeFrame.frameInfo.fileInfo.name}
@@ -260,8 +260,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.CHANNEL}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
-                        checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        checked={animatorStore.animationMode === AnimationMode.CHANNEL}
                         onChange={this.onAnimationModeChanged}
                         label="Channel"
                     />
@@ -273,7 +273,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         step={1}
                         onValueChange={this.onChannelChanged}
                         fill={true}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
                     />
                     }
                     {!hideSliders &&
@@ -287,7 +287,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             labelPrecision={0}
                             showTrackFill={false}
                             onChange={this.onChannelChanged}
-                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {`Req: ${activeFrame.requiredChannel}; Current: ${activeFrame.channel}`}
@@ -308,7 +308,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             labelStepSize={channelStep}
                             labelPrecision={0}
                             onChange={this.onRangeChanged}
-                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info"/>
                     </React.Fragment>
@@ -323,8 +323,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 <div className="animator-slider">
                     <Radio
                         value={AnimationMode.STOKES}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
-                        checked={appStore.animatorStore.animationMode === AnimationMode.STOKES}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
+                        checked={animatorStore.animationMode === AnimationMode.STOKES}
                         onChange={this.onAnimationModeChanged}
                         label="Stokes"
                     />
@@ -335,7 +335,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                         max={activeFrame.frameInfo.fileInfoExtended.stokes}
                         stepSize={1}
                         onValueChange={this.onStokesChanged}
-                        disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        disabled={animatorStore.animationState === AnimationState.PLAYING}
                         fill={true}
                     />
                     }
@@ -347,7 +347,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                             showTrackFill={false}
                             max={activeFrame.frameInfo.fileInfoExtended.stokes - 1}
                             onChange={this.onStokesChanged}
-                            disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                            disabled={animatorStore.animationState === AnimationState.PLAYING}
                         />
                         <div className="slider-info">
                             {`Req: ${activeFrame.requiredStokes}; Current: ${activeFrame.stokes}`}
@@ -368,16 +368,16 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 className="playback-mode"
                 content={
                     <Menu>
-                        <MenuItem icon="arrow-right" text="Play Forward" active={appStore.animatorStore.playMode === PlayMode.FORWARD} onClick={() => appStore.animatorStore.playMode = PlayMode.FORWARD}/>
-                        <MenuItem icon="arrow-left" text="Play Backwards" active={appStore.animatorStore.playMode === PlayMode.BACKWARD} onClick={() => appStore.animatorStore.playMode = PlayMode.BACKWARD}/>
-                        <MenuItem icon="swap-horizontal" text="Bouncing" active={appStore.animatorStore.playMode === PlayMode.BOUNCING} onClick={() => appStore.animatorStore.playMode = PlayMode.BOUNCING}/>
-                        <MenuItem icon="exchange" text="Blink" active={appStore.animatorStore.playMode === PlayMode.BLINK} onClick={() => appStore.animatorStore.playMode = PlayMode.BLINK}/>
+                        <MenuItem icon="arrow-right" text="Play Forward" active={animatorStore.playMode === PlayMode.FORWARD} onClick={() => animatorStore.playMode = PlayMode.FORWARD}/>
+                        <MenuItem icon="arrow-left" text="Play Backwards" active={animatorStore.playMode === PlayMode.BACKWARD} onClick={() => animatorStore.playMode = PlayMode.BACKWARD}/>
+                        <MenuItem icon="swap-horizontal" text="Bouncing" active={animatorStore.playMode === PlayMode.BOUNCING} onClick={() => animatorStore.playMode = PlayMode.BOUNCING}/>
+                        <MenuItem icon="exchange" text="Blink" active={animatorStore.playMode === PlayMode.BLINK} onClick={() => animatorStore.playMode = PlayMode.BLINK}/>
                     </Menu>
                 }
                 position={Position.TOP}
             >
                 <Tooltip content="Playback Mode" position={Position.TOP}>
-                    <Button icon={this.getPlayModeIcon()} disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}>{!iconOnly && "Mode"}</Button>
+                    <Button icon={this.getPlayModeIcon()} disabled={animatorStore.animationState === AnimationState.PLAYING}>{!iconOnly && "Mode"}</Button>
                 </Tooltip>
             </Popover>
         );
@@ -386,11 +386,11 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             <ButtonGroup fill={true} className="playback-buttons">
                 <Button icon={"chevron-backward"} onClick={this.onFirstClicked}>{!iconOnly && "First"}</Button>
                 <Button icon={"step-backward"} onClick={this.onPrevClicked}>{!iconOnly && "Prev"}</Button>
-                {appStore.animatorStore.animationState === AnimationState.PLAYING &&
-                <Button icon={"stop"} onClick={appStore.animatorStore.stopAnimation}>{!iconOnly && "Stop"}</Button>
+                {animatorStore.animationState === AnimationState.PLAYING &&
+                <Button icon={"stop"} onClick={animatorStore.stopAnimation}>{!iconOnly && "Stop"}</Button>
                 }
-                {appStore.animatorStore.animationState === AnimationState.STOPPED &&
-                <Button icon={"play"} onClick={appStore.animatorStore.startAnimation}>{!iconOnly && "Play"}</Button>
+                {animatorStore.animationState === AnimationState.STOPPED &&
+                <Button icon={"play"} onClick={animatorStore.startAnimation}>{!iconOnly && "Play"}</Button>
                 }
                 <Button icon={"step-forward"} onClick={this.onNextClicked}>{!iconOnly && "Next"}</Button>
                 <Button icon={"chevron-forward"} onClick={this.onLastClicked}>{!iconOnly && "Last"}</Button>
@@ -401,14 +401,14 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             <FormGroup label="Frame rate" inline={true} className="playback-framerate">
                 <SafeNumericInput
                     id="framerate-numeric"
-                    value={appStore.animatorStore.frameRate}
-                    min={appStore.animatorStore.minFrameRate}
-                    max={appStore.animatorStore.maxFrameRate}
+                    value={animatorStore.frameRate}
+                    min={animatorStore.minFrameRate}
+                    max={animatorStore.maxFrameRate}
                     stepSize={1}
                     minorStepSize={1}
                     majorStepSize={1}
-                    onValueChange={appStore.animatorStore.setFrameRate}
-                    disabled={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                    onValueChange={animatorStore.setFrameRate}
+                    disabled={animatorStore.animationState === AnimationState.PLAYING}
                 />
             </FormGroup>
         );

--- a/src/components/App/UIControllerComponent.tsx
+++ b/src/components/App/UIControllerComponent.tsx
@@ -23,16 +23,16 @@ export class UIControllerComponent extends React.Component<{appStore: AppStore}>
         return (
             <React.Fragment>
                 <SplashScreenComponent/>
-                <RootMenuComponent appStore={appStore}/>
-                <OverlaySettingsDialogComponent appStore={appStore}/>
-                <AuthDialogComponent appStore={appStore}/>
-                <FileBrowserDialogComponent appStore={appStore}/>
-                <AboutDialogComponent appStore={appStore}/>
-                <RegionDialogComponent appStore={appStore}/>
-                <PreferenceDialogComponent appStore={appStore}/>
-                <SaveLayoutDialogComponent appStore={appStore}/>
-                <FileInfoDialogComponent appStore={appStore}/>
-                <ContourDialogComponent appStore={appStore}/>
+                <RootMenuComponent/>
+                <OverlaySettingsDialogComponent/>
+                <AuthDialogComponent/>
+                <FileBrowserDialogComponent/>
+                <AboutDialogComponent/>
+                <RegionDialogComponent/>
+                <PreferenceDialogComponent/>
+                <SaveLayoutDialogComponent/>
+                <FileInfoDialogComponent/>
+                <ContourDialogComponent/>
                 <HelpDrawerComponent/>
             </React.Fragment>
         );

--- a/src/components/App/UIControllerComponent.tsx
+++ b/src/components/App/UIControllerComponent.tsx
@@ -22,7 +22,7 @@ export class UIControllerComponent extends React.Component<{appStore: AppStore}>
 
         return (
             <React.Fragment>
-                <SplashScreenComponent appStore={appStore}/>
+                <SplashScreenComponent/>
                 <RootMenuComponent appStore={appStore}/>
                 <OverlaySettingsDialogComponent appStore={appStore}/>
                 <AuthDialogComponent appStore={appStore}/>

--- a/src/components/App/UIControllerComponent.tsx
+++ b/src/components/App/UIControllerComponent.tsx
@@ -12,14 +12,11 @@ import {
     FileInfoDialogComponent,
     ContourDialogComponent
 } from "components/Dialogs";
-import { AppStore } from "stores";
 
 @observer
-export class UIControllerComponent extends React.Component<{appStore: AppStore}> {
+export class UIControllerComponent extends React.Component {
  
     render() {
-        const appStore = this.props.appStore;
-
         return (
             <React.Fragment>
                 <SplashScreenComponent/>

--- a/src/components/App/UIControllerComponent.tsx
+++ b/src/components/App/UIControllerComponent.tsx
@@ -33,7 +33,7 @@ export class UIControllerComponent extends React.Component<{appStore: AppStore}>
                 <SaveLayoutDialogComponent appStore={appStore}/>
                 <FileInfoDialogComponent appStore={appStore}/>
                 <ContourDialogComponent appStore={appStore}/>
-                <HelpDrawerComponent appStore={appStore}/>
+                <HelpDrawerComponent/>
             </React.Fragment>
         );
     }

--- a/src/components/CatalogOverlay/CatalogOverlayFilterComponent/CatalogOverlayFilterComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayFilterComponent/CatalogOverlayFilterComponent.tsx
@@ -6,11 +6,12 @@ import {AppStore} from "stores";
 import {CatalogOverlayWidgetStore} from "stores/widgets";
 
 @observer
-export class CatalogOverlayFilterComponent extends React.Component<{widgetStore: CatalogOverlayWidgetStore, appStore: AppStore}> {
+export class CatalogOverlayFilterComponent extends React.Component<{widgetStore: CatalogOverlayWidgetStore}> {
     
     private handleRegionChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
-        if (this.props.appStore.activeFrame) {
-            this.props.widgetStore.setRegionId(this.props.appStore.activeFrame.frameInfo.fileId, parseInt(changeEvent.target.value));
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
+            this.props.widgetStore.setRegionId(frame.frameInfo.fileId, parseInt(changeEvent.target.value));
         }
     };
 
@@ -19,16 +20,16 @@ export class CatalogOverlayFilterComponent extends React.Component<{widgetStore:
     };
 
     public render() {
-        const appStore = this.props.appStore;
+        const frame = AppStore.Instance.activeFrame;
         const widgetStore = this.props.widgetStore;
 
         let enableRegionSelect = false;
         let regionId = 0;
         let profileRegionOptions: IOptionProps[];
-        if (appStore.activeFrame && appStore.activeFrame.regionSet) {
-            let fileId = appStore.activeFrame.frameInfo.fileId;
+        if (frame && frame.regionSet) {
+            let fileId = frame.frameInfo.fileId;
             regionId = widgetStore.regionIdMap.get(fileId) || 0;
-            profileRegionOptions = appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary && (r.isClosedRegion || r.regionType === CARTA.RegionType.POINT)).map(r => {
+            profileRegionOptions = frame.regionSet.regions.filter(r => !r.isTemporary && (r.isClosedRegion || r.regionType === CARTA.RegionType.POINT)).map(r => {
                 return {
                     value: r.regionId,
                     label: r.nameString

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsComponent/CatalogOverlayPlotSettingsComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsComponent/CatalogOverlayPlotSettingsComponent.tsx
@@ -1,14 +1,14 @@
 import {observer} from "mobx-react";
 import * as React from "react";
 import {FormGroup, HTMLSelect, NumericInput} from "@blueprintjs/core";
-import {AppStore, SystemType} from "stores";
+import {AppStore, CatalogStore, SystemType} from "stores";
 import {CatalogOverlayWidgetStore, CatalogOverlayShape} from "stores/widgets";
 import {ColorResult} from "react-color";
 import {ColorPickerComponent} from "components/Shared";
 import {SWATCH_COLORS} from "utilities";
 
 @observer
-export class CatalogOverlayPlotSettingsComponent extends React.Component<{widgetStore: CatalogOverlayWidgetStore, appStore: AppStore, id: string}> {
+export class CatalogOverlayPlotSettingsComponent extends React.Component<{widgetStore: CatalogOverlayWidgetStore, id: string}> {
     private readonly MinOverlaySize = 1;
     private readonly MaxOverlaySize = 100;
 
@@ -23,19 +23,19 @@ export class CatalogOverlayPlotSettingsComponent extends React.Component<{widget
     private handleCatalogShapeChange(changeEvent: React.ChangeEvent<HTMLSelectElement>) {
         const val = changeEvent.currentTarget.value as CatalogOverlayShape;
         this.props.widgetStore.setCatalogShape(val);
-        this.props.appStore.catalogStore.updateCatalogShape(this.props.id, val);
+        CatalogStore.Instance.updateCatalogShape(this.props.id, val);
     }
 
     private handleCatalogSizeChange(val: number) {
         this.props.widgetStore.setCatalogSize(val);
         if (val >= this.MinOverlaySize && val <= this.MaxOverlaySize) {
-            this.props.appStore.catalogStore.updateCatalogSize(this.props.id, val);   
+            CatalogStore.Instance.updateCatalogSize(this.props.id, val);
         }
     }
 
     private handleCatalogColorChange(color: string) {
         this.props.widgetStore.setCatalogColor(color);
-        this.props.appStore.catalogStore.updateCatalogColor(this.props.id, color);
+        CatalogStore.Instance.updateCatalogColor(this.props.id, color);
     }
 
     private handleHeaderCatalogSystemChange(changeEvent: React.ChangeEvent<HTMLSelectElement>) {
@@ -44,7 +44,6 @@ export class CatalogOverlayPlotSettingsComponent extends React.Component<{widget
     }
 
     public render() {
-        const appStore = this.props.appStore;
         const widgetStore = this.props.widgetStore;
 
         let systemOptions = [];
@@ -67,7 +66,7 @@ export class CatalogOverlayPlotSettingsComponent extends React.Component<{widget
                             this.handleCatalogColorChange(color.hex === "transparent" ? "#000000" : color.hex);
                         }}
                         disableAlpha={true}
-                        darkTheme={appStore.darkTheme}
+                        darkTheme={AppStore.Instance.darkTheme}
                     />
                 </FormGroup>
                 <FormGroup  inline={true} label="Shape">

--- a/src/components/CatalogOverlay/CatalogScatterComponent/CatalogScatterComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogScatterComponent/CatalogScatterComponent.tsx
@@ -7,7 +7,7 @@ import {observer} from "mobx-react";
 import {FormGroup, HTMLSelect, AnchorButton, Intent, Tooltip, Switch} from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
 import {CARTA} from "carta-protobuf";
-import {WidgetConfig, WidgetProps, HelpType} from "stores";
+import {WidgetConfig, WidgetProps, HelpType, AppStore, WidgetsStore, CatalogStore} from "stores";
 import {CatalogScatterWidgetStore, Border, CatalogUpdateMode, DragMode} from "stores/widgets";
 import {ProfilerInfoComponent} from "components/Shared";
 import {Colors} from "@blueprintjs/core";
@@ -42,7 +42,7 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
                 let progressString = "";
                 const catalogFile = this.widgetStore.catalogOverlayWidgetStore.catalogInfo;
                 const fileName = catalogFile.fileInfo.name || "";
-                const appStore = this.props.appStore;
+                const appStore = AppStore.Instance;
                 const frame = appStore.activeFrame;
                 const progress = this.widgetStore.catalogOverlayWidgetStore.progress;
                 if (progress && isFinite(progress) && progress < 1) {
@@ -53,10 +53,10 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
                     // const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
                     // const selectedString = this.matchesSelectedRegion ? "(Selected)" : "";
                     const catalogFileId = catalogFile.fileId || "";
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `Catalog ${fileName} : ${catalogFileId} ${progressString}`);
+                    WidgetsStore.Instance.setWidgetTitle(this.props.id, `Catalog ${fileName} : ${catalogFileId} ${progressString}`);
                 }
             } else {
-                this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `Catalog : Cursor`);
+                WidgetsStore.Instance.setWidgetTitle(this.props.id, `Catalog : Cursor`);
             }
         });
     }
@@ -67,7 +67,7 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
     };
 
     @computed get widgetStore(): CatalogScatterWidgetStore {
-        const widgetStore = this.props.appStore.widgetsStore.catalogScatterWidgets.get(this.props.id); 
+        const widgetStore = WidgetsStore.Instance.catalogScatterWidgets.get(this.props.id);
         return widgetStore;
     }
 
@@ -104,7 +104,7 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
         const val = changeEvent.target.checked;
         this.widgetStore.catalogOverlayWidgetStore.setShowSelectedData(val);
         const storeId = this.widgetStore.catalogOverlayWidgetStore.storeId;
-        this.props.appStore.catalogStore.updateShowSelectedData(storeId, val);
+        CatalogStore.Instance.updateShowSelectedData(storeId, val);
     }
 
     private onHover = (event: Plotly.PlotMouseEvent) => {
@@ -146,7 +146,7 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
 
     private handlePlotClick = () => {
         const catalogOverlayWidgetStore = this.widgetStore.catalogOverlayWidgetStore;
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
 
         if (catalogOverlayWidgetStore.shouldUpdateData) {
             catalogOverlayWidgetStore.setUpdateMode(CatalogUpdateMode.PlotsUpdate);
@@ -167,16 +167,17 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
             }
             this.widgetStore.catalogOverlayWidgetStore.setselectedPointIndexs(selectedPointIndexs, true);
             const storeId = this.widgetStore.catalogOverlayWidgetStore.storeId;
-            this.props.appStore.catalogStore.updateSelectedPoints(storeId, selectedPointIndexs);
+            CatalogStore.Instance.updateSelectedPoints(storeId, selectedPointIndexs);
         }
     }
 
     private onDeselect = () => {
+        const catalogStore = CatalogStore.Instance;
         this.widgetStore.catalogOverlayWidgetStore.setselectedPointIndexs([]);
         const storeId = this.widgetStore.catalogOverlayWidgetStore.storeId;
-        this.props.appStore.catalogStore.updateSelectedPoints(storeId, []);
+        catalogStore.updateSelectedPoints(storeId, []);
         this.widgetStore.catalogOverlayWidgetStore.setShowSelectedData(false);
-        this.props.appStore.catalogStore.updateShowSelectedData(storeId, false);
+        catalogStore.updateShowSelectedData(storeId, false);
     }
 
     // Single source selected
@@ -189,13 +190,12 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
             selectedPointIndex.push(selectedPoint.pointIndex);
             this.widgetStore.catalogOverlayWidgetStore.setselectedPointIndexs(selectedPointIndex, true);
             const storeId = this.widgetStore.catalogOverlayWidgetStore.storeId;
-            this.props.appStore.catalogStore.updateSelectedPoints(storeId, selectedPointIndex);
+            CatalogStore.Instance.updateSelectedPoints(storeId, selectedPointIndex);
         }
     }
 
     public render() {
         const widgetStore = this.widgetStore;
-        const appStore = this.props.appStore;
         const columnsName = widgetStore.catalogOverlayWidgetStore.displayedColumnHeaders;
         const xyOptions = [];
         const fontFamily = "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif";
@@ -212,7 +212,7 @@ export class CatalogScatterComponent extends React.Component<WidgetProps> {
             }
         }
 
-        if (appStore.darkTheme) {
+        if (AppStore.Instance.darkTheme) {
             gridColor = Colors.DARK_GRAY5;
             lableColor = Colors.LIGHT_GRAY5;
             themeColor = Colors.DARK_GRAY3;

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -2,31 +2,30 @@ import * as React from "react";
 import {observer} from "mobx-react";
 import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {DraggableDialogComponent} from "components/Dialogs";
-import {AppStore, HelpType} from "stores";
+import {DialogStore} from "stores";
 import {CARTA_INFO} from "models";
 import "./AboutDialogComponent.css";
 import * as logoPng from "static/carta_logo.png";
 
 @observer
-export class AboutDialogComponent extends React.Component<{ appStore: AppStore }> {
-
+export class AboutDialogComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
+        const dialogStore = DialogStore.Instance;
 
         const dialogProps: IDialogProps = {
             icon: "info-sign",
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: true,
             lazy: true,
-            isOpen: appStore.dialogStore.aboutDialogVisible,
-            onClose: appStore.dialogStore.hideAboutDialog,
+            isOpen: dialogStore.aboutDialogVisible,
+            onClose: dialogStore.hideAboutDialog,
             className: "about-dialog",
             canEscapeKeyClose: true,
             title: "About CARTA",
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} defaultWidth={620} defaultHeight={700} enableResizing={false}>
+            <DraggableDialogComponent dialogProps={dialogProps} defaultWidth={620} defaultHeight={700} enableResizing={false}>
                 <div className={Classes.DIALOG_BODY}>
                     <div className={"image-div"}>
                         <img src={logoPng} width={80}/>
@@ -57,7 +56,7 @@ export class AboutDialogComponent extends React.Component<{ appStore: AppStore }
                 </div>
                 <div className={Classes.DIALOG_FOOTER}>
                     <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-                        <AnchorButton intent={Intent.NONE} onClick={appStore.dialogStore.hideAboutDialog} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={dialogStore.hideAboutDialog} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/Dialogs/AuthDialog/AuthDialogComponent.tsx
+++ b/src/components/Dialogs/AuthDialog/AuthDialogComponent.tsx
@@ -26,7 +26,7 @@ export class AuthDialogComponent extends React.Component {
         }
 
         return (
-            <Dialog icon="key" className={className} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={DialogStore.Instance.authDialogVisible} isCloseButtonShown={false} title="Sign In">
+            <Dialog icon="key" className={className} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.dialogStore.authDialogVisible} isCloseButtonShown={false} title="Sign In">
                 <div className={Classes.DIALOG_BODY}>
                     <FormGroup helperText={this.errorString} intent={this.errorString ? "danger" : "none"}>
                         <InputGroup placeholder="Username" value={this.username} onChange={this.handleUsernameInput} onKeyDown={this.handleKeyDown} autoFocus={true}/>
@@ -69,7 +69,7 @@ export class AuthDialogComponent extends React.Component {
                             appStore.backendService.setAuthToken(responseData.token);
                             appStore.setUsername(responseData.username);
                             appStore.connectToServer(responseData.socket);
-                            DialogStore.Instance.hideAuthDialog();
+                            appStore.dialogStore.hideAuthDialog();
                         }, 50);
                     }
                 }, parseError => {

--- a/src/components/Dialogs/AuthDialog/AuthDialogComponent.tsx
+++ b/src/components/Dialogs/AuthDialog/AuthDialogComponent.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import {observer} from "mobx-react";
 import {computed, observable} from "mobx";
 import {AnchorButton, Classes, Dialog, FormGroup, InputGroup, Intent} from "@blueprintjs/core";
-import {AppStore} from "stores";
+import {AppStore, DialogStore} from "stores";
 import "./AuthDialogComponent.css";
 
 const KEYCODE_ENTER = 13;
 
 @observer
-export class AuthDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class AuthDialogComponent extends React.Component {
     @observable username: string = "";
     @observable password: string = "";
     @observable isAuthenticating: boolean;
@@ -19,14 +19,14 @@ export class AuthDialogComponent extends React.Component<{ appStore: AppStore }>
     }
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         let className = "auth-dialog";
         if (appStore.darkTheme) {
             className += " bp3-dark";
         }
 
         return (
-            <Dialog icon="key" className={className} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.dialogStore.authDialogVisible} isCloseButtonShown={false} title="Sign In">
+            <Dialog icon="key" className={className} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={DialogStore.Instance.authDialogVisible} isCloseButtonShown={false} title="Sign In">
                 <div className={Classes.DIALOG_BODY}>
                     <FormGroup helperText={this.errorString} intent={this.errorString ? "danger" : "none"}>
                         <InputGroup placeholder="Username" value={this.username} onChange={this.handleUsernameInput} onKeyDown={this.handleKeyDown} autoFocus={true}/>
@@ -58,7 +58,7 @@ export class AuthDialogComponent extends React.Component<{ appStore: AppStore }>
 
     onSignInClicked = () => {
         this.isAuthenticating = true;
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         appStore.backendService.authenticate(this.username, this.password).then(res => {
             this.isAuthenticating = false;
             if (res.ok) {
@@ -69,7 +69,7 @@ export class AuthDialogComponent extends React.Component<{ appStore: AppStore }>
                             appStore.backendService.setAuthToken(responseData.token);
                             appStore.setUsername(responseData.username);
                             appStore.connectToServer(responseData.socket);
-                            appStore.dialogStore.hideAuthDialog();
+                            DialogStore.Instance.hideAuthDialog();
                         }, 50);
                     }
                 }, parseError => {

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -66,21 +66,20 @@ export class ContourDialogComponent extends React.Component {
     @action setDefaultContourParameters() {
         const appStore = AppStore.Instance;
         const dataSource = appStore.contourDataSource;
-        const preferenceStore = PreferenceStore.Instance;
         if (dataSource) {
             this.levels = dataSource.contourConfig.levels.slice();
             this.smoothingMode = dataSource.contourConfig.smoothingMode;
             this.smoothingFactor = dataSource.contourConfig.smoothingFactor;
         } else {
             this.levels = [];
-            this.smoothingMode = preferenceStore.contourSmoothingMode;
-            this.smoothingFactor = preferenceStore.contourSmoothingFactor;
+            this.smoothingMode = appStore.preferenceStore.contourSmoothingMode;
+            this.smoothingFactor = appStore.preferenceStore.contourSmoothingFactor;
         }
     }
 
     componentDidUpdate() {
         const appStore = AppStore.Instance;
-        if (AppStore.Instance.contourDataSource !== this.cachedFrame) {
+        if (appStore.contourDataSource !== this.cachedFrame) {
             this.cachedFrame = appStore.contourDataSource;
             this.widgetStore.clearXYBounds();
             this.setDefaultContourParameters();
@@ -267,15 +266,14 @@ export class ContourDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
 
         const dialogProps: IDialogProps = {
             icon: <CustomIcon icon="contour" size={CustomIcon.SIZE_LARGE}/>,
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: dialogStore.contourDialogVisible,
-            onClose: dialogStore.hideContourDialog,
+            isOpen: appStore.dialogStore.contourDialogVisible,
+            onClose: appStore.dialogStore.hideContourDialog,
             className: "contour-dialog",
             canEscapeKeyClose: true,
             title: "Contour Configuration",
@@ -418,7 +416,7 @@ export class ContourDialogComponent extends React.Component {
                 <div className="histogram-plot">
                     <LinePlotComponent {...linePlotProps}/>
                 </div>
-                <ContourGeneratorPanelComponent frame={dataSource} generatorType={PreferenceStore.Instance.contourGeneratorType} onLevelsGenerated={this.handleLevelsGenerated}/>
+                <ContourGeneratorPanelComponent frame={dataSource} generatorType={appStore.preferenceStore.contourGeneratorType} onLevelsGenerated={this.handleLevelsGenerated}/>
                 <div className="contour-level-panel-levels">
                     <FormGroup label={"Levels"} inline={true}>
                         <TagInput
@@ -496,7 +494,7 @@ export class ContourDialogComponent extends React.Component {
                     <div className={Classes.DIALOG_FOOTER_ACTIONS}>
                         <AnchorButton intent={Intent.WARNING} onClick={this.handleClearContours} disabled={!dataSource.contourConfig.enabled} text="Clear"/>
                         <AnchorButton intent={Intent.SUCCESS} onClick={this.handleApplyContours} disabled={!hasLevels || (!this.contourConfigChanged && dataSource.contourConfig.enabled)} text="Apply"/>
-                        <AnchorButton intent={Intent.NONE} onClick={dialogStore.hideContourDialog} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={appStore.dialogStore.hideContourDialog} text="Close"/>
                     </div>
                 </div>
                 <Alert icon={"time"} isOpen={this.showCubeHistogramAlert} onCancel={this.handleAlertCancel} onConfirm={this.handleAlertConfirm} cancelButtonText={"Cancel"}>

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -8,7 +8,7 @@ import {DraggableDialogComponent, TaskProgressDialogComponent} from "components/
 import {LinePlotComponent, LinePlotComponentProps, PlotType, SafeNumericInput, SCALING_POPOVER_PROPS} from "components/Shared";
 import {ContourStylePanelComponent} from "./ContourStylePanel/ContourStylePanelComponent";
 import {ContourGeneratorPanelComponent} from "./ContourGeneratorPanel/ContourGeneratorPanelComponent";
-import {AppStore, DialogStore, FrameStore, HelpType} from "stores";
+import {AppStore, DialogStore, FrameStore, HelpType, PreferenceStore} from "stores";
 import {RenderConfigWidgetStore} from "stores/widgets";
 import {Point2D} from "models";
 import {clamp, toExponential, toFixed} from "utilities";
@@ -66,14 +66,15 @@ export class ContourDialogComponent extends React.Component {
     @action setDefaultContourParameters() {
         const appStore = AppStore.Instance;
         const dataSource = appStore.contourDataSource;
+        const preferenceStore = PreferenceStore.Instance;
         if (dataSource) {
             this.levels = dataSource.contourConfig.levels.slice();
             this.smoothingMode = dataSource.contourConfig.smoothingMode;
             this.smoothingFactor = dataSource.contourConfig.smoothingFactor;
         } else {
             this.levels = [];
-            this.smoothingMode = appStore.preferenceStore.contourSmoothingMode;
-            this.smoothingFactor = appStore.preferenceStore.contourSmoothingFactor;
+            this.smoothingMode = preferenceStore.contourSmoothingMode;
+            this.smoothingFactor = preferenceStore.contourSmoothingFactor;
         }
     }
 
@@ -417,7 +418,7 @@ export class ContourDialogComponent extends React.Component {
                 <div className="histogram-plot">
                     <LinePlotComponent {...linePlotProps}/>
                 </div>
-                <ContourGeneratorPanelComponent frame={dataSource} generatorType={appStore.preferenceStore.contourGeneratorType} onLevelsGenerated={this.handleLevelsGenerated}/>
+                <ContourGeneratorPanelComponent frame={dataSource} generatorType={PreferenceStore.Instance.contourGeneratorType} onLevelsGenerated={this.handleLevelsGenerated}/>
                 <div className="contour-level-panel-levels">
                     <FormGroup label={"Levels"} inline={true}>
                         <TagInput

--- a/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
+++ b/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
@@ -3,11 +3,10 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {ResizeEnable, Rnd} from "react-rnd";
 import {Dialog, IDialogProps, Button} from "@blueprintjs/core";
+import {HelpStore, HelpType} from "stores";
 import "./DraggableDialogComponent.css";
-import {AppStore, HelpStore, HelpType} from "stores";
 
 export class ResizableDialogComponentProps {
-    appStore: AppStore;
     dialogProps: IDialogProps;
     defaultWidth: number;
     defaultHeight: number;

--- a/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
+++ b/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from "react-dom";
 import {ResizeEnable, Rnd} from "react-rnd";
 import {Dialog, IDialogProps, Button} from "@blueprintjs/core";
 import "./DraggableDialogComponent.css";
-import { AppStore, HelpType } from "stores";
+import {AppStore, HelpStore, HelpType} from "stores";
 
 export class ResizableDialogComponentProps {
     appStore: AppStore;
@@ -40,7 +40,7 @@ export class DraggableDialogComponent extends React.Component<ResizableDialogCom
 
     private onClickHelpButton = () => {
         const centerX = this.rnd.draggable.state.x + this.rnd.resizable.size.width * 0.5;
-        this.props.appStore.helpStore.showHelpDrawer(this.props.helpType, centerX);
+        HelpStore.Instance.showHelpDrawer(this.props.helpType, centerX);
     }
 
     render() {

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -7,7 +7,7 @@ import {FileListComponent} from "./FileList/FileListComponent";
 import {FileInfoComponent, FileInfoType} from "components/FileInfo/FileInfoComponent";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {TableComponentProps, TableType} from "components/Shared";
-import {AppStore, BrowserMode, DialogStore, HelpType} from "stores";
+import {AppStore, BrowserMode, DialogStore, FileBrowserStore, HelpType} from "stores";
 import {CatalogOverlayWidgetStore} from "stores/widgets";
 import "./FileBrowserDialogComponent.css";
 
@@ -16,17 +16,17 @@ export class FileBrowserDialogComponent extends React.Component {
     @observable overwriteExistingFileAlertVisible: boolean;
 
     private handleTabChange = (newId: TabId) => {
-        AppStore.Instance.fileBrowserStore.setSelectedTab(newId);
+        FileBrowserStore.Instance.setSelectedTab(newId);
     };
 
     private loadSelectedFile = () => {
-        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
         this.loadFile(fileBrowserStore.selectedFile, fileBrowserStore.selectedHDU);
     };
 
     private loadFile = (fileInfo: CARTA.IFileInfo | CARTA.ICatalogFileInfo, hdu?: string) => {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
 
         // Ignore load if in export mode
         if (fileBrowserStore.browserMode === BrowserMode.RegionExport) {
@@ -51,7 +51,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     private handleExportRegionsClicked = () => {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
         const filename = fileBrowserStore.exportFilename.trim();
         if (fileBrowserStore.fileList && fileBrowserStore.fileList.files && fileBrowserStore.fileList.files.find(f => f.name.trim() === filename)) {
             // Existing file being replaced. Alert the user
@@ -68,7 +68,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
         filename = filename.trim();
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
         appStore.exportRegions(directory, filename, fileBrowserStore.exportCoordinateType, fileBrowserStore.exportFileType);
         console.log(`Exporting all regions to ${directory}/${filename}`);
     }
@@ -76,8 +76,8 @@ export class FileBrowserDialogComponent extends React.Component {
     private handleOverwriteAlertConfirmed = () => {
         this.overwriteExistingFileAlertVisible = false;
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
-        const filename = appStore.fileBrowserStore.exportFilename.trim();
+        const fileBrowserStore = FileBrowserStore.Instance;
+        const filename = fileBrowserStore.exportFilename.trim();
         this.exportRegion(fileBrowserStore.fileList.directory, filename);
     };
 
@@ -86,7 +86,7 @@ export class FileBrowserDialogComponent extends React.Component {
     };
 
     private handleExportInputChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
-        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
         fileBrowserStore.setExportFilename(ev.target.value);
     };
 
@@ -97,7 +97,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     private renderActionButton(browserMode: BrowserMode, appending: boolean) {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
 
         if (browserMode === BrowserMode.File) {
             if (appending) {
@@ -160,7 +160,7 @@ export class FileBrowserDialogComponent extends React.Component {
     }
 
     private renderExportFilenameInput() {
-        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
 
         const coordinateTypeMenu = (
             <Popover
@@ -206,7 +206,7 @@ export class FileBrowserDialogComponent extends React.Component {
     // Refresh file list to trigger the Breadcrumb re-rendering
     @action
     private refreshFileList() {
-        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
         switch (fileBrowserStore.browserMode) {
             case BrowserMode.Catalog:
                 fileBrowserStore.catalogFileList = {...fileBrowserStore.catalogFileList};
@@ -219,7 +219,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = appStore.fileBrowserStore;
+        const fileBrowserStore = FileBrowserStore.Instance;
 
         let className = "file-browser-dialog";
         if (appStore.darkTheme) {
@@ -355,9 +355,11 @@ export class FileBrowserDialogComponent extends React.Component {
 
     @computed get pathItems() {
         const appStore = AppStore.Instance;
+        const fileBrowserStore = FileBrowserStore.Instance;
+
         // let pathItems: IBreadcrumbProps[] = [{icon: "desktop", target: "."}];
-        let pathItems: IBreadcrumbProps[] = [{icon: "desktop", onClick: () => appStore.fileBrowserStore.selectFolder(".", true)}];
-        const fileList = appStore.fileBrowserStore.getfileListByMode;
+        let pathItems: IBreadcrumbProps[] = [{icon: "desktop", onClick: () => fileBrowserStore.selectFolder(".", true)}];
+        const fileList = fileBrowserStore.getfileListByMode;
         if (fileList) {
             const path = fileList.directory;
             if (path && path !== ".") {
@@ -379,7 +381,7 @@ export class FileBrowserDialogComponent extends React.Component {
                         const targetPath = parentPath;
                         pathItems.push({
                             text: dirName,
-                            onClick: () => appStore.fileBrowserStore.selectFolder(targetPath, true)
+                            onClick: () => fileBrowserStore.selectFolder(targetPath, true)
                         });
                     }
                 }

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -7,25 +7,26 @@ import {FileListComponent} from "./FileList/FileListComponent";
 import {FileInfoComponent, FileInfoType} from "components/FileInfo/FileInfoComponent";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {TableComponentProps, TableType} from "components/Shared";
-import {AppStore, BrowserMode, HelpType} from "stores";
+import {AppStore, BrowserMode, DialogStore, HelpType} from "stores";
 import {CatalogOverlayWidgetStore} from "stores/widgets";
 import "./FileBrowserDialogComponent.css";
 
 @observer
-export class FileBrowserDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class FileBrowserDialogComponent extends React.Component {
     @observable overwriteExistingFileAlertVisible: boolean;
 
     private handleTabChange = (newId: TabId) => {
-        this.props.appStore.fileBrowserStore.setSelectedTab(newId);
+        AppStore.Instance.fileBrowserStore.setSelectedTab(newId);
     };
 
     private loadSelectedFile = () => {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
         this.loadFile(fileBrowserStore.selectedFile, fileBrowserStore.selectedHDU);
     };
 
     private loadFile = (fileInfo: CARTA.IFileInfo | CARTA.ICatalogFileInfo, hdu?: string) => {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
 
         // Ignore load if in export mode
         if (fileBrowserStore.browserMode === BrowserMode.RegionExport) {
@@ -33,23 +34,24 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
         }
 
         if (fileBrowserStore.browserMode === BrowserMode.File) {
-            const frames = this.props.appStore.frames;
+            const frames = appStore.frames;
             if (!fileBrowserStore.appendingFrame || !frames.length) {
-                this.props.appStore.openFile(fileBrowserStore.fileList.directory, fileInfo.name, hdu);
+                appStore.openFile(fileBrowserStore.fileList.directory, fileInfo.name, hdu);
             } else {
-                this.props.appStore.appendFile(fileBrowserStore.fileList.directory, fileInfo.name, hdu);
+                appStore.appendFile(fileBrowserStore.fileList.directory, fileInfo.name, hdu);
             }
         } else if (fileBrowserStore.browserMode === BrowserMode.Catalog) {
-            this.props.appStore.appendCatalog(fileBrowserStore.catalogFileList.directory, fileInfo.name, CatalogOverlayWidgetStore.InitTableRows, CARTA.CatalogFileType.VOTable);
+            appStore.appendCatalog(fileBrowserStore.catalogFileList.directory, fileInfo.name, CatalogOverlayWidgetStore.InitTableRows, CARTA.CatalogFileType.VOTable);
         } else {
-            this.props.appStore.importRegion(fileBrowserStore.fileList.directory, fileInfo.name, fileInfo.type);
+            appStore.importRegion(fileBrowserStore.fileList.directory, fileInfo.name, fileInfo.type);
         }
 
         fileBrowserStore.saveStartingDirectory();
     };
 
     private handleExportRegionsClicked = () => {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
         const filename = fileBrowserStore.exportFilename.trim();
         if (fileBrowserStore.fileList && fileBrowserStore.fileList.files && fileBrowserStore.fileList.files.find(f => f.name.trim() === filename)) {
             // Existing file being replaced. Alert the user
@@ -65,15 +67,17 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
         }
 
         filename = filename.trim();
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
-        this.props.appStore.exportRegions(directory, filename, fileBrowserStore.exportCoordinateType, fileBrowserStore.exportFileType);
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
+        appStore.exportRegions(directory, filename, fileBrowserStore.exportCoordinateType, fileBrowserStore.exportFileType);
         console.log(`Exporting all regions to ${directory}/${filename}`);
     }
 
     private handleOverwriteAlertConfirmed = () => {
         this.overwriteExistingFileAlertVisible = false;
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
-        const filename = this.props.appStore.fileBrowserStore.exportFilename.trim();
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
+        const filename = appStore.fileBrowserStore.exportFilename.trim();
         this.exportRegion(fileBrowserStore.fileList.directory, filename);
     };
 
@@ -82,7 +86,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     };
 
     private handleExportInputChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
         fileBrowserStore.setExportFilename(ev.target.value);
     };
 
@@ -92,7 +96,8 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     }
 
     private renderActionButton(browserMode: BrowserMode, appending: boolean) {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
 
         if (browserMode === BrowserMode.File) {
             if (appending) {
@@ -100,7 +105,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                     <Tooltip content={"Append this file as a new frame"}>
                         <AnchorButton
                             intent={Intent.PRIMARY}
-                            disabled={this.props.appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo}
+                            disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo}
                             onClick={this.loadSelectedFile}
                             text="Append"
                         />
@@ -110,7 +115,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                     <Tooltip content={"Close any existing frames and load this file"}>
                         <AnchorButton
                             intent={Intent.PRIMARY}
-                            disabled={this.props.appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo}
+                            disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo}
                             onClick={this.loadSelectedFile}
                             text="Load"
                         />
@@ -122,7 +127,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                 <Tooltip content={"Load a region file for the currently active frame"}>
                     <AnchorButton
                         intent={Intent.PRIMARY}
-                        disabled={this.props.appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo || !this.props.appStore.activeFrame}
+                        disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo || !appStore.activeFrame}
                         onClick={this.loadSelectedFile}
                         text="Load Region"
                     />
@@ -133,14 +138,14 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                 <Tooltip content={"Load a catalog file for the currently active frame"}>
                     <AnchorButton
                         intent={Intent.PRIMARY}
-                        disabled={this.props.appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo || !this.props.appStore.activeFrame}
+                        disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo || !appStore.activeFrame}
                         onClick={this.loadSelectedFile}
                         text="Load Catalog"
                     />
                 </Tooltip>
             );
         } else {
-            const frame = this.props.appStore.activeFrame;
+            const frame = appStore.activeFrame;
             return (
                 <Tooltip content={"Export all regions for the currently active frame"}>
                     <AnchorButton
@@ -155,7 +160,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     }
 
     private renderExportFilenameInput() {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
 
         const coordinateTypeMenu = (
             <Popover
@@ -201,7 +206,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     // Refresh file list to trigger the Breadcrumb re-rendering
     @action
     private refreshFileList() {
-        const fileBrowserStore = this.props.appStore.fileBrowserStore;
+        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
         switch (fileBrowserStore.browserMode) {
             case BrowserMode.Catalog:
                 fileBrowserStore.catalogFileList = {...fileBrowserStore.catalogFileList};
@@ -213,20 +218,21 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     }
 
     public render() {
+        const appStore = AppStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
+
         let className = "file-browser-dialog";
-        if (this.props.appStore.darkTheme) {
+        if (appStore.darkTheme) {
             className += " bp3-dark";
         }
 
-        const appStore = this.props.appStore;
-        const fileBrowserStore = appStore.fileBrowserStore;
         const dialogProps: IDialogProps = {
             icon: "folder-open",
             className: className,
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: appStore.dialogStore.fileBrowserDialogVisible,
+            isOpen: DialogStore.Instance.fileBrowserDialogVisible,
             onClose: fileBrowserStore.hideFileBrowser,
             onOpened: () => this.refreshFileList(),
             title: "File Browser",
@@ -255,7 +261,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
         }
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.FILE_Browser} minWidth={400} minHeight={400} defaultWidth={1200} defaultHeight={600} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.FILE_Browser} minWidth={400} minHeight={400} defaultWidth={1200} defaultHeight={600} enableResizing={true}>
                 <div className="file-path">
                     {this.pathItems &&
                     <React.Fragment>
@@ -278,7 +284,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                     <div className={paneClassName}>
                         <div className="file-list">
                             <FileListComponent
-                                darkTheme={this.props.appStore.darkTheme}
+                                darkTheme={appStore.darkTheme}
                                 files={fileBrowserStore.getfileListByMode}
                                 fileBrowserMode={fileBrowserStore.browserMode}
                                 selectedFile={fileBrowserStore.selectedFile}
@@ -306,7 +312,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                 </div>
                 <div className="bp3-dialog-footer">
                     <div className="bp3-dialog-footer-actions">
-                        <AnchorButton intent={Intent.NONE} onClick={fileBrowserStore.hideFileBrowser} disabled={this.props.appStore.fileLoading} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={fileBrowserStore.hideFileBrowser} disabled={appStore.fileLoading} text="Close"/>
                         {actionButton}
                     </div>
                 </div>
@@ -348,9 +354,10 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
     }
 
     @computed get pathItems() {
+        const appStore = AppStore.Instance;
         // let pathItems: IBreadcrumbProps[] = [{icon: "desktop", target: "."}];
-        let pathItems: IBreadcrumbProps[] = [{icon: "desktop", onClick: () => this.props.appStore.fileBrowserStore.selectFolder(".", true)}];
-        const fileList = this.props.appStore.fileBrowserStore.getfileListByMode;
+        let pathItems: IBreadcrumbProps[] = [{icon: "desktop", onClick: () => appStore.fileBrowserStore.selectFolder(".", true)}];
+        const fileList = appStore.fileBrowserStore.getfileListByMode;
         if (fileList) {
             const path = fileList.directory;
             if (path && path !== ".") {
@@ -372,7 +379,7 @@ export class FileBrowserDialogComponent extends React.Component<{ appStore: AppS
                         const targetPath = parentPath;
                         pathItems.push({
                             text: dirName,
-                            onClick: () => this.props.appStore.fileBrowserStore.selectFolder(targetPath, true)
+                            onClick: () => appStore.fileBrowserStore.selectFolder(targetPath, true)
                         });
                     }
                 }

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -26,7 +26,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     private loadFile = (fileInfo: CARTA.IFileInfo | CARTA.ICatalogFileInfo, hdu?: string) => {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = FileBrowserStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
 
         // Ignore load if in export mode
         if (fileBrowserStore.browserMode === BrowserMode.RegionExport) {
@@ -50,7 +50,6 @@ export class FileBrowserDialogComponent extends React.Component {
     };
 
     private handleExportRegionsClicked = () => {
-        const appStore = AppStore.Instance;
         const fileBrowserStore = FileBrowserStore.Instance;
         const filename = fileBrowserStore.exportFilename.trim();
         if (fileBrowserStore.fileList && fileBrowserStore.fileList.files && fileBrowserStore.fileList.files.find(f => f.name.trim() === filename)) {
@@ -75,7 +74,6 @@ export class FileBrowserDialogComponent extends React.Component {
 
     private handleOverwriteAlertConfirmed = () => {
         this.overwriteExistingFileAlertVisible = false;
-        const appStore = AppStore.Instance;
         const fileBrowserStore = FileBrowserStore.Instance;
         const filename = fileBrowserStore.exportFilename.trim();
         this.exportRegion(fileBrowserStore.fileList.directory, filename);
@@ -97,7 +95,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     private renderActionButton(browserMode: BrowserMode, appending: boolean) {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = FileBrowserStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
 
         if (browserMode === BrowserMode.File) {
             if (appending) {
@@ -219,7 +217,7 @@ export class FileBrowserDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const fileBrowserStore = FileBrowserStore.Instance;
+        const fileBrowserStore = appStore.fileBrowserStore;
 
         let className = "file-browser-dialog";
         if (appStore.darkTheme) {
@@ -232,7 +230,7 @@ export class FileBrowserDialogComponent extends React.Component {
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: DialogStore.Instance.fileBrowserDialogVisible,
+            isOpen: appStore.dialogStore.fileBrowserDialogVisible,
             onClose: fileBrowserStore.hideFileBrowser,
             onOpened: () => this.refreshFileList(),
             title: "File Browser",
@@ -354,7 +352,6 @@ export class FileBrowserDialogComponent extends React.Component {
     }
 
     @computed get pathItems() {
-        const appStore = AppStore.Instance;
         const fileBrowserStore = FileBrowserStore.Instance;
 
         // let pathItems: IBreadcrumbProps[] = [{icon: "desktop", target: "."}];

--- a/src/components/Dialogs/FileInfoDialog/FileInfoDialogComponent.tsx
+++ b/src/components/Dialogs/FileInfoDialog/FileInfoDialogComponent.tsx
@@ -3,20 +3,20 @@ import {observer} from "mobx-react";
 import {IDialogProps} from "@blueprintjs/core";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {FileInfoComponent, FileInfoType} from "components/FileInfo/FileInfoComponent";
-import {AppStore, HelpType} from "stores";
+import {AppStore, DialogStore, HelpType} from "stores";
 import "./FileInfoDialogComponent.css";
 
 @observer
-export class FileInfoDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class FileInfoDialogComponent extends React.Component {
 
     render() {
+        const appStore = AppStore.Instance;
+        const dialogStore = DialogStore.Instance;
+
         let className = "file-info-dialog";
-        if (this.props.appStore.darkTheme) {
+        if (appStore.darkTheme) {
             className += " bp3-dark";
         }
-
-        const appStore = this.props.appStore;
-        const dialogStore = appStore.dialogStore;
 
         const dialogProps: IDialogProps = {
             icon: "info-sign",
@@ -30,7 +30,7 @@ export class FileInfoDialogComponent extends React.Component<{ appStore: AppStor
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.FILE_INFO} minWidth={400} minHeight={400} defaultWidth={800} defaultHeight={600} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.FILE_INFO} minWidth={400} minHeight={400} defaultWidth={800} defaultHeight={600} enableResizing={true}>
                 <div className="bp3-dialog-body">
                     <FileInfoComponent
                         infoTypes={[FileInfoType.IMAGE_FILE, FileInfoType.IMAGE_HEADER]}

--- a/src/components/Dialogs/FileInfoDialog/FileInfoDialogComponent.tsx
+++ b/src/components/Dialogs/FileInfoDialog/FileInfoDialogComponent.tsx
@@ -11,7 +11,6 @@ export class FileInfoDialogComponent extends React.Component {
 
     render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
 
         let className = "file-info-dialog";
         if (appStore.darkTheme) {
@@ -24,8 +23,8 @@ export class FileInfoDialogComponent extends React.Component {
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: dialogStore.fileInfoDialogVisible,
-            onClose: dialogStore.hideFileInfoDialog,
+            isOpen: appStore.dialogStore.fileInfoDialogVisible,
+            onClose: appStore.dialogStore.hideFileInfoDialog,
             title: "File Info",
         };
 
@@ -37,8 +36,8 @@ export class FileInfoDialogComponent extends React.Component {
                         fileInfoExtended={appStore.activeFrame ? appStore.activeFrame.frameInfo.fileInfoExtended : null}
                         regionFileInfo={""}
                         catalogFileInfo={null}
-                        selectedTab={dialogStore.selectedFileInfoDialogTab as FileInfoType}
-                        handleTabChange={dialogStore.setSelectedFileInfoDialogTab}
+                        selectedTab={appStore.dialogStore.selectedFileInfoDialogTab as FileInfoType}
+                        handleTabChange={appStore.dialogStore.setSelectedFileInfoDialogTab}
                         isLoading={false}
                         errorMessage={""}
                     />

--- a/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {observable, computed} from "mobx";
 import {observer} from "mobx-react";
 import {FormGroup, InputGroup, IDialogProps, Button, Intent, Classes, Tooltip} from "@blueprintjs/core";
 import {DraggableDialogComponent} from "components/Dialogs";
-import {AppStore, HelpType} from "stores";
+import {AlertStore, AppStore, HelpType} from "stores";
 import {PresetLayout} from "models";
 import "./SaveLayoutDialogComponent.css";
 
@@ -30,7 +30,7 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
     private saveLayout = () => {
         const appStore = this.props.appStore;
         const layoutStore = this.props.appStore.layoutStore;
-        const alertStore = this.props.appStore.alertStore;
+        const alertStore = AlertStore.Instance;
 
         appStore.dialogStore.hideSaveLayoutDialog();
         layoutStore.setLayoutToBeSaved(this.layoutName);

--- a/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
@@ -29,23 +29,21 @@ export class SaveLayoutDialogComponent extends React.Component {
 
     private saveLayout = () => {
         const appStore = AppStore.Instance;
-        const layoutStore = appStore.layoutStore;
-        const alertStore = AlertStore.Instance;
 
-        DialogStore.Instance.hideSaveLayoutDialog();
-        layoutStore.setLayoutToBeSaved(this.layoutName);
-        if (layoutStore.layoutExist(this.layoutName)) {
+        appStore.dialogStore.hideSaveLayoutDialog();
+        appStore.layoutStore.setLayoutToBeSaved(this.layoutName);
+        if (appStore.layoutStore.layoutExist(this.layoutName)) {
             if (PresetLayout.isPreset(this.layoutName)) {
-                alertStore.showAlert("Layout name cannot be the same as system presets.");
+                appStore.alertStore.showAlert("Layout name cannot be the same as system presets.");
             } else {
-                alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`, (confirmed: boolean) => {
+                appStore.alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`, (confirmed: boolean) => {
                     if (confirmed) {
-                        layoutStore.saveLayout();
+                        appStore.layoutStore.saveLayout();
                     }
                 });
             }
         } else {
-            layoutStore.saveLayout();
+            appStore.layoutStore.saveLayout();
         }
         this.clearInput();
     };
@@ -56,7 +54,6 @@ export class SaveLayoutDialogComponent extends React.Component {
 
     render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
 
         let className = "preference-dialog";
         if (appStore.darkTheme) {
@@ -69,8 +66,8 @@ export class SaveLayoutDialogComponent extends React.Component {
             className: className,
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: dialogStore.saveLayoutDialogVisible,
-            onClose: dialogStore.hideSaveLayoutDialog,
+            isOpen: appStore.dialogStore.saveLayoutDialogVisible,
+            onClose: appStore.dialogStore.hideSaveLayoutDialog,
             title: "Save Layout",
         };
 
@@ -90,7 +87,7 @@ export class SaveLayoutDialogComponent extends React.Component {
                             intent={Intent.NONE}
                             text="Close"
                             onClick={() => {
-                                dialogStore.hideSaveLayoutDialog();
+                                appStore.dialogStore.hideSaveLayoutDialog();
                                 this.clearInput();
                             }}
                         />

--- a/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/SaveLayoutDialogComponent.tsx
@@ -3,14 +3,14 @@ import {observable, computed} from "mobx";
 import {observer} from "mobx-react";
 import {FormGroup, InputGroup, IDialogProps, Button, Intent, Classes, Tooltip} from "@blueprintjs/core";
 import {DraggableDialogComponent} from "components/Dialogs";
-import {AlertStore, AppStore, HelpType} from "stores";
+import {AlertStore, AppStore, DialogStore, HelpType} from "stores";
 import {PresetLayout} from "models";
 import "./SaveLayoutDialogComponent.css";
 
 const KEYCODE_ENTER = 13;
 
 @observer
-export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class SaveLayoutDialogComponent extends React.Component {
     @observable private layoutName: string = "";
 
     private handleInput = (ev: React.FormEvent<HTMLInputElement>) => {
@@ -28,11 +28,11 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
     };
 
     private saveLayout = () => {
-        const appStore = this.props.appStore;
-        const layoutStore = this.props.appStore.layoutStore;
+        const appStore = AppStore.Instance;
+        const layoutStore = appStore.layoutStore;
         const alertStore = AlertStore.Instance;
 
-        appStore.dialogStore.hideSaveLayoutDialog();
+        DialogStore.Instance.hideSaveLayoutDialog();
         layoutStore.setLayoutToBeSaved(this.layoutName);
         if (layoutStore.layoutExist(this.layoutName)) {
             if (PresetLayout.isPreset(this.layoutName)) {
@@ -55,7 +55,8 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
     }
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
+        const dialogStore = DialogStore.Instance;
 
         let className = "preference-dialog";
         if (appStore.darkTheme) {
@@ -68,13 +69,13 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
             className: className,
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: appStore.dialogStore.saveLayoutDialogVisible,
-            onClose: appStore.dialogStore.hideSaveLayoutDialog,
+            isOpen: dialogStore.saveLayoutDialogVisible,
+            onClose: dialogStore.hideSaveLayoutDialog,
             title: "Save Layout",
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.SAVE_LAYOUT} defaultWidth={400} defaultHeight={185} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.SAVE_LAYOUT} defaultWidth={400} defaultHeight={185} enableResizing={true}>
                 <div className={Classes.DIALOG_BODY}>
                     <FormGroup inline={true} label="Save current layout as:">
                         <InputGroup className="layout-name-input" placeholder="Enter layout name" value={this.layoutName} autoFocus={true} onChange={this.handleInput} onKeyDown={this.handleKeyDown}/>
@@ -89,7 +90,7 @@ export class SaveLayoutDialogComponent extends React.Component<{ appStore: AppSt
                             intent={Intent.NONE}
                             text="Close"
                             onClick={() => {
-                                appStore.dialogStore.hideSaveLayoutDialog();
+                                dialogStore.hideSaveLayoutDialog();
                                 this.clearInput();
                             }}
                         />

--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -90,7 +90,7 @@ export class OverlaySettingsDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const overlayStore = OverlayStore.Instance;
+        const overlayStore = appStore.overlayStore;
         const global = overlayStore.global;
         const title = overlayStore.title;
         const grid = overlayStore.grid;

--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -12,7 +12,7 @@ import {DraggableDialogComponent} from "components/Dialogs";
 import {ColorComponent} from "./ColorComponent";
 import {ColorResult} from "react-color";
 import {ColorPickerComponent, SafeNumericInput} from "components/Shared";
-import {AppStore, BeamType, LabelType, SystemType, HelpType} from "stores";
+import {AppStore, BeamType, LabelType, SystemType, HelpType, DialogStore} from "stores";
 import {hexStringToRgba, SWATCH_COLORS} from "utilities";
 import "./OverlaySettingsDialogComponent.css";
 
@@ -64,7 +64,7 @@ export const renderFont: ItemRenderer<Font> = (font, {handleClick, modifiers, qu
 };
 
 @observer
-export class OverlaySettingsDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class OverlaySettingsDialogComponent extends React.Component {
     @observable selectedTab: TabId = "global";
 
     private fontSelect(visible: boolean, currentFontId: number, fontSetter: Function) {
@@ -89,7 +89,7 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
     }
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const overlayStore = appStore.overlayStore;
         const global = overlayStore.global;
         const title = overlayStore.title;
@@ -569,7 +569,7 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
             <div className="panel-container">
                 <FormGroup inline={true} label="Frame">
                     <HTMLSelect
-                        options={this.props.appStore.frameNames}
+                        options={appStore.frameNames}
                         value={beam.selectedFileId}
                         onChange={(event: React.FormEvent<HTMLSelectElement>) => beam.setSelectedFrame(parseInt(event.currentTarget.value))}
                     />
@@ -586,7 +586,7 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
                         presetColors={SWATCH_COLORS}
                         setColor={(color: ColorResult) => beamSettings.setColor(color.hex)}
                         disableAlpha={true}
-                        darkTheme={this.props.appStore.darkTheme}
+                        darkTheme={appStore.darkTheme}
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Type">
@@ -636,9 +636,11 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
         ) : null;
 
         let className = "overlay-settings-dialog";
-        if (this.props.appStore.darkTheme) {
+        if (appStore.darkTheme) {
             className += " bp3-dark";
         }
+
+        const dialogStore = DialogStore.Instance;
 
         const dialogProps: IDialogProps = {
             icon: "settings",
@@ -646,13 +648,13 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
             className: className,
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: appStore.dialogStore.overlaySettingsDialogVisible,
-            onClose: appStore.dialogStore.hideOverlaySettings,
+            isOpen: dialogStore.overlaySettingsDialogVisible,
+            onClose: dialogStore.hideOverlaySettings,
             title: "Overlay Settings",
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.OVERLAY_SETTINGS} minWidth={300} minHeight={300} defaultWidth={630} defaultHeight={425} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.OVERLAY_SETTINGS} minWidth={300} minHeight={300} defaultWidth={630} defaultHeight={425} enableResizing={true}>
                 <div className="bp3-dialog-body">
                     <Tabs
                         id="overlayTabs"
@@ -668,12 +670,12 @@ export class OverlaySettingsDialogComponent extends React.Component<{ appStore: 
                         <Tab id="axes" title="Axes" panel={axesPanel}/>
                         <Tab id="numbers" title="Numbers" panel={numbersPanel}/>
                         <Tab id="labels" title="Labels" panel={labelsPanel}/>
-                        <Tab id="beam" title="Beam" panel={beamPanel} disabled={this.props.appStore.frameNum <= 0}/>
+                        <Tab id="beam" title="Beam" panel={beamPanel} disabled={appStore.frameNum <= 0}/>
                     </Tabs>
                 </div>
                 <div className="bp3-dialog-footer">
                     <div className="bp3-dialog-footer-actions">
-                        <Button intent={Intent.PRIMARY} onClick={appStore.dialogStore.hideOverlaySettings} text="Close"/>
+                        <Button intent={Intent.PRIMARY} onClick={dialogStore.hideOverlaySettings} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -12,7 +12,7 @@ import {DraggableDialogComponent} from "components/Dialogs";
 import {ColorComponent} from "./ColorComponent";
 import {ColorResult} from "react-color";
 import {ColorPickerComponent, SafeNumericInput} from "components/Shared";
-import {AppStore, BeamType, LabelType, SystemType, HelpType, DialogStore} from "stores";
+import {AppStore, BeamType, LabelType, SystemType, HelpType, DialogStore, OverlayStore} from "stores";
 import {hexStringToRgba, SWATCH_COLORS} from "utilities";
 import "./OverlaySettingsDialogComponent.css";
 
@@ -90,7 +90,7 @@ export class OverlaySettingsDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const overlayStore = appStore.overlayStore;
+        const overlayStore = OverlayStore.Instance;
         const global = overlayStore.global;
         const title = overlayStore.title;
         const grid = overlayStore.grid;

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -11,7 +11,7 @@ import {ScalingSelectComponent} from "components/Shared/ScalingSelectComponent/S
 import {ColorComponent} from "components/Dialogs/OverlaySettings/ColorComponent";
 import {ColormapComponent, ColorPickerComponent, SafeNumericInput} from "components/Shared";
 import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
-import {AppStore, BeamType, ContourGeneratorType, DialogStore, FrameScaling, HelpType, PreferenceKeys, RegionStore, RenderConfigStore} from "stores";
+import {AppStore, BeamType, ContourGeneratorType, DialogStore, FrameScaling, HelpType, PreferenceKeys, PreferenceStore, RegionStore, RenderConfigStore} from "stores";
 import {hexStringToRgba, SWATCH_COLORS} from "utilities";
 import "./PreferenceDialogComponent.css";
 
@@ -34,26 +34,25 @@ export class PreferenceDialogComponent extends React.Component {
     private renderPercentileSelectItem = (percentile: string, {handleClick, modifiers, query}) => {
         return <MenuItem text={percentile + "%"} onClick={handleClick} key={percentile}/>;
     };
-
-    // TODO: PreferenceStore will also be a singleton
+    
     private handleImageCompressionQualityChange = _.throttle((value: number) => {
-        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY, value);
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY, value);
     }, 100);
 
     private handleAnimationCompressionQualityChange = _.throttle((value: number) => {
-        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_ANIMATION_COMPRESSION_QUALITY, value);
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_ANIMATION_COMPRESSION_QUALITY, value);
     }, 100);
 
     private handleGPUTileCacheChange = _.throttle((value: number) => {
-        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_GPU_TILE_CACHE, value);
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_GPU_TILE_CACHE, value);
     }, 100);
 
     private handleSystemTileCacheChange = _.throttle((value: number) => {
-        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE, value);
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE, value);
     }, 100);
 
     private reset = () => {
-        const preference = AppStore.Instance.preferenceStore;
+        const preference = PreferenceStore.Instance;
         switch (this.selectedTab) {
             case TABS.RENDER_CONFIG:
                 preference.resetRenderConfigSettings();
@@ -82,7 +81,7 @@ export class PreferenceDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const preference = appStore.preferenceStore;
+        const preference = PreferenceStore.Instance;
         const layoutStore = appStore.layoutStore;
 
         const globalPanel = (

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -11,7 +11,7 @@ import {ScalingSelectComponent} from "components/Shared/ScalingSelectComponent/S
 import {ColorComponent} from "components/Dialogs/OverlaySettings/ColorComponent";
 import {ColormapComponent, ColorPickerComponent, SafeNumericInput} from "components/Shared";
 import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
-import {AppStore, BeamType, ContourGeneratorType, FrameScaling, HelpType, PreferenceKeys, RegionStore, RenderConfigStore} from "stores";
+import {AppStore, BeamType, ContourGeneratorType, DialogStore, FrameScaling, HelpType, PreferenceKeys, RegionStore, RenderConfigStore} from "stores";
 import {hexStringToRgba, SWATCH_COLORS} from "utilities";
 import "./PreferenceDialogComponent.css";
 
@@ -28,31 +28,32 @@ enum TABS {
 const PercentileSelect = Select.ofType<string>();
 
 @observer
-export class PreferenceDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class PreferenceDialogComponent extends React.Component {
     @observable selectedTab: TabId = TABS.GLOBAL;
 
     private renderPercentileSelectItem = (percentile: string, {handleClick, modifiers, query}) => {
         return <MenuItem text={percentile + "%"} onClick={handleClick} key={percentile}/>;
     };
 
+    // TODO: PreferenceStore will also be a singleton
     private handleImageCompressionQualityChange = _.throttle((value: number) => {
-        this.props.appStore.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY, value);
+        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY, value);
     }, 100);
 
     private handleAnimationCompressionQualityChange = _.throttle((value: number) => {
-        this.props.appStore.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_ANIMATION_COMPRESSION_QUALITY, value);
+        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_ANIMATION_COMPRESSION_QUALITY, value);
     }, 100);
 
     private handleGPUTileCacheChange = _.throttle((value: number) => {
-        this.props.appStore.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_GPU_TILE_CACHE, value);
+        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_GPU_TILE_CACHE, value);
     }, 100);
 
     private handleSystemTileCacheChange = _.throttle((value: number) => {
-        this.props.appStore.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE, value);
+        AppStore.Instance.preferenceStore.setPreference(PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE, value);
     }, 100);
 
     private reset = () => {
-        const preference = this.props.appStore.preferenceStore;
+        const preference = AppStore.Instance.preferenceStore;
         switch (this.selectedTab) {
             case TABS.RENDER_CONFIG:
                 preference.resetRenderConfigSettings();
@@ -80,7 +81,7 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
     };
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const preference = appStore.preferenceStore;
         const layoutStore = appStore.layoutStore;
 
@@ -335,7 +336,7 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                         presetColors={SWATCH_COLORS}
                         setColor={(color: ColorResult) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_BEAM_COLOR, color.hex)}
                         disableAlpha={true}
-                        darkTheme={this.props.appStore.darkTheme}
+                        darkTheme={appStore.darkTheme}
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Beam Type">
@@ -536,19 +537,21 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
             className += " bp3-dark";
         }
 
+        const dialogStore = DialogStore.Instance;
+
         const dialogProps: IDialogProps = {
             icon: "cog",
             backdropClassName: "minimal-dialog-backdrop",
             className: className,
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: appStore.dialogStore.preferenceDialogVisible,
-            onClose: appStore.dialogStore.hidePreferenceDialog,
+            isOpen: dialogStore.preferenceDialogVisible,
+            onClose: dialogStore.hidePreferenceDialog,
             title: "Preferences",
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.PREFERENCES} minWidth={450} minHeight={300} defaultWidth={775} defaultHeight={500} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.PREFERENCES} minWidth={450} minHeight={300} defaultWidth={775} defaultHeight={500} enableResizing={true}>
                 <div className="bp3-dialog-body">
                     <Tabs
                         id="preferenceTabs"
@@ -570,7 +573,7 @@ export class PreferenceDialogComponent extends React.Component<{ appStore: AppSt
                         <Tooltip content="Apply to current tab only." position={Position.TOP}>
                             <AnchorButton intent={Intent.WARNING} icon={"refresh"} onClick={this.reset} text="Restore defaults"/>
                         </Tooltip>
-                        <Button intent={Intent.NONE} onClick={appStore.dialogStore.hidePreferenceDialog} text="Close"/>
+                        <Button intent={Intent.NONE} onClick={dialogStore.hidePreferenceDialog} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -81,7 +81,7 @@ export class PreferenceDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const preference = PreferenceStore.Instance;
+        const preference = appStore.preferenceStore;
         const layoutStore = appStore.layoutStore;
 
         const globalPanel = (
@@ -536,16 +536,14 @@ export class PreferenceDialogComponent extends React.Component {
             className += " bp3-dark";
         }
 
-        const dialogStore = DialogStore.Instance;
-
         const dialogProps: IDialogProps = {
             icon: "cog",
             backdropClassName: "minimal-dialog-backdrop",
             className: className,
             canOutsideClickClose: false,
             lazy: true,
-            isOpen: dialogStore.preferenceDialogVisible,
-            onClose: dialogStore.hidePreferenceDialog,
+            isOpen: appStore.dialogStore.preferenceDialogVisible,
+            onClose: appStore.dialogStore.hidePreferenceDialog,
             title: "Preferences",
         };
 
@@ -572,7 +570,7 @@ export class PreferenceDialogComponent extends React.Component {
                         <Tooltip content="Apply to current tab only." position={Position.TOP}>
                             <AnchorButton intent={Intent.WARNING} icon={"refresh"} onClick={this.reset} text="Restore defaults"/>
                         </Tooltip>
-                        <Button intent={Intent.NONE} onClick={dialogStore.hidePreferenceDialog} text="Close"/>
+                        <Button intent={Intent.NONE} onClick={appStore.dialogStore.hidePreferenceDialog} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -18,7 +18,7 @@ export class RegionDialogComponent extends React.Component {
 
     private handleDeleteClicked = () => {
         const appStore = AppStore.Instance;
-        DialogStore.Instance.hideRegionDialog();
+        appStore.dialogStore.hideRegionDialog();
         if (appStore.activeFrame && appStore.activeFrame.regionSet.selectedRegion) {
             appStore.deleteRegion(appStore.activeFrame.regionSet.selectedRegion);
         }
@@ -28,15 +28,14 @@ export class RegionDialogComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
 
         const dialogProps: IDialogProps = {
             icon: "info-sign",
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: true,
             lazy: true,
-            isOpen: dialogStore.regionDialogVisible,
-            onClose: dialogStore.hideRegionDialog,
+            isOpen: appStore.dialogStore.regionDialogVisible,
+            onClose: appStore.dialogStore.hideRegionDialog,
             className: "region-dialog",
             canEscapeKeyClose: true,
             title: "No region selected",
@@ -116,7 +115,7 @@ export class RegionDialogComponent extends React.Component {
                     <div className={Classes.DIALOG_FOOTER_ACTIONS}>
                         {tooltips}
                         {editableRegion && <AnchorButton intent={Intent.DANGER} icon={"trash"} text="Delete" onClick={this.handleDeleteClicked}/>}
-                        <AnchorButton intent={Intent.NONE} onClick={dialogStore.hideRegionDialog} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={appStore.dialogStore.hideRegionDialog} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import {AnchorButton, Classes, IDialogProps, Intent, NonIdealState, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {DraggableDialogComponent} from "components/Dialogs";
-import {AppStore, RegionStore, HelpType} from "stores";
+import {AppStore, RegionStore, HelpType, DialogStore} from "stores";
 import {PointRegionForm} from "./PointRegionForm/PointRegionForm";
 import {RectangularRegionForm} from "./RectangularRegionForm/RectangularRegionForm";
 import {EllipticalRegionForm} from "./EllipticalRegionForm/EllipticalRegionForm";
@@ -12,30 +12,31 @@ import {PolygonRegionForm} from "./PolygonRegionForm/PolygonRegionForm";
 import "./RegionDialogComponent.css";
 
 @observer
-export class RegionDialogComponent extends React.Component<{ appStore: AppStore }> {
+export class RegionDialogComponent extends React.Component {
     private static readonly MissingRegionNode = <NonIdealState icon={"folder-open"} title={"No region selected"} description={"Select a region using the list or image view"}/>;
     private static readonly InvalidRegionNode = <NonIdealState icon={"error"} title={"Region not supported"} description={"The selected region does not have any editable properties"}/>;
 
     private handleDeleteClicked = () => {
-        const appStore = this.props.appStore;
-        appStore.dialogStore.hideRegionDialog();
+        const appStore = AppStore.Instance;
+        DialogStore.Instance.hideRegionDialog();
         if (appStore.activeFrame && appStore.activeFrame.regionSet.selectedRegion) {
             appStore.deleteRegion(appStore.activeFrame.regionSet.selectedRegion);
         }
     };
 
-    private handleFocusClicked = () => this.props.appStore.activeFrame.regionSet.selectedRegion.focusCenter();
+    private handleFocusClicked = () => AppStore.Instance.activeFrame.regionSet.selectedRegion.focusCenter();
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
+        const dialogStore = DialogStore.Instance;
 
         const dialogProps: IDialogProps = {
             icon: "info-sign",
             backdropClassName: "minimal-dialog-backdrop",
             canOutsideClickClose: true,
             lazy: true,
-            isOpen: appStore.dialogStore.regionDialogVisible,
-            onClose: appStore.dialogStore.hideRegionDialog,
+            isOpen: dialogStore.regionDialogVisible,
+            onClose: dialogStore.hideRegionDialog,
             className: "region-dialog",
             canEscapeKeyClose: true,
             title: "No region selected",
@@ -107,7 +108,7 @@ export class RegionDialogComponent extends React.Component<{ appStore: AppStore 
         );
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} appStore={appStore} helpType={HelpType.REGION_DIALOG} defaultWidth={600} defaultHeight={450} minHeight={300} minWidth={400} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.REGION_DIALOG} defaultWidth={600} defaultHeight={450} minHeight={300} minWidth={400} enableResizing={true}>
                 <div className={Classes.DIALOG_BODY}>
                     {bodyContent}
                 </div>
@@ -115,7 +116,7 @@ export class RegionDialogComponent extends React.Component<{ appStore: AppStore 
                     <div className={Classes.DIALOG_FOOTER_ACTIONS}>
                         {tooltips}
                         {editableRegion && <AnchorButton intent={Intent.DANGER} icon={"trash"} text="Delete" onClick={this.handleDeleteClicked}/>}
-                        <AnchorButton intent={Intent.NONE} onClick={appStore.dialogStore.hideRegionDialog} text="Close"/>
+                        <AnchorButton intent={Intent.NONE} onClick={dialogStore.hideRegionDialog} text="Close"/>
                     </div>
                 </div>
             </DraggableDialogComponent>

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {Rnd} from "react-rnd";
 import {Icon, Position, Tooltip} from "@blueprintjs/core";
 import {PlaceholderComponent} from "components";
-import {AppStore, WidgetConfig} from "stores";
+import {AppStore, HelpStore, WidgetConfig} from "stores";
 import "./FloatingWidgetComponent.css";
 
 class FloatingWidgetComponentProps {
@@ -72,7 +72,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
 
     private onClickHelpButton = () => {
         const centerX = this.rnd.draggable.state.x + this.rnd.resizable.size.width * 0.5;
-        this.props.appStore.helpStore.showHelpDrawer(this.props.widgetConfig.helpType, centerX);
+        HelpStore.Instance.showHelpDrawer(this.props.widgetConfig.helpType, centerX);
     }
 
     constructor(props: FloatingWidgetComponentProps) {

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -4,12 +4,11 @@ import {observer} from "mobx-react";
 import {Rnd} from "react-rnd";
 import {Icon, Position, Tooltip} from "@blueprintjs/core";
 import {PlaceholderComponent} from "components";
-import {AppStore, HelpStore, WidgetConfig} from "stores";
+import {AppStore, HelpStore, LayoutStore, WidgetConfig} from "stores";
 import "./FloatingWidgetComponent.css";
 
 class FloatingWidgetComponentProps {
     widgetConfig: WidgetConfig;
-    appStore: AppStore;
     showPinButton: boolean;
     showFloatingSettingsButton?: boolean;
     children?: any;
@@ -39,9 +38,10 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
     }
 
     updateDragSource() {
-        if (this.props.appStore.layoutStore.dockedLayout && this.pinElementRef) {
+        const layoutStore = LayoutStore.Instance;
+        if (layoutStore.dockedLayout && this.pinElementRef) {
             // Check for existing drag sources
-            const layout = this.props.appStore.layoutStore.dockedLayout;
+            const layout = layoutStore.dockedLayout;
             const matchingSources = layout["_dragSources"].filter(d => d._itemConfig.id === this.props.widgetConfig.id);
             const existingSource = matchingSources.find(d => d._element[0] === this.pinElementRef);
             if (existingSource) {
@@ -57,7 +57,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
                 title: this.props.widgetConfig.title,
                 id: this.props.widgetConfig.id,
                 isClosable: this.props.widgetConfig.isCloseable,
-                props: {appStore: this.props.appStore, id: this.props.widgetConfig.id, docked: true}
+                props: {id: this.props.widgetConfig.id, docked: true}
             };
 
             if (this.props.widgetConfig.type === PlaceholderComponent.WIDGET_CONFIG.type) {
@@ -81,8 +81,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
 
     public render() {
         const headerHeight = 25;
-        const appStore = this.props.appStore;
-        const widgetsStore = appStore.widgetsStore;
+        const appStore = AppStore.Instance;
         let className = "floating-widget";
         let floatingContentClassName = "floating-content";
         let titleClass = this.props.isSelected ? "floating-header selected" : "floating-header";

--- a/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
+++ b/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
@@ -22,19 +22,19 @@ import {
     RenderConfigSettingsPanelComponent,
     HistogramSettingsPanelComponent
 } from "components";
-import {AppStore, WidgetConfig} from "stores";
+import {AppStore, WidgetConfig, WidgetsStore} from "stores";
 
 @observer
-export class FloatingWidgetManagerComponent extends React.Component<{ appStore: AppStore }> {
+export class FloatingWidgetManagerComponent extends React.Component {
     private floatingSettingType = "floating-settings";
 
     onFloatingWidgetSelected = (widget: WidgetConfig) => {
         // rearrange will cause a bug of empty table, change to zIndex 
-        this.props.appStore.widgetsStore.updateSelectFloatingWidgetzIndex(widget.id);
+        WidgetsStore.Instance.updateSelectFloatingWidgetzIndex(widget.id);
     };
 
     onFloatingWidgetClosed = (widget: WidgetConfig) => {
-        const widgetsStore = this.props.appStore.widgetsStore;
+        const widgetsStore = WidgetsStore.Instance;
         switch (widget.type) {
             case CatalogOverlayComponent.WIDGET_CONFIG.type:
                 // remove widget component only
@@ -47,53 +47,51 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
     };
 
     private getWidgetContent(widgetConfig: WidgetConfig) {
-        const appStore = this.props.appStore;
         switch (widgetConfig.type) {
             case ImageViewComponent.WIDGET_CONFIG.type:
-                return <ImageViewComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <ImageViewComponent id={widgetConfig.id} docked={false}/>;
             case LayerListComponent.WIDGET_CONFIG.type:
-                return <LayerListComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <LayerListComponent id={widgetConfig.id} docked={false}/>;
             case LogComponent.WIDGET_CONFIG.type:
-                return <LogComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <LogComponent id={widgetConfig.id} docked={false}/>;
             case RenderConfigComponent.WIDGET_CONFIG.type:
-                return <RenderConfigComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <RenderConfigComponent id={widgetConfig.id} docked={false}/>;
             case AnimatorComponent.WIDGET_CONFIG.type:
-                return <AnimatorComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <AnimatorComponent id={widgetConfig.id} docked={false}/>;
             case SpatialProfilerComponent.WIDGET_CONFIG.type:
-                return <SpatialProfilerComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <SpatialProfilerComponent id={widgetConfig.id} docked={false}/>;
             case SpectralProfilerComponent.WIDGET_CONFIG.type:
-                return <SpectralProfilerComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <SpectralProfilerComponent id={widgetConfig.id} docked={false}/>;
             case StatsComponent.WIDGET_CONFIG.type:
-                return <StatsComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <StatsComponent id={widgetConfig.id} docked={false}/>;
             case HistogramComponent.WIDGET_CONFIG.type:
-                return <HistogramComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <HistogramComponent id={widgetConfig.id} docked={false}/>;
             case RegionListComponent.WIDGET_CONFIG.type:
-                return <RegionListComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <RegionListComponent id={widgetConfig.id} docked={false}/>;
             case StokesAnalysisComponent.WIDGET_CONFIG.type:
-                return <StokesAnalysisComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <StokesAnalysisComponent id={widgetConfig.id} docked={false}/>;
             case CatalogOverlayComponent.WIDGET_CONFIG.type:
-                return <CatalogOverlayComponent appStore={appStore} id={widgetConfig.componentId} docked={false}/>;
+                return <CatalogOverlayComponent id={widgetConfig.componentId} docked={false}/>;
             case CatalogScatterComponent.WIDGET_CONFIG.type:
-                return <CatalogScatterComponent appStore={appStore} id={widgetConfig.id} docked={false}/>;
+                return <CatalogScatterComponent id={widgetConfig.id} docked={false}/>;
             default:
-                return <PlaceholderComponent appStore={appStore} id={widgetConfig.id} docked={false} label={widgetConfig.title}/>;
+                return <PlaceholderComponent id={widgetConfig.id} docked={false} label={widgetConfig.title}/>;
         }
     }
 
     private getWidgetSettings(widgetConfig: WidgetConfig) {
         if (widgetConfig.parentId) {
-            const appStore = this.props.appStore;
             switch (widgetConfig.parentType) {
                 case StokesAnalysisComponent.WIDGET_CONFIG.type:
-                    return <StokesAnalysisSettingsPanelComponent appStore={appStore} id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
+                    return <StokesAnalysisSettingsPanelComponent id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
                 case SpectralProfilerComponent.WIDGET_CONFIG.type:
-                    return <SpectralProfilerSettingsPanelComponent appStore={appStore} id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
+                    return <SpectralProfilerSettingsPanelComponent id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
                 case SpatialProfilerComponent.WIDGET_CONFIG.type:
-                    return <SpatialProfilerSettingsPanelComponent appStore={appStore} id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
+                    return <SpatialProfilerSettingsPanelComponent id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
                 case RenderConfigComponent.WIDGET_CONFIG.type:
-                    return <RenderConfigSettingsPanelComponent appStore={appStore} id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
+                    return <RenderConfigSettingsPanelComponent id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
                 case HistogramComponent.WIDGET_CONFIG.type:
-                    return <HistogramSettingsPanelComponent appStore={appStore} id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
+                    return <HistogramSettingsPanelComponent id={widgetConfig.parentId} docked={false} floatingSettingsId={widgetConfig.id}/>;
                 default:
                     return null;
             }
@@ -126,8 +124,7 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
     }
 
     public render() {
-        const appStore = this.props.appStore;
-        const widgetConfigs = appStore.widgetsStore.floatingWidgets;
+        const widgetConfigs = WidgetsStore.Instance.floatingWidgets;
         return (
             <div>
                 {widgetConfigs.map((w) => {
@@ -137,7 +134,6 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
                         <div key={id}>
                             <FloatingWidgetComponent
                                 isSelected={w.zIndex === widgetConfigs.length}
-                                appStore={appStore}
                                 key={id}
                                 widgetConfig={w}
                                 zIndex={w.zIndex}
@@ -145,7 +141,7 @@ export class FloatingWidgetManagerComponent extends React.Component<{ appStore: 
                                 onSelected={() => this.onFloatingWidgetSelected(w)}
                                 onClosed={() => this.onFloatingWidgetClosed(w)}
                                 showFloatingSettingsButton={this.showFloatingSettingsButton(w)}
-                                floatingWidgets={this.props.appStore.widgetsStore.floatingWidgets.length}
+                                floatingWidgets={widgetConfigs.length}
                             >
                                 {showPinButton ?
                                     this.getWidgetContent(w)

--- a/src/components/HelpDrawer/HelpContent/AnimatorHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/AnimatorHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headAnimatorButton from "static/help/head_animator_button.png";
 import * as headAnimatorButton_d from "static/help/head_animator_button_d.png";
 
-export class AnimatorHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class AnimatorHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headAnimatorButton} dark={headAnimatorButton_d} width="90%"/></p>
+                <p><ImageComponent light={headAnimatorButton} dark={headAnimatorButton_d} width="90%"/></p>
                 <p>The animator widget controls which frame (a.k.a image file), which channel (if exists per image file), and which
                 Stokes (if exists per image file) to view in the image viewer. Users may also enable animation playback for
                 frame, channel, or Stokes, via the &quot;Play&quot; button. The radio buttons control which one to animate. Playback mode includes</p>

--- a/src/components/HelpDrawer/HelpContent/ContourHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/ContourHelpComponent.tsx
@@ -4,9 +4,9 @@ import {ImageComponent} from "./ImageComponent";
 import * as headContourButton from "static/help/head_contour_button.png";
 import * as headContourButton_d from "static/help/head_contour_button_d.png";
 
-export class ContourHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class ContourHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         return (
             <div>
                 <p><ImageComponent appStore={appStore} light={headContourButton} dark={headContourButton_d} width="90%"/></p>

--- a/src/components/HelpDrawer/HelpContent/ContourHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/ContourHelpComponent.tsx
@@ -6,10 +6,9 @@ import * as headContourButton_d from "static/help/head_contour_button_d.png";
 
 export class ContourHelpComponent extends React.Component {
     public render() {
-        const appStore = AppStore.Instance;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headContourButton} dark={headContourButton_d} width="90%"/></p>
+                <p><ImageComponent light={headContourButton} dark={headContourButton_d} width="90%"/></p>
                 <p>Contour configuration dialogue allows users to generate a contour layer on top of a raster image in the image
         viewer. Steps to create a contour layer with the &quot;Levels&quot; tab are:</p>
                 <ol>

--- a/src/components/HelpDrawer/HelpContent/FileBrowserHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/FileBrowserHelpComponent.tsx
@@ -3,7 +3,7 @@ import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as underConstruction from "static/help/under_construction.png";
 
-export class FileBrowserHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class FileBrowserHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/FileInfoHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/FileInfoHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headFileinfoButton from "static/help/head_fileinfo_button.png";
 import * as headFileinfoButton_d from "static/help/head_fileinfo_button_d.png";
 
-export class FileInfoHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class FileInfoHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headFileinfoButton} dark={headFileinfoButton_d} width="90%"/></p>
+                <p><ImageComponent light={headFileinfoButton} dark={headFileinfoButton_d} width="90%"/></p>
                 <p>File information dialogue provides a summary of the properties and the full image header of the image in the current
         image viewer. To switch to other images, use the frame slider in the animator widget.</p>
             </div>

--- a/src/components/HelpDrawer/HelpContent/HistogramHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/HistogramHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headHistogramButton from "static/help/head_histogram_button.png";
 import * as headHistogramButton_d from "static/help/head_histogram_button_d.png";
 
-export class HistogramHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class HistogramHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headHistogramButton} dark={headHistogramButton_d} width="90%"/></p>
+                <p><ImageComponent light={headHistogramButton} dark={headHistogramButton_d} width="90%"/></p>
                 <p>Histogram widget displays a histogram plot derived from a 2D region. When no region is created or selected, it
         displays a histogram derived from the current full image in the image viewer.</p>
                 <h3 id="regions">Regions</h3>

--- a/src/components/HelpDrawer/HelpContent/HistogramSettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/HistogramSettingsHelpComponent.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
-import * as underConstruction from "static/help/under_construction.png";
 
-export class HistogramSettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class HistogramSettingsHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/ImageComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/ImageComponent.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 import { AppStore } from "stores";
 
-export class ImageComponent extends React.Component<{ 
-    appStore: AppStore,
+export class ImageComponent extends React.Component<{
     light: string,
     dark: string,
     width: string
  }> {
     public render() {
+        const appStore = AppStore.Instance;
         return (
-            <img src={this.props.appStore.darkTheme ? this.props.dark : this.props.light} style={{width: this.props.width, height: "auto"}}/>
+            <img src={appStore.darkTheme ? this.props.dark : this.props.light} style={{width: this.props.width, height: "auto"}}/>
         );
     }
 }

--- a/src/components/HelpDrawer/HelpContent/ImageViewHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/ImageViewHelpComponent.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as contourButton from "static/help/contour_button.png";
 import * as contourButton_d from "static/help/contour_button_d.png";
@@ -18,9 +17,8 @@ import * as WCSMatchButton_d from "static/help/wcs_match_button_d.png";
 import * as zoomButton from "static/help/zoom_button.png";
 import * as zoomButton_d from "static/help/zoom_button_d.png";
 
-export class ImageViewHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class ImageViewHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
                 <p>The image viewer widget serves as the core component of CARTA. It allows users to visualize images in rasters and in contours. Region of interests can be defined interactively with the image viewer and subsequent image
@@ -38,16 +36,16 @@ export class ImageViewHelpComponent extends React.Component<{ appStore: AppStore
                     <li>Enable/disable grid lines and coordinate labels</li>
                     <li>Export image</li>
                 </ul>
-                <p><ImageComponent appStore={appStore} light={imageTools} dark={imageTools_d} width="90%"/></p>
+                <p><ImageComponent light={imageTools} dark={imageTools_d} width="90%"/></p>
                 <h3 id="zoom-and-pan">Zoom and pan</h3>
                 <p>Zoom actions can be triggered in different ways. The most common one is to use mouse and scroll wheel. By scrolling up, image is zoomed in, while by scrolling down, image is zoomed out. Alternatively, users may use the
                     tool buttons at the bottom-right corner of the image viewer to zoom in, zoom out, zoom to fit screen resolution, or zoom to fit image view.</p>
-                <p><ImageComponent appStore={appStore} light={zoomButton} dark={zoomButton_d} width="70%"/></p>
+                <p><ImageComponent light={zoomButton} dark={zoomButton_d} width="70%"/></p>
                 <p>Pan action is achieved by <code>Click-and-drag</code> as default. This default can be changed via the preferences dialogue (<strong>File</strong> -&gt; <strong>Preferences</strong> -&gt; <strong>Global</strong>). The
                     alternative mode is <code>Click</code> and the clicked pixel will be centered in the image viewer.</p>
                 <h3 id="matching-image-spatially-and-spectrally">Matching image spatially and spectrally</h3>
                 <p>Appended images may be matched in world coordinate spatially and/or spectrally. This can be triggered by the &quot;WCS matching&quot; button. Matching WCS on appending can be enabled in the preferences dialogue.</p>
-                <p><ImageComponent appStore={appStore} light={WCSMatchButton} dark={WCSMatchButton_d} width="70%"/></p>
+                <p><ImageComponent light={WCSMatchButton} dark={WCSMatchButton_d} width="70%"/></p>
                 <p>CARTA supports the following matching schemes:</p>
                 <ul>
                     <li>None: zoom levels of different images are independent. No matching in the spectral domain.</li>
@@ -59,7 +57,7 @@ export class ImageViewHelpComponent extends React.Component<{ appStore: AppStore
                     lines are still accurate per image. If contour layers exist, they will match the raster image in the current image view with high position accuracy. Spectral matching is performed with nearest interpolation.</p>
                 <h3 id="contour-layers">Contour layers</h3>
                 <p>A contour layer can be generated via the contour configuration dialogue. Contours of spatially matched image are re-projected to other spatially matched raster image.</p>
-                <p><ImageComponent appStore={appStore} light={contourButton} dark={contourButton_d} width="25%"/></p>
+                <p><ImageComponent light={contourButton} dark={contourButton_d} width="25%"/></p>
                 <h3 id="region-of-interest">Region of interest</h3>
                 <p>Four types of region of interest are supported, including:</p>
                 <ul>
@@ -68,17 +66,17 @@ export class ImageViewHelpComponent extends React.Component<{ appStore: AppStore
                     <li>Ellipse (rotatable)</li>
                     <li>Polygon</li>
                 </ul>
-                <p><ImageComponent appStore={appStore} light={regionButton} dark={regionButton_d} width="70%"/></p>
+                <p><ImageComponent light={regionButton} dark={regionButton_d} width="70%"/></p>
                 <p>The default region type and the default region creation mode are customizable in the preferences dialogue.</p>
                 <h3 id="customizing-the-image-plot">Customizing the image plot</h3>
                 <p>The image overlay can be customized via the overlay settings dialogue. Plenty amounts of options are provided.</p>
-                <p><ImageComponent appStore={appStore} light={overlaySettingButton} dark={overlaySettingButton_d} width="25%"/></p>
+                <p><ImageComponent light={overlaySettingButton} dark={overlaySettingButton_d} width="25%"/></p>
                 <h3 id="exports">Exports</h3>
                 <p>What users see in the current image view can be exported as a PNG file with the &quot;Export image&quot; button in the image tool bar.</p>
-                <p><ImageComponent appStore={appStore} light={exportPNGButton} dark={exportPNGButton_d} width="70%"/></p>
+                <p><ImageComponent light={exportPNGButton} dark={exportPNGButton_d} width="70%"/></p>
                 <h3 id="image-information-and-header">Image information and header</h3>
                 <p>Basic image information and full image headers are displayed in the image information dialogue.</p>
-                <p><ImageComponent appStore={appStore} light={imageInfoButton} dark={imageInfoButton_d} width="25%"/></p>
+                <p><ImageComponent light={imageInfoButton} dark={imageInfoButton_d} width="25%"/></p>
             </div>
         );
     }

--- a/src/components/HelpDrawer/HelpContent/LayerListHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/LayerListHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headLayerButton from "static/help/head_layer_button.png";
 import * as headLayerButton_d from "static/help/head_layer_button_d.png";
 
-export class LayerListHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class LayerListHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headLayerButton} dark={headLayerButton_d} width="90%"/></p>
+                <p><ImageComponent light={headLayerButton} dark={headLayerButton_d} width="90%"/></p>
                 <p>The layer list widget displays loaded images as a list, which includes image name, rendering type (R as raster and C as contours) and layer visibility state, WCS matching state, channel index, and Stokes index. The
                     channel index and Stokes index are synchronized with the animator.</p>
                 <p>Users may click &quot;R&quot; and/or &quot;C&quot; to hide/show a layer. For example, if users want to generate an image with contours only, users can hide raster images by clicking &quot;R&quot;.</p>

--- a/src/components/HelpDrawer/HelpContent/LogHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/LogHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headLogButton from "static/help/head_log_button.png";
 import * as headLogButton_d from "static/help/head_log_button_d.png";
 
-export class LogHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class LogHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headLogButton} dark={headLogButton_d} width="90%"/></p>
+                <p><ImageComponent light={headLogButton} dark={headLogButton_d} width="90%"/></p>
                 <p>Log widget provides information for diagnostics when something went wrong. The log levels include:</p>
                 <ul>
                     <li>Debug</li>

--- a/src/components/HelpDrawer/HelpContent/OverlaySettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/OverlaySettingsHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headOverlayButton from "static/help/head_overlay_button.png";
 import * as headOverlayButton_d from "static/help/head_overlay_button_d.png";
 
-export class OverlaySettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class OverlaySettingsHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headOverlayButton} dark={headOverlayButton_d} width="90%"/></p>
+                <p><ImageComponent light={headOverlayButton} dark={headOverlayButton_d} width="90%"/></p>
                 <p>The overlay settings dialogue allows users to customize coordinate grid related properties in the image viewer.</p>
                 <h3 id="global">Global</h3>
                 <p>This section allows users to</p>

--- a/src/components/HelpDrawer/HelpContent/PlaceholderHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/PlaceholderHelpComponent.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
 import * as underConstruction from "static/help/under_construction.png";
 
-export class PlaceholderHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class PlaceholderHelpComponent extends React.Component {
     public render() {
         return (
             <React.Fragment>

--- a/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headPreferenceButton from "static/help/head_preference_button.png";
 import * as headPreferenceButton_d from "static/help/head_preference_button_d.png";
 
-export class PreferencesHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class PreferencesHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headPreferenceButton} dark={headPreferenceButton_d} width="90%"/></p>
+                <p><ImageComponent light={headPreferenceButton} dark={headPreferenceButton_d} width="90%"/></p>
                 <p>The preferences dialogue provides a centralized place to customize the entire graphical user interface and performance control parameters. All settings are recorded and applied to new CARTA sessions. Some settings are
                     effective immediately.</p>
                 <h3 id="global">Global</h3>

--- a/src/components/HelpDrawer/HelpContent/RegionDialogHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/RegionDialogHelpComponent.tsx
@@ -3,7 +3,7 @@ import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as underConstruction from "static/help/under_construction.png";
 
-export class RegionDialogHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class RegionDialogHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/RegionListHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/RegionListHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headRegionButton from "static/help/head_region_button.png";
 import * as headRegionButton_d from "static/help/head_region_button_d.png";
 
-export class RegionListHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class RegionListHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headRegionButton} dark={headRegionButton_d} width="90%"/></p>
+                <p><ImageComponent light={headRegionButton} dark={headRegionButton_d} width="90%"/></p>
                 <p>Region list widget provides users a list of region created via the graphical user interface and/or via region import (<strong>File</strong> -&gt; <strong>Import regions</strong>). Basic information of a region is shown in
                     an entry in the list. The current active region is highlighted in the list and region control anchors are shown in the image viewer. To unselect a region, press <code>esc</code> key.</p>
                 <p><code>Double-Click</code> on a list entry or on a region in the image viewer will bring up the region configuration dialogue, where we can adjust region appearance and region properties.</p>

--- a/src/components/HelpDrawer/HelpContent/RenderConfigHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/RenderConfigHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headRenderconfigButton from "static/help/head_renderconfig_button.png";
 import * as headRenderconfigButton_d from "static/help/head_renderconfig_button_d.png";
 
-export class RenderConfigHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class RenderConfigHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headRenderconfigButton} dark={headRenderconfigButton_d} width="90%"/></p>
+                <p><ImageComponent light={headRenderconfigButton} dark={headRenderconfigButton_d} width="90%"/></p>
                 <p>Render configuration widget controls how a raster image is rendered in color space. The widget equips with a set of clip levels as buttons on the top. The clip boundaries are displayed in the &quot;Clip
                     Min&quot; and &quot;Clip Max&quot; fields. These fields can be manually edited and the clip level will switch to &quot;Custom&quot;. The clip boundaries are visualized as two vertical lines (also draggable) in red in the
                     histogram.</p>

--- a/src/components/HelpDrawer/HelpContent/RenderConfigSettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/RenderConfigSettingsHelpComponent.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
 
-export class RenderConfigSettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class RenderConfigSettingsHelpComponent extends React.Component {
     public render() {
         return (
             <div>
@@ -16,7 +14,6 @@ export class RenderConfigSettingsHelpComponent extends React.Component<{ appStor
                     <li>display mean and RMS</li>
                     <li>display clip labels</li>
                 </ul>
-
             </div>
         );
     }

--- a/src/components/HelpDrawer/HelpContent/SaveLayoutHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/SaveLayoutHelpComponent.tsx
@@ -3,7 +3,7 @@ import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as underConstruction from "static/help/under_construction.png";
 
-export class SaveLayoutHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class SaveLayoutHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/SpatialProfilerHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/SpatialProfilerHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headSpatialButton from "static/help/head_spatial_button.png";
 import * as headSpatialButton_d from "static/help/head_spatial_button_d.png";
 
-export class SpatialProfilerHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class SpatialProfilerHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headSpatialButton} dark={headSpatialButton_d} width="90%"/></p>
+                <p><ImageComponent light={headSpatialButton} dark={headSpatialButton_d} width="90%"/></p>
                 <p>Spatial profiler widget allows users to view a profile from a horizontal cut or a vertical cut at the cursor position in the image viewer. The cursor position may be fixed in the image viewer by
                     pressing <code>F</code> key. Pressing again will unfreeze the cursor.</p>
                 <p>The cursor position in image coordinate is displayed as a red vertical line in the spatial profile plot.</p>

--- a/src/components/HelpDrawer/HelpContent/SpatialProfilerSettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/SpatialProfilerSettingsHelpComponent.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
-import * as underConstruction from "static/help/under_construction.png";
 
-export class SpatialProfilerSettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class SpatialProfilerSettingsHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/SpectralProfilerHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/SpectralProfilerHelpComponent.tsx
@@ -4,12 +4,11 @@ import {ImageComponent} from "./ImageComponent";
 import * as headSpectralButton from "static/help/head_spectral_button.png";
 import * as headSpectralButton_d from "static/help/head_spectral_button_d.png";
 
-export class SpectralProfilerHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class SpectralProfilerHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headSpectralButton} dark={headSpectralButton_d} width="90%"/></p>
+                <p><ImageComponent light={headSpectralButton} dark={headSpectralButton_d} width="90%"/></p>
                 <p>The spectral profiler widget allows users to view a region spectral profile of an image cube with a specific statistic (via the &quot;Statistic&quot; dropdown; default as mean). If Stokes axis exists, users may view a
                     specific Stokes via the &quot;Stokes&quot; dropdown.</p>
                 <h3 id="regions">Regions</h3>

--- a/src/components/HelpDrawer/HelpContent/SpectralProfilerSettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/SpectralProfilerSettingsHelpComponent.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
-import * as underConstruction from "static/help/under_construction.png";
 
-export class SpectralProfilerSettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class SpectralProfilerSettingsHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpContent/StatsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/StatsHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headStatisticsButton from "static/help/head_statistics_button.png";
 import * as headStatisticsButton_d from "static/help/head_statistics_button_d.png";
 
-export class StatsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class StatsHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headStatisticsButton} dark={headStatisticsButton_d} width="90%"/></p>
+                <p><ImageComponent light={headStatisticsButton} dark={headStatisticsButton_d} width="90%"/></p>
                 <p>Statistics widget allows users to view statistical quantities over a 2D region. When no region is created or selected, it displays statistical quantities of the full image in the image viewer.</p>
                 <h3 id="regions">Regions</h3>
                 <p>The region dropdown defaults to &quot;Active&quot; region which means a selected region in the image viewer. Users can select a region by clicking one on the image viewer, or by clicking a region entry on the region list

--- a/src/components/HelpDrawer/HelpContent/StokesAnalysisHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/StokesAnalysisHelpComponent.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {AppStore} from "stores";
 import {ImageComponent} from "./ImageComponent";
 import * as headStokesButton from "static/help/head_stokes_button.png";
 import * as headStokesButton_d from "static/help/head_stokes_button_d.png";
 
-export class StokesAnalysisHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class StokesAnalysisHelpComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
         return (
             <div>
-                <p><ImageComponent appStore={appStore} light={headStokesButton} dark={headStokesButton_d} width="90%"/></p>
+                <p><ImageComponent light={headStokesButton} dark={headStokesButton_d} width="90%"/></p>
                 <p>The Stokes analysis widget is specifically made for efficient visualization of a Stokes cube. The widget includes plots, such as:</p>
                 <ul>
                     <li>Region spectral profiles for Stokes Q and Stokes U, as absolute or fractional values</li>

--- a/src/components/HelpDrawer/HelpContent/StokesAnalysisSettingsHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/StokesAnalysisSettingsHelpComponent.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
-import {AppStore} from "stores";
-import {ImageComponent} from "./ImageComponent";
-import * as underConstruction from "static/help/under_construction.png";
 
-export class StokesAnalysisSettingsHelpComponent extends React.Component<{ appStore: AppStore }> {
+export class StokesAnalysisSettingsHelpComponent extends React.Component {
     public render() {
         return (
             <div>

--- a/src/components/HelpDrawer/HelpDrawerComponent.tsx
+++ b/src/components/HelpDrawer/HelpDrawerComponent.tsx
@@ -27,19 +27,18 @@ import {
     StokesAnalysisHelpComponent,
     StokesAnalysisSettingsHelpComponent
 } from "./HelpContent";
-import {AppStore, HelpType} from "stores";
+import {AppStore, HelpStore, HelpType} from "stores";
 
 @observer
-export class HelpDrawerComponent extends React.Component<{ appStore: AppStore }> {
+export class HelpDrawerComponent extends React.Component {
 
     render() {
         let className = "help-drawer";
-        if (this.props.appStore.darkTheme) {
+        if (AppStore.Instance.darkTheme) {
             className += " bp3-dark";
         }
 
-        const appStore = this.props.appStore;
-        const helpStore = appStore.helpStore;
+        const helpStore = HelpStore.Instance;
 
         const drawerProps: IDrawerProps = {
             icon: "help",
@@ -69,102 +68,102 @@ export class HelpDrawerComponent extends React.Component<{ appStore: AppStore }>
         [
             HelpType.CONTOUR, {
                 title: "Contour Configuration",
-                content: <ContourHelpComponent appStore={this.props.appStore}/>
+                content: <ContourHelpComponent/>
         }], [
             HelpType.FILE_Browser, {
                 title: "File Browser",
-                content: <FileBrowserHelpComponent appStore={this.props.appStore}/>
+                content: <FileBrowserHelpComponent/>
         }], [
             HelpType.FILE_INFO, {
                 title: "File Info",
-                content: <FileInfoHelpComponent appStore={this.props.appStore}/>
+                content: <FileInfoHelpComponent/>
         }], [
             HelpType.SAVE_LAYOUT, {
                 title: "Save Layout",
-                content: <SaveLayoutHelpComponent appStore={this.props.appStore}/>
+                content: <SaveLayoutHelpComponent/>
         }], [
             HelpType.OVERLAY_SETTINGS, {
                 title: "Overlay Settings",
-                content: <OverlaySettingsHelpComponent appStore={this.props.appStore}/>
+                content: <OverlaySettingsHelpComponent/>
         }], [
             HelpType.PREFERENCES, {
                 title: "Preferences",
-                content: <PreferencesHelpComponent appStore={this.props.appStore}/>
+                content: <PreferencesHelpComponent/>
         }], [
             HelpType.REGION_DIALOG, {
                 title: "Region Dialog",
-                content: <RegionDialogHelpComponent appStore={this.props.appStore}/>
+                content: <RegionDialogHelpComponent/>
         }],
 
         // Widgets
         [
             HelpType.ANIMATOR, {
                 title: "Animator",
-                content: <AnimatorHelpComponent appStore={this.props.appStore}/>
+                content: <AnimatorHelpComponent/>
         }], [
             HelpType.HISTOGRAM, {
                 title: "Histogram",
-                content: <HistogramHelpComponent appStore={this.props.appStore}/>
+                content: <HistogramHelpComponent/>
         }], [
             HelpType.HISTOGRAM_SETTINGS, {
                 title: "Histogram Settings",
-                content: <HistogramSettingsHelpComponent appStore={this.props.appStore}/>
+                content: <HistogramSettingsHelpComponent/>
         }], [
             HelpType.IMAGE_VIEW, {
                 title: "Image View",
-                content: <ImageViewHelpComponent appStore={this.props.appStore}/>
+                content: <ImageViewHelpComponent/>
         }], [
             HelpType.LAYER_LIST, {
                 title: "Layer List",
-                content: <LayerListHelpComponent appStore={this.props.appStore}/>
+                content: <LayerListHelpComponent/>
         }], [
             HelpType.LOG, {
                 title: "Log",
-                content: <LogHelpComponent appStore={this.props.appStore}/>
+                content: <LogHelpComponent/>
         }], [
             HelpType.PLACEHOLDER, {
                 title: "Placeholder",
-                content: <PlaceholderHelpComponent appStore={this.props.appStore}/>
+                content: <PlaceholderHelpComponent/>
         }], [
             HelpType.REGION_LIST, {
                 title: "Region List",
-                content: <RegionListHelpComponent appStore={this.props.appStore}/>
+                content: <RegionListHelpComponent/>
         }], [
             HelpType.RENDER_CONFIG, {
                 title: "Render Configuration",
-                content: <RenderConfigHelpComponent appStore={this.props.appStore}/>
+                content: <RenderConfigHelpComponent/>
         }], [
             HelpType.RENDER_CONFIG_SETTINGS, {
                 title: "Render Configuration Settings",
-                content: <RenderConfigSettingsHelpComponent appStore={this.props.appStore}/>
+                content: <RenderConfigSettingsHelpComponent/>
         }], [
             HelpType.SPATIAL_PROFILER, {
                 title: "Spatial Profiler",
-                content: <SpatialProfilerHelpComponent appStore={this.props.appStore}/>
+                content: <SpatialProfilerHelpComponent/>
         }], [
             HelpType.SPATIAL_PROFILER_SETTINGS, {
                 title: "Spatial Profiler Settings",
-                content: <SpatialProfilerSettingsHelpComponent appStore={this.props.appStore}/>
+                content: <SpatialProfilerSettingsHelpComponent/>
         }], [
             HelpType.SPECTRAL_PROFILER, {
                 title: "Spectral Profiler",
-                content: <SpectralProfilerHelpComponent appStore={this.props.appStore}/>
+                content: <SpectralProfilerHelpComponent/>
         }], [
             HelpType.SPECTRAL_PROFILER_SETTINGS, {
                 title: "Spectral Profiler Settings",
-                content: <SpectralProfilerSettingsHelpComponent appStore={this.props.appStore}/>
+                content: <SpectralProfilerSettingsHelpComponent/>
         }], [
             HelpType.STATS, {
                 title: "Statistics",
-                content: <StatsHelpComponent appStore={this.props.appStore}/>
+                content: <StatsHelpComponent/>
         }], [
             HelpType.STOKES_ANALYSIS, {
                 title: "Stokes Analysis",
-                content: <StokesAnalysisHelpComponent appStore={this.props.appStore}/>
+                content: <StokesAnalysisHelpComponent/>
         }], [
             HelpType.STOKES_ANALYSIS_SETTINGS, {
                 title: "Stokes Settings",
-                content: <StokesAnalysisSettingsHelpComponent appStore={this.props.appStore}/>
+                content: <StokesAnalysisSettingsHelpComponent/>
         }]
     ]);
 }

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -43,7 +43,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             }
         }
         console.log("can't find store for widget");
-        return new HistogramWidgetStore(this.props.appStore);
+        return new HistogramWidgetStore();
     }
 
     @computed get histogramData(): CARTA.IHistogram {
@@ -134,7 +134,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
         } else {
             if (!this.props.appStore.widgetsStore.histogramWidgets.has(this.props.id)) {
                 console.log(`can't find store for widget with id=${this.props.id}`);
-                this.props.appStore.widgetsStore.histogramWidgets.set(this.props.id, new HistogramWidgetStore(this.props.appStore));
+                this.props.appStore.widgetsStore.histogramWidgets.set(this.props.id, new HistogramWidgetStore());
             }
         }
         // Update widget title when region or coordinate changes

--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -4,7 +4,7 @@ import {computed, autorun} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {LinePlotSettingsPanelComponentProps, LinePlotSettingsPanelComponent} from "components/Shared";
 import {HistogramWidgetStore} from "stores/widgets";
-import {WidgetProps, WidgetConfig, HelpType} from "stores";
+import {WidgetProps, WidgetConfig, HelpType, WidgetsStore, AppStore} from "stores";
 import {parseNumber} from "utilities";
 
 const KEYCODE_ENTER = 13;
@@ -29,8 +29,9 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
     }
 
     @computed get widgetStore(): HistogramWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.histogramWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.histogramWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.histogramWidgets) {
+            const widgetStore = widgetsStore.histogramWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -44,7 +45,7 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
 
         // Update widget title when region or coordinate changes
         autorun(() => {
-            const appStore = this.props.appStore;
+            const appStore = AppStore.Instance;
             if (this.widgetStore && appStore.activeFrame) {
                 let regionString = "Unknown";
                 const regionId = this.widgetStore.effectiveRegionId;
@@ -140,7 +141,7 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
     render() {
         const widgetStore = this.widgetStore;
         const lineSettingsProps: LinePlotSettingsPanelComponentProps = {
-            darkMode: this.props.appStore.darkTheme,
+            darkMode: AppStore.Instance.darkTheme,
             primaryDarkModeLineColor: Colors.BLUE4,
             primaryLineColor: widgetStore.primaryLineColor,
             lineWidth: widgetStore.lineWidth,

--- a/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
+++ b/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
@@ -6,12 +6,12 @@ import {RegionSelectorComponent} from "components";
 import "./HistogramToolbarComponent.css";
 
 @observer
-export class HistogramToolbarComponent extends React.Component<{ widgetStore: HistogramWidgetStore, appStore: AppStore }> {
+export class HistogramToolbarComponent extends React.Component<{ widgetStore: HistogramWidgetStore}> {
 
     public render() {
         return (
             <div className="spectral-profiler-toolbar">
-                <RegionSelectorComponent widgetStore={this.props.widgetStore} appStore={this.props.appStore}/>
+                <RegionSelectorComponent widgetStore={this.props.widgetStore}/>
             </div>
         );
     }

--- a/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
@@ -2,13 +2,11 @@ import {observer} from "mobx-react";
 import * as React from "react";
 import * as Plotly from "plotly.js";
 import Plot from "react-plotly.js";
-import {AppStore, OverlayStore} from "stores";
+import {AppStore, CatalogStore, OverlayStore} from "stores";
 import "./CatalogViewComponent.css";
 import {computed} from "mobx";
 
 export interface CatalogViewComponentProps {
-    overlaySettings: OverlayStore;
-    appStore: AppStore;
     docked: boolean;
 }
 
@@ -16,7 +14,7 @@ export interface CatalogViewComponentProps {
 export class CatalogViewComponent extends React.Component<CatalogViewComponentProps> {
 
     @computed get scatterDatasets() {
-        const catalogStore = this.props.appStore.catalogStore;
+        const catalogStore = CatalogStore.Instance;
         let scatterDatasets: Plotly.Data[] = [];
 
         catalogStore.catalogs.forEach((catalog, key) => {
@@ -63,10 +61,11 @@ export class CatalogViewComponent extends React.Component<CatalogViewComponentPr
     }
 
     render() {
-        const frame = this.props.appStore.activeFrame;
+        const appStore = AppStore.Instance;
+        const frame = appStore.activeFrame;
         const width = frame ? frame.renderWidth || 1 : 1;
         const height = frame ? frame.renderHeight || 1 : 1;
-        const padding = this.props.overlaySettings.padding;
+        const padding = appStore.overlayStore.padding;
         let className = "catalog-div";
         if (this.props.docked) {
             className += " docked";

--- a/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
@@ -69,7 +69,7 @@ export class CatalogViewComponent extends React.Component<CatalogViewComponentPr
     }
 
     private onClick = (event: Readonly<Plotly.PlotMouseEvent>) => {
-        const appStore = AppStore.Instance
+        const appStore = AppStore.Instance;
         if (event && event.points && event.points.length > 0) {
             const catalogWidgetId = event.points[0].data.name;
             const catalogWidget = appStore.widgetsStore.catalogOverlayWidgets.get(catalogWidgetId);

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -6,8 +6,6 @@ import {ContourWebGLService} from "services";
 import "./ContourViewComponent.css";
 
 export interface ContourViewComponentProps {
-    overlaySettings: OverlayStore;
-    appStore: AppStore;
     docked: boolean;
 }
 
@@ -30,7 +28,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
     }
 
     private resizeAndClearCanvas() {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (!frame) {
             return;
         }
@@ -50,8 +48,9 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
     }
 
     private updateCanvas = () => {
-        const baseFrame = this.props.appStore.activeFrame;
-        const contourFrames = this.props.appStore.contourFrames;
+        const appStore = AppStore.Instance;
+        const baseFrame = appStore.activeFrame;
+        const contourFrames = appStore.contourFrames;
         if (baseFrame && this.canvas && this.gl && this.contourWebGLService.shaderUniforms) {
             this.resizeAndClearCanvas();
 
@@ -186,12 +185,13 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
 
     render() {
         // dummy values to trigger React's componentDidUpdate()
-        const baseFrame = this.props.appStore.activeFrame;
+        const appStore = AppStore.Instance;
+        const baseFrame = appStore.activeFrame;
         if (baseFrame) {
             const view = baseFrame.requiredFrameView;
         }
 
-        const contourFrames = this.props.appStore.contourFrames;
+        const contourFrames = appStore.contourFrames;
         for (const frame of contourFrames) {
             const config = frame.contourConfig;
             const thickness = config.thickness;
@@ -204,7 +204,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             });
         }
 
-        const padding = this.props.overlaySettings.padding;
+        const padding = appStore.overlayStore.padding;
         let className = "contour-div";
         if (this.props.docked) {
             className += " docked";

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -89,9 +89,9 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         super(props);
 
         autorun(() => {
-            const appStore = this.props.appStore;
-            if (appStore.activeFrame) {
-                const imageSize = {x: appStore.activeFrame.renderWidth, y: appStore.activeFrame.renderHeight};
+            const frame = AppStore.Instance.activeFrame;
+            if (frame) {
+                const imageSize = {x: frame.renderWidth, y: frame.renderHeight};
                 // Compare to cached image size to prevent duplicate events when changing frames
                 if (!this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y) {
                     this.cachedImageSize = imageSize;
@@ -107,46 +107,46 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
     onResize = (width: number, height: number) => {
         if (width > 0 && height > 0) {
-            this.props.appStore.setImageViewDimensions(width, height);
+            AppStore.Instance.setImageViewDimensions(width, height);
         }
     };
 
     onClicked = (cursorInfo: CursorInfo) => {
-        const appStore = this.props.appStore;
-        if (appStore.activeFrame) {
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
             // Shift from one-indexed image space position to zero-indexed
-            appStore.activeFrame.setCenter(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1);
+            frame.setCenter(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1);
         }
     };
 
     onZoomed = (cursorInfo: CursorInfo, delta: number) => {
-        const appStore = this.props.appStore;
-        if (appStore.activeFrame) {
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
             const zoomSpeed = 1 + Math.abs(delta / 750.0);
 
             // If frame is spatially matched, apply zoom to the reference frame, rather than the active frame
-            if (appStore.activeFrame.spatialReference) {
-                const newZoom = appStore.activeFrame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+            if (frame.spatialReference) {
+                const newZoom = frame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
                 // Shift from one-indexed image space position to zero-indexed
-                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
+                frame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
             } else {
-                const newZoom = appStore.activeFrame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+                const newZoom = frame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
                 // Shift from one-indexed image space position to zero-indexed
-                appStore.activeFrame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
+                frame.zoomToPoint(cursorInfo.posImageSpace.x + 1, cursorInfo.posImageSpace.y + 1, newZoom, true);
             }
         }
     };
 
     onMouseEnter = () => {
-        this.props.appStore.showImageToolbar();
+        AppStore.Instance.showImageToolbar();
     };
 
     onMouseLeave = () => {
-        this.props.appStore.hideImageToolbar();
+        AppStore.Instance.hideImageToolbar();
     };
 
     private handleRegionDoubleClicked = (region: RegionStore) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (region) {
             const frame = appStore.getFrame(region.fileId);
             if (frame) {
@@ -225,7 +225,6 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     />
                     }
                     <ToolbarComponent
-                        appStore={appStore}
                         docked={this.props.docked}
                         visible={appStore.imageToolbarVisible}
                         vertical={false}
@@ -247,16 +246,11 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <RasterViewComponent
                     docked={this.props.docked}
-                    overlaySettings={overlayStore}
                 />
                 <ContourViewComponent
-                    appStore={appStore}
                     docked={this.props.docked}
-                    overlaySettings={overlayStore}
                 />
                 <CatalogViewComponent
-                    appStore={appStore}
-                    overlaySettings={overlayStore}
                     docked={this.props.docked}
                 />
                 {divContents}

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -151,15 +151,14 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             const frame = appStore.getFrame(region.fileId);
             if (frame) {
                 frame.regionSet.selectRegion(region);
-                DialogStore.Instance.showRegionDialog();
+                appStore.dialogStore.showRegionDialog();
             }
         }
     };
 
     render() {
         const appStore = AppStore.Instance;
-        const preferenceStore = PreferenceStore.Instance;
-        const overlayStore = OverlayStore.Instance;
+        const overlayStore = appStore.overlayStore;
         let divContents;
         if (appStore.activeFrame && appStore.activeFrame.isRenderable && appStore.astReady) {
             const effectiveWidth = appStore.activeFrame.renderWidth * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
@@ -218,8 +217,8 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                         onRegionDoubleClicked={this.handleRegionDoubleClicked}
                         onZoomed={this.onZoomed}
                         overlaySettings={overlayStore}
-                        isRegionCornerMode={preferenceStore.isRegionCornerMode}
-                        dragPanningEnabled={preferenceStore.dragPanning}
+                        isRegionCornerMode={appStore.preferenceStore.isRegionCornerMode}
+                        dragPanningEnabled={appStore.preferenceStore.dragPanning}
                         cursorFrozen={appStore.activeFrame.cursorFrozen}
                         cursorPoint={appStore.activeFrame.cursorInfo.posImageSpace}
                         docked={this.props.docked}

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -10,7 +10,7 @@ import {RasterViewComponent} from "./RasterView/RasterViewComponent";
 import {ToolbarComponent} from "./Toolbar/ToolbarComponent";
 import {BeamProfileOverlayComponent} from "./BeamProfileOverlay/BeamProfileOverlayComponent";
 import {RegionViewComponent} from "./RegionView/RegionViewComponent";
-import {AnimationMode, AnimationState, RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore} from "stores";
+import {AnimationMode, AnimationState, RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore, PreferenceStore, AppStore, OverlayStore} from "stores";
 import {CursorInfo, Point2D} from "models";
 import {toFixed} from "utilities";
 import "./ImageViewComponent.css";
@@ -157,20 +157,21 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     };
 
     render() {
-        const appStore = this.props.appStore;
-
+        const appStore = AppStore.Instance;
+        const preferenceStore = PreferenceStore.Instance;
+        const overlayStore = OverlayStore.Instance;
         let divContents;
         if (appStore.activeFrame && appStore.activeFrame.isRenderable && appStore.astReady) {
             const effectiveWidth = appStore.activeFrame.renderWidth * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
             const effectiveHeight = appStore.activeFrame.renderHeight * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
-            const imageRatioTagOffset = {x: appStore.overlayStore.padding.left + appStore.overlayStore.viewWidth / 2.0, y: appStore.overlayStore.padding.top + appStore.overlayStore.viewHeight / 2.0};
+            const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
 
             divContents = (
                 <React.Fragment>
                     {appStore.activeFrame.valid &&
                     <OverlayComponent
                         frame={appStore.activeFrame}
-                        overlaySettings={appStore.overlayStore}
+                        overlaySettings={overlayStore}
                         docked={this.props.docked}
                     />
                     }
@@ -179,12 +180,12 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                         cursorInfo={appStore.activeFrame.cursorInfo}
                         cursorValue={appStore.activeFrame.cursorValue}
                         spectralInfo={appStore.activeFrame.spectralInfo}
-                        width={appStore.overlayStore.viewWidth}
-                        left={appStore.overlayStore.padding.left}
-                        right={appStore.overlayStore.padding.right}
+                        width={overlayStore.viewWidth}
+                        left={overlayStore.padding.left}
+                        right={overlayStore.padding.right}
                         docked={this.props.docked}
                         unit={appStore.activeFrame.unit}
-                        top={appStore.overlayStore.padding.top}
+                        top={overlayStore.padding.top}
                         showImage={true}
                         showWCS={true}
                         showValue={true}
@@ -198,8 +199,8 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     <BeamProfileOverlayComponent
                         width={appStore.activeFrame.renderWidth}
                         height={appStore.activeFrame.renderHeight}
-                        top={appStore.overlayStore.padding.top}
-                        left={appStore.overlayStore.padding.left}
+                        top={overlayStore.padding.top}
+                        left={overlayStore.padding.left}
                         frame={appStore.activeFrame}
                         docked={this.props.docked}
                         padding={10}
@@ -211,14 +212,14 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                         frame={appStore.activeFrame}
                         width={appStore.activeFrame.renderWidth}
                         height={appStore.activeFrame.renderHeight}
-                        top={appStore.overlayStore.padding.top}
-                        left={appStore.overlayStore.padding.left}
+                        top={overlayStore.padding.top}
+                        left={overlayStore.padding.left}
                         onClicked={this.onClicked}
                         onRegionDoubleClicked={this.handleRegionDoubleClicked}
                         onZoomed={this.onZoomed}
-                        overlaySettings={appStore.overlayStore}
-                        isRegionCornerMode={appStore.preferenceStore.isRegionCornerMode}
-                        dragPanningEnabled={appStore.preferenceStore.dragPanning}
+                        overlaySettings={overlayStore}
+                        isRegionCornerMode={preferenceStore.isRegionCornerMode}
+                        dragPanningEnabled={preferenceStore.dragPanning}
                         cursorFrozen={appStore.activeFrame.cursorFrozen}
                         cursorPoint={appStore.activeFrame.cursorInfo.posImageSpace}
                         docked={this.props.docked}
@@ -246,18 +247,17 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         return (
             <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <RasterViewComponent
-                    appStore={appStore}
                     docked={this.props.docked}
-                    overlaySettings={appStore.overlayStore}
+                    overlaySettings={overlayStore}
                 />
                 <ContourViewComponent
                     appStore={appStore}
                     docked={this.props.docked}
-                    overlaySettings={appStore.overlayStore}
+                    overlaySettings={overlayStore}
                 />
                 <CatalogViewComponent
                     appStore={appStore}
-                    overlaySettings={appStore.overlayStore}
+                    overlaySettings={overlayStore}
                     docked={this.props.docked}
                 />
                 {divContents}

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -10,7 +10,7 @@ import {RasterViewComponent} from "./RasterView/RasterViewComponent";
 import {ToolbarComponent} from "./Toolbar/ToolbarComponent";
 import {BeamProfileOverlayComponent} from "./BeamProfileOverlay/BeamProfileOverlayComponent";
 import {RegionViewComponent} from "./RegionView/RegionViewComponent";
-import {AnimationMode, AnimationState, RegionStore, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {AnimationMode, AnimationState, RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore} from "stores";
 import {CursorInfo, Point2D} from "models";
 import {toFixed} from "utilities";
 import "./ImageViewComponent.css";
@@ -151,7 +151,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             const frame = appStore.getFrame(region.fileId);
             if (frame) {
                 frame.regionSet.selectRegion(region);
-                appStore.dialogStore.showRegionDialog();
+                DialogStore.Instance.showRegionDialog();
             }
         }
     };

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -237,7 +237,6 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     }
                     {appStore.activeFrame &&
                     <CatalogViewComponent
-                        frame={appStore.activeFrame}
                         width={appStore.activeFrame.renderWidth}
                         height={appStore.activeFrame.renderHeight}
                         activeLayer={this.activeLayer}

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -7,7 +7,6 @@ import {RasterTile, TILE_SIZE, TileService, TileWebGLService} from "services";
 import "./RasterViewComponent.css";
 
 export class RasterViewComponentProps {
-    overlaySettings: OverlayStore;
     docked: boolean;
 }
 
@@ -49,26 +48,27 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     };
 
     private updateUniforms() {
-        const tileRenderService = TileWebGLService.Instance;
-        const frame = AppStore.Instance.activeFrame;
+        const appStore = AppStore.Instance;
+        const shaderUniforms = TileWebGLService.Instance.shaderUniforms;
+        const frame = appStore.activeFrame;
         const renderConfig = frame.renderConfig;
-        const preference = PreferenceStore.Instance;
-        if (renderConfig && preference && tileRenderService.shaderUniforms) {
-            this.gl.uniform1f(tileRenderService.shaderUniforms.MinVal, renderConfig.scaleMinVal);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.MaxVal, renderConfig.scaleMaxVal);
-            this.gl.uniform1i(tileRenderService.shaderUniforms.CmapIndex, renderConfig.colorMap);
-            this.gl.uniform1i(tileRenderService.shaderUniforms.ScaleType, renderConfig.scaling);
-            this.gl.uniform1i(tileRenderService.shaderUniforms.Inverted, renderConfig.inverted ? 1 : 0);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.Bias, renderConfig.bias);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.Contrast, renderConfig.contrast);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.Gamma, renderConfig.gamma);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.Alpha, renderConfig.alpha);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.CanvasWidth, frame.renderWidth * devicePixelRatio);
-            this.gl.uniform1f(tileRenderService.shaderUniforms.CanvasHeight, frame.renderHeight * devicePixelRatio);
 
-            const rgba = hexStringToRgba(preference.nanColorHex, preference.nanAlpha);
+        if (renderConfig && shaderUniforms) {
+            this.gl.uniform1f(shaderUniforms.MinVal, renderConfig.scaleMinVal);
+            this.gl.uniform1f(shaderUniforms.MaxVal, renderConfig.scaleMaxVal);
+            this.gl.uniform1i(shaderUniforms.CmapIndex, renderConfig.colorMap);
+            this.gl.uniform1i(shaderUniforms.ScaleType, renderConfig.scaling);
+            this.gl.uniform1i(shaderUniforms.Inverted, renderConfig.inverted ? 1 : 0);
+            this.gl.uniform1f(shaderUniforms.Bias, renderConfig.bias);
+            this.gl.uniform1f(shaderUniforms.Contrast, renderConfig.contrast);
+            this.gl.uniform1f(shaderUniforms.Gamma, renderConfig.gamma);
+            this.gl.uniform1f(shaderUniforms.Alpha, renderConfig.alpha);
+            this.gl.uniform1f(shaderUniforms.CanvasWidth, frame.renderWidth * devicePixelRatio);
+            this.gl.uniform1f(shaderUniforms.CanvasHeight, frame.renderHeight * devicePixelRatio);
+
+            const rgba = hexStringToRgba(appStore.preferenceStore.nanColorHex, appStore.preferenceStore.nanAlpha);
             if (rgba) {
-                this.gl.uniform4f(tileRenderService.shaderUniforms.NaNColor, rgba.r / 255, rgba.g / 255, rgba.b / 255, rgba.a);
+                this.gl.uniform4f(shaderUniforms.NaNColor, rgba.r / 255, rgba.g / 255, rgba.b / 255, rgba.a);
             }
         }
     }
@@ -261,8 +261,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
     render() {
         // dummy values to trigger React's componentDidUpdate()
-        const frame = AppStore.Instance.activeFrame;
-        const preference = PreferenceStore.Instance;
+        const appStore = AppStore.Instance;
+        const frame = appStore.activeFrame;
         if (frame) {
             const spatialReference = frame.spatialReference || frame;
             const frameView = spatialReference.requiredFrameView;
@@ -280,11 +280,11 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 alpha: frame.renderConfig.alpha,
                 inverted: frame.renderConfig.inverted,
                 visibility: frame.renderConfig.visible,
-                nanColorHex: preference.nanColorHex,
-                nanAlpha: preference.nanAlpha
+                nanColorHex: appStore.preferenceStore.nanColorHex,
+                nanAlpha: appStore.preferenceStore.nanAlpha
             };
         }
-        const padding = this.props.overlaySettings.padding;
+        const padding = appStore.overlayStore.padding;
         let className = "raster-div";
         if (this.props.docked) {
             className += " docked";

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -60,8 +60,8 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
 
     render() {
         const appStore = AppStore.Instance;
-        const preferenceStore = PreferenceStore.Instance;
-        const overlay = OverlayStore.Instance;
+        const preferenceStore = appStore.preferenceStore;
+        const overlay = appStore.overlayStore;
         const frame = appStore.activeFrame;
         const grid = overlay.grid;
 
@@ -94,7 +94,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             </Menu>
         );
 
-        let coordinateSystem = OverlayStore.Instance.global.system;
+        let coordinateSystem = overlay.global.system;
 
         const coordinateSystemMenu = (
             <Menu>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {Button, ButtonGroup, IconName, Menu, MenuItem, Popover, PopoverPosition, Position, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {exportImage} from "components";
-import {AppStore, RegionMode, SystemType} from "stores";
+import {AppStore, OverlayStore, PreferenceStore, RegionMode, SystemType} from "stores";
 import {toFixed} from "utilities";
 import "./ToolbarComponent.css";
 
@@ -55,13 +55,14 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
     };
 
     handleCoordinateSystemClicked = (coordinateSystem: SystemType) => {
-        this.props.appStore.overlayStore.global.setSystem(coordinateSystem);
+        OverlayStore.Instance.global.setSystem(coordinateSystem);
     };
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
+        const preferenceStore = PreferenceStore.Instance;
+        const overlay = OverlayStore.Instance;
         const frame = appStore.activeFrame;
-        const overlay = appStore.overlayStore;
         const grid = overlay.grid;
 
         let styleProps: CSSProperties = {
@@ -93,7 +94,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             </Menu>
         );
 
-        let coordinateSystem = this.props.appStore.overlayStore.global.system;
+        let coordinateSystem = OverlayStore.Instance.global.system;
 
         const coordinateSystemMenu = (
             <Menu>
@@ -131,7 +132,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const wcsButtonSuperscript = (spatialMatchingEnabled ? "x" : "") + (spectralMatchingEnabled ? "z" : "");
         const wcsButtonTooltipEntries = [];
         if (spectralMatchingEnabled) {
-            wcsButtonTooltipEntries.push(`Spectral (${appStore.preferenceStore.spectralMatchingType})`);
+            wcsButtonTooltipEntries.push(`Spectral (${preferenceStore.spectralMatchingType})`);
         }
         if (spatialMatchingEnabled) {
             wcsButtonTooltipEntries.push("Spatial");
@@ -141,13 +142,13 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const wcsMatchingMenu = (
             <Menu>
                 <MenuItem
-                    text={`Spectral (${appStore.preferenceStore.spectralMatchingType}) and Spatial`}
+                    text={`Spectral (${preferenceStore.spectralMatchingType}) and Spatial`}
                     disabled={!canEnableSpatialMatching || !canEnableSpectralMatching}
                     active={spectralMatchingEnabled && spatialMatchingEnabled}
                     onClick={() => appStore.setMatchingEnabled(true, true)}
                 />
                 <MenuItem
-                    text={`Spectral (${appStore.preferenceStore.spectralMatchingType})  only`}
+                    text={`Spectral (${preferenceStore.spectralMatchingType})  only`}
                     disabled={!canEnableSpectralMatching}
                     active={spectralMatchingEnabled && !spatialMatchingEnabled}
                     onClick={() => appStore.setMatchingEnabled(false, true)}

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -9,7 +9,6 @@ import {toFixed} from "utilities";
 import "./ToolbarComponent.css";
 
 export class ToolbarComponentProps {
-    appStore: AppStore;
     docked: boolean;
     visible: boolean;
     vertical: boolean;
@@ -36,22 +35,25 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
     ]);
 
     handleZoomToActualSizeClicked = () => {
-        this.props.appStore.activeFrame.setZoom(1.0);
+        AppStore.Instance.activeFrame.setZoom(1.0);
     };
 
     handleZoomInClicked = () => {
-        const frame = this.props.appStore.activeFrame.spatialReference || this.props.appStore.activeFrame;
+        const appStore = AppStore.Instance;
+        const frame = appStore.activeFrame.spatialReference || appStore.activeFrame;
         frame.setZoom(frame.zoomLevel * 2.0, true);
     };
 
     handleZoomOutClicked = () => {
-        const frame = this.props.appStore.activeFrame.spatialReference || this.props.appStore.activeFrame;
+        const appStore = AppStore.Instance;
+        const frame = appStore.activeFrame.spatialReference || appStore.activeFrame;
         frame.setZoom(frame.zoomLevel / 2.0, true);
     };
 
     handleRegionTypeClicked = (type: CARTA.RegionType) => {
-        this.props.appStore.activeFrame.regionSet.setNewRegionType(type);
-        this.props.appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
+        const appStore = AppStore.Instance;
+        appStore.activeFrame.regionSet.setNewRegionType(type);
+        appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
     };
 
     handleCoordinateSystemClicked = (coordinateSystem: SystemType) => {
@@ -180,7 +182,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 }
                 {frame.regionSet.mode === RegionMode.MOVING &&
                 <Tooltip position={tooltipPosition} content={<span>Create region<br/><i><small>Double-click to select region type</small></i></span>}>
-                    <Button icon={regionIcon} onClick={() => this.props.appStore.activeFrame.regionSet.setMode(RegionMode.CREATING)}/>
+                    <Button icon={regionIcon} onClick={() => frame.regionSet.setMode(RegionMode.CREATING)}/>
                 </Tooltip>
                 }
                 <Tooltip position={tooltipPosition} content="Select and pan mode">
@@ -217,7 +219,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels}/>
                 </Tooltip>
                 <Tooltip position={tooltipPosition} content={`Export image (${appStore.modifierString}E)`}>
-                    <Button icon="floppy-disk" onClick={() => exportImage(overlay.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>
+                    <Button icon="floppy-disk" onClick={() => exportImage(overlay.padding, appStore.darkTheme, frame.frameInfo.fileInfo.name)}/>
                 </Tooltip>
             </ButtonGroup>
         );

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -6,7 +6,7 @@ import {AnchorButton, Menu, MenuDivider, MenuItem, NonIdealState, Tooltip} from 
 import {Cell, Column, ColumnHeaderCell, RowHeaderCell, SelectionModes, Table} from "@blueprintjs/table";
 import {IMenuContext} from "@blueprintjs/table/src/interactions/menus/menuContext";
 import ReactResizeDetector from "react-resize-detector";
-import {WidgetConfig, WidgetProps, HelpType} from "stores";
+import {WidgetConfig, WidgetProps, HelpType, AppStore} from "stores";
 import "./LayerListComponent.css";
 
 @observer
@@ -46,15 +46,15 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         if (oldIndex === newIndex) {
             return;
         }
-        this.props.appStore.reorderFrame(oldIndex, newIndex, length);
+        AppStore.Instance.reorderFrame(oldIndex, newIndex, length);
     };
 
     private rowHeaderCellRenderer = (rowIndex: number) => {
-        return <RowHeaderCell name={rowIndex.toString()} className={rowIndex === this.props.appStore.activeFrameIndex ? "active-row-cell" : ""}/>;
+        return <RowHeaderCell name={rowIndex.toString()} className={rowIndex === AppStore.Instance.activeFrameIndex ? "active-row-cell" : ""}/>;
     };
 
     private fileNameRenderer = (rowIndex: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
@@ -73,7 +73,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     };
 
     private channelRenderer = (rowIndex: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
@@ -81,7 +81,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     };
 
     private stokesRenderer = (rowIndex: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
@@ -89,7 +89,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     };
 
     private typeRenderer = (rowIndex: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
@@ -113,7 +113,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     };
 
     private matchingRenderer = (rowIndex: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rowIndex < 0 || rowIndex >= appStore.frames.length) {
             return <Cell/>;
         }
@@ -210,7 +210,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
 
     private contextMenuRenderer = (context: IMenuContext) => {
         const rows = context.getTarget().rows;
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (rows && rows.length && appStore.frames[rows[0]]) {
             const frame = appStore.frames[rows[0]];
             if (frame) {
@@ -228,7 +228,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     };
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frameNum = appStore.frameNum;
 
         if (frameNum <= 0) {
@@ -244,7 +244,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         // There is probably a neater way to do this, though
         const frameChannels = appStore.frameChannels;
         const frameStokes = appStore.frameStokes;
-        const activeFrameIndex = this.props.appStore.activeFrameIndex;
+        const activeFrameIndex = appStore.activeFrameIndex;
         const visibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
         const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference);

--- a/src/components/Log/LogComponent.tsx
+++ b/src/components/Log/LogComponent.tsx
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import {Button, Code, Colors, FormGroup, HTMLSelect, NonIdealState, Tag, Intent} from "@blueprintjs/core";
 import ScrollToBottom from "react-scroll-to-bottom";
 import {CARTA} from "carta-protobuf";
-import {WidgetConfig, WidgetProps, HelpType} from "stores";
+import {WidgetConfig, WidgetProps, HelpType, LogStore} from "stores";
 import "./LogComponent.css";
 
 @observer
@@ -23,19 +23,19 @@ export class LogComponent extends React.Component<WidgetProps> {
     }
 
     onClearClicked = () => {
-        this.props.appStore.logStore.clearLog();
+        LogStore.Instance.clearLog();
     };
 
     onTagClicked = (tag: string) => {
-        this.props.appStore.logStore.toggleTag(tag);
+        LogStore.Instance.toggleTag(tag);
     };
 
     onLogLevelChanged = (event: React.FormEvent<HTMLSelectElement>) => {
-        this.props.appStore.logStore.setLevel(parseInt(event.currentTarget.value));
+        LogStore.Instance.setLevel(parseInt(event.currentTarget.value));
     };
 
     private isTagHidden = (tag: string) => {
-        return (this.props.appStore.logStore.hiddenTags.indexOf(tag) !== -1);
+        return (LogStore.Instance.hiddenTags.indexOf(tag) !== -1);
     };
 
     private colorFromSeverity(severity: CARTA.ErrorSeverity): string {
@@ -63,7 +63,7 @@ export class LogComponent extends React.Component<WidgetProps> {
     }
 
     render() {
-        const logStore = this.props.appStore.logStore;
+        const logStore = LogStore.Instance;
         const entries = logStore.logEntries;
         const hiddenTags = logStore.hiddenTags;
 

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -5,7 +5,7 @@ import {Alert, Icon, Menu, Popover, Position, Tooltip, Tag} from "@blueprintjs/c
 import {ToolbarMenuComponent} from "./ToolbarMenu/ToolbarMenuComponent";
 import {exportImage} from "components";
 import {PresetLayout} from "models";
-import {AppStore, BrowserMode, DialogStore, FileBrowserStore, PreferenceKeys} from "stores";
+import {AppStore, BrowserMode, DialogStore, FileBrowserStore, OverlayStore, PreferenceKeys, PreferenceStore} from "stores";
 import {ConnectionStatus} from "services";
 import {toFixed} from "utilities";
 import {CustomIcon} from "icons/CustomIcons";
@@ -20,6 +20,7 @@ export class RootMenuComponent extends React.Component {
         const appStore = AppStore.Instance;
         const dialogStore = DialogStore.Instance;
         const fileBrowserStore = FileBrowserStore.Instance;
+        const preferenceStore = PreferenceStore.Instance;
         const modString = appStore.modifierString;
         const connectionStatus = appStore.backendService.connectionStatus;
 
@@ -71,9 +72,9 @@ export class RootMenuComponent extends React.Component {
                     text="Export image"
                     label={`${modString}E`}
                     disabled={!appStore.activeFrame}
-                    onClick={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}
+                    onClick={() => exportImage(OverlayStore.Instance.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}
                 />
-                <Menu.Item text="Preferences" onClick={dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
+                <Menu.Item text="Preferences" onClick={dialogStore.showPreferenceDialog} disabled={preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
             </Menu>
         );
 
@@ -159,8 +160,8 @@ export class RootMenuComponent extends React.Component {
                                 active={value === appStore.layoutStore.currentLayoutName}
                                 onClick={() => {
                                     appStore.layoutStore.deleteLayout(value);
-                                    if (value === appStore.preferenceStore.layout) {
-                                        appStore.preferenceStore.setPreference(PreferenceKeys.GLOBAL_LAYOUT, PresetLayout.DEFAULT);
+                                    if (value === preferenceStore.layout) {
+                                        preferenceStore.setPreference(PreferenceKeys.GLOBAL_LAYOUT, PresetLayout.DEFAULT);
                                     }
                                 }}
                             />
@@ -280,7 +281,7 @@ export class RootMenuComponent extends React.Component {
                     Documentation will open in a new tab. Please ensure any popup blockers are disabled.
                 </Alert>
                 {loadingIndicator}
-                {appStore.preferenceStore.lowBandwidthMode &&
+                {preferenceStore.lowBandwidthMode &&
                 <Tooltip content={<span>CARTA is running in low bandwidth mode<br/><i><small>Image resolution and cursor responsiveness will be reduced</small></i></span>}>
                     <Icon icon={"feed"} className="connectivity-icon warning"/>
                 </Tooltip>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -5,24 +5,25 @@ import {Alert, Icon, Menu, Popover, Position, Tooltip, Tag} from "@blueprintjs/c
 import {ToolbarMenuComponent} from "./ToolbarMenu/ToolbarMenuComponent";
 import {exportImage} from "components";
 import {PresetLayout} from "models";
-import {AppStore, BrowserMode, PreferenceKeys} from "stores";
+import {AppStore, BrowserMode, DialogStore, PreferenceKeys} from "stores";
 import {ConnectionStatus} from "services";
 import {toFixed} from "utilities";
 import {CustomIcon} from "icons/CustomIcons";
 import "./RootMenuComponent.css";
 
 @observer
-export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
+export class RootMenuComponent extends React.Component {
     @observable documentationAlertVisible: boolean;
     private documentationAlertTimeoutHandle;
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
+        const dialogStore = DialogStore.Instance;
         const modString = appStore.modifierString;
         const connectionStatus = appStore.backendService.connectionStatus;
 
         let stokesClassName = "stokes-item";
-        if (this.props.appStore.darkTheme) {
+        if (appStore.darkTheme) {
             stokesClassName += " bp3-dark";
         }
 
@@ -71,7 +72,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                     disabled={!appStore.activeFrame}
                     onClick={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}
                 />
-                <Menu.Item text="Preferences" onClick={appStore.dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
+                <Menu.Item text="Preferences" onClick={dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
             </Menu>
         );
 
@@ -93,7 +94,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                     <Menu.Item text="Dark" icon={"moon"} onClick={appStore.setDarkTheme}/>
                 </Menu.Item>
                 <Menu.Item text="Overlay" icon={"widget"}>
-                    <Menu.Item text="Customize..." icon={"settings"} onClick={appStore.dialogStore.showOverlaySettings}/>
+                    <Menu.Item text="Customize..." icon={"settings"} onClick={dialogStore.showOverlaySettings}/>
                 </Menu.Item>
                 {layerItems.length > 0 &&
                 <Menu.Item text="Frames" icon={"layers"}>
@@ -107,12 +108,12 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                     text="File info"
                     icon={"info-sign"}
                     disabled={!appStore.activeFrame}
-                    onClick={appStore.dialogStore.showFileInfoDialog}
+                    onClick={dialogStore.showFileInfoDialog}
                 />
                 <Menu.Item
                     text="Contours"
                     icon={<CustomIcon icon="contour"/>}
-                    onClick={appStore.dialogStore.showContourDialog}
+                    onClick={dialogStore.showContourDialog}
                 />
             </Menu>
         );
@@ -148,7 +149,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                             />
                         )}
                     </Menu.Item>
-                    <Menu.Item text="Save Layout" onClick={appStore.dialogStore.showSaveLayoutDialog}/>
+                    <Menu.Item text="Save Layout" onClick={dialogStore.showSaveLayoutDialog}/>
                     <Menu.Item text="Delete Layout" disabled={!userLayouts || userLayouts.length <= 0}>
                         {userLayouts && userLayouts.length > 0 && userLayouts.map((value) =>
                             <Menu.Item
@@ -184,8 +185,8 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
         const helpMenu = (
             <Menu>
                 <Menu.Item text="Online Manual" icon={"help"} onClick={this.handleDocumentationClicked}/>
-                <Menu.Item text="Controls and Shortcuts" label={"Shift + ?"} onClick={appStore.dialogStore.showHotkeyDialog}/>
-                <Menu.Item text="About" icon={"info-sign"} onClick={appStore.dialogStore.showAboutDialog}/>
+                <Menu.Item text="Controls and Shortcuts" label={"Shift + ?"} onClick={dialogStore.showHotkeyDialog}/>
+                <Menu.Item text="About" icon={"info-sign"} onClick={dialogStore.showAboutDialog}/>
             </Menu>
         );
 
@@ -273,7 +274,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                         <Menu.Item text="Help"/>
                     </Menu>
                 </Popover>
-                <ToolbarMenuComponent appStore={appStore}/>
+                <ToolbarMenuComponent/>
                 <Alert isOpen={this.documentationAlertVisible} onClose={this.handleAlertDismissed} canEscapeKeyCancel={true} canOutsideClickCancel={true} confirmButtonText={"Dismiss"}>
                     Documentation will open in a new tab. Please ensure any popup blockers are disabled.
                 </Alert>
@@ -304,7 +305,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
     };
 
     handleFrameSelect = (fileId: number) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (appStore.activeFrame && appStore.activeFrame.frameInfo.fileId === fileId) {
             return;
         } else {

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -18,9 +18,6 @@ export class RootMenuComponent extends React.Component {
 
     render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
-        const fileBrowserStore = FileBrowserStore.Instance;
-        const preferenceStore = PreferenceStore.Instance;
         const modString = appStore.modifierString;
         const connectionStatus = appStore.backendService.connectionStatus;
 
@@ -35,13 +32,13 @@ export class RootMenuComponent extends React.Component {
                     text="Open image"
                     label={`${modString}O`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || appStore.fileLoading}
-                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.File, false)}
+                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, false)}
                 />
                 <Menu.Item
                     text="Append image"
                     label={`${modString}L`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || !appStore.activeFrame || appStore.fileLoading}
-                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.File, true)}
+                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)}
                 />
                 <Menu.Item
                     text="Close image"
@@ -53,19 +50,19 @@ export class RootMenuComponent extends React.Component {
                 <Menu.Item
                     text="Import regions"
                     disabled={!appStore.activeFrame}
-                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)}
+                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)}
                 />
                 <Menu.Item
                     text="Export regions"
                     disabled={!appStore.activeFrame || !appStore.activeFrame.regionSet.regions || appStore.activeFrame.regionSet.regions.length <= 1}
-                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.RegionExport, false)}
+                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionExport, false)}
                 />
                 <Menu.Divider/>
                 <Menu.Item
                     text="Append catalog"
                     label={`${modString}C`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || !appStore.activeFrame || appStore.fileLoading}
-                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}
+                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}
                 />
                 <Menu.Divider/>
                 <Menu.Item
@@ -74,7 +71,7 @@ export class RootMenuComponent extends React.Component {
                     disabled={!appStore.activeFrame}
                     onClick={() => exportImage(OverlayStore.Instance.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}
                 />
-                <Menu.Item text="Preferences" onClick={dialogStore.showPreferenceDialog} disabled={preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
+                <Menu.Item text="Preferences" onClick={appStore.dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE}/>
             </Menu>
         );
 
@@ -96,7 +93,7 @@ export class RootMenuComponent extends React.Component {
                     <Menu.Item text="Dark" icon={"moon"} onClick={appStore.setDarkTheme}/>
                 </Menu.Item>
                 <Menu.Item text="Overlay" icon={"widget"}>
-                    <Menu.Item text="Customize..." icon={"settings"} onClick={dialogStore.showOverlaySettings}/>
+                    <Menu.Item text="Customize..." icon={"settings"} onClick={appStore.dialogStore.showOverlaySettings}/>
                 </Menu.Item>
                 {layerItems.length > 0 &&
                 <Menu.Item text="Frames" icon={"layers"}>
@@ -110,12 +107,12 @@ export class RootMenuComponent extends React.Component {
                     text="File info"
                     icon={"info-sign"}
                     disabled={!appStore.activeFrame}
-                    onClick={dialogStore.showFileInfoDialog}
+                    onClick={appStore.dialogStore.showFileInfoDialog}
                 />
                 <Menu.Item
                     text="Contours"
                     icon={<CustomIcon icon="contour"/>}
-                    onClick={dialogStore.showContourDialog}
+                    onClick={appStore.dialogStore.showContourDialog}
                 />
             </Menu>
         );
@@ -151,7 +148,7 @@ export class RootMenuComponent extends React.Component {
                             />
                         )}
                     </Menu.Item>
-                    <Menu.Item text="Save Layout" onClick={dialogStore.showSaveLayoutDialog}/>
+                    <Menu.Item text="Save Layout" onClick={appStore.dialogStore.showSaveLayoutDialog}/>
                     <Menu.Item text="Delete Layout" disabled={!userLayouts || userLayouts.length <= 0}>
                         {userLayouts && userLayouts.length > 0 && userLayouts.map((value) =>
                             <Menu.Item
@@ -160,8 +157,8 @@ export class RootMenuComponent extends React.Component {
                                 active={value === appStore.layoutStore.currentLayoutName}
                                 onClick={() => {
                                     appStore.layoutStore.deleteLayout(value);
-                                    if (value === preferenceStore.layout) {
-                                        preferenceStore.setPreference(PreferenceKeys.GLOBAL_LAYOUT, PresetLayout.DEFAULT);
+                                    if (value === appStore.preferenceStore.layout) {
+                                        appStore.preferenceStore.setPreference(PreferenceKeys.GLOBAL_LAYOUT, PresetLayout.DEFAULT);
                                     }
                                 }}
                             />
@@ -187,8 +184,8 @@ export class RootMenuComponent extends React.Component {
         const helpMenu = (
             <Menu>
                 <Menu.Item text="Online Manual" icon={"help"} onClick={this.handleDocumentationClicked}/>
-                <Menu.Item text="Controls and Shortcuts" label={"Shift + ?"} onClick={dialogStore.showHotkeyDialog}/>
-                <Menu.Item text="About" icon={"info-sign"} onClick={dialogStore.showAboutDialog}/>
+                <Menu.Item text="Controls and Shortcuts" label={"Shift + ?"} onClick={appStore.dialogStore.showHotkeyDialog}/>
+                <Menu.Item text="About" icon={"info-sign"} onClick={appStore.dialogStore.showAboutDialog}/>
             </Menu>
         );
 
@@ -281,7 +278,7 @@ export class RootMenuComponent extends React.Component {
                     Documentation will open in a new tab. Please ensure any popup blockers are disabled.
                 </Alert>
                 {loadingIndicator}
-                {preferenceStore.lowBandwidthMode &&
+                {appStore.preferenceStore.lowBandwidthMode &&
                 <Tooltip content={<span>CARTA is running in low bandwidth mode<br/><i><small>Image resolution and cursor responsiveness will be reduced</small></i></span>}>
                     <Icon icon={"feed"} className="connectivity-icon warning"/>
                 </Tooltip>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -5,7 +5,7 @@ import {Alert, Icon, Menu, Popover, Position, Tooltip, Tag} from "@blueprintjs/c
 import {ToolbarMenuComponent} from "./ToolbarMenu/ToolbarMenuComponent";
 import {exportImage} from "components";
 import {PresetLayout} from "models";
-import {AppStore, BrowserMode, DialogStore, PreferenceKeys} from "stores";
+import {AppStore, BrowserMode, DialogStore, FileBrowserStore, PreferenceKeys} from "stores";
 import {ConnectionStatus} from "services";
 import {toFixed} from "utilities";
 import {CustomIcon} from "icons/CustomIcons";
@@ -19,6 +19,7 @@ export class RootMenuComponent extends React.Component {
     render() {
         const appStore = AppStore.Instance;
         const dialogStore = DialogStore.Instance;
+        const fileBrowserStore = FileBrowserStore.Instance;
         const modString = appStore.modifierString;
         const connectionStatus = appStore.backendService.connectionStatus;
 
@@ -33,13 +34,13 @@ export class RootMenuComponent extends React.Component {
                     text="Open image"
                     label={`${modString}O`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || appStore.fileLoading}
-                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, false)}
+                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.File, false)}
                 />
                 <Menu.Item
                     text="Append image"
                     label={`${modString}L`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || !appStore.activeFrame || appStore.fileLoading}
-                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)}
+                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.File, true)}
                 />
                 <Menu.Item
                     text="Close image"
@@ -51,19 +52,19 @@ export class RootMenuComponent extends React.Component {
                 <Menu.Item
                     text="Import regions"
                     disabled={!appStore.activeFrame}
-                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)}
+                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)}
                 />
                 <Menu.Item
                     text="Export regions"
                     disabled={!appStore.activeFrame || !appStore.activeFrame.regionSet.regions || appStore.activeFrame.regionSet.regions.length <= 1}
-                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionExport, false)}
+                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.RegionExport, false)}
                 />
                 <Menu.Divider/>
                 <Menu.Item
                     text="Append catalog"
                     label={`${modString}C`}
                     disabled={connectionStatus !== ConnectionStatus.ACTIVE || !appStore.activeFrame || appStore.fileLoading}
-                    onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}
+                    onClick={() => fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)}
                 />
                 <Menu.Divider/>
                 <Menu.Item

--- a/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
+++ b/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {Button, ButtonGroup, Tooltip} from "@blueprintjs/core";
-import {AppStore, WidgetConfig} from "stores";
+import {AppStore, DialogStore, WidgetConfig} from "stores";
 import {
     AnimatorComponent, 
     HistogramComponent, 
@@ -18,7 +18,7 @@ import {
 import {CustomIcon} from "icons/CustomIcons";
 import "./ToolbarMenuComponent.css";
 @observer
-export class ToolbarMenuComponent extends React.Component<{ appStore: AppStore }> {
+export class ToolbarMenuComponent extends React.Component {
     public static get DRAGSOURCE_WIDGETCONFIG_MAP(): Map<string, WidgetConfig> {
         return new Map<string, WidgetConfig>([
             ["renderConfigButton", RenderConfigComponent.WIDGET_CONFIG],
@@ -36,57 +36,58 @@ export class ToolbarMenuComponent extends React.Component<{ appStore: AppStore }
     }
 
     public render() {
+        const appStore = AppStore.Instance;
+        const dialogStore = DialogStore.Instance;
+
         let className = "toolbar-menu";
         let dialogClassName = "dialog-toolbar-menu";
-        if (this.props.appStore.darkTheme) {
+        if (appStore.darkTheme) {
             className += " bp3-dark";
             dialogClassName += " bp3-dark";
         }
-
-        const dialogStore = this.props.appStore.dialogStore;
 
         const commonTooltip = <span><br/><i><small>Drag to place docked widget<br/>Click to place a floating widget</small></i></span>;
         return (
             <React.Fragment>
                 <ButtonGroup className={className}>
                     <Tooltip content={<span>Region List Widget{commonTooltip}</span>}>
-                        <Button icon={"th-list"} id="regionListButton" onClick={this.props.appStore.widgetsStore.createFloatingRegionListWidget}/>
+                        <Button icon={"th-list"} id="regionListButton" onClick={appStore.widgetsStore.createFloatingRegionListWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Log Widget{commonTooltip}</span>}>
-                        <Button icon={"application"} id="logButton" onClick={this.props.appStore.widgetsStore.createFloatingLogWidget}/>
+                        <Button icon={"application"} id="logButton" onClick={appStore.widgetsStore.createFloatingLogWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Spatial Profiler{commonTooltip}</span>}>
-                        <Button icon={"pulse"} id="spatialProfilerButton" className={"profiler-button"} onClick={this.props.appStore.widgetsStore.createFloatingSpatialProfilerWidget}>
+                        <Button icon={"pulse"} id="spatialProfilerButton" className={"profiler-button"} onClick={appStore.widgetsStore.createFloatingSpatialProfilerWidget}>
                             xy
                         </Button>
                     </Tooltip>
                     <Tooltip content={<span>Spectral Profiler{commonTooltip}</span>}>
-                        <Button icon={"pulse"} id="spectralProfilerButton" className={"profiler-button"} onClick={this.props.appStore.widgetsStore.createFloatingSpectralProfilerWidget}>
+                        <Button icon={"pulse"} id="spectralProfilerButton" className={"profiler-button"} onClick={appStore.widgetsStore.createFloatingSpectralProfilerWidget}>
                             &nbsp;z
                         </Button>
                     </Tooltip>
                     <Tooltip content={<span>Statistics Widget{commonTooltip}</span>}>
-                        <Button icon={"calculator"} id="statsButton" onClick={this.props.appStore.widgetsStore.createFloatingStatsWidget}/>
+                        <Button icon={"calculator"} id="statsButton" onClick={appStore.widgetsStore.createFloatingStatsWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Histogram Widget{commonTooltip}</span>}>
-                        <Button icon={"timeline-bar-chart"} id="histogramButton" onClick={this.props.appStore.widgetsStore.createFloatingHistogramWidget}/>
+                        <Button icon={"timeline-bar-chart"} id="histogramButton" onClick={appStore.widgetsStore.createFloatingHistogramWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Animator Widget{commonTooltip}</span>}>
-                        <Button icon={"video"} id="animatorButton" onClick={this.props.appStore.widgetsStore.createFloatingAnimatorWidget}/>
+                        <Button icon={"video"} id="animatorButton" onClick={appStore.widgetsStore.createFloatingAnimatorWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Render Config Widget{commonTooltip}</span>}>
-                        <Button icon={"style"} id="renderConfigButton" onClick={this.props.appStore.widgetsStore.createFloatingRenderWidget}/>
+                        <Button icon={"style"} id="renderConfigButton" onClick={appStore.widgetsStore.createFloatingRenderWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Stokes Analysis Widget{commonTooltip}</span>}>
-                        <Button icon={"pulse"} id="stokesAnalysisButton" className={"profiler-button"} onClick={this.props.appStore.widgetsStore.createFloatingStokesWidget}>
+                        <Button icon={"pulse"} id="stokesAnalysisButton" className={"profiler-button"} onClick={appStore.widgetsStore.createFloatingStokesWidget}>
                             &nbsp;s
                         </Button>
                     </Tooltip>
                     <Tooltip content={<span>Layer List Widget{commonTooltip}</span>}>
-                        <Button icon={"layers"} id="layerListButton" onClick={this.props.appStore.widgetsStore.createFloatingLayerListWidget}/>
+                        <Button icon={"layers"} id="layerListButton" onClick={appStore.widgetsStore.createFloatingLayerListWidget}/>
                     </Tooltip>
                     <Tooltip content={<span>Catalog Widget{commonTooltip}</span>}>
-                        <Button icon={"heatmap"} id="catalogOverlayButton" onClick={this.props.appStore.widgetsStore.reloadFloatingCatalogOverlayWidget}/>
+                        <Button icon={"heatmap"} id="catalogOverlayButton" onClick={appStore.widgetsStore.reloadFloatingCatalogOverlayWidget}/>
                     </Tooltip>
                 </ButtonGroup>
                 <ButtonGroup className={dialogClassName}>

--- a/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
+++ b/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
@@ -37,7 +37,7 @@ export class ToolbarMenuComponent extends React.Component {
 
     public render() {
         const appStore = AppStore.Instance;
-        const dialogStore = DialogStore.Instance;
+        const dialogStore = appStore.dialogStore;
 
         let className = "toolbar-menu";
         let dialogClassName = "dialog-toolbar-menu";

--- a/src/components/Placeholder/PlaceholderComponent.tsx
+++ b/src/components/Placeholder/PlaceholderComponent.tsx
@@ -4,7 +4,6 @@ import {AppStore, WidgetConfig, HelpType} from "stores";
 import "./PlaceholderComponent.css";
 
 class PlaceholderComponentProps {
-    appStore: AppStore;
     id: string;
     label: string;
     docked: boolean;

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import { HTMLTable, Icon, NonIdealState } from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
 import { CARTA } from "carta-protobuf";
-import { RegionStore, WidgetConfig, WidgetProps, HelpType } from "stores";
+import {RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore} from "stores";
 import { Point2D} from "models";
 import { toFixed } from "utilities";
 import "./RegionListComponent.css";
@@ -59,7 +59,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     };
 
     private handleRegionListDoubleClick = () => {
-        this.props.appStore.dialogStore.showRegionDialog();
+        DialogStore.Instance.showRegionDialog();
     };
 
     render() {

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import { HTMLTable, Icon, NonIdealState } from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
 import { CARTA } from "carta-protobuf";
-import {RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore} from "stores";
+import {RegionStore, WidgetConfig, WidgetProps, HelpType, DialogStore, AppStore} from "stores";
 import { Point2D} from "models";
 import { toFixed } from "utilities";
 import "./RegionListComponent.css";
@@ -12,8 +12,9 @@ import "./RegionListComponent.css";
 @observer
 export class RegionListComponent extends React.Component<WidgetProps> {
     @computed get validRegions(): RegionStore[] {
-        if (this.props.appStore.activeFrame) {
-            return this.props.appStore.activeFrame.regionSet.regions.filter(r => !r.isTemporary);
+        const frame = AppStore.Instance.activeFrame;
+        if (frame) {
+            return frame.regionSet.regions.filter(r => !r.isTemporary);
         }
         return [];
     }
@@ -63,7 +64,8 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     };
 
     render() {
-        const frame = this.props.appStore.activeFrame;
+        const appStore = AppStore.Instance;
+        const frame = appStore.activeFrame;
 
         if (!frame) {
             return (
@@ -112,7 +114,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
 
         const rows = this.validRegions.map(region => {
             let point: Point2D = region.center;
-            
+
             let pixelCenterEntry;
             if (isFinite(point.x) && isFinite(point.y)) {
                 pixelCenterEntry = <td style={{width: RegionListComponent.CENTER_COLUMN_DEFAULT_WIDTH}} onDoubleClick={this.handleRegionListDoubleClick} >{`(${toFixed(point.x, 1)}, ${toFixed(point.y, 1)})`}</td>;
@@ -164,7 +166,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         return (
             <div className="region-list-widget">
                 <HTMLTable style={{height: tableHeight}}>
-                    <thead className={this.props.appStore.darkTheme ? "dark-theme" : ""}>
+                    <thead className={appStore.darkTheme ? "dark-theme" : ""}>
                     <tr>
                         <th style={{width: RegionListComponent.ACTION_COLUMN_DEFAULT_WIDTH * 2}}><Icon icon={"blank"}/><Icon icon={"blank"}/></th>
                         <th style={{width: nameWidth}}>Name</th>
@@ -174,7 +176,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                         {showRotationColumn && <th style={{width: RegionListComponent.ROTATION_COLUMN_DEFAULT_WIDTH}}>P.A. (deg)</th>}
                     </tr>
                     </thead>
-                    <tbody className={this.props.appStore.darkTheme ? "dark-theme" : ""}>
+                    <tbody className={appStore.darkTheme ? "dark-theme" : ""}>
                     {rows}
                     </tbody>
                 </HTMLTable>

--- a/src/components/RegionSelector/RegionSelectorComponent.tsx
+++ b/src/components/RegionSelector/RegionSelectorComponent.tsx
@@ -7,17 +7,17 @@ import {RegionWidgetStore, RegionsType, RegionId} from "stores/widgets";
 import "./RegionSelectorComponent.css";
 
 @observer
-export class RegionSelectorComponent extends React.Component<{ widgetStore: RegionWidgetStore, appStore: AppStore }> {
+export class RegionSelectorComponent extends React.Component<{ widgetStore: RegionWidgetStore}> {
 
     private handleRegionChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (appStore.activeFrame) {
             this.props.widgetStore.setRegionId(appStore.activeFrame.frameInfo.fileId, parseInt(changeEvent.target.value));
         }
     };
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const widgetStore = this.props.widgetStore;
 
         let enableRegionSelect = false;

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -9,7 +9,7 @@ import {ColormapConfigComponent} from "./ColormapConfigComponent/ColormapConfigC
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent} from "components/Shared";
 import {TaskProgressDialogComponent} from "components/Dialogs";
 import {RenderConfigWidgetStore} from "stores/widgets";
-import {AnimationState, FrameScaling, FrameStore, RenderConfigStore, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {AnimationState, FrameScaling, FrameStore, RenderConfigStore, WidgetConfig, WidgetProps, HelpType, AlertStore, LogStore, AppStore, AnimatorStore} from "stores";
 import {Point2D} from "models";
 import {clamp, toExponential, toFixed} from "utilities";
 import "./RenderConfigComponent.css";
@@ -163,8 +163,8 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
 
     handlePercentileRankClick = (value: number) => {
         if (!this.props.appStore.activeFrame.renderConfig.setPercentileRank(value)) {
-            this.props.appStore.alertStore.showAlert(`Couldn't set percentile of rank ${value}%`);
-            this.props.appStore.logStore.addError(`Couldn't set percentile of rank ${value}%`, ["render"]);
+            AlertStore.Instance.showAlert(`Couldn't set percentile of rank ${value}%`);
+            LogStore.Instance.addError(`Couldn't set percentile of rank ${value}%`, ["render"]);
         }
     };
 
@@ -236,7 +236,7 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
     };
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
 
         if (!frame || !this.widgetStore) {
@@ -407,7 +407,7 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                         renderConfig={frame.renderConfig}
                         onCubeHistogramSelected={this.handleCubeHistogramSelected}
                         showHistogramSelect={frame.frameInfo.fileInfoExtended.depth > 1}
-                        disableHistogramSelect={appStore.animatorStore.animationState === AnimationState.PLAYING}
+                        disableHistogramSelect={AnimatorStore.Instance.animationState === AnimationState.PLAYING}
                         warnOnCubeHistogram={(frame.frameInfo.fileFeatureFlags & CARTA.FileFeatureFlags.CUBE_HISTOGRAMS) === 0}
                     />
                     <FormGroup label={"Clip Min"} inline={true}>

--- a/src/components/RenderConfig/RenderConfigSettingsPanelComponent/RenderConfigSettingsPanelComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigSettingsPanelComponent/RenderConfigSettingsPanelComponent.tsx
@@ -4,7 +4,7 @@ import {computed} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {LinePlotSettingsPanelComponentProps, LinePlotSettingsPanelComponent} from "components/Shared";
 import {RenderConfigWidgetStore} from "stores/widgets/RenderConfigWidgetStore";
-import {WidgetProps, WidgetConfig, HelpType} from "stores";
+import {WidgetProps, WidgetConfig, HelpType, WidgetsStore, AppStore} from "stores";
 import {parseNumber} from "utilities";
 
 const KEYCODE_ENTER = 13;
@@ -29,8 +29,9 @@ export class RenderConfigSettingsPanelComponent extends React.Component<WidgetPr
     }
 
     @computed get widgetStore(): RenderConfigWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.renderConfigWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.renderConfigWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.renderConfigWidgets) {
+            const widgetStore = widgetsStore.renderConfigWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -118,7 +119,7 @@ export class RenderConfigSettingsPanelComponent extends React.Component<WidgetPr
     render() {
         const widgetStore = this.widgetStore;
         const lineSettingsProps: LinePlotSettingsPanelComponentProps = {
-            darkMode: this.props.appStore.darkTheme,
+            darkMode: AppStore.Instance.darkTheme,
             primaryDarkModeLineColor: Colors.BLUE4,
             primaryLineColor: widgetStore.primaryLineColor,
             lineWidth: widgetStore.lineWidth,

--- a/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
+++ b/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
@@ -6,10 +6,10 @@ import {AppStore} from "stores";
 import {SpectralSystem} from "models";
 
 @observer
-export class SpectralSettingsComponent extends React.Component<{appStore: AppStore, widgetStore: SpectralProfileWidgetStore|StokesAnalysisWidgetStore, disable: boolean}> {
+export class SpectralSettingsComponent extends React.Component<{widgetStore: SpectralProfileWidgetStore|StokesAnalysisWidgetStore, disable: boolean}> {
 
     render() {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         const nativeSpectralCoordinate = frame ? frame.nativeSpectralCoordinate : undefined;
         const widgetStore = this.props.widgetStore;
         const spectralCoordinateOptions: IOptionProps[] = frame && frame.spectralCoordsSupported ?

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -7,7 +7,7 @@ import {Colors, NonIdealState} from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
-import {ASTSettingsString, FrameStore, SpatialProfileStore, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {ASTSettingsString, FrameStore, SpatialProfileStore, WidgetConfig, WidgetProps, HelpType, OverlayStore} from "stores";
 import {SpatialProfileWidgetStore} from "stores/widgets";
 import {Point2D} from "models";
 import {binarySearchByX, clamp, formattedNotation, toExponential, toFixed} from "utilities";
@@ -276,7 +276,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         const isXProfile = this.widgetStore.coordinate.indexOf("x") >= 0;
 
         let astString = new ASTSettingsString();
-        astString.add("System", this.props.appStore.overlayStore.global.explicitSystem);
+        astString.add("System", OverlayStore.Instance.global.explicitSystem);
 
         if (isXProfile) {
             for (let i = 0; i < values.length; i++) {

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {Colors} from "@blueprintjs/core";
 import {LinePlotSettingsPanelComponentProps, LinePlotSettingsPanelComponent} from "components/Shared";
 import {SpatialProfileWidgetStore} from "stores/widgets";
-import {WidgetProps, WidgetConfig, HelpType} from "stores";
+import {WidgetProps, WidgetConfig, HelpType, WidgetsStore, AppStore} from "stores";
 import {parseNumber} from "utilities";
 
 const KEYCODE_ENTER = 13;
@@ -29,8 +29,9 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
     }
 
     @computed get widgetStore(): SpatialProfileWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.spatialProfileWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.spatialProfileWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.spatialProfileWidgets) {
+            const widgetStore = widgetsStore.spatialProfileWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -41,19 +42,18 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
 
     constructor(props: WidgetProps) {
         super(props);
-
+        const appStore = AppStore.Instance;
         // Update widget title when region or coordinate changes
         autorun(() => {
             if (this.widgetStore) {
                 const coordinate = this.widgetStore.coordinate;
-                const appStore = this.props.appStore;
                 if (appStore && coordinate) {
                     const coordinateString = `${coordinate.toUpperCase()} Profile`;
                     const regionString = this.widgetStore.regionId === 0 ? "Cursor" : `Region #${this.widgetStore.regionId}`;
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `${coordinateString} Settings: ${regionString}`);
+                    appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `${coordinateString} Settings: ${regionString}`);
                 }
             } else {
-                this.props.appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `X Profile Settings: Cursor`);
+                appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `X Profile Settings: Cursor`);
             }
         });
     }
@@ -143,7 +143,7 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
         }];
 
         const lineSettingsProps: LinePlotSettingsPanelComponentProps = {
-            darkMode: this.props.appStore.darkTheme,
+            darkMode: AppStore.Instance.darkTheme,
             primaryDarkModeLineColor: Colors.BLUE4,
             primaryLineColor: widgetStore.primaryLineColor,
             lineWidth: widgetStore.lineWidth,

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -9,7 +9,7 @@ import {CARTA} from "carta-protobuf";
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 import {SpectralProfilerToolbarComponent} from "./SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent";
-import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType, AnimatorStore} from "stores";
 import {SpectralProfileWidgetStore} from "stores/widgets";
 import {Point2D, ProcessedSpectralProfile} from "models";
 import {binarySearchByX, clamp, formattedNotation, toExponential, toFixed} from "utilities";
@@ -212,7 +212,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
     onChannelChanged = (x: number) => {
         const frame = this.props.appStore.activeFrame;
-        if (this.props.appStore.animatorStore.animationState === AnimationState.PLAYING) {
+        if (AnimatorStore.Instance.animationState === AnimationState.PLAYING) {
             return;
         }
 
@@ -396,7 +396,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 linePlotProps.markers.push({
                     value: this.requiredChannelValue,
                     id: "marker-channel-required",
-                    draggable: appStore.animatorStore.animationState !== AnimationState.PLAYING,
+                    draggable: AnimatorStore.Instance.animationState !== AnimationState.PLAYING,
                     dragMove: this.onChannelChanged,
                     horizontal: false,
                 });

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -9,7 +9,7 @@ import {CARTA} from "carta-protobuf";
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 import {SpectralProfilerToolbarComponent} from "./SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent";
-import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType, AnimatorStore} from "stores";
+import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType, AnimatorStore, WidgetsStore, AppStore} from "stores";
 import {SpectralProfileWidgetStore} from "stores/widgets";
 import {Point2D, ProcessedSpectralProfile} from "models";
 import {binarySearchByX, clamp, formattedNotation, toExponential, toFixed} from "utilities";
@@ -37,8 +37,9 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     @observable height: number;
 
     @computed get widgetStore(): SpectralProfileWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.spectralProfileWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.spectralProfileWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.spectralProfileWidgets) {
+            const widgetStore = widgetsStore.spectralProfileWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -48,10 +49,11 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     }
 
     @computed get profileStore(): SpectralProfileStore {
-        if (this.props.appStore && this.props.appStore.activeFrame) {
-            let fileId = this.props.appStore.activeFrame.frameInfo.fileId;
+        const appStore = AppStore.Instance;
+        if (appStore.activeFrame) {
+            let fileId = appStore.activeFrame.frameInfo.fileId;
             const regionId = this.widgetStore.effectiveRegionId;
-            const frameMap = this.props.appStore.spectralProfiles.get(fileId);
+            const frameMap = appStore.spectralProfiles.get(fileId);
             if (frameMap) {
                 return frameMap.get(regionId);
             }
@@ -60,7 +62,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     }
 
     @computed get plotData(): PlotData {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (!frame) {
             return null;
         }
@@ -143,7 +145,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
     @computed get exportHeaders(): string[] {
         let headerString = [];
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (frame && frame.frameInfo && frame.regionSet) {
             const regionId = this.widgetStore.effectiveRegionId;
             const region = frame.regionSet.regions.find(r => r.regionId === regionId);
@@ -162,22 +164,22 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
     constructor(props: WidgetProps) {
         super(props);
+        const appStore = AppStore.Instance;
         // Check if this widget hasn't been assigned an ID yet
         if (!props.docked && props.id === SpectralProfilerComponent.WIDGET_CONFIG.type) {
             // Assign the next unique ID
-            const id = props.appStore.widgetsStore.addSpectralProfileWidget();
-            props.appStore.widgetsStore.changeWidgetId(props.id, id);
+            const id = appStore.widgetsStore.addSpectralProfileWidget();
+            appStore.widgetsStore.changeWidgetId(props.id, id);
         } else {
-            if (!this.props.appStore.widgetsStore.spectralProfileWidgets.has(this.props.id)) {
+            if (!appStore.widgetsStore.spectralProfileWidgets.has(this.props.id)) {
                 console.log(`can't find store for widget with id=${this.props.id}`);
-                this.props.appStore.widgetsStore.addSpectralProfileWidget(this.props.id);
+                appStore.widgetsStore.addSpectralProfileWidget(this.props.id);
             }
         }
         // Update widget title when region or coordinate changes
         autorun(() => {
             if (this.widgetStore) {
                 const coordinate = this.widgetStore.coordinate;
-                const appStore = this.props.appStore;
                 const frame = appStore.activeFrame;
                 let progressString = "";
                 const currentData = this.plotData;
@@ -194,13 +196,13 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                     const regionId = this.widgetStore.effectiveRegionId;
                     const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
                     const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `${coordinateString}: ${regionString} ${selectedString} ${progressString}`);
+                    appStore.widgetsStore.setWidgetTitle(this.props.id, `${coordinateString}: ${regionString} ${selectedString} ${progressString}`);
                 }
                 if (currentData) {
                     this.widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
                 }
             } else {
-                this.props.appStore.widgetsStore.setWidgetTitle(this.props.id, `Z Profile: Cursor`);
+                appStore.widgetsStore.setWidgetTitle(this.props.id, `Z Profile: Cursor`);
             }
         });
     }
@@ -211,7 +213,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     };
 
     onChannelChanged = (x: number) => {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (AnimatorStore.Instance.animationState === AnimationState.PLAYING) {
             return;
         }
@@ -237,7 +239,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     };
 
     @computed get currentChannelValue(): number {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (!frame || !frame.channelValues) {
             return null;
         }
@@ -249,7 +251,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     }
 
     @computed get requiredChannelValue(): number {
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (!frame || !frame.channelValues) {
             return null;
         }
@@ -266,7 +268,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
 
     private genProfilerInfo = (): string[] => {
         let profilerInfo: string[] = [];
-        const frame = this.props.appStore.activeFrame;
+        const frame = AppStore.Instance.activeFrame;
         if (frame && this.plotData) {
             const cursorX = {
                 profiler: this.widgetStore.cursorX,
@@ -299,7 +301,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     };
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         if (!this.widgetStore) {
             return <NonIdealState icon={"error"} title={"Missing profile"} description={"Profile not found"}/>;
         }
@@ -438,7 +440,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return (
             <div className={className}>
                 <div className="profile-container">
-                    <SpectralProfilerToolbarComponent widgetStore={this.widgetStore} appStore={appStore}/>
+                    <SpectralProfilerToolbarComponent widgetStore={this.widgetStore}/>
                     <div className="profile-plot">
                         <LinePlotComponent {...linePlotProps}/>
                         <ProfilerInfoComponent info={this.genProfilerInfo()}/>

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -44,7 +44,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             }
         }
         console.log("can't find store for widget");
-        return new SpectralProfileWidgetStore(this.props.appStore);
+        return new SpectralProfileWidgetStore();
     }
 
     @computed get profileStore(): SpectralProfileStore {

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {Colors, Tab, Tabs} from "@blueprintjs/core";
 import {LinePlotSettingsPanelComponentProps, LinePlotSettingsPanelComponent, SpectralSettingsComponent} from "components/Shared";
 import {SpectralProfileWidgetStore} from "stores/widgets";
-import {WidgetProps, WidgetConfig, HelpType} from "stores";
+import {WidgetProps, WidgetConfig, HelpType, AppStore, WidgetsStore} from "stores";
 import {parseNumber} from "utilities";
 import "./SpectralProfilerSettingsPanelComponent.css";
 
@@ -30,8 +30,9 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
     }
 
     @computed get widgetStore(): SpectralProfileWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.spectralProfileWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.spectralProfileWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.spectralProfileWidgets) {
+            const widgetStore = widgetsStore.spectralProfileWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -42,10 +43,9 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
 
     constructor(props: WidgetProps) {
         super(props);
-
+        const appStore = AppStore.Instance;
         autorun(() => {
             if (this.widgetStore) {
-                const appStore = this.props.appStore;
                 const frame = appStore.activeFrame;
                 const coordinate = this.widgetStore.coordinate;
                 if (frame && coordinate) {
@@ -58,7 +58,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
                     const regionId = this.widgetStore.effectiveRegionId;
                     const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
                     const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `${coordinateString} Settings: ${regionString} ${selectedString}`);
+                    appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `${coordinateString} Settings: ${regionString} ${selectedString}`);
                 }
             }
         });
@@ -135,7 +135,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
     render() {
         const widgetStore = this.widgetStore;
         const lineSettingsProps: LinePlotSettingsPanelComponentProps = {
-            darkMode: this.props.appStore.darkTheme,
+            darkMode: AppStore.Instance.darkTheme,
             primaryDarkModeLineColor: Colors.BLUE4,
             primaryLineColor: widgetStore.primaryLineColor,
             lineWidth: widgetStore.lineWidth,
@@ -163,7 +163,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
         return (
             <div className="spectral-settings">
                 <Tabs id="spectralSettingTabs">
-                    <Tab id="conversion" title="Conversion" panel={<SpectralSettingsComponent appStore={this.props.appStore} widgetStore={widgetStore} disable={false}/>}/>
+                    <Tab id="conversion" title="Conversion" panel={<SpectralSettingsComponent widgetStore={widgetStore} disable={false}/>}/>
                     <Tab id="styling" title="Styling" panel={<LinePlotSettingsPanelComponent {...lineSettingsProps}/>}/>
                 </Tabs>
             </div>

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -8,7 +8,7 @@ import {RegionSelectorComponent} from "components";
 import "./SpectralProfilerToolbarComponent.css";
 
 @observer
-export class SpectralProfilerToolbarComponent extends React.Component<{ widgetStore: SpectralProfileWidgetStore, appStore: AppStore }> {
+export class SpectralProfilerToolbarComponent extends React.Component<{ widgetStore: SpectralProfileWidgetStore }> {
 
     private handleStatsChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
         this.props.widgetStore.setStatsType(parseInt(changeEvent.target.value));
@@ -19,7 +19,7 @@ export class SpectralProfilerToolbarComponent extends React.Component<{ widgetSt
     };
 
     public render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const widgetStore = this.props.widgetStore;
 
         let enableStatsSelect = false;
@@ -55,7 +55,7 @@ export class SpectralProfilerToolbarComponent extends React.Component<{ widgetSt
 
         return (
             <div className="spectral-profiler-toolbar">
-                <RegionSelectorComponent widgetStore={widgetStore} appStore={appStore}/>
+                <RegionSelectorComponent widgetStore={widgetStore}/>
                 <FormGroup label={"Statistic"} inline={true} disabled={!enableStatsSelect}>
                     <HTMLSelect value={enableStatsSelect ? widgetStore.statsType : CARTA.StatsType.Mean} options={profileStatsOptions} onChange={this.handleStatsChanged} disabled={!enableStatsSelect}/>
                 </FormGroup>

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {Classes, Intent, Overlay, Spinner} from "@blueprintjs/core";
-import {AppStore} from "stores";
+import {AppStore, LogStore} from "stores";
 import {CARTA_INFO} from "models";
 import * as logoPng from "static/carta_logo.png";
 import "./SplashScreenComponent.css";
 
 @observer
-export class SplashScreenComponent extends React.Component<{ appStore: AppStore }> {
+export class SplashScreenComponent extends React.Component {
     public render() {
-        const appStore = this.props.appStore;
-        const logStore = this.props.appStore.logStore;
+        const appStore = AppStore.Instance;
+        const logStore = LogStore.Instance;
 
         let className = "splash-screen";
         if (appStore.darkTheme) {

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -10,7 +10,6 @@ import "./SplashScreenComponent.css";
 export class SplashScreenComponent extends React.Component {
     public render() {
         const appStore = AppStore.Instance;
-        const logStore = LogStore.Instance;
 
         let className = "splash-screen";
         if (appStore.darkTheme) {
@@ -29,7 +28,7 @@ export class SplashScreenComponent extends React.Component {
                     </div>
                     <Spinner intent={Intent.PRIMARY} size={30} value={null}/>
                     <div className={"loadingInfo-div"}>
-                        <p>{logStore.newestMsg}</p>
+                        <p>{appStore.logStore.newestMsg}</p>
                     </div>
                 </div>
             </Overlay>

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -38,7 +38,7 @@ export class StatsComponent extends React.Component<WidgetProps> {
             }
         }
         console.log("can't find store for widget");
-        return new StatsWidgetStore(this.props.appStore);
+        return new StatsWidgetStore();
     }
 
     @computed get statsData(): CARTA.RegionStatsData {
@@ -81,7 +81,7 @@ export class StatsComponent extends React.Component<WidgetProps> {
         } else {
             if (!this.props.appStore.widgetsStore.statsWidgets.has(this.props.id)) {
                 console.log(`can't find store for widget with id=${this.props.id}`);
-                this.props.appStore.widgetsStore.statsWidgets.set(this.props.id, new StatsWidgetStore(this.props.appStore));
+                this.props.appStore.widgetsStore.statsWidgets.set(this.props.id, new StatsWidgetStore());
             }
         }
         // Update widget title when region or coordinate changes

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -10,7 +10,7 @@ import {CARTA} from "carta-protobuf";
 import {LinePlotComponent, LinePlotComponentProps, ProfilerInfoComponent, ScatterPlotComponent, ScatterPlotComponentProps, VERTICAL_RANGE_PADDING, PlotType} from "components/Shared";
 import {StokesAnalysisToolbarComponent} from "./StokesAnalysisToolbarComponent/StokesAnalysisToolbarComponent";
 import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
-import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType} from "stores";
+import {AnimationState, SpectralProfileStore, WidgetConfig, WidgetProps, HelpType, AnimatorStore} from "stores";
 import {StokesAnalysisWidgetStore, StokesCoordinate} from "stores/widgets";
 import {Point2D} from "models";
 import {clamp, normalising, polarizationAngle, polarizedIntensity, binarySearchByX, closestPointIndexToCursor, toFixed, toExponential, minMaxPointArrayZ, formattedNotation} from "utilities";
@@ -155,7 +155,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
 
     onChannelChanged = (x: number) => {
         const frame = this.props.appStore.activeFrame;
-        if (this.props.appStore.animatorStore.animationState === AnimationState.PLAYING) {
+        if (AnimatorStore.Instance.animationState === AnimationState.PLAYING) {
             return;
         }
 
@@ -181,7 +181,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
 
     onScatterChannelChanged = (x: number, y: number, data: Point3D[]) => {
         const frame = this.props.appStore.activeFrame;
-        if (this.props.appStore.animatorStore.animationState === AnimationState.PLAYING) {
+        if (AnimatorStore.Instance.animationState === AnimationState.PLAYING) {
             return;
         }
         if (data.length > 0 && frame && frame.channelInfo) {
@@ -1069,7 +1069,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 let channelRequired = {
                     value: this.requiredChannelValue,
                     id: "marker-channel-required",
-                    draggable: appStore.animatorStore.animationState !== AnimationState.PLAYING,
+                    draggable: AnimatorStore.Instance.animationState !== AnimationState.PLAYING,
                     dragMove: this.onChannelChanged,
                     horizontal: false,
                 };

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -57,7 +57,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
             }
         }
         console.log("can't find store for widget");
-        return new StokesAnalysisWidgetStore(this.props.appStore);
+        return new StokesAnalysisWidgetStore();
     }
 
     @computed get profileStore(): SpectralProfileStore {
@@ -94,7 +94,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
         } else {
             if (!this.props.appStore.widgetsStore.stokesAnalysisWidgets.has(this.props.id)) {
                 console.log(`can't find store for widget with id=${this.props.id}`);
-                this.props.appStore.widgetsStore.stokesAnalysisWidgets.set(this.props.id, new StokesAnalysisWidgetStore(this.props.appStore));
+                this.props.appStore.widgetsStore.stokesAnalysisWidgets.set(this.props.id, new StokesAnalysisWidgetStore());
             }
         }
 

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {Colors, Tab, Tabs} from "@blueprintjs/core";
 import {LinePlotSettingsPanelComponent, LinePlotSettingsPanelComponentProps, ScatterPlotSettingsPanelComponentProps, ScatterPlotSettingsPanelComponent, SpectralSettingsComponent} from "components/Shared";
 import {StokesAnalysisWidgetStore} from "stores/widgets";
-import {WidgetProps, WidgetConfig, HelpType} from "stores";
+import {WidgetProps, WidgetConfig, HelpType, WidgetsStore, AppStore} from "stores";
 import "./StokesAnalysisSettingsPanelComponent.css";
 
 @observer
@@ -27,8 +27,9 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
     }
 
     @computed get widgetStore(): StokesAnalysisWidgetStore {
-        if (this.props.appStore && this.props.appStore.widgetsStore.stokesAnalysisWidgets) {
-            const widgetStore = this.props.appStore.widgetsStore.stokesAnalysisWidgets.get(this.props.id);
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.stokesAnalysisWidgets) {
+            const widgetStore = widgetsStore.stokesAnalysisWidgets.get(this.props.id);
             if (widgetStore) {
                 return widgetStore;
             }
@@ -39,16 +40,16 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
 
     constructor(props: WidgetProps) {
         super(props);
+        const appStore = AppStore.Instance;
 
         autorun(() => {
             if (this.widgetStore) {
-                const appStore = this.props.appStore;
                 const frame = appStore.activeFrame;
                 if (frame) {
                     const regionId = this.widgetStore.effectiveRegionId;
                     const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
                     const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    this.props.appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `Stokes Analysis Settings: ${regionString} ${selectedString}`);
+                    appStore.widgetsStore.setWidgetTitle(this.props.floatingSettingsId, `Stokes Analysis Settings: ${regionString} ${selectedString}`);
                 }
             }
         });
@@ -59,7 +60,7 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
     };
 
     render() {
-        const appStore = this.props.appStore;
+        const appStore = AppStore.Instance;
         const widgetStore = this.widgetStore;
         const lineSettingsProps: LinePlotSettingsPanelComponentProps = {
             darkMode: appStore.darkTheme,
@@ -77,7 +78,7 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
             setSecondaryLineColor: widgetStore.setSecondaryLineColor
         };
 
-        const scatterSettingsProrps: ScatterPlotSettingsPanelComponentProps = {
+        const scatterSettingsProps: ScatterPlotSettingsPanelComponentProps = {
             colorMap: widgetStore.colorMap,
             scatterPlotPointSize: widgetStore.scatterPlotPointSize,
             pointTransparency: widgetStore.pointTransparency,
@@ -93,9 +94,9 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
         return (
             <div className="stokes-settings">
                 <Tabs id="spectralSettingTabs">
-                    <Tab id="conversion" title="Conversion" panel={<SpectralSettingsComponent appStore={appStore} widgetStore={widgetStore} disable={!hasStokes}/>}/>
+                    <Tab id="conversion" title="Conversion" panel={<SpectralSettingsComponent widgetStore={widgetStore} disable={!hasStokes}/>}/>
                     <Tab id="linePlotStyling" title="Line Plot Styling" panel={<LinePlotSettingsPanelComponent {...lineSettingsProps}/>}/>
-                    <Tab id="scatterPlotStyling" title="Scatter Plot Styling" panel={<ScatterPlotSettingsPanelComponent {...scatterSettingsProrps}/>}/>
+                    <Tab id="scatterPlotStyling" title="Scatter Plot Styling" panel={<ScatterPlotSettingsPanelComponent {...scatterSettingsProps}/>}/>
                 </Tabs>
             </div>
         );

--- a/src/components/StokesAnalysis/StokesAnalysisToolbarComponent/StokesAnalysisToolbarComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisToolbarComponent/StokesAnalysisToolbarComponent.tsx
@@ -7,24 +7,24 @@ import {RegionSelectorComponent} from "components";
 import "./StokesAnalysisToolbarComponent.css";
 
 @observer
-export class StokesAnalysisToolbarComponent extends React.Component<{widgetStore: StokesAnalysisWidgetStore, appStore: AppStore}> {
+export class StokesAnalysisToolbarComponent extends React.Component<{widgetStore: StokesAnalysisWidgetStore}> {
 
     private handleFractionalPolChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {
         this.props.widgetStore.setFractionalPolVisible(changeEvent.target.checked);
     };
 
     public render() {
-        const appStore = this.props.appStore;
         const widgetStore = this.props.widgetStore;
+        const frame = AppStore.Instance.activeFrame;
 
         let enableFractionalPol = false;
-        if (appStore.activeFrame && appStore.activeFrame.regionSet) {
-            enableFractionalPol = appStore.activeFrame.frameInfo.fileInfoExtended.stokes > 1;
+        if (frame && frame.regionSet) {
+            enableFractionalPol = frame.frameInfo.fileInfoExtended.stokes > 1;
         }
 
         return (
             <div className="stokes-analysis-toolbar">
-                <RegionSelectorComponent widgetStore={this.props.widgetStore} appStore={this.props.appStore}/>
+                <RegionSelectorComponent widgetStore={this.props.widgetStore}/>
                 <FormGroup label={"Frac. Pol."} inline={true} disabled={!enableFractionalPol}>
                     <Switch checked={widgetStore.fractionalPolVisible} onChange={this.handleFractionalPolChanged} disabled={!enableFractionalPol}/>
                 </FormGroup>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,10 +29,8 @@ FocusStyleManager.onlyShowFocusOnTabs();
 window["React"] = React; // tslint:disable-line
 window["ReactDOM"] = ReactDOM; // tslint:disable-line
 
-const appStore = new AppStore();
-
 ReactDOM.render(
-    <App appStore={appStore}/>,
+    <App/>,
     document.getElementById("root") as HTMLElement
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {FocusStyleManager} from "@blueprintjs/core";
 import {App} from "./App";
-import {AppStore} from "./stores";
 import {unregister} from "./registerServiceWorker";
 import "./index.css";
 import "@blueprintjs/core/lib/css/blueprint.css";

--- a/src/models/LayoutConfig.ts
+++ b/src/models/LayoutConfig.ts
@@ -467,8 +467,8 @@ export class LayoutConfig {
         });
     };
 
-    public static CreateConfigToApply = (appStore: AppStore, newParentContent: any, parentContent: any, componentConfigs: any[]) => {
-        if (!appStore || !newParentContent || !Array.isArray(newParentContent) || !parentContent || !Array.isArray(parentContent)) {
+    public static CreateConfigToApply = (newParentContent: any, parentContent: any, componentConfigs: any[]) => {
+        if (!newParentContent || !Array.isArray(newParentContent) || !parentContent || !Array.isArray(parentContent)) {
             return;
         }
 
@@ -487,7 +487,7 @@ export class LayoutConfig {
                     }
                     newParentContent.push(simpleChild);
                     if (child.content) {
-                        LayoutConfig.CreateConfigToApply(appStore, simpleChild.content, child.content, componentConfigs);
+                        LayoutConfig.CreateConfigToApply(simpleChild.content, child.content, componentConfigs);
                     }
                 } else if (child.type === "component" && child.id) {
                     const widgetType = (child.id).replace(/\-\d+$/, "");
@@ -502,7 +502,7 @@ export class LayoutConfig {
                         if ("widgetSettings" in child) {
                             componentConfig["widgetSettings"] = child.widgetSettings;
                         }
-                        componentConfig.props = {appStore: appStore, id: "", docked: true};
+                        componentConfig.props = {appStore: AppStore.Instance, id: "", docked: true};
                         componentConfigs.push(componentConfig);
                         newParentContent.push(componentConfig);
                     }

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -39,17 +39,17 @@ export class BackendService {
     private observerRequestMap: Map<number, Observer<any>>;
     private eventCounter: number;
     private sessionId: number;
-    // TODO: These can be readonly instead of private to get rid of boilerplate gets
-    private readonly rasterTileStream: Subject<CARTA.RasterTileData>;
+
+    readonly rasterTileStream: Subject<CARTA.RasterTileData>;
     readonly rasterSyncStream: Subject<CARTA.RasterTileSync>;
-    private readonly histogramStream: Subject<CARTA.RegionHistogramData>;
-    private readonly errorStream: Subject<CARTA.ErrorData>;
-    private readonly spatialProfileStream: Subject<CARTA.SpatialProfileData>;
-    private readonly spectralProfileStream: Subject<CARTA.SpectralProfileData>;
-    private readonly statsStream: Subject<CARTA.RegionStatsData>;
-    private readonly contourStream: Subject<CARTA.ContourImageData>;
-    private readonly catalogStream: Subject<CARTA.CatalogFilterResponse>;
-    private readonly reconnectStream: Subject<void>;
+    readonly histogramStream: Subject<CARTA.RegionHistogramData>;
+    readonly errorStream: Subject<CARTA.ErrorData>;
+    readonly spatialProfileStream: Subject<CARTA.SpatialProfileData>;
+    readonly spectralProfileStream: Subject<CARTA.SpectralProfileData>;
+    readonly statsStream: Subject<CARTA.RegionStatsData>;
+    readonly contourStream: Subject<CARTA.ContourImageData>;
+    readonly catalogStream: Subject<CARTA.CatalogFilterResponse>;
+    readonly reconnectStream: Subject<void>;
     private readonly handlerMap: Map<CARTA.EventType, HandlerFunction>;
     private readonly decoderMap: Map<CARTA.EventType, any>;
 
@@ -131,42 +131,6 @@ export class BackendService {
 
         // check ping every 5 seconds
         setInterval(this.sendPing, 5000);
-    }
-
-    getRasterTileStream() {
-        return this.rasterTileStream;
-    }
-
-    getRegionHistogramStream() {
-        return this.histogramStream;
-    }
-
-    getErrorStream() {
-        return this.errorStream;
-    }
-
-    getSpatialProfileStream() {
-        return this.spatialProfileStream;
-    }
-
-    getSpectralProfileStream() {
-        return this.spectralProfileStream;
-    }
-
-    getRegionStatsStream() {
-        return this.statsStream;
-    }
-
-    getContourStream() {
-        return this.contourStream;
-    }
-
-    getCatalogStream() {
-        return this.catalogStream;
-    }
-
-    getReconnectStream() {
-        return this.reconnectStream;
     }
 
     @action("connect")

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -14,6 +14,15 @@ export const INVALID_ANIMATION_ID = -1;
 type HandlerFunction = (eventId: number, parsedMessage: any) => void;
 
 export class BackendService {
+    private static staticInstance: BackendService;
+
+    static get Instance() {
+        if (!BackendService.staticInstance) {
+            BackendService.staticInstance = new BackendService();
+        }
+        return BackendService.staticInstance;
+    }
+
     private static readonly IcdVersion = 12;
     private static readonly DefaultFeatureFlags = CARTA.ClientFeatureFlags.WEB_ASSEMBLY | CARTA.ClientFeatureFlags.WEB_GL;
     @observable connectionStatus: ConnectionStatus;
@@ -41,14 +50,10 @@ export class BackendService {
     private readonly contourStream: Subject<CARTA.ContourImageData>;
     private readonly catalogStream: Subject<CARTA.CatalogFilterResponse>;
     private readonly reconnectStream: Subject<void>;
-    private readonly logStore: LogStore;
-    private readonly preferenceStore: PreferenceStore;
     private readonly handlerMap: Map<CARTA.EventType, HandlerFunction>;
     private readonly decoderMap: Map<CARTA.EventType, any>;
 
-    constructor(logStore: LogStore, preferenceStore: PreferenceStore) {
-        this.logStore = logStore;
-        this.preferenceStore = preferenceStore;
+    private constructor() {
         this.loggingEnabled = true;
         this.observerRequestMap = new Map<number, Observer<any>>();
         this.eventCounter = 1;
@@ -845,7 +850,7 @@ export class BackendService {
 
     private logEvent(eventType: CARTA.EventType, eventId: number, message: any, incoming: boolean = true) {
         const eventName = CARTA.EventType[eventType];
-        if (this.loggingEnabled && this.preferenceStore.isEventLoggingEnabled(eventType)) {
+        if (this.loggingEnabled && PreferenceStore.Instance.isEventLoggingEnabled(eventType)) {
             if (incoming) {
                 if (eventId === 0) {
                     console.log(`<== ${eventName} [Stream]`);

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -110,7 +110,7 @@ export class TileService {
         this.animationEnabled = false;
 
         this.tileStream = new Subject<TileStreamDetails>();
-        this.backendService.getRasterTileStream().subscribe(this.handleStreamedTiles);
+        this.backendService.rasterTileStream.subscribe(this.handleStreamedTiles);
         this.backendService.rasterSyncStream.subscribe(this.handleStreamSync);
 
         const ZFPWorker = require("worker-loader!zfp_wrapper");

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -33,6 +33,15 @@ export const NUM_PERSISTENT_LAYERS = 4;
 export const NUM_PERSISTENT_TILES = 85;
 
 export class TileService {
+    private static staticInstance: TileService;
+
+    static get Instance() {
+        if (!TileService.staticInstance) {
+            TileService.staticInstance = new TileService();
+        }
+        return TileService.staticInstance;
+    }
+
     private readonly backendService: BackendService;
     private readonly persistentTiles: Map<number, RasterTile>;
     private readonly cacheMapCompressedTiles: Map<number, LRUCache<number, CompressedTile>>;
@@ -85,8 +94,8 @@ export class TileService {
         this.lruCapacitySystem = lruCapacitySystem;
     };
 
-    constructor(backendService: BackendService) {
-        this.backendService = backendService;
+    private constructor() {
+        this.backendService = BackendService.Instance;
         this.gl = TileWebGLService.Instance.gl;
 
         this.channelMap = new Map<number, { channel: number, stokes: number }>();

--- a/src/stores/AlertStore.ts
+++ b/src/stores/AlertStore.ts
@@ -1,10 +1,19 @@
 import {action, observable} from "mobx";
 
 export class AlertStore {
-    @observable alertVisible;
-    @observable alertText;
-    @observable interactiveAlertVisible;
-    @observable interactiveAlertText;
+    private static staticInstance: AlertStore;
+
+    static get Instance() {
+        if (!AlertStore.staticInstance) {
+            AlertStore.staticInstance = new AlertStore();
+        }
+        return AlertStore.staticInstance;
+    }
+
+    @observable alertVisible: boolean;
+    @observable alertText: string;
+    @observable interactiveAlertVisible: boolean;
+    @observable interactiveAlertText: string;
     interactiveAlertCallback: (confirmed: boolean) => void;
 
     @action("show_alert") showAlert = (text: string) => {
@@ -31,5 +40,10 @@ export class AlertStore {
         if (this.interactiveAlertCallback) {
             this.interactiveAlertCallback(confirmed);
         }
+    }
+
+    private constructor() {
+        this.alertVisible = false;
+        this.interactiveAlertVisible = false;
     }
 }

--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -1,6 +1,6 @@
 import {action, computed, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
-import {AppStore, FrameStore} from "stores";
+import {AppStore, FrameStore, PreferenceStore} from "stores";
 import {clamp, GetRequiredTiles} from "utilities";
 import {FrameView, Point2D} from "models";
 
@@ -53,6 +53,7 @@ export class AnimatorStore {
 
     @action startAnimation = () => {
         const appStore = AppStore.Instance;
+        const preferenceStore = PreferenceStore.Instance;
         const frame = appStore.activeFrame;
         if (!frame) {
             return;
@@ -86,7 +87,7 @@ export class AnimatorStore {
             fileId: frame.frameInfo.fileId,
             tiles: tiles,
             compressionType: CARTA.CompressionType.ZFP,
-            compressionQuality: appStore.preferenceStore.animationCompressionQuality,
+            compressionQuality: preferenceStore.animationCompressionQuality,
         };
 
         const animationMessage: CARTA.IStartAnimation = {
@@ -111,7 +112,7 @@ export class AnimatorStore {
         this.animationState = AnimationState.PLAYING;
 
         clearTimeout(this.stopHandle);
-        this.stopHandle = setTimeout(this.stopAnimation, 1000 * 60 * appStore.preferenceStore.stopAnimationPlaybackMinutes);
+        this.stopHandle = setTimeout(this.stopAnimation, 1000 * 60 * preferenceStore.stopAnimationPlaybackMinutes);
     };
 
     @action stopAnimation = () => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -80,8 +80,6 @@ export class AppStore {
     readonly fileBrowserStore: FileBrowserStore;
     // Widgets
     readonly widgetsStore: WidgetsStore;
-    // Help
-    @observable helpStore: HelpStore;
 
     // Profiles and region data
     @observable spatialProfiles: Map<string, SpatialProfileStore>;
@@ -736,7 +734,6 @@ export class AppStore {
         this.widgetsStore = new WidgetsStore(this);
         this.initRequirements();
         this.dialogStore = new DialogStore(this);
-        this.helpStore = new HelpStore();
 
         const throttledSetCursorRotated = _.throttle(this.setCursor, AppStore.CursorThrottleTimeRotated);
         const throttledSetCursor = _.throttle(this.setCursor, AppStore.CursorThrottleTime);

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -825,14 +825,14 @@ export class AppStore {
         setInterval(this.recalculateRequirements, AppStore.RequirementsCheckInterval);
 
         // Subscribe to frontend streams
-        this.backendService.getSpatialProfileStream().subscribe(this.handleSpatialProfileStream);
-        this.backendService.getSpectralProfileStream().subscribe(this.handleSpectralProfileStream);
-        this.backendService.getRegionHistogramStream().subscribe(this.handleRegionHistogramStream);
-        this.backendService.getContourStream().subscribe(this.handleContourImageStream);
-        this.backendService.getCatalogStream().subscribe(this.handleCatalogFilterStream);
-        this.backendService.getErrorStream().subscribe(this.handleErrorStream);
-        this.backendService.getRegionStatsStream().subscribe(this.handleRegionStatsStream);
-        this.backendService.getReconnectStream().subscribe(this.handleReconnectStream);
+        this.backendService.spatialProfileStream.subscribe(this.handleSpatialProfileStream);
+        this.backendService.spectralProfileStream.subscribe(this.handleSpectralProfileStream);
+        this.backendService.histogramStream.subscribe(this.handleRegionHistogramStream);
+        this.backendService.contourStream.subscribe(this.handleContourImageStream);
+        this.backendService.catalogStream.subscribe(this.handleCatalogFilterStream);
+        this.backendService.errorStream.subscribe(this.handleErrorStream);
+        this.backendService.statsStream.subscribe(this.handleRegionStatsStream);
+        this.backendService.reconnectStream.subscribe(this.handleReconnectStream);
         this.tileService.tileStream.subscribe(this.handleTileStream);
 
         // Auth and connection

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -30,7 +30,7 @@ import {
     SpatialProfileStore,
     SpectralProfileStore,
     WidgetsStore,
-    CatalogStore
+    CatalogStore, HelpStore
 } from ".";
 import {distinct, GetRequiredTiles} from "utilities";
 import {BackendService, ConnectionStatus, TileService, TileStreamDetails} from "services";
@@ -50,8 +50,21 @@ export class AppStore {
     }
 
     // Backend services
-    backendService: BackendService;
-    tileService: TileService;
+    readonly backendService: BackendService;
+    readonly tileService: TileService;
+
+    // Other stores
+    readonly alertStore: AlertStore;
+    readonly animatorStore: AnimatorStore;
+    readonly catalogStore: CatalogStore;
+    readonly dialogStore: DialogStore;
+    readonly fileBrowserStore: FileBrowserStore;
+    readonly helpStore: HelpStore;
+    readonly layoutStore: LayoutStore;
+    readonly logStore: LogStore;
+    readonly overlayStore: OverlayStore;
+    readonly preferenceStore: PreferenceStore;
+    readonly widgetsStore: WidgetsStore;
 
     // WebAssembly Module status
     @observable astReady: boolean;
@@ -65,12 +78,6 @@ export class AppStore {
 
     // catalog map catalog widget store with file Id
     @observable catalogs: Map<string, number>;
-    // catalog data for image viewer
-    @observable catalogStore: CatalogStore;
-
-    readonly layoutStore: LayoutStore;
-    // Widgets
-    readonly widgetsStore: WidgetsStore;
 
     // Profiles and region data
     @observable spatialProfiles: Map<string, SpatialProfileStore>;
@@ -704,9 +711,23 @@ export class AppStore {
     }, AppStore.ImageChannelThrottleTime);
 
     private constructor() {
-        this.layoutStore = new LayoutStore(this, AlertStore.Instance);
+        // Assign service instances
         this.backendService = BackendService.Instance;
         this.tileService = TileService.Instance;
+
+        // Assign lower level store instances
+        this.alertStore = AlertStore.Instance;
+        this.animatorStore = AnimatorStore.Instance;
+        this.catalogStore = CatalogStore.Instance;
+        this.dialogStore = DialogStore.Instance;
+        this.fileBrowserStore = FileBrowserStore.Instance;
+        this.helpStore = HelpStore.Instance;
+        this.layoutStore = LayoutStore.Instance;
+        this.logStore = LogStore.Instance;
+        this.overlayStore = OverlayStore.Instance;
+        this.preferenceStore = PreferenceStore.Instance;
+        this.widgetsStore = WidgetsStore.Instance;
+
         this.astReady = false;
         this.cartaComputeReady = false;
         this.spatialProfiles = new Map<string, SpatialProfileStore>();
@@ -717,12 +738,10 @@ export class AppStore {
 
         this.frames = [];
         this.catalogs = new Map();
-        this.catalogStore = new CatalogStore();
         this.activeFrame = null;
         this.contourDataSource = null;
         this.syncFrameToContour = true;
         this.syncContourToFrame = true;
-        this.widgetsStore = new WidgetsStore(this);
         this.initRequirements();
 
         const throttledSetCursorRotated = _.throttle(this.setCursor, AppStore.CursorThrottleTimeRotated);

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -72,8 +72,6 @@ export class AppStore {
     @observable catalogStore: CatalogStore;
 
     readonly layoutStore: LayoutStore;
-    // Dialogs
-    readonly dialogStore: DialogStore;
     // Overlay
     readonly overlayStore: OverlayStore;
     // File Browser
@@ -733,7 +731,6 @@ export class AppStore {
         this.overlayStore = new OverlayStore(this, this.preferenceStore);
         this.widgetsStore = new WidgetsStore(this);
         this.initRequirements();
-        this.dialogStore = new DialogStore(this);
 
         const throttledSetCursorRotated = _.throttle(this.setCursor, AppStore.CursorThrottleTimeRotated);
         const throttledSetCursor = _.throttle(this.setCursor, AppStore.CursorThrottleTime);
@@ -840,7 +837,7 @@ export class AppStore {
 
         // Auth and connection
         if (process.env.REACT_APP_AUTHENTICATION === "true") {
-            this.dialogStore.showAuthDialog();
+            DialogStore.Instance.showAuthDialog();
         } else {
             this.connectToServer();
         }

--- a/src/stores/CatalogStore.ts
+++ b/src/stores/CatalogStore.ts
@@ -15,13 +15,22 @@ type CatalogSettings = {
 };
 
 export class CatalogStore {
+    private static staticInstance: CatalogStore;
+
+    static get Instance() {
+        if (!CatalogStore.staticInstance) {
+            CatalogStore.staticInstance = new CatalogStore();
+        }
+        return CatalogStore.staticInstance;
+    }
+
     private readonly degreeUnits = ["deg", "degrees"];
     private readonly arcsecUnits = ["arcsec", "arcsecond"];
     private readonly arcminUnits = ["arcmin", "arcminute"];
 
     @observable catalogs: ObservableMap<string, CatalogSettings>;
 
-    constructor() {
+    private constructor() {
         this.catalogs = new ObservableMap();
     }
 

--- a/src/stores/DialogStore.ts
+++ b/src/stores/DialogStore.ts
@@ -4,12 +4,19 @@ import {TabId} from "@blueprintjs/core";
 import {FileInfoType} from "../components";
 
 export class DialogStore {
-    private readonly appStore: AppStore;
-    
+    private static staticInstance: DialogStore;
+
+    static get Instance() {
+        if (!DialogStore.staticInstance) {
+            DialogStore.staticInstance = new DialogStore();
+        }
+        return DialogStore.staticInstance;
+    }
+
     // Region
     @observable regionDialogVisible: boolean;
     @action showRegionDialog = () => {
-        console.log(`Showing dialog for ${this.appStore.activeFrame.regionSet.selectedRegion}`);
+        console.log(`Showing dialog for ${AppStore.Instance.activeFrame.regionSet.selectedRegion}`);
         this.regionDialogVisible = true;
     };
     @action hideRegionDialog = () => {
@@ -109,9 +116,4 @@ export class DialogStore {
     @action hideContourDialog = () => {
         this.contourDialogVisible = false;
     };
-
-    constructor(appStore: AppStore) {
-        this.appStore = appStore;
-    }
-
 }

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -2,7 +2,7 @@ import {action, computed, observable} from "mobx";
 import {TabId} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {BackendService} from "services";
-import { AppStore } from "stores";
+import {AppStore, DialogStore} from "stores";
 import {FileInfoType} from "components";
 
 export enum BrowserMode {
@@ -44,7 +44,7 @@ export class FileBrowserStore {
     @action showFileBrowser = (mode: BrowserMode, append = false) => {
         this.appendingFrame = append;
         this.browserMode = mode;
-        this.appStore.dialogStore.showFileBrowserDialog();
+        DialogStore.Instance.showFileBrowserDialog();
         this.fileList = null;
         this.selectedTab = this.getBrowserMode;
         this.responseErrorMessage = "";
@@ -54,7 +54,7 @@ export class FileBrowserStore {
     };
 
     @action hideFileBrowser = () => {
-        this.appStore.dialogStore.hideFileBrowserDialog();
+        DialogStore.Instance.hideFileBrowserDialog();
     };
 
     @action getFileList = (directory: string) => {

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -17,7 +17,14 @@ export type ImageFileType = CARTA.FileType.CASA | CARTA.FileType.FITS | CARTA.Fi
 export type CatalogFileType = CARTA.CatalogFileType.VOTable;
 
 export class FileBrowserStore {
-    private readonly appStore: AppStore;
+    private static staticInstance: FileBrowserStore;
+
+    static get Instance() {
+        if (!FileBrowserStore.staticInstance) {
+            FileBrowserStore.staticInstance = new FileBrowserStore();
+        }
+        return FileBrowserStore.staticInstance;
+    }
 
     @observable browserMode: BrowserMode = BrowserMode.File;
     @observable appendingFrame = false;
@@ -58,6 +65,7 @@ export class FileBrowserStore {
     };
 
     @action getFileList = (directory: string) => {
+        const backendService = BackendService.Instance;
         this.loadingList = true;
         this.selectedFile = null;
         this.selectedHDU = null;
@@ -65,21 +73,21 @@ export class FileBrowserStore {
         this.regionFileInfo = null;
 
         if (this.browserMode === BrowserMode.File) {
-            this.backendService.getFileList(directory).subscribe(res => {
+            backendService.getFileList(directory).subscribe(res => {
                 this.fileList = res;
             }, err => {
                 console.log(err);
                 this.loadingList = false;
             });
         } else if (this.browserMode === BrowserMode.Catalog) {
-            this.backendService.getCatalogList(directory).subscribe(res => {
+            backendService.getCatalogList(directory).subscribe(res => {
                 this.catalogFileList = res;
             }, err => {
                 console.log(err);
                 this.loadingList = false;
             });
         } else {
-            this.backendService.getRegionList(directory).subscribe(res => {
+            backendService.getRegionList(directory).subscribe(res => {
                 this.fileList = res;
             }, err => {
                 console.log(err);
@@ -89,11 +97,13 @@ export class FileBrowserStore {
     };
 
     @action getFileInfo = (directory: string, file: string, hdu: string) => {
+        const backendService = BackendService.Instance;
         this.loadingInfo = true;
         this.fileInfoResp = false;
         this.fileInfoExtended = null;
         this.responseErrorMessage = "";
-        this.backendService.getFileInfo(directory, file, hdu).subscribe((res: CARTA.FileInfoResponse) => {
+
+        backendService.getFileInfo(directory, file, hdu).subscribe((res: CARTA.FileInfoResponse) => {
             if (res.fileInfo && this.selectedFile && res.fileInfo.name === this.selectedFile.name) {
                 this.fileInfoExtended = res.fileInfoExtended;
                 this.loadingInfo = false;
@@ -109,11 +119,13 @@ export class FileBrowserStore {
     };
 
     @action getRegionFileInfo = (directory: string, file: string) => {
+        const backendService = BackendService.Instance;
         this.loadingInfo = true;
         this.fileInfoResp = false;
         this.regionFileInfo = null;
         this.responseErrorMessage = "";
-        this.backendService.getRegionFileInfo(directory, file).subscribe((res: CARTA.IRegionFileInfoResponse) => {
+
+        backendService.getRegionFileInfo(directory, file).subscribe((res: CARTA.IRegionFileInfoResponse) => {
             if (res.fileInfo && this.selectedFile && res.fileInfo.name === this.selectedFile.name) {
                 this.loadingInfo = false;
                 this.regionFileInfo = res.contents;
@@ -129,11 +141,13 @@ export class FileBrowserStore {
     };
 
     @action getCatalogFileInfo = (directory: string, filename: string) => {
+        const backendService = BackendService.Instance;
         this.loadingInfo = true;
         this.fileInfoResp = false;
         this.catalogFileInfor = null;
         this.catalogHeaders = [];
-        this.backendService.getCatalogFileInfo(directory, filename).subscribe((res: CARTA.ICatalogFileInfoResponse) => {
+
+        backendService.getCatalogFileInfo(directory, filename).subscribe((res: CARTA.ICatalogFileInfoResponse) => {
             if (res.fileInfo && this.selectedFile && res.fileInfo.name === this.selectedFile.name) {
                 this.loadingInfo = false;
                 this.catalogFileInfor = res.fileInfo;
@@ -281,11 +295,7 @@ export class FileBrowserStore {
         return {columnHeaders: columnHeaders, columnsData: columnsData};
     }
 
-    private backendService: BackendService;
-
-    constructor(appStore: AppStore, backendService: BackendService) {
-        this.appStore = appStore;
-        this.backendService = backendService;
+    constructor() {
         this.exportCoordinateType = CARTA.CoordinateType.WORLD;
         this.exportFileType = CARTA.FileType.CRTF;
     }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -518,10 +518,11 @@ export class FrameStore {
     private static readonly CursorInfoMaxPrecision = 25;
     private static readonly ZoomInertiaDuration = 250;
 
-    constructor(overlay: OverlayStore, logStore: LogStore, frameInfo: FrameInfo, backendService: BackendService) {
-        this.overlayStore = overlay;
-        this.logStore = logStore;
-        this.backendService = backendService;
+    constructor(frameInfo: FrameInfo) {
+        this.overlayStore = OverlayStore.Instance;
+        this.logStore = LogStore.Instance;
+        this.backendService = BackendService.Instance;
+        const preferenceStore = PreferenceStore.Instance;
 
         this.spectralFrame = null;
         this.spectralType = null;
@@ -539,8 +540,8 @@ export class FrameStore {
         this.channel = 0;
         this.requiredStokes = 0;
         this.requiredChannel = 0;
-        this.renderConfig = new RenderConfigStore(PreferenceStore.Instance);
-        this.contourConfig = new ContourConfigStore(PreferenceStore.Instance);
+        this.renderConfig = new RenderConfigStore(preferenceStore);
+        this.contourConfig = new ContourConfigStore(preferenceStore);
         this.contourStores = new Map<number, ContourStore>();
         this.renderType = RasterRenderType.NONE;
         this.moving = false;
@@ -551,20 +552,19 @@ export class FrameStore {
         this.secondarySpatialImages = [];
         this.secondarySpectralImages = [];
 
-        const preferenceStore = PreferenceStore.Instance;
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preferenceStore.astColor;
-        if (astColor !== overlay.global.color) {
-            overlay.global.setColor(astColor);
+        if (astColor !== this.overlayStore.global.color) {
+            this.overlayStore.global.setColor(astColor);
         }
         const astGridVisible = preferenceStore.astGridVisible;
-        if (astGridVisible !== overlay.grid.visible) {
-            overlay.grid.setVisible(astGridVisible);
+        if (astGridVisible !== this.overlayStore.grid.visible) {
+            this.overlayStore.grid.setVisible(astGridVisible);
         }
         const astLabelsVisible = preferenceStore.astLabelsVisible;
-        if (astLabelsVisible !== overlay.labels.visible) {
-            overlay.labels.setVisible(astLabelsVisible);
+        if (astLabelsVisible !== this.overlayStore.labels.visible) {
+            this.overlayStore.labels.setVisible(astLabelsVisible);
         }
 
         this.regionSet = new RegionSetStore(this, PreferenceStore.Instance, BackendService.Instance);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -552,7 +552,6 @@ export class FrameStore {
         this.secondarySpatialImages = [];
         this.secondarySpectralImages = [];
 
-
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preferenceStore.astColor;
         if (astColor !== this.overlayStore.global.color) {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -99,7 +99,7 @@ export class FrameStore {
 
             const {minPoint, maxPoint} = minMax2D(corners);
             // Manually get adjusted zoom level and round to a power of 2
-            const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale;
+            const mipAdjustment = (PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0) / this.spatialTransform.scale;
             const mipExact = Math.max(1.0, mipAdjustment / this.spatialReference.zoomLevel);
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
@@ -128,7 +128,7 @@ export class FrameStore {
             const imageWidth = pixelRatio * this.renderWidth / this.zoomLevel;
             const imageHeight = pixelRatio * this.renderHeight / this.zoomLevel;
 
-            const mipAdjustment = (this.preference.lowBandwidthMode ? 2.0 : 1.0);
+            const mipAdjustment = (PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0);
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
@@ -508,7 +508,6 @@ export class FrameStore {
 
     private readonly overlayStore: OverlayStore;
     private readonly logStore: LogStore;
-    private readonly preference: PreferenceStore;
     private readonly backendService: BackendService;
     private readonly controlMaps: Map<FrameStore, ControlMap>;
     private spatialTransformAST: number;
@@ -519,11 +518,11 @@ export class FrameStore {
     private static readonly CursorInfoMaxPrecision = 25;
     private static readonly ZoomInertiaDuration = 250;
 
-    constructor(preference: PreferenceStore, overlay: OverlayStore, logStore: LogStore, frameInfo: FrameInfo, backendService: BackendService) {
+    constructor(overlay: OverlayStore, logStore: LogStore, frameInfo: FrameInfo, backendService: BackendService) {
         this.overlayStore = overlay;
         this.logStore = logStore;
         this.backendService = backendService;
-        this.preference = preference;
+
         this.spectralFrame = null;
         this.spectralType = null;
         this.spectralUnit = null;
@@ -540,33 +539,35 @@ export class FrameStore {
         this.channel = 0;
         this.requiredStokes = 0;
         this.requiredChannel = 0;
-        this.renderConfig = new RenderConfigStore(preference);
-        this.contourConfig = new ContourConfigStore(preference);
+        this.renderConfig = new RenderConfigStore(PreferenceStore.Instance);
+        this.contourConfig = new ContourConfigStore(PreferenceStore.Instance);
         this.contourStores = new Map<number, ContourStore>();
         this.renderType = RasterRenderType.NONE;
         this.moving = false;
         this.zooming = false;
-        this.overlayBeamSettings = new OverlayBeamStore(preference);
+        this.overlayBeamSettings = new OverlayBeamStore();
         this.spatialTransformAST = null;
         this.controlMaps = new Map<FrameStore, ControlMap>();
         this.secondarySpatialImages = [];
         this.secondarySpectralImages = [];
 
+        const preferenceStore = PreferenceStore.Instance;
+
         // synchronize AST overlay's color/grid/label with preference when frame is created
-        const astColor = preference.astColor;
+        const astColor = preferenceStore.astColor;
         if (astColor !== overlay.global.color) {
             overlay.global.setColor(astColor);
         }
-        const astGridVisible = preference.astGridVisible;
+        const astGridVisible = preferenceStore.astGridVisible;
         if (astGridVisible !== overlay.grid.visible) {
             overlay.grid.setVisible(astGridVisible);
         }
-        const astLabelsVisible = preference.astLabelsVisible;
+        const astLabelsVisible = preferenceStore.astLabelsVisible;
         if (astLabelsVisible !== overlay.labels.visible) {
             overlay.labels.setVisible(astLabelsVisible);
         }
 
-        this.regionSet = new RegionSetStore(this, preference, backendService);
+        this.regionSet = new RegionSetStore(this, PreferenceStore.Instance, BackendService.Instance);
         this.valid = true;
         this.currentFrameView = {
             xMin: 0,
@@ -584,7 +585,7 @@ export class FrameStore {
         this.initSpectralFrame();
         this.initSupportedSpectralConversion();
         this.initCenter();
-        this.zoomLevel = preference.isZoomRAWMode ? 1.0 : this.zoomLevelForFit;
+        this.zoomLevel = preferenceStore.isZoomRAWMode ? 1.0 : this.zoomLevelForFit;
 
         // init spectral settings
         if (this.spectralAxis && IsSpectralTypeSupported(this.spectralAxis.type.code as string) && IsSpectralUnitSupported(this.spectralAxis.type.unit as string)) {
@@ -598,7 +599,7 @@ export class FrameStore {
         // need initialized wcs to get correct cursor info
         this.cursorInfo = this.getCursorInfo(this.center);
         this.cursorValue = 0;
-        this.cursorFrozen = preference.isCursorFrozen;
+        this.cursorFrozen = preferenceStore.isCursorFrozen;
 
         autorun(() => {
             // update zoomLevel when image viewer is available for drawing
@@ -917,14 +918,15 @@ export class FrameStore {
     }
 
     public getControlMap(frame: FrameStore) {
+        const preferenceStore = PreferenceStore.Instance;
         let controlMap = this.controlMaps.get(frame);
         if (!controlMap) {
             const tStart = performance.now();
-            controlMap = new ControlMap(this, frame, -1, this.preference.contourControlMapWidth, this.preference.contourControlMapWidth);
+            controlMap = new ControlMap(this, frame, -1, preferenceStore.contourControlMapWidth, preferenceStore.contourControlMapWidth);
             this.controlMaps.set(frame, controlMap);
             const tEnd = performance.now();
             const dt = tEnd - tStart;
-            console.log(`Created ${this.preference.contourControlMapWidth}x${this.preference.contourControlMapWidth} transform grid for ${this.frameInfo.fileId} -> ${frame.frameInfo.fileId} in ${dt} ms`);
+            console.log(`Created ${preferenceStore.contourControlMapWidth}x${preferenceStore.contourControlMapWidth} transform grid for ${this.frameInfo.fileId} -> ${frame.frameInfo.fileId} in ${dt} ms`);
         }
 
         return controlMap;
@@ -993,7 +995,7 @@ export class FrameStore {
 
         if (recursive) {
             this.spectralSiblings.forEach(frame => {
-                const siblingChannel = getTransformedChannel(this.fullWcsInfo, frame.fullWcsInfo, this.preference.spectralMatchingType, sanitizedChannel);
+                const siblingChannel = getTransformedChannel(this.fullWcsInfo, frame.fullWcsInfo, PreferenceStore.Instance.spectralMatchingType, sanitizedChannel);
                 frame.setChannels(siblingChannel, frame.requiredStokes, false);
             });
 
@@ -1063,7 +1065,7 @@ export class FrameStore {
             const pointRefImage = getTransformedCoordinates(this.spatialTransformAST, {x, y}, true);
             this.spatialReference.zoomToPoint(pointRefImage.x, pointRefImage.y, adjustedZoom);
         } else {
-            if (this.preference.zoomPoint === ZoomPoint.CURSOR) {
+            if (PreferenceStore.Instance.zoomPoint === ZoomPoint.CURSOR) {
                 this.center = {
                     x: x + this.zoomLevel / zoom * (this.center.x - x),
                     y: y + this.zoomLevel / zoom * (this.center.y - y)
@@ -1135,6 +1137,7 @@ export class FrameStore {
             return;
         }
 
+        const preferenceStore = PreferenceStore.Instance;
         this.contourConfig.setEnabled(true);
 
         // TODO: Allow a different reference frame
@@ -1150,9 +1153,9 @@ export class FrameStore {
                 yMin: 0,
                 yMax: this.frameInfo.fileInfoExtended.height,
             },
-            decimationFactor: this.preference.contourDecimation,
-            compressionLevel: this.preference.contourCompressionLevel,
-            contourChunkSize: this.preference.contourChunkSize
+            decimationFactor: preferenceStore.contourDecimation,
+            compressionLevel: preferenceStore.contourCompressionLevel,
+            contourChunkSize: preferenceStore.contourChunkSize
         };
         this.backendService.setContourParameters(contourParameters);
     };
@@ -1271,11 +1274,12 @@ export class FrameStore {
         // For now, this is just done to ensure a mapping can be constructed
         const copySrc = AST.copy(this.fullWcsInfo);
         const copyDest = AST.copy(frame.fullWcsInfo);
-        const spectralMatchingType = this.preference.spectralMatchingType;
+        const preferenceStore = PreferenceStore.Instance;
+        const spectralMatchingType = preferenceStore.spectralMatchingType;
         // Ensure that a mapping for the current alignment system is possible
         if (spectralMatchingType !== SpectralType.CHANNEL) {
-            AST.set(copySrc, `AlignSystem=${this.preference.spectralMatchingType}`);
-            AST.set(copyDest, `AlignSystem=${this.preference.spectralMatchingType}`);
+            AST.set(copySrc, `AlignSystem=${preferenceStore.spectralMatchingType}`);
+            AST.set(copyDest, `AlignSystem=${preferenceStore.spectralMatchingType}`);
         }
         AST.invert(copySrc);
         AST.invert(copyDest);
@@ -1291,7 +1295,7 @@ export class FrameStore {
 
         this.spectralReference = frame;
         this.spectralReference.addSecondarySpectralImage(this);
-        const matchedChannel = getTransformedChannel(frame.fullWcsInfo, this.fullWcsInfo, this.preference.spectralMatchingType, frame.requiredChannel);
+        const matchedChannel = getTransformedChannel(frame.fullWcsInfo, this.fullWcsInfo, preferenceStore.spectralMatchingType, frame.requiredChannel);
         this.setChannels(matchedChannel, this.requiredStokes, false);
         return true;
     };

--- a/src/stores/HelpStore.ts
+++ b/src/stores/HelpStore.ts
@@ -2,6 +2,15 @@ import {action, observable} from "mobx";
 import {Position} from "@blueprintjs/core";
 
 export class HelpStore {
+    private static staticInstance: HelpStore;
+
+    static get Instance() {
+        if (!HelpStore.staticInstance) {
+            HelpStore.staticInstance = new HelpStore();
+        }
+        return HelpStore.staticInstance;
+    }
+
     @observable type: HelpType;
     @observable helpVisible: boolean = false;
     @observable position: Position = Position.RIGHT;

--- a/src/stores/LogStore.ts
+++ b/src/stores/LogStore.ts
@@ -9,12 +9,21 @@ export class LogEntry {
 }
 
 export class LogStore {
+    private static staticInstance: LogStore;
+
+    static get Instance() {
+        if (!LogStore.staticInstance) {
+            LogStore.staticInstance = new LogStore();
+        }
+        return LogStore.staticInstance;
+    }
+
     @observable logEntries: LogEntry[];
     @observable hiddenTags: string[];
     @observable logLevel: CARTA.ErrorSeverity;
     readonly logLimit = 1000;
 
-    constructor() {
+    private constructor() {
         this.logEntries = [];
         this.hiddenTags = [];
         this.logLevel = CARTA.ErrorSeverity.INFO;

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -702,9 +702,9 @@ export class OverlayBeamSettings {
     constructor() {
         this.selectedFileId = -1;
         this.settingsForDisplay = null;
-        const appStore = AppStore.Instance;
 
         autorun(() => {
+            const appStore = AppStore.Instance;
             if (appStore.activeFrame && appStore.activeFrame.frameInfo && appStore.activeFrame.frameInfo.fileInfo) {
                 this.setSelectedFrame(appStore.activeFrame.frameInfo.fileId);
             }

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -114,10 +114,10 @@ export class OverlayGlobalSettings {
         return this.system;
     }
 
-    constructor(readonly preferenceStore: PreferenceStore) {
+    constructor() {
         this.system = SystemType.Auto;
         this.labelType = LabelType.Exterior;
-        this.color = preferenceStore.astColor;
+        this.color = PreferenceStore.Instance.astColor;
         this.tolerance = 2; // percentage
 
         this.defaultSystem = SystemType.Auto;
@@ -236,8 +236,8 @@ export class OverlayGridSettings {
         return astString.toString();
     }
 
-    constructor(readonly preference: PreferenceStore) {
-        this.visible = preference.astGridVisible;
+    constructor() {
+        this.visible = PreferenceStore.Instance.astGridVisible;
         this.customColor = false;
         this.color = AST_DEFAULT_COLOR;
         this.width = 1;
@@ -587,8 +587,8 @@ export class OverlayLabelSettings {
     @observable customLabelX: string;
     @observable customLabelY: string;
 
-    constructor(readonly preference: PreferenceStore) {
-        this.visible = preference.astLabelsVisible;
+    constructor() {
+        this.visible = PreferenceStore.Instance.astLabelsVisible;
         this.hidden = false;
         this.fontSize = 15;
         this.font = 0;
@@ -661,7 +661,8 @@ export class OverlayBeamStore {
     @observable shiftX: number;
     @observable shiftY: number;
 
-    constructor(readonly preference: PreferenceStore) {
+    constructor() {
+        const preference = PreferenceStore.Instance;
         this.visible = preference.beamVisible;
         this.color = preference.beamColor;
         this.type = preference.beamType;
@@ -695,19 +696,17 @@ export class OverlayBeamStore {
 }
 
 export class OverlayBeamSettings {
-    private readonly appStore: AppStore;
-
     @observable selectedFileId: number;
     @observable settingsForDisplay: OverlayBeamStore;
 
-    constructor(appStore: AppStore) {
-        this.appStore = appStore;
+    constructor() {
         this.selectedFileId = -1;
         this.settingsForDisplay = null;
+        const appStore = AppStore.Instance;
 
         autorun(() => {
-            if (this.appStore.activeFrame && this.appStore.activeFrame.frameInfo && this.appStore.activeFrame.frameInfo.fileInfo) {
-                this.setSelectedFrame(this.appStore.activeFrame.frameInfo.fileId);
+            if (appStore.activeFrame && appStore.activeFrame.frameInfo && appStore.activeFrame.frameInfo.fileInfo) {
+                this.setSelectedFrame(appStore.activeFrame.frameInfo.fileId);
             }
         });
     }
@@ -718,7 +717,7 @@ export class OverlayBeamSettings {
 
     @action setSelectedFrame = (selectedFileId: number) => {
         this.selectedFileId = selectedFileId;
-        const frame = this.appStore.getFrame(selectedFileId);
+        const frame = AppStore.Instance.getFrame(selectedFileId);
         if (frame && frame.overlayBeamSettings) {
             this.settingsForDisplay = frame.overlayBeamSettings;
         }
@@ -726,7 +725,14 @@ export class OverlayBeamSettings {
 }
 
 export class OverlayStore {
-    private readonly preference: PreferenceStore;
+    private static staticInstance: OverlayStore;
+
+    static get Instance() {
+        if (!OverlayStore.staticInstance) {
+            OverlayStore.staticInstance = new OverlayStore();
+        }
+        return OverlayStore.staticInstance;
+    }
 
     // View size options
     @observable viewWidth: number;
@@ -743,17 +749,16 @@ export class OverlayStore {
     @observable ticks: OverlayTickSettings;
     @observable beam: OverlayBeamSettings;
 
-    constructor(appStore: AppStore, preference: PreferenceStore) {
-        this.preference = preference;
-        this.global = new OverlayGlobalSettings(preference);
+    private constructor() {
+        this.global = new OverlayGlobalSettings();
         this.title = new OverlayTitleSettings();
-        this.grid = new OverlayGridSettings(preference);
+        this.grid = new OverlayGridSettings();
         this.border = new OverlayBorderSettings();
         this.axes = new OverlayAxisSettings();
         this.numbers = new OverlayNumberSettings();
-        this.labels = new OverlayLabelSettings(preference);
+        this.labels = new OverlayLabelSettings();
         this.ticks = new OverlayTickSettings();
-        this.beam = new OverlayBeamSettings(appStore);
+        this.beam = new OverlayBeamSettings();
         this.viewHeight = 1;
         this.viewWidth = 1;
 
@@ -775,7 +780,7 @@ export class OverlayStore {
             this.numbers.setDefaultFormatX(undefined);
             this.numbers.setDefaultFormatY(undefined);
         } else {
-            switch (this.preference.wcsType) {
+            switch (PreferenceStore.Instance.wcsType) {
                 case WCSType.DEGREES:
                     this.numbers.setDefaultFormatX("d");
                     this.numbers.setDefaultFormatY("d");

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -57,7 +57,6 @@ export class WidgetConfig {
 }
 
 export class WidgetProps {
-    appStore: AppStore;
     id: string;
     docked: boolean;
     floatingSettingsId?: string;
@@ -420,7 +419,7 @@ export class WidgetsStore {
                     const stackHeaderControlButtons = stack.header.controlsContainer[0];
                     if (component && showCogWidgets.includes(component) && stackHeaderControlButtons && stackHeaderControlButtons.childElementCount < 5) {
                         const cogPinedButton = $(`<li class="lm_settings" title="settings"><span class="bp3-icon-standard bp3-icon-cog"/></li>`);
-                        cogPinedButton.on("click", () => contentItem.config.props.appStore.widgetsStore.onCogPinedClick(stack.getActiveContentItem()));
+                        cogPinedButton.on("click", () => WidgetsStore.Instance.onCogPinedClick(stack.getActiveContentItem()));
                         stack.header.controlsContainer.prepend(cogPinedButton);
                     } else if (!showCogWidgets.includes(component) && stackHeaderControlButtons && stackHeaderControlButtons.childElementCount === 5) {
                         stack.header.controlsContainer[0].children[0].remove();

--- a/src/stores/WidgetsStore.ts
+++ b/src/stores/WidgetsStore.ts
@@ -25,7 +25,7 @@ import {
     RenderConfigSettingsPanelComponent,
     HistogramSettingsPanelComponent
 } from "components";
-import {AppStore, HelpType} from "stores";
+import {AppStore, HelpStore, HelpType} from "stores";
 import {
     EmptyWidgetStore, 
     HistogramWidgetStore, 
@@ -532,7 +532,7 @@ export class WidgetsStore {
             if (container && container.width) {
                 centerX = ev.target.getBoundingClientRect().right + 36 - container.width * 0.5; // 36(px) is the length between help button and right border of widget
             }
-            this.appStore.helpStore.showHelpDrawer(widgetConfig.helpType, centerX);
+            HelpStore.Instance.showHelpDrawer(widgetConfig.helpType, centerX);
         }
     };
 

--- a/src/stores/widgets/CatalogOverlayWidgetStore.ts
+++ b/src/stores/widgets/CatalogOverlayWidgetStore.ts
@@ -106,8 +106,8 @@ export class CatalogOverlayWidgetStore extends RegionWidgetStore {
     @observable showSelectedData: boolean;
     @observable catalogTableRef: Table;
 
-    constructor(appStore: AppStore, catalogInfo: CatalogInfo, catalogHeader: Array<CARTA.ICatalogHeader>, catalogData: CARTA.ICatalogColumnsData, id: string) {
-        super(appStore, RegionsType.CLOSED_AND_POINT);
+    constructor(catalogInfo: CatalogInfo, catalogHeader: Array<CARTA.ICatalogHeader>, catalogData: CARTA.ICatalogColumnsData, id: string) {
+        super(RegionsType.CLOSED_AND_POINT);
         this.storeId = id;
         this.catalogInfo = catalogInfo;
         this.catalogHeader = catalogHeader.sort((a, b) => { return (a.columnIndex - b.columnIndex); });

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -121,8 +121,8 @@ export class HistogramWidgetStore extends RegionWidgetStore {
         return diffList;
     }
 
-    constructor(appStore: AppStore) {
-        super(appStore, RegionsType.CLOSED);
+    constructor() {
+        super(RegionsType.CLOSED);
         this.logScaleY = true;
         this.plotType = PlotType.STEPS;
         this.primaryLineColor = { colorHex: Colors.BLUE2, fixed: false };

--- a/src/stores/widgets/RegionWidgetStore.ts
+++ b/src/stores/widgets/RegionWidgetStore.ts
@@ -17,8 +17,9 @@ export class RegionWidgetStore {
     @observable regionIdMap: Map<number, number>;
     @observable type: RegionsType;
 
-    constructor(appStore: AppStore, type: RegionsType) {
-        this.appStore = appStore;
+    constructor(type: RegionsType) {
+        // TODO: Do we need a ref here?
+        this.appStore = AppStore.Instance;
         this.type = type;
         this.regionIdMap = new Map<number, number>();
     }

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -153,8 +153,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.isMouseMoveIntoLinePlots = val;
     };
 
-    constructor(appStore: AppStore, coordinate: string = "z") {
-        super(appStore, RegionsType.CLOSED_AND_POINT);
+    constructor(coordinate: string = "z") {
+        super(RegionsType.CLOSED_AND_POINT);
         this.coordinate = coordinate;
         this.statsType = CARTA.StatsType.Mean;
 

--- a/src/stores/widgets/StatsWidgetStore.ts
+++ b/src/stores/widgets/StatsWidgetStore.ts
@@ -4,8 +4,8 @@ import {RegionWidgetStore, RegionsType} from "stores/widgets";
 
 export class StatsWidgetStore extends RegionWidgetStore {
 
-    constructor(appStore: AppStore) {
-        super(appStore, RegionsType.CLOSED);
+    constructor() {
+        super(RegionsType.CLOSED);
     }
 
     public static DiffRequirementsArray(originalRequirements: Map<number, Array<number>>, updatedRequirements: Map<number, Array<number>>) {

--- a/src/stores/widgets/StokesAnalysisWidgetStore.ts
+++ b/src/stores/widgets/StokesAnalysisWidgetStore.ts
@@ -214,8 +214,8 @@ export class StokesAnalysisWidgetStore extends RegionWidgetStore {
         this.clearScatterPlotXYBounds();
     };
 
-    constructor(appStore: AppStore) {
-        super(appStore, RegionsType.CLOSED_AND_POINT);
+    constructor() {
+        super(RegionsType.CLOSED_AND_POINT);
         this.colorMap = DEFAULTS.colorMap;
         this.colorPixel = getColorsForValues(DEFAULTS.colorMap);
         this.statsType = CARTA.StatsType.Mean;


### PR DESCRIPTION
Code refactoring using the singleton pattern, as discussed in frontend channel and mentioned in #872.

This should allow us to avoid passing single-instance stores and services (e.g. `AppStore`) to loads of components. I've tried to be consistent with my use of `<store name>.Instance`:

- if a function requires `AppStore` more than once (or any of the stores that are contained in `AppStore`), then a temporary variable `const appStore = AppStore.Instance` is used, and `appStore` is used to access the stores contained by `AppStore`, rather than using `SubStore.Instance`
- if a function only requires a sub-store once, I use `SubStore.Instance`, rather than `AppStore.Instance.subStore`. 
- if a sub-store is used _many_ times in a function, I create a temporary variable `const subStore = appStore.subStore` or `const subStore = SubStore.Instance`. 

In the end, this PR is about making things more easily maintained and more readable. Let me know if any things look _less_ readable after these changes, or if you spot any inconsistencies.