### PR TITLE
Angus/fix 1109

### DIFF
--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -51,7 +51,7 @@ export class RegionDialogComponent extends React.Component {
             bodyContent = RegionDialogComponent.InvalidRegionNode;
         } else {
             region = appStore.activeFrame.regionSet.selectedRegion;
-            const frame = appStore.activeFrame;
+            const frame = appStore.activeFrame.spatialReference ?? appStore.activeFrame;
 
             dialogProps.title = `Editing ${region.nameString}`;
             switch (region.regionType) {

--- a/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
+++ b/src/components/Dialogs/RegionDialog/RegionDialogComponent.tsx
@@ -52,8 +52,7 @@ export class RegionDialogComponent extends React.Component {
         } else {
             region = appStore.activeFrame.regionSet.selectedRegion;
             const frame = appStore.activeFrame.spatialReference ?? appStore.activeFrame;
-
-            dialogProps.title = `Editing ${region.nameString}`;
+            dialogProps.title = `Editing ${region.nameString} (${frame.frameInfo.fileInfo.name})`;
             switch (region.regionType) {
                 case CARTA.RegionType.POINT:
                     bodyContent = (

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {computed, observable} from "mobx";
+import {autorun, computed, observable} from "mobx";
 import {observer} from "mobx-react";
 import {HTMLTable, Icon, NonIdealState, Position, Tooltip} from "@blueprintjs/core";
 import ReactResizeDetector from "react-resize-detector";
@@ -63,6 +63,21 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private handleRegionListDoubleClick = () => {
         DialogStore.Instance.showRegionDialog();
     };
+
+    constructor(props: WidgetProps) {
+        super(props);
+
+        const appStore = AppStore.Instance;
+        // update widget title to include region's associated file name
+        autorun(() => {
+            const frame = appStore.activeFrame?.spatialReference ?? appStore.activeFrame;
+            if (frame) {
+                appStore.widgetsStore.setWidgetTitle(this.props.id, `Region List (${frame.frameInfo.fileInfo.name})`);
+            } else {
+                appStore.widgetsStore.setWidgetTitle(this.props.id, "Region List");
+            }
+        });
+    }
 
     render() {
         const appStore = AppStore.Instance;

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -227,7 +227,11 @@ export class RegionStore {
         this.dashLength = dashLength;
         this.rotation = rotation;
         this.backendService = backendService;
-        this.coordinate = RegionCoordinate.Image;
+        if (activeFrame.validWcs) {
+            this.coordinate = RegionCoordinate.World;
+        } else {
+            this.coordinate = RegionCoordinate.Image;
+        }
         this.regionApproximationMap = new Map<number, Point2D[]>();
         this.simplePolygonTest();
         this.modifiedTimestamp = performance.now();


### PR DESCRIPTION
Uses the _reference image_ for region information, rather than recalculating when the active frame changes. That way, WCS and pixel information is consistent. The region's associated file name is now shown in the title bars of the region list and region editing dialog.

![image](https://user-images.githubusercontent.com/592504/90038572-e06b0700-dcc5-11ea-864e-0c4b26576b64.png)
