### PR TITLE
skip stop animation action when animation is already stopped

### DIFF
--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -116,6 +116,11 @@ export class AnimatorStore {
     };
 
     @action stopAnimation = () => {
+        // Ignore stop when not playing
+        if (this.animationState === AnimationState.STOPPED) {
+            return;
+        }
+
         const appStore = AppStore.Instance;
         const frame = appStore.activeFrame;
         if (!frame) {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -395,17 +395,13 @@ export class AppStore {
 
     @action appendFile = (directory: string, file: string, hdu: string) => {
         // Stop animations playing before loading a new frame
-        if (this.animatorStore.animationState === AnimationState.PLAYING) {
-            this.animatorStore.stopAnimation();
-        }
+        this.animatorStore.stopAnimation();
         return this.addFrame(directory, file, hdu);
     };
 
     @action openFile = (directory: string, file: string, hdu: string) => {
         // Stop animations playing before loading a new frame
-        if (this.animatorStore.animationState === AnimationState.PLAYING) {
-            this.animatorStore.stopAnimation();
-        }
+        this.animatorStore.stopAnimation();
         this.removeAllFrames();
         return this.addFrame(directory, file, hdu);
     };


### PR DESCRIPTION
solves issue with missing tiles when resume is called, because `stopAnimation` is called when resuming a session. 