### PR TITLE
Thchang/fix 1147

### DIFF
--- a/src/components/RegionSelector/RegionSelectorComponent.tsx
+++ b/src/components/RegionSelector/RegionSelectorComponent.tsx
@@ -7,7 +7,7 @@ import {RegionWidgetStore, RegionsType, RegionId, ACTIVE_FILE_ID} from "stores/w
 import "./RegionSelectorComponent.css";
 
 @observer
-export class RegionSelectorComponent extends React.Component<{ widgetStore: RegionWidgetStore, onFrameChanged?: (newFrame: FrameStore) => void }> {
+export class RegionSelectorComponent extends React.Component<{ widgetStore: RegionWidgetStore, onFrameChanged?: (newFrame: FrameStore) => void, nonClosedDisabled?: boolean }> {
 
     private handleFrameChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
         const appStore = AppStore.Instance;
@@ -68,7 +68,7 @@ export class RegionSelectorComponent extends React.Component<{ widgetStore: Regi
                 default:
                     fiteredRegions = regions;
             }
-            regionOptions = regionOptions.concat(fiteredRegions.map(r => {return {value: r.regionId, label: r.nameString}; }));
+            regionOptions = regionOptions.concat(fiteredRegions.map(r => {return {value: r.regionId, label: r.nameString, disabled: this.props.nonClosedDisabled ? !r.isClosedRegion : false}; }));
 
             if (widgetStore.type === RegionsType.CLOSED_AND_POINT && regionOptions.length === 1) {
                 regionOptions = regionOptions.concat([{value: RegionId.CURSOR, label: "Cursor"}]);

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -6,7 +6,7 @@ import {ItemPredicate, ItemRenderer, MultiSelect} from "@blueprintjs/select";
 import {RegionSelectorComponent} from "components";
 import {TaskProgressDialogComponent} from "components/Dialogs";
 import {SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
-import {MomentSelectingMode, SpectralProfileWidgetStore} from "stores/widgets";
+import {MomentSelectingMode, SpectralProfileWidgetStore, ACTIVE_FILE_ID} from "stores/widgets";
 import {AnimationState, AppStore} from "stores";
 import {MOMENT_TEXT} from "models";
 import "./MomentGeneratorComponent.css";
@@ -180,9 +180,9 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         );
 
         const effectiveRegion = (frame?.regionSet?.regions) ? frame.regionSet.regions.find(r => r.regionId === widgetStore.effectiveRegionId) : null;
-        const isEnabledRegion = (widgetStore.effectiveRegionId !== 0 && effectiveRegion && effectiveRegion.isClosedRegion);
+        const isEnabledRegion = ((widgetStore.fileId === ACTIVE_FILE_ID && widgetStore.effectiveRegionId === 0) || (effectiveRegion && effectiveRegion.isClosedRegion)); // request image when region dropdown is active with no region selected
         const isAbleToGenerate = frame && frame.numChannels > 1 && appStore.animatorStore.animationState === AnimationState.STOPPED && !widgetStore.isStreamingData && isEnabledRegion;
-        const hint = <span><br/><i><small>Please ensure<br/>1. Animation playback is stopped.<br/>2. Spectral profile generation is complete.<br/>3. Closed region is selected.</small></i></span>;
+        const hint = <span><br/><i><small>Please ensure<br/>1. Animation playback is stopped.<br/>2. Spectral profile generation is complete.<br/>3. Cursor or point region is not selected.</small></i></span>;
         const msg = <span>Unable to generate moment images{hint}</span>;
         const momentsPanel = (
             <React.Fragment>

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -100,7 +100,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         const widgetStore = this.props.widgetStore;
         const frame = widgetStore.effectiveFrame;
 
-        const regionPanel = <RegionSelectorComponent widgetStore={this.props.widgetStore}/>;
+        const regionPanel = <RegionSelectorComponent widgetStore={this.props.widgetStore} nonClosedDisabled={true}/>;
 
         const spectralPanel = (
             <React.Fragment>
@@ -179,8 +179,10 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
             </React.Fragment>
         );
 
-        const isAbleToGenerate = frame && frame.numChannels > 1 && appStore.animatorStore.animationState === AnimationState.STOPPED && !widgetStore.isStreamingData;
-        const hint = <span><br/><i><small>Please ensure<br/>1. Animation playback is stopped.<br/>2. Spectral profile generation is complete.</small></i></span>;
+        const effectiveRegion = (frame?.regionSet?.regions) ? frame.regionSet.regions.find(r => r.regionId === widgetStore.effectiveRegionId) : null;
+        const isEnabledRegion = (widgetStore.effectiveRegionId !== 0 && effectiveRegion && effectiveRegion.isClosedRegion);
+        const isAbleToGenerate = frame && frame.numChannels > 1 && appStore.animatorStore.animationState === AnimationState.STOPPED && !widgetStore.isStreamingData && isEnabledRegion;
+        const hint = <span><br/><i><small>Please ensure<br/>1. Animation playback is stopped.<br/>2. Spectral profile generation is complete.<br/>3. Closed region is selected.</small></i></span>;
         const msg = <span>Unable to generate moment images{hint}</span>;
         const momentsPanel = (
             <React.Fragment>

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -6,7 +6,7 @@ import {ItemPredicate, ItemRenderer, MultiSelect} from "@blueprintjs/select";
 import {RegionSelectorComponent} from "components";
 import {TaskProgressDialogComponent} from "components/Dialogs";
 import {SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
-import {MomentSelectingMode, SpectralProfileWidgetStore, ACTIVE_FILE_ID} from "stores/widgets";
+import {MomentSelectingMode, SpectralProfileWidgetStore, RegionId} from "stores/widgets";
 import {AnimationState, AppStore} from "stores";
 import {MOMENT_TEXT} from "models";
 import "./MomentGeneratorComponent.css";
@@ -180,8 +180,9 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         );
 
         const effectiveRegion = (frame?.regionSet?.regions) ? frame.regionSet.regions.find(r => r.regionId === widgetStore.effectiveRegionId) : null;
-        const isEnabledRegion = ((widgetStore.fileId === ACTIVE_FILE_ID && widgetStore.effectiveRegionId === 0) || (effectiveRegion && effectiveRegion.isClosedRegion)); // request image when region dropdown is active with no region selected
-        const isAbleToGenerate = frame && frame.numChannels > 1 && appStore.animatorStore.animationState === AnimationState.STOPPED && !widgetStore.isStreamingData && isEnabledRegion;
+        const isEnabledRegion = effectiveRegion && effectiveRegion.isClosedRegion;
+        const isImage = widgetStore.regionIdMap.get(widgetStore.fileId) !== RegionId.CURSOR && widgetStore.effectiveRegionId === 0; // request image when region dropdown is active with no region selected
+        const isAbleToGenerate = frame && frame.numChannels > 1 && appStore.animatorStore.animationState === AnimationState.STOPPED && !widgetStore.isStreamingData && (isEnabledRegion || isImage);
         const hint = <span><br/><i><small>Please ensure<br/>1. Animation playback is stopped.<br/>2. Spectral profile generation is complete.<br/>3. Cursor or point region is not selected.</small></i></span>;
         const msg = <span>Unable to generate moment images{hint}</span>;
         const momentsPanel = (

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -2,7 +2,7 @@ import {action, autorun, computed, observable} from "mobx";
 import {Colors, NumberRange} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings} from "components/Shared";
-import {RegionWidgetStore, RegionsType} from "./RegionWidgetStore";
+import {RegionWidgetStore, RegionsType, ACTIVE_FILE_ID} from "./RegionWidgetStore";
 import {SpectralLine} from "./SpectralLineQueryWidgetStore";
 import {AppStore} from "stores";
 import {ProfileSmoothingStore} from "stores/ProfileSmoothingStore";
@@ -195,7 +195,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                 fileId: frame.frameInfo.fileId,
                 moments: this.selectedMoments,
                 axis: CARTA.MomentAxis.SPECTRAL,
-                regionId: this.effectiveRegionId,
+                regionId: (this.fileId === ACTIVE_FILE_ID && this.effectiveRegionId === 0) ? -1 : this.effectiveRegionId, // request image when region dropdown is active with no region selected
                 spectralRange: channelIndexRange,
                 mask: this.momentMask,
                 pixelRange: new CARTA.FloatBounds({min: this.maskRange[0], max: this.maskRange[1]})


### PR DESCRIPTION
closes #1147 
The options of cursor and point regions in the region dropdown of moment generator are disabled.
The moment generator will request **Image** data when both the region is "Active" and there is no region being selected.