### PR TITLE
plotting smoothed value in Q,U scatter plot in Stokes

### DIFF
--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -477,7 +477,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
         const frame = this.widgetStore.effectiveFrame;
         if (qProfile && qProfile.length && uProfile && uProfile.length &&
             frame.channelValues && frame.channelValues.length &&
-            qProfile.length === uProfile.length && qProfile.length === frame.channelValues.length) {
+            qProfile.length === uProfile.length && (qProfile.length === frame.channelValues.length || this.widgetStore.smoothingStore.type === SmoothingType.BINNING)) {
             const channelValues = frame.channelValues;
             let border = this.calculateXYborder(qProfile, uProfile, false, type);
             let values: Array<{ x: number, y: number, z: number }> = [];
@@ -623,6 +623,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
         piSmoothedValues: { dataset: Array<Point2D>, border: Border },
         paSmoothedValues: { dataset: Array<Point2D>, border: Border },
         quValues: { dataset: Array<{ x: number, y: number, z: number }>, border: Border },
+        quSmoothedValues: { dataset: Array<{ x: number, y: number, z: number }>, border: Border },
         qProgress: number,
         uProgress: number,
         iProgress: number
@@ -659,6 +660,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
         let channelInfo = frame.channelInfo;
         if (compositeProfile && channelInfo) {
             let quDic = this.assembleScatterPlotData(compositeProfile.qProfile, compositeProfile.uProfile, StokesCoordinate.PolarizationQU);
+            let quSmoothedDic = this.assembleScatterPlotData(compositeProfile.qProfileSmoothed, compositeProfile.uProfileSmoothed, StokesCoordinate.PolarizationQU);
             let piDic = this.assembleLinePlotData(compositeProfile.piProfile, frame.channelValues, StokesCoordinate.PolarizedIntensity);
             let paDic = this.assembleLinePlotData(compositeProfile.paProfile, frame.channelValues, StokesCoordinate.PolarizationAngle);
             let qDic = this.assembleLinePlotData(compositeProfile.qProfile, frame.channelValues, StokesCoordinate.LinearPolarizationQ);
@@ -678,6 +680,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 piSmoothedValues: piSmoothedDic,
                 paSmoothedValues: paSmoothedDic,
                 quValues: quDic, 
+                quSmoothedValues: quSmoothedDic,
                 qProgress: compositeProfile.qProgress, 
                 uProgress: compositeProfile.uProgress,
                 iProgress: compositeProfile.iProgress
@@ -929,7 +932,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
             if (currentPlotData && currentPlotData.piValues && currentPlotData.paValues && currentPlotData.qValues && currentPlotData.uValues && currentPlotData.quValues) {
                 piLinePlotProps.data = currentPlotData.piValues.dataset;
                 paLinePlotProps.data = currentPlotData.paValues.dataset;
-                quScatterPlotProps.data = currentPlotData.quValues.dataset;
+                quScatterPlotProps.data = (this.widgetStore.smoothingStore.type === SmoothingType.NONE ) ? currentPlotData.quValues.dataset : currentPlotData.quSmoothedValues.dataset;
  
                 const lineOpacity = this.minProgress < 1.0 ? 0.15 + this.minProgress / 4.0 : 1.0;
                 quLinePlotProps.opacity = lineOpacity;
@@ -1087,14 +1090,14 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 }
                 let scatterCursorInfor = {
                     profiler: { x: this.widgetStore.scatterPlotCursorX, y: this.widgetStore.scatterPlotCursorY},
-                    image: this.matchXYindex(cursorX.image, currentPlotData.quValues.dataset),
+                    image: this.matchXYindex(cursorX.image, quScatterPlotProps.data),
                     unit: frame.spectralUnitStr
                 };
                 quScatterPlotProps.cursorXY = scatterCursorInfor;
                 this.cursorInfo = this.getCursorInfo(
-                    currentPlotData.quValues.dataset, 
-                    currentPlotData.piValues.dataset, 
-                    currentPlotData.paValues.dataset, 
+                    quScatterPlotProps.data,
+                    this.widgetStore.smoothingStore.type === SmoothingType.NONE ? currentPlotData.piValues.dataset : currentPlotData.piSmoothedValues.dataset,
+                    this.widgetStore.smoothingStore.type === SmoothingType.NONE ? currentPlotData.paValues.dataset : currentPlotData.paSmoothedValues.dataset,
                     scatterCursorInfor.profiler,
                     cursorX.profiler,
                     scatterCursorInfor.image,
@@ -1196,7 +1199,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
             paLinePlotProps.comments = this.exportHeaders;
             piLinePlotProps.comments = this.exportHeaders;
             quLinePlotProps.comments = this.exportHeaders;
-            quScatterPlotProps.comments = this.exportHeaders;
+            quScatterPlotProps.comments = this.widgetStore.smoothingStore.type === SmoothingType.NONE ? this.exportHeaders : this.exportHeaders.concat(this.widgetStore.smoothingStore.comments);
         }
 
         return (

--- a/src/stores/ProfileSmoothingStore.ts
+++ b/src/stores/ProfileSmoothingStore.ts
@@ -122,6 +122,16 @@ export class ProfileSmoothingStore {
         return exportData;
     }
 
+    @computed get comments(): string[] {
+        let comments: string[] = [];
+        if (this.exportData) {
+            this.exportData.forEach((content, title) => {
+                comments.push(`${title}: ${content}`);
+            });
+        }
+        return comments;
+    }
+
     @computed get gaussianKernel(): number {
         if (this.gaussianSigma < 3) {
             return 3;


### PR DESCRIPTION
closes #1114 
Using smoothed value in Q,U scatter plot in Stokes. 
Displaying smoothed value of Q, U, PI and PA in cursor info when smoothing.
Updating export data file(.csv) of Q,U scatter plot with smoothed value.