### PR TITLE
adjusted lib builds to use a common install directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ src/static/gitInfo.ts
 # NPM package lock (ignored while in active development)
 /package-lock.json
 
+/wasm_libs/built/

--- a/wasm_libs/build_ast.sh
+++ b/wasm_libs/build_ast.sh
@@ -14,10 +14,11 @@ cd ast
 patch -i ../0001-New-attribute-TextGapType-for-the-plot-class.patch
 
 echo "Building AST using Emscripten"
-CFLAGS="-g0 -O3 -s WASM=1" emconfigure ./configure --without-pthreads --without-fortran --without-stardocs --enable-shared=no --host=wasm32
+CFLAGS="-g0 -O3 -s WASM=1" emconfigure ./configure --without-pthreads --without-fortran --without-stardocs --enable-shared=no --host=wasm32 --prefix=${PWD}/../built
 emmake make -j 4
+emmake make install
 echo "Checking for AST static lib..."
-if [[ $(find .libs/libast.a -type f -size +1000000c 2>/dev/null) ]]; then
+if [[ $(find ../built/lib/libast.a -type f -size +1000000c 2>/dev/null) ]]; then
     echo "Found"
 else
     echo "Not found!"

--- a/wasm_libs/build_zfp.sh
+++ b/wasm_libs/build_zfp.sh
@@ -12,10 +12,11 @@ cd zfp
 mkdir -p build
 cd build
 echo "Building ZFP using Emscripten"
-emcmake cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s WASM=1" -DZFP_WITH_OPENMP=OFF -DBUILD_UTILITIES=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DZFP_ENABLE_PIC=OFF ../
+emcmake cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s WASM=1" -DZFP_WITH_OPENMP=OFF -DBUILD_UTILITIES=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DZFP_ENABLE_PIC=OFF -DCMAKE_INSTALL_PREFIX=${PWD}/../../built ../
 emmake make -j4
+emmake make install
 echo "Checking for ZFP static lib..."
-if [[ $(find -L ./lib/libzfp.a -type f -size +192000c 2>/dev/null) ]]; then
+if [[ $(find -L ../../lib/libzfp.a -type f -size +192000c 2>/dev/null) ]]; then
     echo "Found"
 else
     echo "Not found!"

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -6,7 +6,7 @@ printf "Building AST wrapper..."
 npx tsc pre.ts --outFile build/pre.js
 npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
-    -I../../wasm_libs/ast -L../../wasm_libs/ast/.libs -last -last_pal -lm -g0 -O2 \
+    -I../../wasm_libs/built/include -L../../wasm_libs/built/lib -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
     -s EXPORTED_FUNCTIONS='["_malloc", "_free", "_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 

--- a/wasm_src/build_zfp_wrapper.sh
+++ b/wasm_src/build_zfp_wrapper.sh
@@ -5,8 +5,8 @@ mkdir -p build
 printf "Building ZFP wrapper..."
 npx tsc pre.ts --outFile build/pre.js
 npx tsc post.ts --outFile build/post.js
-emcc -o build/zfp_wrapper.js zfp_wrapper.c --pre-js build/pre.js --post-js build/post.js -I ../../wasm_libs/zfp/include \
-    -L../../wasm_libs/zfp/build/lib -lm -lzfp -g0 -O2 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
+emcc -o build/zfp_wrapper.js zfp_wrapper.c --pre-js build/pre.js --post-js build/post.js -I ../../wasm_libs/built/include \
+    -L../../wasm_libs/built/lib -lm -lzfp -g0 -O2 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
     -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS='["_zfpDecompress", "_malloc", "_free"]' \
     -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 


### PR DESCRIPTION
Rather than using half-built libraries, this runs `make install` where applicable and installs the built libs to a `built` directory under `wasm_libs`, which allows for neater including when building wrappers. It's also the only way to get a full set of include files in the right directory for some libraries (GSL, which @TienHao is using for profile smoothing)
