### PR TITLE
optimisations of WCS transforms and catalog plot data arrays

### DIFF
--- a/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewComponent.tsx
@@ -28,8 +28,6 @@ export class CatalogViewComponent extends React.Component<CatalogViewComponentPr
         catalogStore.catalogs.forEach((catalog, key) => {
             const selectedPointIndexs = catalog.selectedPointIndexs;
             let data: Plotly.Data = {};
-            let xArray = [];
-            let yArray = [];
 
             data.type = "scattergl";
             data.mode = "markers";
@@ -43,9 +41,19 @@ export class CatalogViewComponent extends React.Component<CatalogViewComponentPr
                 }
             };
 
+            let totalLength = 0;
             for (let i = 0; i < catalog.xImageCoords.length; i++) {
-                xArray.push(...catalog.xImageCoords[i]);
-                yArray.push(...catalog.yImageCoords[i]);
+                totalLength += catalog.xImageCoords[i].length;
+            }
+
+            const xArray = new Float64Array(totalLength);
+            const yArray = new Float64Array(totalLength);
+
+            let offset = 0;
+            for (let i = 0; i < catalog.xImageCoords.length; i++) {
+                xArray.set(catalog.xImageCoords[i], offset);
+                yArray.set(catalog.yImageCoords[i], offset);
+                offset += catalog.xImageCoords[i].length;
             }
 
             data.x = xArray;

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -474,7 +474,7 @@ export class BackendService {
             }
         }
         return false;
-    } 
+    }
 
     @action("set spatial requirements")
     setSpatialRequirements(requirementsMessage: CARTA.ISetSpectralRequirements) {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -683,6 +683,20 @@ export class FrameStore {
             this.overlayStore.setDefaultsFromAST(this);
             console.log("Initialised WCS info from frame");
         }
+
+        // const N = 100;
+        // const xWCSValues = new Float64Array(N);
+        // const yWCSValues = new Float64Array(N);
+        //
+        // for (let i = 0; i < N; i++) {
+        //     xWCSValues[i] = 2.6349675579325287 + 0.0001 * i;
+        //     yWCSValues[i] = 0.024208492616605525 + 0.0001 * i;
+        // }
+        //
+        // console.log(xWCSValues);
+        // console.log(yWCSValues);
+        // const results = AST.transformPointArrays(this.wcsInfo, xWCSValues, yWCSValues, false);
+        // console.log(results);
     };
 
     @action private initFullWCS = () => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -683,20 +683,6 @@ export class FrameStore {
             this.overlayStore.setDefaultsFromAST(this);
             console.log("Initialised WCS info from frame");
         }
-
-        // const N = 100;
-        // const xWCSValues = new Float64Array(N);
-        // const yWCSValues = new Float64Array(N);
-        //
-        // for (let i = 0; i < N; i++) {
-        //     xWCSValues[i] = 2.6349675579325287 + 0.0001 * i;
-        //     yWCSValues[i] = 0.024208492616605525 + 0.0001 * i;
-        // }
-        //
-        // console.log(xWCSValues);
-        // console.log(yWCSValues);
-        // const results = AST.transformPointArrays(this.wcsInfo, xWCSValues, yWCSValues, false);
-        // console.log(results);
     };
 
     @action private initFullWCS = () => {

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -140,32 +140,35 @@ Module.getFormattedCoordinates = function (wcsInfo: number, x: number, y: number
     return {x: xFormat, y: yFormat};
 };
 
-Module.pixToWCSVector = function (wcsInfo, xIn, yIn) {
+Module.transformPointArrays = function (wcsInfo: number, xIn: Float64Array, yIn: Float64Array, forward: number) {
     // Return empty array if arguments are invalid
     if (!(xIn instanceof Float64Array) || !(yIn instanceof Float64Array) || xIn.length !== yIn.length) {
         return {x: new Float64Array(1), y: new Float64Array(1)};
     }
 
+    // Allocate and assign WASM memory
     const N = xIn.length;
-    // Return
-    if (N > Module.numArrayCoordinates) {
-        Module._free(Module.xIn);
-        Module._free(Module.yIn);
-        Module._free(Module.xOut);
-        Module._free(Module.yOut);
-        Module.numArrayCoordinates = N;
-        Module.xIn = Module._malloc(Module.numArrayCoordinates * 8);
-        Module.yIn = Module._malloc(Module.numArrayCoordinates * 8);
-        Module.xOut = Module._malloc(Module.numArrayCoordinates * 8);
-        Module.yOut = Module._malloc(Module.numArrayCoordinates * 8);
-    }
+    const xInPtr = Module._malloc(N * 8);
+    const yInPtr = Module._malloc(N * 8);
+    const xOutPtr = Module._malloc(N * 8);
+    const yOutPtr = Module._malloc(N * 8);
+    Module.HEAPF64.set(xIn, xInPtr / 8);
+    Module.HEAPF64.set(yIn, yInPtr / 8);
 
-    Module.HEAPF64.set(xIn, Module.xIn / 8);
-    Module.HEAPF64.set(yIn, Module.yIn / 8);
-    Module.transform(wcsInfo, N, Module.xIn, Module.yIn, 1, Module.xOut, Module.yOut);
-    const xOut = new Float64Array(Module.HEAPF64.buffer, Module.xOut, N);
-    const yOut = new Float64Array(Module.HEAPF64.buffer, Module.yOut, N);
-    return {x: xOut.slice(0), y: yOut.slice(0)};
+    // Perform the AST transform
+    Module.transform(wcsInfo, N, xInPtr, yInPtr, forward, xOutPtr, yOutPtr);
+
+    // Copy result out to an object
+    const xOut = new Float64Array(Module.HEAPF64.buffer, xOutPtr, N);
+    const yOut = new Float64Array(Module.HEAPF64.buffer, yOutPtr, N);
+    const result = {x: xOut.slice(0), y: yOut.slice(0)};
+
+    // Free WASM memory
+    Module._free(xInPtr);
+    Module._free(yInPtr);
+    Module._free(xOutPtr);
+    Module._free(yOutPtr);
+    return result;
 };
 
 Module.transformPoint = function (transformFrameSet: number, xIn: number, yIn: number, forward: boolean = true) {

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
+    -s EXPORTED_FUNCTIONS='["_malloc", "_free", "_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then


### PR DESCRIPTION
- makes a single `AST` call for a `Float64Array` of coordinates, rather than transforming one-by-one in separate WebAssembly calls
- stores data for plotly as `Float64Array`, allowing for much faster concatenation using `set`, instead of manually pushing back values to the array.