### PR TITLE
Angus/file list time

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "mnemonist": "^0.29.0",
         "mobx": "^5.14.0",
         "mobx-react": "^5.4.4",
+        "moment": "^2.27.0",
         "plotly.js": "^1.52.3",
         "raw-loader": "^0.5.1",
         "react": "^16.10.2",

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
@@ -28,11 +28,6 @@
             margin-left: 5px;
             margin-right: 5px;
 
-            &.extended {
-                height: 100%;
-
-            }
-
             .file-list {
                 width: 60%;
                 flex: auto;

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -348,6 +348,9 @@ export class FileBrowserDialogComponent extends React.Component {
                                 selectedFile={fileBrowserStore.selectedFile}
                                 selectedHDU={fileBrowserStore.selectedHDU}
                                 filterString={this.debouncedFilterString}
+                                sortingConfig={fileBrowserStore.sortingConfig}
+                                onSortingChanged={fileBrowserStore.setSortingConfig}
+                                onSortingCleared={fileBrowserStore.clearSortingConfig}
                                 onFileClicked={fileBrowserStore.selectFile}
                                 onFileDoubleClicked={this.loadFile}
                                 onFolderClicked={this.handleFolderClicked}

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -232,7 +232,7 @@ export class FileBrowserDialogComponent extends React.Component {
                 content={
                     <Menu>
                         <MenuItem text="CRTF Region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.CRTF)}/>
-                        <MenuItem text="DS9 Region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.REG)}/>
+                        <MenuItem text="DS9 Region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)}/>
                     </Menu>
                 }
                 position={Position.BOTTOM_RIGHT}

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -301,6 +301,7 @@ export class FileBrowserDialogComponent extends React.Component {
                     placeholder="Filter by filename pattern (unix style) or regular expression (using /<expression>/)"
                     value={this.fileFilterString}
                     onChange={this.handleFilterStringInputChanged}
+                    leftIcon="search"
                 />);
         }
 

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
@@ -53,6 +53,10 @@
         }
     }
 
+    .time-cell {
+        text-align: right;
+    }
+
     padding: 1px;
 
     .bp3-table-selection-region {

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
@@ -10,9 +10,13 @@
     }
 
     .sort-icon {
-        margin-right: 5px;
-        position: relative;
-        top: 5px;
+        pointer-events: all;
+        cursor: pointer;
+        margin-top: 2px;
+
+        &.inactive {
+            opacity: 0.25;
+        }
     }
 }
 

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -3,7 +3,7 @@ import {action, autorun, computed, observable} from "mobx";
 import {observer} from "mobx-react";
 import {Cell, Column, ColumnHeaderCell, Regions, RenderMode, SelectionModes, Table} from "@blueprintjs/table";
 import {IRegion} from "@blueprintjs/table/src/regions";
-import {Icon, Label, Menu, MenuItem} from "@blueprintjs/core";
+import {Colors, Icon, Label, Menu, MenuItem, NonIdealState} from "@blueprintjs/core";
 import globToRegExp from "glob-to-regexp";
 import * as moment from "moment";
 import {CARTA} from "carta-protobuf";
@@ -244,19 +244,20 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
             if (sortColumn) {
                 return (
                     <Label className="bp3-inline label">
-                        <Icon className="sort-icon" icon={sortDesc ? "sort-desc" : "sort-asc"}/>
+                        <Icon onClick={() => this.props.onSortingChanged(name, -sortingConfig.direction)} className="sort-icon" icon={sortDesc ? "sort-desc" : "sort-asc"}/>
                         {name}
                     </Label>
                 );
             } else {
                 return (
                     <Label className="bp3-inline label">
+                        <Icon onClick={() => this.props.onSortingChanged(name, 1)} className="sort-icon inactive" icon="sort"/>
                         {name}
                     </Label>
                 );
             }
         };
