### PR TITLE
adds default region on click

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -402,6 +402,15 @@ export class PreferenceDialogComponent extends React.Component {
                         {regionTypes}
                     </HTMLSelect>
                 </FormGroup>
+                <FormGroup inline={true} label="Region radius" labelInfo="(px)">
+                    <SafeNumericInput
+                        placeholder="Region radius"
+                        min={1}
+                        value={preference.regionRadius}
+                        stepSize={1}
+                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_RADIUS, Math.max(1, value))}
+                    />
+                </FormGroup>
                 <FormGroup inline={true} label="Creation Mode">
                     <RadioGroup
                         selectedValue={preference.regionCreationMode}

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -402,13 +402,13 @@ export class PreferenceDialogComponent extends React.Component {
                         {regionTypes}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Region radius" labelInfo="(px)">
+                <FormGroup inline={true} label="Region size" labelInfo="(px)">
                     <SafeNumericInput
-                        placeholder="Region radius"
+                        placeholder="Region size"
                         min={1}
-                        value={preference.regionRadius}
+                        value={preference.regionSize}
                         stepSize={1}
-                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_RADIUS, Math.max(1, value))}
+                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_SIZE, Math.max(1, value))}
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Creation Mode">

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -229,7 +229,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         if (this.creatingRegion) {
             if (this.creatingRegion.controlPoints.length > 1 && length2D(this.creatingRegion.controlPoints[1]) === 0) {
-                const scaleFactor = PreferenceStore.Instance.regionRadius * (this.creatingRegion.regionType === CARTA.RegionType.RECTANGLE ? 2.0 : 1.0) / frame.zoomLevel;
+                const scaleFactor = PreferenceStore.Instance.regionSize * (this.creatingRegion.regionType === CARTA.RegionType.RECTANGLE ? 1.0 : 0.5) / frame.zoomLevel;
                 this.creatingRegion.setControlPoint(1, scale2D({x: 1, y: 1}, scaleFactor));
             }
             if (this.creatingRegion.isValid) {

--- a/src/models/preferences_schema_1.json
+++ b/src/models/preferences_schema_1.json
@@ -194,6 +194,10 @@
                 "corner"
             ]
         },
+        "regionRadius": {
+            "type": "number",
+            "minimum": 1
+        },
         "imageCompressionQuality": {
             "type": "integer",
             "minimum": 4,

--- a/src/models/preferences_schema_1.json
+++ b/src/models/preferences_schema_1.json
@@ -194,7 +194,7 @@
                 "corner"
             ]
         },
-        "regionRadius": {
+        "regionSize": {
             "type": "number",
             "minimum": 1
         },

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -48,6 +48,7 @@ export enum PreferenceKeys {
     REGION_DASH_LENGTH = "regionDashLength",
     REGION_TYPE = "regionType",
     REGION_CREATION_MODE = "regionCreationMode",
+    REGION_RADIUS = "regionRadius",
 
     PERFORMANCE_IMAGE_COMPRESSION_QUALITY = "imageCompressionQuality",
     PERFORMANCE_ANIMATION_COMPRESSION_QUALITY = "animationCompressionQuality",
@@ -111,6 +112,7 @@ const DEFAULTS = {
         regionDashLength: 0,
         regionType: CARTA.RegionType.RECTANGLE,
         regionCreationMode: RegionCreationMode.CENTER,
+        regionRadius: 15
     },
     PERFORMANCE: {
         imageCompressionQuality: CompressionQuality.IMAGE_DEFAULT,
@@ -308,6 +310,10 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.REGION_CREATION_MODE) ?? DEFAULTS.REGION.regionCreationMode;
     }
 
+    @computed get regionRadius(): number {
+        return this.preferences.get(PreferenceKeys.REGION_RADIUS) ?? DEFAULTS.REGION.regionRadius;
+    }
+
     // getters for performance
     @computed get imageCompressionQuality(): number {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY) ?? DEFAULTS.PERFORMANCE.imageCompressionQuality;
@@ -438,7 +444,7 @@ export class PreferenceStore {
     @action resetRegionSettings = () => {
         this.clearPreferences([
             PreferenceKeys.REGION_COLOR, PreferenceKeys.REGION_CREATION_MODE, PreferenceKeys.REGION_DASH_LENGTH,
-            PreferenceKeys.REGION_LINE_WIDTH, PreferenceKeys.REGION_TYPE
+            PreferenceKeys.REGION_LINE_WIDTH, PreferenceKeys.REGION_TYPE, PreferenceKeys.REGION_RADIUS
         ]);
     };
 

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -48,7 +48,7 @@ export enum PreferenceKeys {
     REGION_DASH_LENGTH = "regionDashLength",
     REGION_TYPE = "regionType",
     REGION_CREATION_MODE = "regionCreationMode",
-    REGION_RADIUS = "regionRadius",
+    REGION_SIZE = "regionSize",
 
     PERFORMANCE_IMAGE_COMPRESSION_QUALITY = "imageCompressionQuality",
     PERFORMANCE_ANIMATION_COMPRESSION_QUALITY = "animationCompressionQuality",
@@ -112,7 +112,7 @@ const DEFAULTS = {
         regionDashLength: 0,
         regionType: CARTA.RegionType.RECTANGLE,
         regionCreationMode: RegionCreationMode.CENTER,
-        regionRadius: 15
+        regionSize: 30
     },
     PERFORMANCE: {
         imageCompressionQuality: CompressionQuality.IMAGE_DEFAULT,
@@ -310,8 +310,8 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.REGION_CREATION_MODE) ?? DEFAULTS.REGION.regionCreationMode;
     }
 
-    @computed get regionRadius(): number {
-        return this.preferences.get(PreferenceKeys.REGION_RADIUS) ?? DEFAULTS.REGION.regionRadius;
+    @computed get regionSize(): number {
+        return this.preferences.get(PreferenceKeys.REGION_SIZE) ?? DEFAULTS.REGION.regionSize;
     }
 
     // getters for performance
@@ -444,7 +444,7 @@ export class PreferenceStore {
     @action resetRegionSettings = () => {
         this.clearPreferences([
             PreferenceKeys.REGION_COLOR, PreferenceKeys.REGION_CREATION_MODE, PreferenceKeys.REGION_DASH_LENGTH,
-            PreferenceKeys.REGION_LINE_WIDTH, PreferenceKeys.REGION_TYPE, PreferenceKeys.REGION_RADIUS
+            PreferenceKeys.REGION_LINE_WIDTH, PreferenceKeys.REGION_TYPE, PreferenceKeys.REGION_SIZE
         ]);
     };
 


### PR DESCRIPTION
Adds similar behaviour to DS9: Ellipse and rectangular regions can be created with a default size by simply clicking instead of clicking and dragging. 

![default_regions](https://user-images.githubusercontent.com/592504/90043250-25923780-dccc-11ea-8e71-893f1ef3826f.gif)

The default region radius can be configured in the preferences->region panel. As with DS9, the created region's size depends on this default value and the zoom level. 