### PR TITLE
clamp input values correctly when out of bounds values are entered

### DIFF
--- a/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
+++ b/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
@@ -1,10 +1,17 @@
 import * as React from "react";
 import {NumericInput} from "@blueprintjs/core";
+import {clamp} from "utilities";
 
 export class SafeNumericInput extends React.PureComponent<any> {
     safeHandleValueChanged = (valueAsNumber: number, valueAsString: string) => {
-        if (this.props.onValueChange && isFinite(valueAsNumber) && (!this.props.min || this.props.min <= valueAsNumber) && (!this.props.max || this.props.max >= valueAsNumber)) {
-            this.props.onValueChange(valueAsNumber, valueAsString);
+        if (isFinite(valueAsNumber)) {
+            const clampedValue = clamp(valueAsNumber, this.props.min, this.props.max);
+            if (clampedValue !== valueAsNumber) {
+                valueAsString = valueAsNumber.toString();
+            }
+            if (this.props.onValueChange) {
+                this.props.onValueChange(clampedValue, valueAsString);
+            }
         }
     };
 


### PR DESCRIPTION
Sorts out an issue where incorrect values were being sent to the animator when manually entered values were out of the prescribed range. 