### PR TITLE
adds contour properties to resume message

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1211,6 +1211,18 @@ export class AppStore {
                 };
             });
 
+            let contourSettings: CARTA.IContourSettings;
+            if (frame.contourConfig.enabled) {
+                contourSettings = {
+                    levels: frame.contourConfig.levels,
+                    smoothingMode: frame.contourConfig.smoothingMode,
+                    smoothingFactor: frame.contourConfig.smoothingFactor,
+                    decimationFactor: this.preferenceStore.contourDecimation,
+                    compressionLevel: this.preferenceStore.contourCompressionLevel,
+                    contourChunkSize: this.preferenceStore.contourChunkSize
+                };
+            }
+
             return {
                 file: info.fileInfo.name,
                 directory: info.directory,
@@ -1219,7 +1231,8 @@ export class AppStore {
                 renderMode: info.renderMode,
                 channel: frame.requiredChannel,
                 stokes: frame.requiredStokes,
-                regions
+                regions,
+                contourSettings
             };
         });
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1211,7 +1211,7 @@ export class AppStore {
                 };
             });
 
-            let contourSettings: CARTA.IContourSettings;
+            let contourSettings: CARTA.ISetContourParameters;
             if (frame.contourConfig.enabled) {
                 contourSettings = {
                     levels: frame.contourConfig.levels,

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1214,6 +1214,7 @@ export class AppStore {
             let contourSettings: CARTA.ISetContourParameters;
             if (frame.contourConfig.enabled) {
                 contourSettings = {
+                    fileId: frame.frameInfo.fileId,
                     levels: frame.contourConfig.levels,
                     smoothingMode: frame.contourConfig.smoothingMode,
                     smoothingFactor: frame.contourConfig.smoothingFactor,

--- a/src/stores/widgets/CatalogOverlayWidgetStore.ts
+++ b/src/stores/widgets/CatalogOverlayWidgetStore.ts
@@ -11,6 +11,7 @@ export interface CatalogInfo {
     fileId: number;
     fileInfo: CARTA.ICatalogFileInfo;
     dataSize: number;
+    directory: string;
 }
 
 export enum CatalogOverlay {


### PR DESCRIPTION
Companion PR of https://github.com/CARTAvis/carta-backend/pull/471

Should allow contours to be used correctly when session is resumed