### PR TITLE
Angus/match image scaling

### DIFF
--- a/src/components/LayerList/LayerListComponent.scss
+++ b/src/components/LayerList/LayerListComponent.scss
@@ -14,6 +14,10 @@
         cursor: pointer;
     }
 
+    .bp3-table-column-name {
+        font-size: 12px;
+    }
+
     .bp3-button {
         font-size: 11px;
         &.bp3-small {

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -179,22 +179,22 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         }
 
         let renderConfigMatchingButton: React.ReactNode;
-        if (appStore.renderConfigReference) {
+        if (appStore.rasterScalingReference) {
             let tooltipSubtitle: string;
-            if (frame === appStore.renderConfigReference) {
-                tooltipSubtitle = `${frame.frameInfo.fileInfo.name} is the current render config reference`;
+            if (frame === appStore.rasterScalingReference) {
+                tooltipSubtitle = `${frame.frameInfo.fileInfo.name} is the current raster scaling reference`;
             } else {
-                tooltipSubtitle = `Click to ${frame.renderConfigReference ? "disable" : "enable"} matching to ${appStore.renderConfigReference.frameInfo.fileInfo.name}`;
+                tooltipSubtitle = `Click to ${frame.rasterScalingReference ? "disable" : "enable"} matching to ${appStore.rasterScalingReference.frameInfo.fileInfo.name}`;
             }
             renderConfigMatchingButton = (
-                <Tooltip position={"bottom"} content={<span>Render config matching<br/><i><small>{tooltipSubtitle}</small></i></span>}>
+                <Tooltip position={"bottom"} content={<span>Raster scaling matching<br/><i><small>{tooltipSubtitle}</small></i></span>}>
                     <AnchorButton
-                        className={frame === appStore.renderConfigReference ? "outlined" : ""}
+                        className={frame === appStore.rasterScalingReference ? "outlined" : ""}
                         minimal={true}
                         small={true}
-                        active={!!frame.renderConfigReference}
-                        intent={frame.renderConfigReference ? "success" : "none"}
-                        onClick={() => appStore.toggleRenderConfigMatching(frame)}
+                        active={!!frame.rasterScalingReference}
+                        intent={frame.rasterScalingReference ? "success" : "none"}
+                        onClick={() => appStore.toggleRasterScalingMatching(frame)}
                     >
                         R
                     </AnchorButton>
@@ -254,7 +254,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         <MenuDivider title={frame.frameInfo.fileInfo.name}/>
                         <MenuItem disabled={appStore.spatialReference === frame} text="Set as spatial reference" onClick={() => appStore.setSpatialReference(frame)}/>
                         <MenuItem disabled={appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1} text="Set as spectral reference" onClick={() => appStore.setSpectralReference(frame)}/>
-                        <MenuItem disabled={appStore.renderConfigReference === frame} text="Set as render config reference" onClick={() => appStore.setRenderConfigReference(frame)}/>
+                        <MenuItem disabled={appStore.rasterScalingReference === frame} text="Set as raster scaling reference" onClick={() => appStore.setRasterScalingReference(frame)}/>
                         <MenuDivider/>
                         <MenuItem text="Close image" onClick={() => appStore.closeFile(frame)}/>
                         <MenuItem text="Close other images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(frame)}/>
@@ -289,10 +289,10 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
         const f1 = appStore.frames.map(f => f.spatialReference);
         const f2 = appStore.frames.map(f => f.spectralReference);
-        const f3 = appStore.frames.map(f => f.renderConfigReference);
+        const f3 = appStore.frames.map(f => f.rasterScalingReference);
         const currentSpectralReference = appStore.spectralReference;
         const currentSpatialReference = appStore.spatialReference;
-        const currentRenderConfigReference = appStore.renderConfigReference;
+        const currentRasterScalingReference = appStore.rasterScalingReference;
 
         /* eslint-enable @typescript-eslint/no-unused-vars */
         return (

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -27,7 +27,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
 
     @observable width: number = 0;
     @observable height: number = 0;
-    @observable columnWidths = [150, 75, 85, 77, 68];
+    @observable columnWidths = [132, 70, 110, 75, 67];
 
     constructor(props: any) {
         super(props);

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -254,6 +254,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         <MenuDivider title={frame.frameInfo.fileInfo.name}/>
                         <MenuItem disabled={appStore.spatialReference === frame} text="Set as spatial reference" onClick={() => appStore.setSpatialReference(frame)}/>
                         <MenuItem disabled={appStore.spectralReference === frame || frame.frameInfo.fileInfoExtended.depth <= 1} text="Set as spectral reference" onClick={() => appStore.setSpectralReference(frame)}/>
+                        <MenuItem disabled={appStore.renderConfigReference === frame} text="Set as render config reference" onClick={() => appStore.setRenderConfigReference(frame)}/>
                         <MenuDivider/>
                         <MenuItem text="Close image" onClick={() => appStore.closeFile(frame)}/>
                         <MenuItem text="Close other images" disabled={appStore.frames?.length <= 1} onClick={() => appStore.closeOtherFiles(frame)}/>

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -286,7 +286,9 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         const activeFrameIndex = appStore.activeFrameIndex;
         const visibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
-        const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference && f.renderConfigReference);
+        const f1 = appStore.frames.map(f => f.spatialReference);
+        const f2 = appStore.frames.map(f => f.spectralReference);
+        const f3 = appStore.frames.map(f => f.renderConfigReference);
         const currentSpectralReference = appStore.spectralReference;
         const currentSpatialReference = appStore.spatialReference;
         const currentRenderConfigReference = appStore.renderConfigReference;

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -178,11 +178,36 @@ export class LayerListComponent extends React.Component<WidgetProps> {
             );
         }
 
+        let renderConfigMatchingButton: React.ReactNode;
+        if (appStore.renderConfigReference) {
+            let tooltipSubtitle: string;
+            if (frame === appStore.renderConfigReference) {
+                tooltipSubtitle = `${frame.frameInfo.fileInfo.name} is the current render config reference`;
+            } else {
+                tooltipSubtitle = `Click to ${frame.renderConfigReference ? "disable" : "enable"} matching to ${appStore.renderConfigReference.frameInfo.fileInfo.name}`;
+            }
+            renderConfigMatchingButton = (
+                <Tooltip position={"bottom"} content={<span>Render config matching<br/><i><small>{tooltipSubtitle}</small></i></span>}>
+                    <AnchorButton
+                        className={frame === appStore.renderConfigReference ? "outlined" : ""}
+                        minimal={true}
+                        small={true}
+                        active={!!frame.renderConfigReference}
+                        intent={frame.renderConfigReference ? "success" : "none"}
+                        onClick={() => appStore.toggleRenderConfigMatching(frame)}
+                    >
+                        R
+                    </AnchorButton>
+                </Tooltip>
+            );
+        }
+
         return (
             <Cell className={rowIndex === appStore.activeFrameIndex ? "active-row-cell" : ""}>
                 <React.Fragment>
                     {spatialMatchingButton}
                     {spectralMatchingButton}
+                    {renderConfigMatchingButton}
                 </React.Fragment>
             </Cell>
         );
@@ -261,9 +286,11 @@ export class LayerListComponent extends React.Component<WidgetProps> {
         const activeFrameIndex = appStore.activeFrameIndex;
         const visibilityRaster = appStore.frames.map(f => f.renderConfig.visible);
         const visibilityContour = appStore.frames.map(f => f.contourConfig.visible && f.contourConfig.enabled);
-        const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference);
+        const matchingTypes = appStore.frames.map(f => f.spatialReference && f.spectralReference && f.renderConfigReference);
         const currentSpectralReference = appStore.spectralReference;
         const currentSpatialReference = appStore.spatialReference;
+        const currentRenderConfigReference = appStore.renderConfigReference;
+
         /* eslint-enable @typescript-eslint/no-unused-vars */
         return (
             <div className="layer-list-widget">

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -89,7 +89,7 @@ export class AppStore {
     // Reference images
     @observable spatialReference: FrameStore;
     @observable spectralReference: FrameStore;
-    @observable renderConfigReference: FrameStore;
+    @observable rasterScalingReference: FrameStore;
 
     // ImageViewer
     @observable activeLayer: ImageViewLayer;
@@ -349,7 +349,7 @@ export class AppStore {
         // First image defaults to spatial reference and contour source
         if (this.frames.length === 1) {
             this.setSpatialReference(this.frames[0]);
-            this.setRenderConfigReference(this.frames[0]);
+            this.setRasterScalingReference(this.frames[0]);
             this.setContourDataSource(this.frames[0]);
         }
 
@@ -493,7 +493,7 @@ export class AppStore {
 
             const removedFrameIsSpatialReference = frame === this.spatialReference;
             const removedFrameIsSpectralReference = frame === this.spectralReference;
-            const removedFrameIsRenderConfigReference = frame === this.renderConfigReference;
+            const removedFrameIsRasterScalingReference = frame === this.rasterScalingReference;
             const fileId = frame.frameInfo.fileId;
 
             // adjust requirements for stores
@@ -545,12 +545,12 @@ export class AppStore {
                     }
                 }
 
-                if (removedFrameIsRenderConfigReference) {
+                if (removedFrameIsRasterScalingReference) {
                     const newReference = firstFrame;
                     if (newReference) {
-                        this.setRenderConfigReference(newReference);
+                        this.setRasterScalingReference(newReference);
                     } else {
-                        this.clearRenderConfigReference();
+                        this.clearRasterScalingReference();
                     }
                 }
 
@@ -1651,54 +1651,54 @@ export class AppStore {
         this.setSpectralMatchingEnabled(frame, !frame.spectralReference);
     };
 
-    @action setRenderConfigReference = (frame: FrameStore) => {
-        const oldRef = this.renderConfigReference;
+    @action setRasterScalingReference = (frame: FrameStore) => {
+        const oldRef = this.rasterScalingReference;
 
         // check if the new reference is currently a secondary image of the existing reference
-        const newRefIsSecondary = oldRef && oldRef.secondaryRenderConfigImages.includes(frame);
+        const newRefIsSecondary = oldRef && oldRef.secondaryRasterScalingImages.includes(frame);
 
-        this.renderConfigReference = frame;
+        this.rasterScalingReference = frame;
 
         // Maintain link between old and new references
         if (newRefIsSecondary) {
-            oldRef.setRenderConfigReference(frame);
+            oldRef.setRasterScalingReference(frame);
         }
 
         for (const f of this.frames) {
             // The reference image can't reference itself
             if (f === frame) {
-                f.clearRenderConfigReference();
-            } else if (f.renderConfigReference) {
-                f.setRenderConfigReference(frame);
+                f.clearRasterScalingReference();
+            } else if (f.rasterScalingReference) {
+                f.setRasterScalingReference(frame);
             }
         }
     };
 
-    @action clearRenderConfigReference = () => {
-        this.renderConfigReference = null;
+    @action clearRasterScalingReference = () => {
+        this.rasterScalingReference = null;
         for (const f of this.frames) {
-            f.clearRenderConfigReference();
+            f.clearRasterScalingReference();
         }
     };
 
-    @action setRenderConfigMatchingEnabled = (frame: FrameStore, val: boolean) => {
-        if (!frame || frame === this.renderConfigReference) {
+    @action setRasterScalingMatchingEnabled = (frame: FrameStore, val: boolean) => {
+        if (!frame || frame === this.rasterScalingReference) {
             return;
         }
 
         if (val) {
-            frame.setRenderConfigReference(this.renderConfigReference);
+            frame.setRasterScalingReference(this.rasterScalingReference);
         } else {
-            frame.clearRenderConfigReference();
+            frame.clearRasterScalingReference();
         }
     };
 
-    @action toggleRenderConfigMatching = (frame: FrameStore) => {
-        if (!frame || frame === this.renderConfigReference) {
+    @action toggleRasterScalingMatching = (frame: FrameStore) => {
+        if (!frame || frame === this.rasterScalingReference) {
             return;
         }
 
-        this.setRenderConfigMatchingEnabled(frame, !frame.renderConfigReference);
+        this.setRasterScalingMatchingEnabled(frame, !frame.rasterScalingReference);
     };
 
     @action setMatchingEnabled = (spatial: boolean, spectral: boolean) => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -88,10 +88,10 @@ export class FrameStore {
     @observable overlayBeamSettings: OverlayBeamStore;
     @observable spatialReference: FrameStore;
     @observable spectralReference: FrameStore;
-    @observable renderConfigReference: FrameStore;
+    @observable rasterScalingReference: FrameStore;
     @observable secondarySpatialImages: FrameStore[];
     @observable secondarySpectralImages: FrameStore[];
-    @observable secondaryRenderConfigImages: FrameStore[];
+    @observable secondaryRasterScalingImages: FrameStore[];
     @observable momentImages: FrameStore[];
 
     @observable isRequestingMoments: boolean;
@@ -516,13 +516,13 @@ export class FrameStore {
     }
 
     @computed get renderConfigSiblings(): FrameStore[] {
-        if (this.renderConfigReference) {
+        if (this.rasterScalingReference) {
             let siblings = [];
-            siblings.push(this.renderConfigReference);
-            siblings.push(...this.renderConfigReference.secondaryRenderConfigImages.slice().filter(f => f !== this));
+            siblings.push(this.rasterScalingReference);
+            siblings.push(...this.rasterScalingReference.secondaryRasterScalingImages.slice().filter(f => f !== this));
             return siblings;
         } else {
-            return this.secondaryRenderConfigImages.slice();
+            return this.secondaryRasterScalingImages.slice();
         }
     }
 
@@ -697,7 +697,7 @@ export class FrameStore {
         this.controlMaps = new Map<FrameStore, ControlMap>();
         this.secondarySpatialImages = [];
         this.secondarySpectralImages = [];
-        this.secondaryRenderConfigImages = [];
+        this.secondaryRasterScalingImages = [];
         this.momentImages = [];
 
         this.isRequestingMoments = false;
@@ -1584,33 +1584,33 @@ export class FrameStore {
         this.secondarySpectralImages = this.secondarySpectralImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
     };
 
-    @action setRenderConfigReference = (frame: FrameStore) => {
+    @action setRasterScalingReference = (frame: FrameStore) => {
         if (frame === this) {
-            this.clearRenderConfigReference();
+            this.clearRasterScalingReference();
             console.log(`Skipping RenderConfig self-reference`);
             return;
         }
 
-        this.renderConfigReference = frame;
-        this.renderConfigReference.addSecondaryRenderConfigImage(this);
+        this.rasterScalingReference = frame;
+        this.rasterScalingReference.addSecondaryRasterScalingImage(this);
         this.renderConfig.updateFrom(frame.renderConfig);
     }
 
-    @action clearRenderConfigReference() {
-        if (this.renderConfigReference) {
-            this.renderConfigReference.removeSecondaryRenderConfigImage(this);
-            this.renderConfigReference = null;
+    @action clearRasterScalingReference() {
+        if (this.rasterScalingReference) {
+            this.rasterScalingReference.removeSecondaryRasterScalingImage(this);
+            this.rasterScalingReference = null;
         }
     }
 
-    @action addSecondaryRenderConfigImage = (frame: FrameStore) => {
-        if (!this.secondaryRenderConfigImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
-            this.secondaryRenderConfigImages.push(frame);
+    @action addSecondaryRasterScalingImage = (frame: FrameStore) => {
+        if (!this.secondaryRasterScalingImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
+            this.secondaryRasterScalingImages.push(frame);
         }
     };
 
-    @action removeSecondaryRenderConfigImage = (frame: FrameStore) => {
-        this.secondaryRenderConfigImages = this.secondaryRenderConfigImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
+    @action removeSecondaryRasterScalingImage = (frame: FrameStore) => {
+        this.secondaryRasterScalingImages = this.secondaryRasterScalingImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
     };
 
     @action addMomentImage = (frame: FrameStore) => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -88,8 +88,10 @@ export class FrameStore {
     @observable overlayBeamSettings: OverlayBeamStore;
     @observable spatialReference: FrameStore;
     @observable spectralReference: FrameStore;
+    @observable renderConfigReference: FrameStore;
     @observable secondarySpatialImages: FrameStore[];
     @observable secondarySpectralImages: FrameStore[];
+    @observable secondaryRenderConfigImages: FrameStore[];
     @observable momentImages: FrameStore[];
 
     @observable isRequestingMoments: boolean;
@@ -513,6 +515,17 @@ export class FrameStore {
         }
     }
 
+    @computed get renderConfigSiblings(): FrameStore[] {
+        if (this.renderConfigReference) {
+            let siblings = [];
+            siblings.push(this.renderConfigReference);
+            siblings.push(...this.renderConfigReference.secondaryRenderConfigImages.slice().filter(f => f !== this));
+            return siblings;
+        } else {
+            return this.secondaryRenderConfigImages.slice();
+        }
+    }
+
     @computed get isCursorValueCurrent(): boolean {
         if (!this.cursorValue || !this.cursorInfo) {
             return false;
@@ -673,7 +686,7 @@ export class FrameStore {
         this.channel = 0;
         this.requiredStokes = 0;
         this.requiredChannel = 0;
-        this.renderConfig = new RenderConfigStore(preferenceStore);
+        this.renderConfig = new RenderConfigStore(preferenceStore, this);
         this.contourConfig = new ContourConfigStore(preferenceStore);
         this.contourStores = new Map<number, ContourStore>();
         this.renderType = RasterRenderType.NONE;
@@ -684,6 +697,7 @@ export class FrameStore {
         this.controlMaps = new Map<FrameStore, ControlMap>();
         this.secondarySpatialImages = [];
         this.secondarySpectralImages = [];
+        this.secondaryRenderConfigImages = [];
         this.momentImages = [];
 
         this.isRequestingMoments = false;
@@ -1568,6 +1582,35 @@ export class FrameStore {
 
     @action removeSecondarySpectralImage = (frame: FrameStore) => {
         this.secondarySpectralImages = this.secondarySpectralImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
+    };
+
+    @action setRenderConfigReference = (frame: FrameStore) => {
+        if (frame === this) {
+            this.clearRenderConfigReference();
+            console.log(`Skipping RenderConfig self-reference`);
+            return;
+        }
+
+        this.renderConfigReference = frame;
+        this.renderConfigReference.addSecondaryRenderConfigImage(this);
+        this.renderConfig.updateFrom(frame.renderConfig);
+    }
+
+    @action clearRenderConfigReference() {
+        if (this.renderConfigReference) {
+            this.renderConfigReference.removeSecondaryRenderConfigImage(this);
+            this.renderConfigReference = null;
+        }
+    }
+
+    @action addSecondaryRenderConfigImage = (frame: FrameStore) => {
+        if (!this.secondaryRenderConfigImages.find(f => f.frameInfo.fileId === frame.frameInfo.fileId)) {
+            this.secondaryRenderConfigImages.push(frame);
+        }
+    };
+
+    @action removeSecondaryRenderConfigImage = (frame: FrameStore) => {
+        this.secondaryRenderConfigImages = this.secondaryRenderConfigImages.filter(f => f.frameInfo.fileId !== frame.frameInfo.fileId);
     };
 
     @action addMomentImage = (frame: FrameStore) => {

--- a/src/stores/RenderConfigStore.ts
+++ b/src/stores/RenderConfigStore.ts
@@ -1,5 +1,5 @@
 import {action, computed, observable, makeObservable} from "mobx";
-import {PreferenceStore} from "stores";
+import {FrameStore, PreferenceStore} from "stores";
 import {CARTA} from "carta-protobuf";
 import {clamp, getPercentiles} from "utilities";
 
@@ -73,8 +73,11 @@ export class RenderConfigStore {
     @observable scaleMax: number[];
     @observable visible: boolean;
 
-    constructor(readonly preference: PreferenceStore) {
+    private frame: FrameStore;
+
+    constructor(readonly preference: PreferenceStore, frame: FrameStore) {
         makeObservable(this);
+        this.frame = frame;
         const percentile = preference.percentile;
         this.selectedPercentile = [percentile, percentile, percentile, percentile];
         this.bias = 0;
@@ -189,6 +192,7 @@ export class RenderConfigStore {
         if (rank === 100) {
             this.scaleMin[this.stokes] = this.histogramMin;
             this.scaleMax[this.stokes] = this.histogramMax;
+            this.updateSiblings();
             return true;
         }
 
@@ -201,6 +205,7 @@ export class RenderConfigStore {
         if (percentiles.length === 2) {
             this.scaleMin[this.stokes] = percentiles[0];
             this.scaleMax[this.stokes] = percentiles[1];
+            this.updateSiblings();
             return true;
         } else {
             return false;
@@ -226,6 +231,7 @@ export class RenderConfigStore {
         this.scaleMin[this.stokes] = minVal;
         this.scaleMax[this.stokes] = maxVal;
         this.selectedPercentile[this.stokes] = -1;
+        this.updateSiblings();
     };
 
     @action setColorMapIndex = (index: number) => {
@@ -242,15 +248,18 @@ export class RenderConfigStore {
     @action setScaling = (newScaling: FrameScaling) => {
         if (RenderConfigStore.SCALING_TYPES.has(newScaling)) {
             this.scaling = newScaling;
+            this.updateSiblings();
         }
     };
 
     @action setGamma = (gamma: number) => {
         this.gamma = gamma;
+        this.updateSiblings();
     };
 
     @action setAlpha = (alpha: number) => {
         this.alpha = alpha;
+        this.updateSiblings();
     };
 
     @action setInverted = (inverted: boolean) => {
@@ -264,4 +273,20 @@ export class RenderConfigStore {
     @action toggleVisibility = () => {
         this.visible = !this.visible;
     };
+
+    @action updateSiblings = () => {
+        const siblings = this.frame?.renderConfigSiblings;
+        for (const frame of siblings) {
+            frame.renderConfig.updateFrom(this);
+        }
+    }
+
+    @action updateFrom = (other: RenderConfigStore) => {
+        this.scaling = other.scaling;
+        this.alpha = other.alpha;
+        this.gamma = other.gamma;
+        this.scaleMin[this.stokes] = other.scaleMinVal;
+        this.scaleMax[this.stokes] = other.scaleMaxVal;
+        this.selectedPercentile[this.stokes] = -1;
+    }
 }


### PR DESCRIPTION
closes #1089 

Adds the ability to match render config properties (clip min, clip max, scaling type, gamma, alpha) by enabling "render config matching" in the image list widget

@Jordatious please use [Mix 'n Match](http://carta.asiaa.sinica.edu.tw/builds/) for testing (branch `angus/match_image_scaling`)