### PR TITLE
supporting extrema stats

### DIFF
--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -67,6 +67,7 @@ export class SpectralProfilerToolbarComponent extends React.Component<{ widgetSt
             {value: CARTA.StatsType.Sigma, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.Sigma)},
             {value: CARTA.StatsType.Min, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.Min)},
             {value: CARTA.StatsType.Max, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.Max)},
+            {value: CARTA.StatsType.Extrema, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.Extrema)},
             {value: CARTA.StatsType.RMS, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.RMS)},
             {value: CARTA.StatsType.SumSq, label: SpectralProfileWidgetStore.StatsTypeString(CARTA.StatsType.SumSq)}
         ];

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -65,6 +65,7 @@ export class StatsComponent extends React.Component<WidgetProps> {
         [CARTA.StatsType.Sigma, "StdDev"],
         [CARTA.StatsType.Min, "Min"],
         [CARTA.StatsType.Max, "Max"],
+        [CARTA.StatsType.Extrema, "Extrema"],
         [CARTA.StatsType.RMS, "RMS"],
         [CARTA.StatsType.SumSq, "SumSq"]
     ]);

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -25,7 +25,7 @@ export class BackendService {
         return BackendService.staticInstance;
     }
 
-    private static readonly IcdVersion = 17;
+    private static readonly IcdVersion = 18;
     private static readonly DefaultFeatureFlags = CARTA.ClientFeatureFlags.WEB_ASSEMBLY | CARTA.ClientFeatureFlags.WEB_GL;
     @observable connectionStatus: ConnectionStatus;
     readonly loggingEnabled: boolean;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -872,7 +872,8 @@ export class AppStore {
         CARTA.StatsType.Sigma,
         CARTA.StatsType.SumSq,
         CARTA.StatsType.Min,
-        CARTA.StatsType.Max
+        CARTA.StatsType.Max,
+        CARTA.StatsType.Extrema
     ];
     private static readonly CursorThrottleTime = 200;
     private static readonly CursorThrottleTimeRotated = 100;

--- a/src/stores/widgets/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidgetStore.ts
@@ -62,6 +62,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                 return "Min";
             case CARTA.StatsType.Max:
                 return "Max";
+            case CARTA.StatsType.Extrema:
+                return "Extrema";
             case CARTA.StatsType.RMS:
                 return "RMS";
             case CARTA.StatsType.SumSq:
@@ -75,7 +77,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
 
     private static ValidStatsTypes = [
         CARTA.StatsType.Sum, CARTA.StatsType.FluxDensity, CARTA.StatsType.Mean, CARTA.StatsType.Sigma,
-        CARTA.StatsType.Min, CARTA.StatsType.Max, CARTA.StatsType.RMS, CARTA.StatsType.SumSq
+        CARTA.StatsType.Min, CARTA.StatsType.Max, CARTA.StatsType.Extrema, CARTA.StatsType.RMS, CARTA.StatsType.SumSq
     ];
 
     @action setRegionId = (fileId: number, regionId: number) => {


### PR DESCRIPTION
closes #1254 (Related to [CARTAvis/carta-backend#438](https://github.com/CARTAvis/carta-backend/issues/438) )
Adding "Extrema" in the stats dropdown of the spectral profiler widgets and the statistics widgets.