-        return <ColumnHeaderCell className={"column-name"} nameRenderer={nameRenderer} menuRenderer={menuRenderer}/>;
+        return <ColumnHeaderCell className={"column-name"} nameRenderer={nameRenderer}/>;
     };
 
     private renderFilenames = (rowIndex: number) => {
@@ -364,6 +365,15 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
         const classes = ["browser-table"];
         if (this.props.darkTheme) {
             classes.push("bp3-dark");
+        }
+
+        const entryCount = this.tableEntries.length;
+        const unfilteredEntryCount = (fileResponse?.files?.length || 0) + (fileResponse?.subdirectories?.length || 0);
+        if (!unfilteredEntryCount) {
+            return <NonIdealState icon="folder-open" title="Empty folder" description="There are no files or subdirectories in this folder"/>;
+        } else if (!entryCount) {
+            return <NonIdealState icon="search" title="No results" description="There are no files or subdirectories matching the filter expression"/>;
+
         }
 
         return (

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -3,7 +3,7 @@ import {action, autorun, computed, observable} from "mobx";
 import {observer} from "mobx-react";
 import {Cell, Column, ColumnHeaderCell, Regions, RenderMode, SelectionModes, Table} from "@blueprintjs/table";
 import {IRegion} from "@blueprintjs/table/src/regions";
-import {Colors, Icon, Label, Menu, MenuItem, NonIdealState} from "@blueprintjs/core";
+import {Icon, Label, NonIdealState} from "@blueprintjs/core";
 import globToRegExp from "glob-to-regexp";
 import * as moment from "moment";
 import {CARTA} from "carta-protobuf";
@@ -229,16 +229,6 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
         const sortingConfig = this.props.sortingConfig;
         const sortColumn = name === sortingConfig?.columnName;
         const sortDesc = sortingConfig?.direction < 0;
-
-        const menuRenderer = () => {
-            return (
-                <Menu className="catalog-sort-menu-item">
-                    <MenuItem icon="sort-asc" active={sortingConfig?.direction > 0} onClick={() => this.props.onSortingChanged(name, 1)} text="Sort Asc"/>
-                    <MenuItem icon="sort-desc" active={sortingConfig?.direction < 0} onClick={() => this.props.onSortingChanged(name, -1)} text="Sort Desc"/>
-                    <MenuItem icon="cross" onClick={this.props.onSortingCleared} text="Clear Sort"/>
-                </Menu>
-            );
-        };
 
         const nameRenderer = () => {
             if (sortColumn) {

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -48,17 +48,17 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
     private cachedFileResponse: CARTA.IFileListResponse | CARTA.ICatalogListResponse;
 
     private static readonly FileTypeMap = new Map<CARTA.FileType, { type: string, description: string }>([
-        [CARTA.FileType.FITS, {type: "FITS", description: "Flexible Image Transport System"}],
         [CARTA.FileType.CASA, {type: "CASA", description: "CASA Image"}],
-        [CARTA.FileType.MIRIAD, {type: "Miriad", description: "Miriad Image"}],
-        [CARTA.FileType.HDF5, {type: "HDF5", description: "HDF5 File (IDIA Schema)"}],
         [CARTA.FileType.CRTF, {type: "CRTF", description: "CASA Region Text Format"}],
-        [CARTA.FileType.REG, {type: "DS9", description: "DS9 Region Format"}],
+        [CARTA.FileType.DS9_REG, {type: "DS9", description: "DS9 Region Format"}],
+        [CARTA.FileType.FITS, {type: "FITS", description: "Flexible Image Transport System"}],
+        [CARTA.FileType.HDF5, {type: "HDF5", description: "HDF5 File (IDIA Schema)"}],
+        [CARTA.FileType.MIRIAD, {type: "Miriad", description: "Miriad Image"}],
     ]);
 
     private static readonly CatalogFileTypeMap = new Map<CARTA.CatalogFileType, { type: string, description: string }>([
-        [CARTA.CatalogFileType.VOTable, {type: "VOTable", description: "XML-Based Table Format"}],
         [CARTA.CatalogFileType.FITSTable, {type: "FITS", description: "Flexible Image Transport System"}],
+        [CARTA.CatalogFileType.VOTable, {type: "VOTable", description: "XML-Based Table Format"}],
     ]);
 
     private static GetFileTypeDisplay(type: CARTA.FileType) {

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -202,7 +202,7 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                 this.cachedSortingConfig = sortingConfig;
                 this.cachedFilterString = filterString;
                 this.cachedFileResponse = fileResponse;
-                this.tableRef?.scrollToRegion(Regions.row(0, 0));
+                setTimeout(() => this.tableRef?.scrollToRegion(Regions.row(0, 0)), 20);
             }
         });
     }

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -138,7 +138,7 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     filteredFiles.sort((a, b) => sortingConfig.direction * (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1));
                     break;
                 case "Type":
-                    filteredFiles.sort((a, b) => sortingConfig.direction * (a.type > b.type ? -1 : 1));
+                    filteredFiles.sort((a, b) => sortingConfig.direction * (a.type < b.type ? -1 : 1));
                     break;
                 case "Size":
                     filteredFiles.sort((a, b) => sortingConfig.direction * (a.size < b.size ? -1 : 1));

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -23,7 +23,7 @@ export class BackendService {
         return BackendService.staticInstance;
     }
 
-    private static readonly IcdVersion = 14;
+    private static readonly IcdVersion = 15;
     private static readonly DefaultFeatureFlags = CARTA.ClientFeatureFlags.WEB_ASSEMBLY | CARTA.ClientFeatureFlags.WEB_GL;
     @observable connectionStatus: ConnectionStatus;
     readonly loggingEnabled: boolean;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -637,7 +637,7 @@ export class AppStore {
 
     // Region file actions
     @action importRegion = (directory: string, file: string, type: CARTA.FileType | CARTA.CatalogFileType) => {
-        if (!this.activeFrame || !(type === CARTA.FileType.CRTF || type === CARTA.FileType.REG)) {
+        if (!this.activeFrame || !(type === CARTA.FileType.CRTF || type === CARTA.FileType.DS9_REG)) {
             AppToaster.show({icon: "warning-sign", message: `Region type not supported`, intent: "danger", timeout: 3000});
             return;
         }

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -14,7 +14,7 @@ export enum BrowserMode {
     Catalog
 }
 
-export type RegionFileType = CARTA.FileType.CRTF | CARTA.FileType.REG;
+export type RegionFileType = CARTA.FileType.CRTF | CARTA.FileType.DS9_REG;
 export type ImageFileType = CARTA.FileType.CASA | CARTA.FileType.FITS | CARTA.FileType.HDF5 | CARTA.FileType.MIRIAD;
 export type CatalogFileType = CARTA.CatalogFileType.VOTable | CARTA.CatalogFileType.FITSTable;
 export interface SortingConfig {

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -17,6 +17,10 @@ export enum BrowserMode {
 export type RegionFileType = CARTA.FileType.CRTF | CARTA.FileType.REG;
 export type ImageFileType = CARTA.FileType.CASA | CARTA.FileType.FITS | CARTA.FileType.HDF5 | CARTA.FileType.MIRIAD;
 export type CatalogFileType = CARTA.CatalogFileType.VOTable | CARTA.CatalogFileType.FITSTable;
+export interface SortingConfig {
+    columnName: string;
+    direction: number;
+}
 
 export class FileBrowserStore {
     private static staticInstance: FileBrowserStore;
@@ -44,6 +48,7 @@ export class FileBrowserStore {
     @observable exportFilename: string;
     @observable exportCoordinateType: CARTA.CoordinateType;
     @observable exportFileType: RegionFileType;
+    @observable sortingConfig: SortingConfig = {columnName: "Date", direction: -1};
 
     @observable catalogFileList: CARTA.ICatalogListResponse;
     @observable selectedCatalogFile: CARTA.ICatalogFileInfo;
@@ -235,6 +240,14 @@ export class FileBrowserStore {
     @action setExportFileType = (fileType: RegionFileType) => {
         this.exportFileType = fileType;
     };
+
+    @action setSortingConfig = (columnName: string, direction: number) => {
+        this.sortingConfig = {columnName, direction: Math.sign(direction)};
+    }
+
+    @action clearSortingConfig = () => {
+        this.sortingConfig = undefined;
+    }
 
     @computed get fileInfo() {
         let fileInfo = "";


### PR DESCRIPTION
closes #686
Companion PR of https://github.com/CARTAvis/carta-backend/pull/550.

This PR adds the ability to sort by modified date. Displayed date is based on the file modification timestamp. If the timestamp is from today, the time is displayed. If older, only the date is displayed. This is similar to the default behaviour in gnome/ubuntu. @kswang1029 and I have checked the behaviour when accessing a server in a different time zone, and the displayed time is based on the _local_ (i.e. client) time.

PR also changes the sorting approach to a more conventional button-based approach, instead of a context menu.