### PR TITLE
Angus/file browser minor changes

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -344,6 +344,7 @@ export class FileBrowserDialogComponent extends React.Component {
                         <div className="file-list">
                             <FileListTableComponent
                                 darkTheme={appStore.darkTheme}
+                                loading={fileBrowserStore.loadingList}
                                 listResponse={fileBrowserStore.getfileListByMode}
                                 fileBrowserMode={fileBrowserStore.browserMode}
                                 selectedFile={fileBrowserStore.selectedFile}

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
@@ -3,19 +3,36 @@
 .column-name {
     overflow: hidden;
 
-    .label {
-        margin: 0;
-        display: inline-flex;
-        position: absolute;
-    }
+    .bp3-table-column-name {
+        width: 100%;
+        height: 100%;
 
-    .sort-icon {
-        pointer-events: all;
-        cursor: pointer;
-        margin-top: 2px;
+        .bp3-table-column-name-text {
+            width: 100%;
+            height: 100%;
 
-        &.inactive {
-            opacity: 0.25;
+            .sort-label {
+                width: 100%;
+                height: 100%;
+
+                pointer-events: all;
+                cursor: pointer;
+
+                .label {
+                    margin: 0;
+                    display: inline-flex;
+                    position: absolute;
+                    cursor: pointer;
+                }
+
+                .sort-icon {
+                    margin-top: 2px;
+
+                    &.inactive {
+                        opacity: 0.25;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {action, autorun, computed, observable} from "mobx";
 import {observer} from "mobx-react";
-import {Cell, Column, ColumnHeaderCell, Regions, RenderMode, SelectionModes, Table} from "@blueprintjs/table";
+import {Cell, Column, ColumnHeaderCell, Regions, RenderMode, SelectionModes, Table, TableLoadingOption} from "@blueprintjs/table";
 import {IRegion} from "@blueprintjs/table/src/regions";
 import {Icon, Label, NonIdealState} from "@blueprintjs/core";
 import globToRegExp from "glob-to-regexp";
@@ -23,6 +23,7 @@ interface FileEntry {
 
 export interface FileListTableComponentProps {
     darkTheme: boolean;
+    loading?: boolean;
     listResponse: CARTA.IFileListResponse | CARTA.ICatalogListResponse;
     selectedFile: CARTA.IFileInfo | CARTA.ICatalogFileInfo;
     selectedHDU: string;
@@ -387,6 +388,7 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                 selectedRegions={this.selectedRegion}
                 enableRowHeader={false}
                 numRows={this.tableEntries.length}
+                loadingOptions={this.props.loading ? [TableLoadingOption.CELLS] : []}
             >
                 <Column name="Filename" columnHeaderCellRenderer={() => this.renderColumnHeader("Filename")} cellRenderer={this.renderFilenames}/>
                 <Column name="Type" columnHeaderCellRenderer={() => this.renderColumnHeader("Type")} cellRenderer={this.renderTypes}/>

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -233,17 +233,21 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
         const nameRenderer = () => {
             if (sortColumn) {
                 return (
-                    <Label className="bp3-inline label">
-                        <Icon onClick={() => this.props.onSortingChanged(name, -sortingConfig.direction)} className="sort-icon" icon={sortDesc ? "sort-desc" : "sort-asc"}/>
-                        {name}
-                    </Label>
+                    <div className="sort-label" onClick={() => this.props.onSortingChanged(name, -sortingConfig.direction)}>
+                        <Label className="bp3-inline label">
+                            <Icon className="sort-icon" icon={sortDesc ? "sort-desc" : "sort-asc"}/>
+                            {name}
+                        </Label>
+                    </div>
                 );
             } else {
                 return (
-                    <Label className="bp3-inline label">
-                        <Icon onClick={() => this.props.onSortingChanged(name, 1)} className="sort-icon inactive" icon="sort"/>
-                        {name}
-                    </Label>
+                    <div className="sort-label" onClick={() => this.props.onSortingChanged(name, 1)}>
+                        <Label className="bp3-inline label">
+                            <Icon className="sort-icon inactive" icon="sort"/>
+                            {name}
+                        </Label>
+                    </div>
                 );
             }
         };

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -183,7 +183,7 @@ export class AppStore {
                 autoFileLoaded = true;
                 this.addFrame(folderSearchParam, fileSearchParam, "");
             }
-            if (this.preferenceStore.autoLaunch) {
+            if (this.preferenceStore.autoLaunch && !fileSearchParam) {
                 this.fileBrowserStore.showFileBrowser(BrowserMode.File);
             }
         }, err => console.log(err));

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -17,6 +17,7 @@ export enum BrowserMode {
 export type RegionFileType = CARTA.FileType.CRTF | CARTA.FileType.DS9_REG;
 export type ImageFileType = CARTA.FileType.CASA | CARTA.FileType.FITS | CARTA.FileType.HDF5 | CARTA.FileType.MIRIAD;
 export type CatalogFileType = CARTA.CatalogFileType.VOTable | CARTA.CatalogFileType.FITSTable;
+
 export interface SortingConfig {
     columnName: string;
     direction: number;
@@ -83,6 +84,7 @@ export class FileBrowserStore {
         if (this.browserMode === BrowserMode.File) {
             backendService.getFileList(directory).subscribe(res => {
                 this.fileList = res;
+                this.loadingList = false;
             }, err => {
                 console.log(err);
                 this.loadingList = false;
@@ -90,6 +92,7 @@ export class FileBrowserStore {
         } else if (this.browserMode === BrowserMode.Catalog) {
             backendService.getCatalogList(directory).subscribe(res => {
                 this.catalogFileList = res;
+                this.loadingList = false;
             }, err => {
                 console.log(err);
                 this.loadingList = false;
@@ -97,6 +100,7 @@ export class FileBrowserStore {
         } else {
             backendService.getRegionList(directory).subscribe(res => {
                 this.fileList = res;
+                this.loadingList = false;
             }, err => {
                 console.log(err);
                 this.loadingList = false;
@@ -243,11 +247,11 @@ export class FileBrowserStore {
 
     @action setSortingConfig = (columnName: string, direction: number) => {
         this.sortingConfig = {columnName, direction: Math.sign(direction)};
-    }
+    };
 
     @action clearSortingConfig = () => {
         this.sortingConfig = undefined;
-    }
+    };
 
     @computed get fileInfo() {
         let fileInfo = "";


### PR DESCRIPTION
- Fixes #894 
- Moves the sort click handler to the entire column header, as suggested by @Jordatious 
- Fixes issue found by @kswang1029 where the file list is still clickable while loading a new folder's list