### PR TITLE
report verbose session info in hidden div

### DIFF
--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -47,4 +47,8 @@
             }
         }
     }
+
+  #hidden-status-info {
+    display: none;
+  }
 }

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -259,7 +259,18 @@ export class RootMenuComponent extends React.Component {
                     connectivityTooltip = <span>Reconnected to server {userString} after disconnect. Some errors may occur<br/><i><small>Latency: {latencyString}</small></i></span>;
                     connectivityClass += " warning";
                 } else {
-                    connectivityTooltip = <span>Connected to server {userString}<br/><i><small>Latency: {latencyString}<br/>Session ID: {appStore.backendService.sessionId}</small></i></span>;
+                    connectivityTooltip = (
+                        <span>
+                            Connected to server {userString}<br/>
+                            <i>
+                                <small>
+                                    Latency: {latencyString}<br/>
+                                    Session ID: {appStore.backendService.sessionId}<br/>
+                                    {appStore.backendService.grpcPort >= 0 && <span>GRPC Port: {appStore.backendService.grpcPort}</span>}
+                                </small>
+                            </i>
+                        </span>
+                    );
                     connectivityClass += " online";
                 }
                 break;
@@ -342,6 +353,11 @@ export class RootMenuComponent extends React.Component {
                 <Tooltip content={connectivityTooltip}>
                     <Icon icon={"symbol-circle"} className={connectivityClass}/>
                 </Tooltip>
+                <div id="hidden-status-info">
+                    <span id="session-id-span">{appStore.backendService.sessionId}</span>
+                    <span id="grpc-port-span">{appStore.backendService.grpcPort}</span>
+                    <span id="server-url-span">{appStore.backendService.serverUrl}</span>
+                </div>
             </div>
         );
     }

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -266,7 +266,7 @@ export class RootMenuComponent extends React.Component {
                                 <small>
                                     Latency: {latencyString}<br/>
                                     Session ID: {appStore.backendService.sessionId}<br/>
-                                    {appStore.backendService.grpcPort >= 0 && <span>GRPC Port: {appStore.backendService.grpcPort}</span>}
+                                    {appStore.backendService.grpcPort > 0 && <span>GRPC Port: {appStore.backendService.grpcPort}</span>}
                                 </small>
                             </i>
                         </span>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -354,9 +354,9 @@ export class RootMenuComponent extends React.Component {
                     <Icon icon={"symbol-circle"} className={connectivityClass}/>
                 </Tooltip>
                 <div id="hidden-status-info">
-                    <span id="session-id-span">{appStore.backendService.sessionId}</span>
-                    <span id="grpc-port-span">{appStore.backendService.grpcPort}</span>
-                    <span id="server-url-span">{appStore.backendService.serverUrl}</span>
+                    <span id="info-session-id">{appStore.backendService.sessionId}</span>
+                    <span id="info-grpc-port">{appStore.backendService.grpcPort}</span>
+                    <span id="info-server-url">{appStore.backendService.serverUrl}</span>
                 </div>
             </div>
         );


### PR DESCRIPTION
Closes #1228.Companion PR of https://github.com/CARTAvis/carta-backend/pull/646

This adds an invisible div with element ID `hidden-status-info`, which can be used to get the session ID, GRPC port or server URL. For example, to get the session ID:

`document.getElementById("info-server-url").innerHTML`