### PR TITLE
Angus/region migration

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1397,7 +1397,8 @@ export class FrameStore {
             this.cursorInfo = this.getCursorInfo(cursorPosImage);
         }
 
-        // Remove old regions. TODO: Migrate them to the reference
+        this.spatialReference.frameRegionSet.migrateRegionsFromExistingSet(this.frameRegionSet, this.spatialTransformAST, true);
+        // Remove old regions after migration
         for (const region of this.frameRegionSet.regions) {
             this.frameRegionSet.deleteRegion(region);
         }
@@ -1408,7 +1409,7 @@ export class FrameStore {
     @action clearSpatialReference = () => {
         // Adjust center and zoom based on existing spatial reference
         if (this.spatialReference) {
-            this.frameRegionSet.migrateRegionsFromReference();
+            this.frameRegionSet.migrateRegionsFromExistingSet(this.spatialReference.frameRegionSet, this.spatialTransformAST);
             this.center = this.spatialTransform.transformCoordinate(this.spatialReference.center, false);
             this.zoomLevel = this.spatialReference.zoomLevel * this.spatialTransform.scale;
             this.spatialReference.removeSecondarySpatialImage(this);

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -26,7 +26,7 @@ import {
     Transform2D,
     ZoomPoint
 } from "models";
-import {clamp, formattedFrequency, getHeaderNumericValue, getTransformedChannel, transformPoint, isAstBadPoint, minMax2D, rotate2D, toFixed, trimFitsComment, round2D} from "utilities";
+import {clamp, formattedFrequency, getHeaderNumericValue, getTransformedChannel, transformPoint, isAstBadPoint, minMax2D, rotate2D, toFixed, trimFitsComment, round2D, scale2D} from "utilities";
 import {BackendService, ContourWebGLService} from "services";
 
 export interface FrameInfo {
@@ -1396,12 +1396,19 @@ export class FrameStore {
             const cursorPosImage = transformPoint(this.spatialTransformAST, spatialRefCursorPos, false);
             this.cursorInfo = this.getCursorInfo(cursorPosImage);
         }
+
+        // Remove old regions. TODO: Migrate them to the reference
+        for (const region of this.frameRegionSet.regions) {
+            this.frameRegionSet.deleteRegion(region);
+        }
+
         return true;
     };
 
     @action clearSpatialReference = () => {
         // Adjust center and zoom based on existing spatial reference
         if (this.spatialReference) {
+            this.frameRegionSet.migrateRegionsFromReference();
             this.center = this.spatialTransform.transformCoordinate(this.spatialReference.center, false);
             this.zoomLevel = this.spatialReference.zoomLevel * this.spatialTransform.scale;
             this.spatialReference.removeSecondarySpatialImage(this);

--- a/src/stores/RegionSetStore.ts
+++ b/src/stores/RegionSetStore.ts
@@ -1,8 +1,9 @@
 import {action, observable} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {CURSOR_REGION_ID, FrameStore, PreferenceStore, RegionStore} from "stores";
-import {Point2D} from "models";
+import {Point2D, Transform2D} from "models";
 import {BackendService} from "../services";
+import {isAstBadPoint, scale2D, transformPoint} from "../utilities";
 
 export enum RegionMode {
     MOVING,
@@ -126,5 +127,59 @@ export class RegionSetStore {
 
     @action toggleMode = () => {
         this.mode = (this.mode === RegionMode.MOVING) ? RegionMode.CREATING : RegionMode.MOVING;
+    };
+
+    @action migrateRegionsFromReference = () => {
+        if (this.frame.spatialReference?.regionSet?.regions?.length <= 1) {
+            return;
+        }
+
+        const spatialTransformAST = this.frame.spatialTransformAST;
+
+        let newId = -1;
+        for (const region of this.frame.spatialReference.regionSet.regions) {
+            if (region.regionId === CURSOR_REGION_ID) {
+                const centerNewFrame = transformPoint(spatialTransformAST, region.center, false);
+                if (this.regions.length && this.regions[0].regionId === CURSOR_REGION_ID) {
+                    this.regions[0].setControlPoint(0, centerNewFrame);
+                }
+            } else {
+
+                let newControlPoints: Point2D[] = [];
+                let rotation: number = 0;
+
+                if (region.regionType === CARTA.RegionType.RECTANGLE || region.regionType === CARTA.RegionType.ELLIPSE) {
+                    const centerNewFrame = transformPoint(spatialTransformAST, region.center, false);
+                    if (!isAstBadPoint(centerNewFrame)) {
+                        const transform = new Transform2D(spatialTransformAST, centerNewFrame);
+                        const size = scale2D(region.controlPoints[1], 1.0 / transform.scale);
+                        rotation = region.rotation - transform.rotation * 180 / Math.PI;
+                        newControlPoints = [centerNewFrame, size];
+                    }
+                } else if (region.regionType === CARTA.RegionType.POINT || region.regionType === CARTA.RegionType.POLYGON) {
+                    for (const point of region.controlPoints) {
+                        const pointNewFrame = transformPoint(spatialTransformAST, point, false);
+                        if (!isAstBadPoint(pointNewFrame)) {
+                            newControlPoints.push(pointNewFrame);
+                        }
+                    }
+                }
+
+                if (newControlPoints.length) {
+                    let newRegion: RegionStore;
+                    if (region.regionType === CARTA.RegionType.POINT) {
+                        newRegion = this.addRegion(newControlPoints, 0, CARTA.RegionType.POINT);
+                        newRegion.setName(region.name);
+                        newRegion.setColor(region.color);
+                    } else {
+                        newRegion = this.addExistingRegion(newControlPoints, rotation, region.regionType, newId, region.name, region.color, region.lineWidth, region.dashLength ? [region.dashLength] : []);
+                        newRegion.endCreating();
+                    }
+                    newRegion.setLocked(region.locked);
+                    newId--;
+                }
+            }
+        }
+
     };
 }

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -40,6 +40,7 @@ export class RegionStore {
 
     private readonly backendService: BackendService;
     private readonly regionApproximationMap: Map<number, Point2D[]>;
+    public modifiedTimestamp: number;
 
     public static RegionTypeString(regionType: CARTA.RegionType): string {
         switch (regionType) {
@@ -229,6 +230,7 @@ export class RegionStore {
         this.coordinate = RegionCoordinate.Image;
         this.regionApproximationMap = new Map<number, Point2D[]>();
         this.simplePolygonTest();
+        this.modifiedTimestamp = performance.now();
     }
 
     @action setRegionId = (id: number) => {
@@ -240,6 +242,7 @@ export class RegionStore {
         if (index >= 0 && index < this.controlPoints.length && !isAstBadPoint(p) && isFinite(p?.x) && isFinite(p?.y)) {
             this.regionApproximationMap.clear();
             this.controlPoints[index] = p;
+            this.modifiedTimestamp = performance.now();
             if (!this.editing && !skipUpdate) {
                 this.updateRegion();
             }
@@ -263,6 +266,7 @@ export class RegionStore {
 
         this.regionApproximationMap.clear();
         this.controlPoints = points;
+        this.modifiedTimestamp = performance.now();
         if (shapeChanged && this.regionType === CARTA.RegionType.POLYGON) {
             this.simplePolygonTest();
         }

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -162,17 +162,22 @@ export function getApproximatePolygonPoints(astTransform: number, controlPoints:
     }
 
     const N = approxPointsOriginalSpace.length;
-    const xCoords = new Float64Array(N);
-    const yCoords = new Float64Array(N);
-    for (let i = 0; i < N; i++) {
-        xCoords[i] = approxPointsOriginalSpace[i].x;
-        yCoords[i] = approxPointsOriginalSpace[i].y;
-    }
 
-    const results = AST.transformPointArrays(astTransform, xCoords, yCoords, 0) as { x: Float64Array, y: Float64Array };
-    const approximatePoints = new Array<Point2D>(N);
-    for (let i = 0; i < N; i++) {
-        approximatePoints[i] = {x: results.x[i], y: results.y[i]};
+    if (N) {
+        const xCoords = new Float64Array(N);
+        const yCoords = new Float64Array(N);
+        for (let i = 0; i < N; i++) {
+            xCoords[i] = approxPointsOriginalSpace[i].x;
+            yCoords[i] = approxPointsOriginalSpace[i].y;
+        }
+
+        const results = AST.transformPointArrays(astTransform, xCoords, yCoords, 0) as { x: Float64Array, y: Float64Array };
+        const approximatePoints = new Array<Point2D>(N);
+        for (let i = 0; i < N; i++) {
+            approximatePoints[i] = {x: results.x[i], y: results.y[i]};
+        }
+        return approximatePoints;
+    } else {
+        return [];
     }
-    return approximatePoints;
 }


### PR DESCRIPTION
Adds ability to migrate regions into and out of WCS group:

1. When enabling matching on a new image with existing regions, those regions are migrated to the reference image
2. When disabling matching on an image where the reference image has existing regions, regions are duplicated in the secondary image (now independent regions)
3. When enabling matching on the same image again, the region's `modifiedTimestamp` property is checked in order to ignore duplicate regions.
4. When changing the reference image from one to another, the regions are migrated to the new reference frame