### PR TITLE
Angus/fix 943

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "@blueprintjs/icons": "^3.11.0",
         "@blueprintjs/select": "^3.11.1",
         "@blueprintjs/table": "3.7.1",
+        "@types/tinycolor2": "^1.4.2",
         "ajv": "^6.10.2",
         "chart.js": "^2.9.3",
         "chartjs-plugin-annotation": "^0.5.7",
@@ -32,7 +33,8 @@
         "react-scroll-to-bottom": "^1.3.2",
         "react-transition-group": "^2.9.0",
         "rxjs": "^6.5.2",
-        "source-map-explorer": "^2.1.0"
+        "source-map-explorer": "^2.1.0",
+        "tinycolor2": "^1.4.1"
     },
     "scripts": {
         "git-info": "echo export default {logMessage: \\\"$(git log -1 --oneline)\\\"}\\;  > src/static/gitInfo.ts",

--- a/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
+++ b/src/components/Dialogs/OverlaySettings/OverlaySettingsDialogComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as AST from "ast_wrapper";
+import * as tinycolor from "tinycolor2";
 import {observer} from "mobx-react";
 import {observable} from "mobx";
 import {Select, ItemRenderer} from "@blueprintjs/select";
@@ -13,7 +14,7 @@ import {ColorComponent} from "./ColorComponent";
 import {ColorResult} from "react-color";
 import {ColorPickerComponent, SafeNumericInput} from "components/Shared";
 import {AppStore, BeamType, LabelType, SystemType, HelpType, DialogStore, OverlayStore} from "stores";
-import {hexStringToRgba, SWATCH_COLORS} from "utilities";
+import { SWATCH_COLORS} from "utilities";
 import "./OverlaySettingsDialogComponent.css";
 
 // Font selector
@@ -582,7 +583,7 @@ export class OverlaySettingsDialogComponent extends React.Component {
                 </FormGroup>
                 <FormGroup inline={true} label="Color">
                     <ColorPickerComponent
-                        color={hexStringToRgba(beamSettings.color)}
+                        color={tinycolor(beamSettings.color).toHexString()}
                         presetColors={SWATCH_COLORS}
                         setColor={(color: ColorResult) => beamSettings.setColor(color.hex)}
                         disableAlpha={true}

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as _ from "lodash";
+import * as tinycolor from "tinycolor2";
 import {observable} from "mobx";
 import {observer} from "mobx-react";
 import {AnchorButton, Button, Checkbox, FormGroup, HTMLSelect, IDialogProps, Intent, MenuItem, Position, Radio, RadioGroup, Switch, Tab, TabId, Tabs, Tooltip} from "@blueprintjs/core";
@@ -12,7 +13,7 @@ import {ColorComponent} from "components/Dialogs/OverlaySettings/ColorComponent"
 import {ColormapComponent, ColorPickerComponent, SafeNumericInput} from "components/Shared";
 import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {AppStore, BeamType, ContourGeneratorType, DialogStore, FrameScaling, HelpType, PreferenceKeys, PreferenceStore, RegionStore, RenderConfigStore} from "stores";
-import {hexStringToRgba, SWATCH_COLORS} from "utilities";
+import {SWATCH_COLORS} from "utilities";
 import "./PreferenceDialogComponent.css";
 
 enum TABS {
@@ -204,7 +205,7 @@ export class PreferenceDialogComponent extends React.Component {
                 }
                 <FormGroup inline={true} label="NaN Color">
                     <ColorPickerComponent
-                        color={hexStringToRgba(preference.nanColorHex, preference.nanAlpha)}
+                        color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
                         presetColors={[...SWATCH_COLORS, "transparent"]}
                         setColor={(color: ColorResult) => {
                             preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, color.hex === "transparent" ? "#000000" : color.hex);
@@ -329,7 +330,7 @@ export class PreferenceDialogComponent extends React.Component {
                 </FormGroup>
                 <FormGroup inline={true} label="Beam Color">
                     <ColorPickerComponent
-                        color={hexStringToRgba(preference.beamColor)}
+                        color={tinycolor(preference.beamColor).toRgb()}
                         presetColors={SWATCH_COLORS}
                         setColor={(color: ColorResult) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_BEAM_COLOR, color.hex)}
                         disableAlpha={true}

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -1,7 +1,7 @@
 import {observer} from "mobx-react";
 import * as React from "react";
 import {AppStore, ContourDashMode, FrameStore, OverlayStore, RenderConfigStore} from "stores";
-import {ceilToPower, GL, rotate2D, scale2D, subtract2D} from "utilities";
+import {ceilToPower, GL, rotate2D, scale2D, subtract2D, hexStringToRgba} from "utilities";
 import {ContourWebGLService} from "services";
 import "./ContourViewComponent.css";
 
@@ -150,7 +150,10 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
 
             const color = frame.contourConfig.color;
             if (color) {
-                this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, color.r / 255.0, color.g / 255.0, color.b / 255.0, color.a || 1.0);
+                const rgbaColor = typeof (color) === "string" ? hexStringToRgba(color) : color;
+                if (rgbaColor) {
+                    this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, rgbaColor.r / 255.0, rgbaColor.g / 255.0, rgbaColor.b / 255.0, rgbaColor.a || 1.0);
+                }
             } else {
                 this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, 1, 1, 1, 1);
             }

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -1,7 +1,7 @@
 import {observer} from "mobx-react";
 import * as React from "react";
 import {AppStore, ContourDashMode, FrameStore, OverlayStore, RenderConfigStore} from "stores";
-import {ceilToPower, GL, rotate2D, scale2D, subtract2D, hexStringToRgba} from "utilities";
+import {ceilToPower, GL, rotate2D, scale2D, subtract2D} from "utilities";
 import {ContourWebGLService} from "services";
 import "./ContourViewComponent.css";
 
@@ -150,10 +150,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
 
             const color = frame.contourConfig.color;
             if (color) {
-                const rgbaColor = typeof (color) === "string" ? hexStringToRgba(color) : color;
-                if (rgbaColor) {
-                    this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, rgbaColor.r / 255.0, rgbaColor.g / 255.0, rgbaColor.b / 255.0, rgbaColor.a || 1.0);
-                }
+                this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, color.r / 255.0, color.g / 255.0, color.b / 255.0, color.a || 1.0);
             } else {
                 this.gl.uniform4f(this.contourWebGLService.shaderUniforms.LineColor, 1, 1, 1, 1);
             }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
