### PR TITLE
fixes #1117

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -781,7 +781,7 @@ export class AppStore {
             frame.resetMomentRequestState();
             if (ack.success && ack.openFileAcks) {
                 ack.openFileAcks.forEach(openFileAck => {
-                    if (this.addFrame(CARTA.OpenFileAck.create(openFileAck), "", "")) {
+                    if (this.addFrame(CARTA.OpenFileAck.create(openFileAck), this.fileBrowserStore.startingDirectory, "")) {
                         this.fileCounter++;
                         frame.addMomentImage(this.frames.find(f => f.frameInfo.fileId === openFileAck.fileId));
                     } else {


### PR DESCRIPTION
keeps the current file browser directory constant instead of reverting to the home directory when generating moment images