### PR TITLE
Angus/auto dark mode

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -34,7 +34,7 @@ export class PreferenceDialogComponent extends React.Component {
     private renderPercentileSelectItem = (percentile: string, {handleClick, modifiers, query}) => {
         return <MenuItem text={percentile + "%"} onClick={handleClick} key={percentile}/>;
     };
-    
+
     private handleImageCompressionQualityChange = _.throttle((value: number) => {
         PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY, value);
     }, 100);
@@ -87,16 +87,14 @@ export class PreferenceDialogComponent extends React.Component {
         const globalPanel = (
             <React.Fragment>
                 <FormGroup inline={true} label="Theme">
-                    <RadioGroup
-                        selectedValue={preference.theme}
-                        onChange={(ev) => {
-                            ev.currentTarget.value === Theme.LIGHT ? appStore.setLightTheme() : appStore.setDarkTheme();
-                        }}
-                        inline={true}
+                    <HTMLSelect
+                        value={preference.theme}
+                        onChange={(ev) => appStore.preferenceStore.setPreference(PreferenceKeys.GLOBAL_THEME, ev.currentTarget.value)}
                     >
-                        <Radio label="Light" value={Theme.LIGHT}/>
-                        <Radio label="Dark" value={Theme.DARK}/>
-                    </RadioGroup>
+                        <option value={Theme.AUTO}>Automatic</option>
+                        <option value={Theme.LIGHT}>Light</option>
+                        <option value={Theme.DARK}>Dark</option>
+                    </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Auto-launch File Browser">
                     <Switch checked={preference.autoLaunch} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_AUTOLAUNCH, ev.currentTarget.checked)}/>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -88,6 +88,7 @@ export class RootMenuComponent extends React.Component {
         const viewMenu = (
             <Menu>
                 <Menu.Item text="Interface" icon={"control"}>
+                    <Menu.Item text="Automatic" icon={"contrast"} onClick={appStore.setAutoTheme}/>
                     <Menu.Item text="Light" icon={"flash"} onClick={appStore.setLightTheme}/>
                     <Menu.Item text="Dark" icon={"moon"} onClick={appStore.setDarkTheme}/>
                 </Menu.Item>

--- a/src/models/Theme.ts
+++ b/src/models/Theme.ts
@@ -1,8 +1,9 @@
 export class Theme {
     public static readonly LIGHT = "light";
     public static readonly DARK = "dark";
+    public static readonly AUTO = "auto";
 
     public static isValid = (theme: string): boolean => {
-        return theme && (theme === Theme.LIGHT || theme === Theme.DARK);
+        return theme && (theme === Theme.LIGHT || theme === Theme.DARK || theme === Theme.AUTO);
     };
 }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -227,9 +227,17 @@ export class AppStore {
         return "alt + ";
     }
 
-    // Dark theme
+    // System theme, based on media query
+    @observable systemTheme: string;
+
+    // Apply dark theme if it is forced or the system theme is dark
     @computed get darkTheme(): boolean {
-        return this.preferenceStore.isDarkTheme;
+        console.log(this.preferenceStore.theme);
+        if (this.preferenceStore.theme === Theme.AUTO) {
+            return this.systemTheme === Theme.DARK;
+        } else {
+            return this.preferenceStore.theme === Theme.DARK;
+        }
     }
 
     // Frame actions
@@ -800,6 +808,15 @@ export class AppStore {
         autorun(() => {
             document.body.style.backgroundColor = this.darkTheme ? Colors.DARK_GRAY4 : Colors.WHITE;
         });
+
+        // Watch for system theme preference changes
+        const handleThemeChange = (darkMode: boolean) => {
+            this.systemTheme = darkMode ? "dark" : "light";
+        };
+
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        mediaQuery.addEventListener("change", changeEvent => handleThemeChange(changeEvent.matches));
+        handleThemeChange(mediaQuery.matches);
 
         // Display toasts when connection status changes
         autorun(() => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -821,7 +821,7 @@ export class AppStore {
             } else if (mediaQuery.addListener) {
                 // Workaround for Safari
                 // @ts-ignore
-                mediaQuery.addListener("change", changeEvent => handleThemeChange(changeEvent.matches));
+                mediaQuery.addListener(changeEvent => handleThemeChange(changeEvent.matches));
             }
         }
         handleThemeChange(mediaQuery.matches);

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -232,7 +232,6 @@ export class AppStore {
 
     // Apply dark theme if it is forced or the system theme is dark
     @computed get darkTheme(): boolean {
-        console.log(this.preferenceStore.theme);
         if (this.preferenceStore.theme === Theme.AUTO) {
             return this.systemTheme === Theme.DARK;
         } else {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -12,6 +12,7 @@ import {
     AnimationState,
     AnimatorStore,
     BrowserMode,
+    CatalogStore,
     CURSOR_REGION_ID,
     dayPalette,
     DialogStore,
@@ -31,13 +32,12 @@ import {
     RegionStore,
     SpatialProfileStore,
     SpectralProfileStore,
-    WidgetsStore,
-    CatalogStore
+    WidgetsStore
 } from ".";
 import {distinct, GetRequiredTiles} from "utilities";
 import {BackendService, ConnectionStatus, ScriptingService, TileService, TileStreamDetails} from "services";
-import {FrameView, Point2D, ProcessedColumnData, ProtobufProcessing, Theme, TileCoordinate, WCSMatchingType} from "models";
-import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore, CatalogInfo, CatalogUpdateMode} from "./widgets";
+import {FrameView, Point2D, ProtobufProcessing, Theme, TileCoordinate, WCSMatchingType} from "models";
+import {CatalogInfo, CatalogUpdateMode, HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore} from "./widgets";
 import {CatalogOverlayComponent, CatalogScatterComponent, getImageCanvas} from "components";
 import {AppToaster} from "components/Shared";
 import GitCommit from "../static/gitInfo";
@@ -676,6 +676,10 @@ export class AppStore {
     @action setLightTheme = () => {
         this.preferenceStore.setPreference(PreferenceKeys.GLOBAL_THEME, Theme.LIGHT);
     };
+
+    @action setAutoTheme = () =>  {
+        this.preferenceStore.setPreference(PreferenceKeys.GLOBAL_THEME, Theme.AUTO);
+    }
 
     @action toggleCursorFrozen = () => {
         if (this.activeFrame) {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -815,7 +815,15 @@ export class AppStore {
         };
 
         const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-        mediaQuery.addEventListener("change", changeEvent => handleThemeChange(changeEvent.matches));
+        if (mediaQuery) {
+            if (mediaQuery.addEventListener) {
+                mediaQuery.addEventListener("change", changeEvent => handleThemeChange(changeEvent.matches));
+            } else if (mediaQuery.addListener) {
+                // Workaround for Safari
+                // @ts-ignore
+                mediaQuery.addListener("change", changeEvent => handleThemeChange(changeEvent.matches));
+            }
+        }
         handleThemeChange(mediaQuery.matches);
 
         // Display toasts when connection status changes

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -124,7 +124,7 @@ const KEY_TO_STRING = new Map<PreferenceKeys, string>([
 
 const DEFAULTS = {
     GLOBAL: {
-        theme: Theme.LIGHT,
+        theme: Theme.AUTO,
         autoLaunch: true,
         layout: PresetLayout.DEFAULT,
         cursorPosition: CursorPosition.TRACKING,
@@ -472,11 +472,6 @@ export class PreferenceStore {
     public isEventLoggingEnabled = (eventType: CARTA.EventType): boolean => {
         return Event.isEventTypeValid(eventType) && this.preferences.get(PreferenceKeys.LOG_EVENT).get(eventType);
     };
-
-    // getters for boolean(convenient)
-    @computed get isDarkTheme(): boolean {
-        return this.theme === Theme.DARK;
-    }
 
     @computed get isZoomRAWMode(): boolean {
         return this.zoomMode === Zoom.RAW;


### PR DESCRIPTION
Adds an "automatic" theme setting that uses the browser's `prefers-color-scheme: dark` media query to determine whether dark mode should be enabled. Chrome, Safari and Firefox on MacOS 10.14+ should automatically update this media query's value when the user switches between themes. This also works on Ubuntu 20.04 and Firefox, but there seem to be issues with Chrome and Gnome. Hopefully we will be able to enable this behaviour in the electron app as well.