+import * as tinycolor from "tinycolor2";
 import {observer} from "mobx-react";
-import {AppStore, OverlayStore, PreferenceStore, RasterRenderType} from "stores";
+import {AppStore, RasterRenderType} from "stores";
 import {FrameView, Point2D, TileCoordinate} from "models";
-import {GetRequiredTiles, GL, LayerToMip, hexStringToRgba, add2D, scale2D} from "utilities";
+import {GetRequiredTiles, GL, LayerToMip, add2D, scale2D} from "utilities";
 import {RasterTile, TILE_SIZE, TileService, TileWebGLService} from "services";
 import "./RasterViewComponent.css";
 
@@ -66,8 +67,9 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.uniform1f(shaderUniforms.CanvasWidth, frame.renderWidth * devicePixelRatio);
             this.gl.uniform1f(shaderUniforms.CanvasHeight, frame.renderHeight * devicePixelRatio);
 
-            const rgba = hexStringToRgba(appStore.preferenceStore.nanColorHex, appStore.preferenceStore.nanAlpha);
-            if (rgba) {
+            const nanColor = tinycolor(appStore.preferenceStore.nanColorHex).setAlpha(appStore.preferenceStore.nanAlpha);
+            if (nanColor.isValid()) {
+                const rgba = nanColor.toRgb();
                 this.gl.uniform4f(shaderUniforms.NaNColor, rgba.r / 255, rgba.g / 255, rgba.b / 255, rgba.a);
             }
         }

