### PR TITLE
show image filename as context menu header in the image list

### DIFF
--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -226,6 +226,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         <MenuItem disabled={appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1} text="Set as spectral reference" onClick={() => appStore.setSpectralReference(frame)}/>
                         <MenuDivider/>
                         <MenuItem text="Close image" onClick={() => appStore.closeFile(frame)}/>
+                        <MenuItem text="Close all other images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(frame)}/>
                     </Menu>
                 );
             }

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -226,7 +226,8 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         <MenuItem disabled={appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1} text="Set as spectral reference" onClick={() => appStore.setSpectralReference(frame)}/>
                         <MenuDivider/>
                         <MenuItem text="Close image" onClick={() => appStore.closeFile(frame)}/>
-                        <MenuItem text="Close all other images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(frame)}/>
+                        <MenuItem text="Close other images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(frame)}/>
+                        <MenuItem text="Close all images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(null, false)}/>
                     </Menu>
                 );
             }

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -56,7 +56,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
     private onFileSelected = (appStore: AppStore, frame: FrameStore) => {
         const fileId = frame.frameInfo.fileId;
         appStore.setActiveFrame(fileId);
-    }
+    };
 
     private fileNameRenderer = (rowIndex: number) => {
         const appStore = AppStore.Instance;
@@ -221,6 +221,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             if (frame) {
                 return (
                     <Menu>
+                        <MenuDivider title={frame.frameInfo.fileInfo.name}/>
                         <MenuItem disabled={appStore.spatialReference === frame} text="Set as spatial reference" onClick={() => appStore.setSpatialReference(frame)}/>
                         <MenuItem disabled={appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1} text="Set as spectral reference" onClick={() => appStore.setSpectralReference(frame)}/>
                         <MenuDivider/>

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -34,7 +34,7 @@ import {
     SpectralProfileStore,
     WidgetsStore,
     CatalogProfileStore,
-    CatalogInfo, 
+    CatalogInfo,
     CatalogUpdateMode
 } from ".";
 import {distinct, GetRequiredTiles, mapToObject} from "utilities";
@@ -423,6 +423,13 @@ export class AppStore {
         this.closeFile(this.activeFrame, confirmClose);
     };
 
+    @action closeOtherFiles = (frame: FrameStore, confirmClose: boolean = true) => {
+        const otherFiles = this.frames.filter(f => f !== frame);
+        for (const f of otherFiles) {
+            this.closeFile(f, confirmClose);
+        }
+    };
+
     @action removeFrame = (frame: FrameStore) => {
         if (frame) {
             // Unlink any associated secondary images
@@ -571,7 +578,7 @@ export class AppStore {
                     associatedCatalogFiles = currentAssociatedCatalogFile;
                 } else {
                     // new image append
-                    catalogStore.catalogProfiles.forEach((value , componentId) => {
+                    catalogStore.catalogProfiles.forEach((value, componentId) => {
                         catalogStore.catalogProfiles.set(componentId, fileId);
                     });
                 }
@@ -616,7 +623,9 @@ export class AppStore {
             // remove overlay
             catalogStore.removeCatalog(fileId);
             // remove profile store
-            catalogStore.catalogProfileStores = catalogStore.catalogProfileStores.filter(catalogProfileStore => { return catalogProfileStore.catalogFileId !== fileId; });
+            catalogStore.catalogProfileStores = catalogStore.catalogProfileStores.filter(catalogProfileStore => {
+                return catalogProfileStore.catalogFileId !== fileId;
+            });
 
             if (!this.activeFrame) {
                 return;
@@ -626,8 +635,10 @@ export class AppStore {
             const activeImageId = AppStore.Instance.activeFrame.frameInfo.fileId;
             let associatedCatalogId = [];
             if (fileIds) {
-                associatedCatalogId = fileIds.filter(catalogFileId => { return catalogFileId !== fileId; });
-                catalogStore.updateImageAssociatedCatalogId(activeImageId, associatedCatalogId);    
+                associatedCatalogId = fileIds.filter(catalogFileId => {
+                    return catalogFileId !== fileId;
+                });
+                catalogStore.updateImageAssociatedCatalogId(activeImageId, associatedCatalogId);
             }
 
             // update catalogProfiles fileId            


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/592504/89946833-d4c70400-dc23-11ea-90bc-b9fd6f1ed2c8.png)

To avoid accidentally closing images, the filename is now shown as a header in the context menu.

bonus: added ability to close other images or all images