--- a/src/components/Shared/ColorPicker/ColorPickerComponent.tsx
+++ b/src/components/Shared/ColorPicker/ColorPickerComponent.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import * as _ from "lodash";
 import {observer} from "mobx-react";
 import {observable} from "mobx";
-import {SketchPicker, ColorResult} from "react-color";
-import {AnchorButton, Button, Popover, PopoverPosition} from "@blueprintjs/core";
-import {RGBA} from "utilities";
+import * as tinycolor from "tinycolor2";
+import {SketchPicker, ColorResult, RGBColor} from "react-color";
+import {Button, Popover, PopoverPosition} from "@blueprintjs/core";
 import "./ColorPickerComponent.css";
 
 interface ColorPickerComponentProps {
-    color: string | RGBA;
+    color: string | RGBColor;
     presetColors: string[];
     darkTheme: boolean;
     disableAlpha: boolean;
@@ -41,8 +41,7 @@ export class ColorPickerComponent extends React.Component<ColorPickerComponentPr
         if (this.props.darkTheme) {
             popoverClassName += " bp3-dark";
         }
-        const buttonColor = typeof this.props.color === "string" ? this.props.color : `rgba(${this.props.color.r}, ${this.props.color.g}, ${this.props.color.b}, ${this.props.color.a})`;
-
+        const buttonColor = tinycolor(this.props.color).toString();
         return (
             <Popover isOpen={this.displayColorPicker} onClose={this.handleColorClose} position={PopoverPosition.RIGHT} popoverClassName={popoverClassName}>
                 <Button onClick={this.handleColorClick} className="color-swatch-button" disabled={this.props.disabled}>

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import * as _ from "lodash";
-import {ChartArea, ChartData, ChartDataSets, ChartOptions} from "chart.js";
+import * as tinycolor from "tinycolor2";
+import {ChartArea, ChartDataSets, ChartOptions} from "chart.js";
 import {Scatter} from "react-chartjs-2";
 import {Colors} from "@blueprintjs/core";
-import {clamp, hexStringToRgba, toExponential, toFixed} from "utilities";
+import {clamp, toExponential, toFixed} from "utilities";
 
 export enum TickType {
     Automatic,
@@ -321,10 +322,7 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         let lineColor = this.props.lineColor || (this.props.darkMode ? Colors.BLUE4 : Colors.BLUE2);
         const opacity = clamp(this.props.opacity || 1.0, 0, 1);
         if (opacity < 1.0) {
-            const rgb = hexStringToRgba(lineColor);
-            if (rgb) {
-                lineColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${opacity})`;
-            }
+            lineColor = tinycolor(lineColor).setAlpha(opacity).toRgbString();
         }
 
         // ChartJS plot
@@ -462,10 +460,7 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
             this.props.multiPlotData.forEach((value, key) => {
                 let currentLineColor = this.props.multiPlotBorderColor ? this.props.multiPlotBorderColor.get(key) : lineColor;
                 if (opacity < 1.0) {
-                    const rgb = hexStringToRgba(currentLineColor);
-                    if (rgb) {
-                        currentLineColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${opacity})`;
-                    }
+                    currentLineColor = tinycolor(currentLineColor).setAlpha(opacity).toRgbString();
                 }
                 const multiPlotDatasetConfig: MulticolorLineChartDatasets = {
                     type: this.props.plotType ? this.props.plotType : "line",

--- a/src/services/GLSL/pixel_shader_raster.glsl
+++ b/src/services/GLSL/pixel_shader_raster.glsl
@@ -87,5 +87,5 @@ void main(void) {
 
     float cmapYVal = (float(uCmapIndex) + 0.5) / float(uNumCmaps);
     vec2 cmapCoords = vec2(x, cmapYVal);
-    gl_FragColor = isnan(rawVal) ? uNaNColor : texture2D(uCmapTexture, cmapCoords);
+    gl_FragColor = isnan(rawVal) ? uNaNColor * uNaNColor.a : texture2D(uCmapTexture, cmapCoords);
 }

--- a/src/stores/ContourConfigStore.ts
+++ b/src/stores/ContourConfigStore.ts
@@ -1,7 +1,8 @@
 import {action, observable} from "mobx";
+import * as tinycolor from "tinycolor2";
 import {CARTA} from "carta-protobuf";
 import {PreferenceStore} from "./PreferenceStore";
-import {hexStringToRgba, RGBA} from "../utilities";
+import {RGBColor} from "react-color";
 
 export enum ContourGeneratorType {
     StartStepMultiplier = "start-step-multiplier",
@@ -22,7 +23,7 @@ export class ContourConfigStore {
     @observable smoothingMode: CARTA.SmoothingMode;
     @observable smoothingFactor: number;
 
-    @observable color: RGBA | string;
+    @observable color: RGBColor;
     @observable colormapEnabled: boolean;
     @observable colormap: string;
     @observable colormapContrast: number;
@@ -40,7 +41,7 @@ export class ContourConfigStore {
         this.smoothingMode = this.preferenceStore.contourSmoothingMode;
         this.smoothingFactor = this.preferenceStore.contourSmoothingFactor;
 
-        this.color = hexStringToRgba(this.preferenceStore.contourColor);
+        this.color = tinycolor(this.preferenceStore.contourColor).toRgb();
         this.colormapEnabled = this.preferenceStore.contourColormapEnabled;
         this.colormap = this.preferenceStore.contourColormap;
         this.colormapBias = 0.0;
@@ -61,8 +62,11 @@ export class ContourConfigStore {
     };
 
     // Styling
-    @action setColor = (color: RGBA | string) => {
-        this.color = color;
+    @action setColor = (color: tinycolor.ColorInput) => {
+        const colorObj = tinycolor(color);
+        if (colorObj.isValid()) {
+            this.color = colorObj.toRgb();
+        }
     };
 
     @action setDashMode = (mode: ContourDashMode) => {

--- a/src/stores/ContourConfigStore.ts
+++ b/src/stores/ContourConfigStore.ts
@@ -22,7 +22,7 @@ export class ContourConfigStore {
     @observable smoothingMode: CARTA.SmoothingMode;
     @observable smoothingFactor: number;
 
-    @observable color: RGBA;
+    @observable color: RGBA | string;
     @observable colormapEnabled: boolean;
     @observable colormap: string;
     @observable colormapContrast: number;
@@ -61,7 +61,7 @@ export class ContourConfigStore {
     };
 
     // Styling
-    @action setColor = (color: RGBA) => {
+    @action setColor = (color: RGBA | string) => {
         this.color = color;
     };
 

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -1,10 +1,11 @@
 import {observable, computed, action} from "mobx";
 import {Colors} from "@blueprintjs/core";
+import * as tinycolor from "tinycolor2";
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 import {AppStore, BeamType, ContourGeneratorType, FrameScaling, RenderConfigStore, RegionStore, AlertStore} from "stores";
 import {Theme, PresetLayout, CursorPosition, Zoom, ZoomPoint, WCSType, RegionCreationMode, CompressionQuality, TileCache, Event, ControlMap, SpectralType, IsSpectralMatchingTypeValid, WCSMatchingType, IsWCSMatchingTypeValid} from "models";
-import {isColorValid, parseBoolean} from "utilities";
+import {parseBoolean} from "utilities";
 
 export enum PreferenceKeys {
     GLOBAL_THEME = 1,
@@ -217,7 +218,7 @@ export class PreferenceStore {
         [PreferenceKeys.RENDER_CONFIG_PERCENTILE, (value: string): number => { return value && isFinite(Number(value)) && RenderConfigStore.IsPercentileValid(Number(value)) ? Number(value) : DEFAULTS.RENDER_CONFIG.percentile; }],
         [PreferenceKeys.RENDER_CONFIG_SCALING_ALPHA, (value: string): number => { return value && isFinite(Number(value)) ? Number(value) : DEFAULTS.RENDER_CONFIG.scalingAlpha; }],
         [PreferenceKeys.RENDER_CONFIG_SCALING_GAMMA, (value: string): number => { return value && isFinite(Number(value)) && RenderConfigStore.IsGammaValid(Number(value)) ? Number(value) : DEFAULTS.RENDER_CONFIG.scalingGamma; }],
-        [PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, (value: string): string => { return value && isColorValid(value) ? value : DEFAULTS.RENDER_CONFIG.nanColorHex; }],
+        [PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, (value: string): string => { return value && tinycolor(value).isValid() ? value : DEFAULTS.RENDER_CONFIG.nanColorHex; }],
         [PreferenceKeys.RENDER_CONFIG_NAN_ALPHA, (value: string): number => { return value && isFinite(Number(value)) && Number(value) >= 0 && Number(value) <= 1 ? Number(value) : DEFAULTS.RENDER_CONFIG.nanAlpha; }],
 
         [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_GENERATOR_TYPE, (value: ContourGeneratorType): ContourGeneratorType => {
@@ -233,7 +234,7 @@ export class PreferenceStore {
         [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_THICKNESS,
             (value: string): number => { return value && (isFinite(parseFloat(value)) && parseFloat(value) > 0 && parseFloat(value) <= 10) ? parseFloat(value) : DEFAULTS.CONTOUR_CONFIG.contourThickness; }],
         [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP_ENABLED, (value: string): boolean => { return parseBoolean(value, DEFAULTS.CONTOUR_CONFIG.contourColormapEnabled); }],
-        [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLOR, (value: string): string => { return value && isColorValid(value) ? value : DEFAULTS.CONTOUR_CONFIG.contourColor; }],
+        [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLOR, (value: string): string => { return value && tinycolor(value).isValid() ? value : DEFAULTS.CONTOUR_CONFIG.contourColor; }],
         [PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP, (value: string): string => { return value && RenderConfigStore.IsColormapValid(value) ? value : DEFAULTS.CONTOUR_CONFIG.contourColormap; }],
 
         [PreferenceKeys.WCS_OVERLAY_AST_COLOR, (value: string): number => { return value && isFinite(Number(value)) && Number(value) >= 0 && Number(value) < AST.colors.length ? Number(value) : DEFAULTS.WCS_OVERLAY.astColor; }],
@@ -241,11 +242,11 @@ export class PreferenceStore {
         [PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE, (value: string): boolean => { return parseBoolean(value, DEFAULTS.WCS_OVERLAY.astLabelsVisible); }],
         [PreferenceKeys.WCS_OVERLAY_WCS_TYPE, (value: string): string => { return value && WCSType.isValid(value) ? value : DEFAULTS.WCS_OVERLAY.wcsType; }],
         [PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE, (value: string): boolean => { return parseBoolean(value, DEFAULTS.WCS_OVERLAY.beamVisible); }],
-        [PreferenceKeys.WCS_OVERLAY_BEAM_COLOR, (value: string): string => { return value && isColorValid(value) ? value : DEFAULTS.WCS_OVERLAY.beamColor; }],
+        [PreferenceKeys.WCS_OVERLAY_BEAM_COLOR, (value: string): string => { return value && tinycolor(value).isValid() ? value : DEFAULTS.WCS_OVERLAY.beamColor; }],
         [PreferenceKeys.WCS_OVERLAY_BEAM_TYPE, (value: BeamType): BeamType => { return value && (value === BeamType.Open || value === BeamType.Solid) ? value : DEFAULTS.WCS_OVERLAY.beamType; }],
         [PreferenceKeys.WCS_OVERLAY_BEAM_WIDTH, (value: string): number => { return value && (isFinite(Number(value)) && Number(value) > 0 && Number(value) <= 10) ? Number(value) : DEFAULTS.WCS_OVERLAY.beamWidth; }],
 
-        [PreferenceKeys.REGION_COLOR, (value: string): string => { return value && isColorValid(value) ? value : DEFAULTS.REGION.regionColor; }],
+        [PreferenceKeys.REGION_COLOR, (value: string): string => { return value && tinycolor(value).isValid() ? value : DEFAULTS.REGION.regionColor; }],
         [PreferenceKeys.REGION_LINE_WIDTH, (value: string): number => { return value && isFinite(Number(value)) && RegionStore.IsRegionLineWidthValid(Number(value)) ? Number(value) : DEFAULTS.REGION.regionLineWidth; }],
         [PreferenceKeys.REGION_DASH_LENGTH, (value: string): number => { return value && isFinite(Number(value)) && RegionStore.IsRegionDashLengthValid(Number(value)) ? Number(value) : DEFAULTS.REGION.regionDashLength; }],
         [PreferenceKeys.REGION_TYPE, (value: string): number => { return value && isFinite(Number(value)) && RegionStore.IsRegionTypeValid(Number(value)) ? Number(value) : DEFAULTS.REGION.regionType; }],

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -2,9 +2,8 @@ import {action, computed, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {Colors} from "@blueprintjs/core";
 import {PlotType, LineSettings} from "components/Shared";
-import {AppStore} from "../AppStore";
 import {RegionWidgetStore, RegionsType} from "./RegionWidgetStore";
-import {isColorValid} from "utilities";
+import * as tinycolor from "tinycolor2";
 
 export class HistogramWidgetStore extends RegionWidgetStore {
     @observable minX: number;
@@ -160,8 +159,9 @@ export class HistogramWidgetStore extends RegionWidgetStore {
         if (!widgetSettings) {
             return;
         }
-        if (typeof widgetSettings.primaryLineColor === "string" && isColorValid(widgetSettings.primaryLineColor)) {
-            this.primaryLineColor.colorHex = widgetSettings.primaryLineColor;
+        const lineColor = tinycolor(widgetSettings.primaryLineColor);
+        if (lineColor.isValid()) {
+            this.primaryLineColor.colorHex = lineColor.toHexString();
         }
         if (typeof widgetSettings.lineWidth === "number" && widgetSettings.lineWidth >= LineSettings.MIN_WIDTH && widgetSettings.lineWidth <= LineSettings.MAX_WIDTH) {
             this.lineWidth = widgetSettings.lineWidth;

--- a/src/stores/widgets/RenderConfigWidgetStore.ts
+++ b/src/stores/widgets/RenderConfigWidgetStore.ts
@@ -1,7 +1,8 @@
 import {action, computed, observable} from "mobx";
 import {Colors} from "@blueprintjs/core";
+import * as tinycolor from "tinycolor2";
+
 import {PlotType, LineSettings} from "components/Shared";
-import {isColorValid} from "utilities";
 
 export class RenderConfigWidgetStore {
     @observable minX: number;
@@ -118,8 +119,9 @@ export class RenderConfigWidgetStore {
         if (!widgetSettings) {
             return;
         }
-        if (typeof widgetSettings.primaryLineColor === "string" && isColorValid(widgetSettings.primaryLineColor)) {
-            this.primaryLineColor.colorHex = widgetSettings.primaryLineColor;
+        const lineColor = tinycolor(widgetSettings.primaryLineColor);
+        if (lineColor.isValid()) {
+            this.primaryLineColor.colorHex = lineColor.toHexString();
         }
         if (typeof widgetSettings.lineWidth === "number" && widgetSettings.lineWidth >= LineSettings.MIN_WIDTH && widgetSettings.lineWidth <= LineSettings.MAX_WIDTH) {
             this.lineWidth = widgetSettings.lineWidth;

--- a/src/stores/widgets/SpatialProfileWidgetStore.ts
+++ b/src/stores/widgets/SpatialProfileWidgetStore.ts
@@ -1,9 +1,9 @@
+import * as tinycolor from "tinycolor2";
 import {action, computed, observable} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {FrameStore} from "../FrameStore";
 import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings} from "components/Shared";
-import {isColorValid} from "utilities";
 
 export class SpatialProfileWidgetStore {
     @observable fileId: number;
@@ -269,8 +269,9 @@ export class SpatialProfileWidgetStore {
         if (typeof widgetSettings.coordinate === "string" && SpatialProfileWidgetStore.ValidCoordinates.includes(widgetSettings.coordinate)) {
             this.coordinate = widgetSettings.coordinate;
         }
-        if (typeof widgetSettings.primaryLineColor === "string" && isColorValid(widgetSettings.primaryLineColor)) {
-            this.primaryLineColor.colorHex = widgetSettings.primaryLineColor;
+        const lineColor = tinycolor(widgetSettings.primaryLineColor);
+        if (lineColor.isValid()) {
+            this.primaryLineColor.colorHex = lineColor.toHexString();
         }
         if (typeof widgetSettings.lineWidth === "number" && widgetSettings.lineWidth >= LineSettings.MIN_WIDTH && widgetSettings.lineWidth <= LineSettings.MAX_WIDTH) {
             this.lineWidth = widgetSettings.lineWidth;

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -3,9 +3,9 @@ import {Colors} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings} from "components/Shared";
 import {RegionWidgetStore, RegionsType} from "./RegionWidgetStore";
-import {AppStore, FrameStore} from "..";
-import {isColorValid} from "utilities";
+import {FrameStore} from "stores";
 import {SpectralSystem, SpectralType, SpectralUnit} from "models";
+import * as tinycolor from "tinycolor2";
 
 export class SpectralProfileWidgetStore extends RegionWidgetStore {
     @observable coordinate: string;
@@ -340,8 +340,9 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         if (!widgetSettings) {
             return;
         }
-        if (typeof widgetSettings.primaryLineColor === "string" && isColorValid(widgetSettings.primaryLineColor)) {
-            this.primaryLineColor.colorHex = widgetSettings.primaryLineColor;
+        const lineColor = tinycolor(widgetSettings.primaryLineColor);
+        if (lineColor.isValid()) {
+            this.primaryLineColor.colorHex = lineColor.toHexString();
         }
         if (typeof widgetSettings.lineWidth === "number" && widgetSettings.lineWidth >= LineSettings.MIN_WIDTH && widgetSettings.lineWidth <= LineSettings.MAX_WIDTH) {
             this.lineWidth = widgetSettings.lineWidth;

--- a/src/stores/widgets/StokesAnalysisWidgetStore.ts
+++ b/src/stores/widgets/StokesAnalysisWidgetStore.ts
@@ -5,8 +5,9 @@ import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings, ScatterSettings} from "components/Shared";
 import {RegionWidgetStore, RegionsType} from "./RegionWidgetStore";
 import {AppStore, FrameStore} from "stores";
-import {getColorsForValues, isColorValid} from "utilities";
+import {getColorsForValues} from "utilities";
 import {SpectralSystem, SpectralType, SpectralUnit} from "models";
+import * as tinycolor from "tinycolor2";
 
 export enum StokesCoordinate {
     CurrentZ = "z",
@@ -372,11 +373,13 @@ export class StokesAnalysisWidgetStore extends RegionWidgetStore {
         if (!widgetSettings) {
             return;
         }
-        if (typeof widgetSettings.primaryLineColor === "string" && isColorValid(widgetSettings.primaryLineColor)) {
-            this.primaryLineColor.colorHex = widgetSettings.primaryLineColor;
+        const lineColor = tinycolor(widgetSettings.primaryLineColor);
+        if (lineColor.isValid()) {
+            this.primaryLineColor.colorHex = lineColor.toHexString();
         }
-        if (typeof widgetSettings.secondaryLineColor === "string" && isColorValid(widgetSettings.secondaryLineColor)) {
-            this.secondaryLineColor.colorHex = widgetSettings.secondaryLineColor;
+        const secondaryLineColor = tinycolor(widgetSettings.secondaryLineColor);
+        if (secondaryLineColor.isValid()) {
+            this.secondaryLineColor.colorHex = secondaryLineColor.toHexString();
         }
         if (typeof widgetSettings.lineWidth === "number" && widgetSettings.lineWidth >= LineSettings.MIN_WIDTH && widgetSettings.lineWidth <= LineSettings.MAX_WIDTH) {
             this.lineWidth = widgetSettings.lineWidth;

--- a/src/utilities/color.ts
+++ b/src/utilities/color.ts
@@ -1,14 +1,7 @@
 // Static assets
 import allMaps from "static/allmaps.png";
-import { Colors } from "@blueprintjs/core";
+import {Colors} from "@blueprintjs/core";
 import {RenderConfigStore} from "stores";
-
-export interface RGBA {
-    r: number;
-    g: number;
-    b: number;
-    a?: number;
-}
 
 export const SWATCH_COLORS = [
     Colors.BLUE3,
@@ -32,39 +25,14 @@ export const SWATCH_COLORS = [
     Colors.WHITE
 ];
 
-export function isColorValid(colorString: string): boolean {
-    const colorHex: RegExp = /^#([A-Fa-f0-9]{3}){1,2}$/;
-    return colorHex.test(colorString);
-}
-
-// adapted from https://stackoverflow.com/questions/21646738/convert-hex-to-rgba
-export function hexStringToRgba(colorString: string, alpha: number = 1): RGBA {
-    if (!isColorValid(colorString)) {
-        return null;
-    }
-
-    let c = colorString.substring(1).split("");
-    if (c.length === 3) { // shorthand hex color
-        c = [c[0], c[0], c[1], c[1], c[2], c[2]];
-    }
-    const hex = Number("0x" + c.join(""));
-
-    return {
-        r: (hex >> 16) & 255,
-        g: (hex >> 8) & 255,
-        b: hex & 255,
-        a: alpha
-    };
-}
-// end stolen from https://stackoverflow.com/questions/21646738/convert-hex-to-rgba
-
 function initContextWithSize(width: number, height: number) {
     const canvas = document.createElement("canvas") as HTMLCanvasElement;
     canvas.width = width; 
-    canvas.height = height; 
-    const ctx = canvas.getContext("2d");
-    return ctx;
+    canvas.height = height;
+    return canvas.getContext("2d");
 }
+
+let colormapContext: CanvasRenderingContext2D | undefined;
 
 // return color map as Uint8ClampedArray according colorMap
 export function getColorsForValues (colorMap: string): {color: Uint8ClampedArray, size: number} {
@@ -72,13 +40,15 @@ export function getColorsForValues (colorMap: string): {color: Uint8ClampedArray
     const colorMapIndex = colorMaps.indexOf(colorMap);
 
     // the source image for colormaps is 1024x790, with each colormap taking a 1024x10 region
-    const ctx = initContextWithSize(1024, 1);
+    if (!colormapContext) {
+        colormapContext = initContextWithSize(1024, 1);
+    }
     if (!allMaps) {
         return null;
     }
     const imageObj = new Image();
     imageObj.src = allMaps;
-    ctx.drawImage(imageObj, 0, 10 * colorMapIndex + 1, 1024, 1, 0, 0, 1024, 1);
-    const colorMapPixel = ctx.getImageData(0, 0, 1023, 1);
+    colormapContext.drawImage(imageObj, 0, 10 * colorMapIndex + 1, 1024, 1, 0, 0, 1024, 1);
+    const colorMapPixel = colormapContext.getImageData(0, 0, 1023, 1);
     return {color: colorMapPixel.data, size: colorMapPixel.width}; 
 }


### PR DESCRIPTION
This should allow a wider range of color formats to be supported via the scripting interface, by using the [tinycolor library](https://github.com/bgrins/TinyColor) to convert between rgba, hex and other formats.

This removes the need for our own color validation and conversion functions, so I've removed those. I also noticed a bug in the rendering of NaNs in the raster view shader code, so I fixed that too