### PR TITLE
guard against WebGL initialisation errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,10 +33,11 @@ export class App extends React.Component {
         return (
             <div className={className}>
                 <UIControllerComponent/>
-                <Alert className={appStore.darkTheme ? "bp3-dark" : ""} isOpen={appStore.alertStore.alertVisible} onClose={appStore.alertStore.dismissAlert} canEscapeKeyCancel={true}>
+                <Alert icon={appStore.alertStore.alertIcon} className={appStore.darkTheme ? "bp3-dark" : ""} isOpen={appStore.alertStore.alertVisible} onClose={appStore.alertStore.dismissAlert} canEscapeKeyCancel={true}>
                     <p>{appStore.alertStore.alertText}</p>
                 </Alert>
                 <Alert
+                    icon={appStore.alertStore.alertIcon}
                     className={appStore.darkTheme ? "bp3-dark" : ""}
                     isOpen={appStore.alertStore.interactiveAlertVisible}
                     confirmButtonText="OK"

--- a/src/services/ContourWebGLService.ts
+++ b/src/services/ContourWebGLService.ts
@@ -1,5 +1,4 @@
-import {AlertStore} from "stores";
-import {getShaderFromString, loadImageTexture} from "utilities";
+import {getShaderFromString, initWebGL, loadImageTexture} from "utilities";
 
 import allMaps from "../static/allmaps.png";
 import vertexShaderLine from "!raw-loader!./GLSL/vertex_shader_contours.glsl";
@@ -105,11 +104,8 @@ export class ContourWebGLService {
     }
 
     private constructor() {
-        this.gl = document.createElement("canvas").getContext("webgl");
-        const floatExtension = this.gl?.getExtension("OES_texture_float");
-        if (!this.gl || !floatExtension) {
-            AlertStore.Instance.showAlert("Could not load WebGL. CARTA requires a browser with WebGL support! Images will not be displayed correctly");
-            this.gl = null;
+        this.gl = initWebGL();
+        if (!this.gl) {
             return;
         }
 

--- a/src/services/TileWebGLService.ts
+++ b/src/services/TileWebGLService.ts
@@ -1,5 +1,4 @@
-import {AlertStore} from "stores";
-import {getShaderProgram, loadImageTexture} from "utilities";
+import {getShaderProgram, initWebGL, loadImageTexture} from "utilities";
 import {TEXTURE_SIZE, TILE_SIZE} from "./TileService";
 
 import allMaps from "static/allmaps.png";
@@ -151,11 +150,8 @@ export class TileWebGLService {
     }
 
     private constructor() {
-        this.gl = document.createElement("canvas").getContext("webgl");
-        const floatExtension = this.gl?.getExtension("OES_texture_float");
-        if (!this.gl || !floatExtension) {
-            AlertStore.Instance.showAlert("Could not load WebGL. CARTA requires a browser with WebGL support! Images will not be displayed correctly");
-            this.gl = null;
+        this.gl = initWebGL();
+        if (!this.gl) {
             return;
         }
         this.initShaders();

--- a/src/services/TileWebGLService.ts
+++ b/src/services/TileWebGLService.ts
@@ -1,4 +1,4 @@
-import {AlertStore} from "../stores";
+import {AlertStore} from "stores";
 import {getShaderProgram, loadImageTexture} from "utilities";
 import {TEXTURE_SIZE, TILE_SIZE} from "./TileService";
 

--- a/src/stores/AlertStore.ts
+++ b/src/stores/AlertStore.ts
@@ -1,4 +1,5 @@
 import { action, observable, makeObservable } from "mobx";
+import React from "react";
 
 export class AlertStore {
     private static staticInstance: AlertStore;
@@ -11,13 +12,15 @@ export class AlertStore {
     }
 
     @observable alertVisible: boolean;
-    @observable alertText: string;
+    @observable alertText: string | React.ReactNode;
+    @observable alertIcon: any;
     @observable interactiveAlertVisible: boolean;
-    @observable interactiveAlertText: string;
+    @observable interactiveAlertText: string | React.ReactNode;
     interactiveAlertCallback: (confirmed: boolean) => void;
 
-    @action("show_alert") showAlert = (text: string) => {
+    @action("show_alert") showAlert = (text: string | React.ReactNode, icon?: any) => {
         this.alertText = text;
+        this.alertIcon = icon;
         this.alertVisible = true;
     };
 
@@ -25,8 +28,9 @@ export class AlertStore {
         this.alertVisible = false;
     };
 
-    @action("show_alert") showInteractiveAlert = (text: string, onClose: (confirmed: boolean) => void) => {
+    @action("show_alert") showInteractiveAlert = (text: string | React.ReactNode, onClose: (confirmed: boolean) => void, icon?: any) => {
         this.interactiveAlertText = text;
+        this.alertIcon = icon;
         this.interactiveAlertVisible = true;
         this.interactiveAlertCallback = onClose;
     };

--- a/src/stores/ContourStore.ts
+++ b/src/stores/ContourStore.ts
@@ -75,8 +75,9 @@ export class ContourStore {
             this.vertexBuffers = [];
         }
 
-        if (this.vertexBuffers.length !== index) {
+        if (!this.gl || this.vertexBuffers.length !== index) {
             console.log(`WebGL buffer index is incorrect!`);
+            return;
         }
 
         // TODO: handle buffer cleanup when no longer needed

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -8,3 +8,4 @@ export * from "./units";
 export * from "./webgl";
 export * from "./wcs";
 export * from "./table";
+export * from "./templates";

--- a/src/utilities/templates.tsx
+++ b/src/utilities/templates.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export const TemplateNodes = {
+    WebGLErrorMessage: (
+        <React.Fragment>
+            <p>
+                <b>Could not load WebGL. Images will not be displayed properly.</b>
+            </p>
+            <p>
+                <small> If you are using CARTA through a browser, please ensure your browser supports WebGL. If you are using the CARTA standalone app, please ensure you are not running in a remote desktop. </small>
+            </p>
+        </React.Fragment>
+    )
+};

--- a/src/utilities/webgl.ts
+++ b/src/utilities/webgl.ts
@@ -1,7 +1,7 @@
 export const GL = WebGLRenderingContext;
 
 export function getShaderFromString(gl: WebGLRenderingContext, shaderScript: string, type: number) {
-    if (!shaderScript || !(type === GL.VERTEX_SHADER || type === GL.FRAGMENT_SHADER)) {
+    if (!gl || !shaderScript || !(type === GL.VERTEX_SHADER || type === GL.FRAGMENT_SHADER)) {
         return null;
     }
 
@@ -16,6 +16,10 @@ export function getShaderFromString(gl: WebGLRenderingContext, shaderScript: str
 }
 
 export function getShaderProgram(gl: WebGLRenderingContext, vertexShaderString: string, pixelShaderString: string) {
+    if (!gl) {
+        return null;
+    }
+
     let vertexShader = getShaderFromString(gl, vertexShaderString, GL.VERTEX_SHADER);
     let fragmentShader = getShaderFromString(gl, pixelShaderString, GL.FRAGMENT_SHADER);
 
@@ -32,6 +36,9 @@ export function getShaderProgram(gl: WebGLRenderingContext, vertexShaderString: 
 }
 export function loadImageTexture(gl: WebGLRenderingContext, url: string, texIndex: number): Promise<WebGLTexture> {
     return new Promise<WebGLTexture>((resolve, reject) => {
+        if (!gl) {
+            reject();
+        }
         const image = new Image();
         // Replace the existing texture with the real one once loaded
         image.onload = () => {
@@ -51,6 +58,9 @@ export function loadImageTexture(gl: WebGLRenderingContext, url: string, texInde
 }
 
 export function createFP32Texture(gl: WebGLRenderingContext, width: number, height: number, texIndex: number, filtering: number = GL.NEAREST) {
+    if (!gl) {
+        return null;
+    }
     const texture = gl.createTexture();
     gl.activeTexture(texIndex);
     gl.bindTexture(GL.TEXTURE_2D, texture);
@@ -63,6 +73,9 @@ export function createFP32Texture(gl: WebGLRenderingContext, width: number, heig
 }
 
 export function copyToFP32Texture(gl: WebGLRenderingContext, texture: WebGLTexture, data: Float32Array, texIndex: number, dataWidth: number, dataHeight: number, xOffset: number, yOffset: number) {
+    if (!gl) {
+        return;
+    }
     gl.bindTexture(GL.TEXTURE_2D, texture);
     gl.activeTexture(texIndex);
     gl.texSubImage2D(GL.TEXTURE_2D, 0, xOffset, yOffset, dataWidth, dataHeight, GL.LUMINANCE, GL.FLOAT, data);

--- a/src/utilities/webgl.ts
+++ b/src/utilities/webgl.ts
@@ -1,3 +1,6 @@
+import {AlertStore} from "stores";
+import {TemplateNodes} from "./templates";
+
 export const GL = WebGLRenderingContext;
 
 export function getShaderFromString(gl: WebGLRenderingContext, shaderScript: string, type: number) {
@@ -83,4 +86,14 @@ export function copyToFP32Texture(gl: WebGLRenderingContext, texture: WebGLTextu
     gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
     gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
     gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+}
+
+export function initWebGL(){
+    const gl = document.createElement("canvas").getContext("webgl");
+    const floatExtension = gl?.getExtension("OES_texture_float");
+    if (!gl || !floatExtension) {
+        AlertStore.Instance.showAlert(TemplateNodes.WebGLErrorMessage, "issue");
+        return null;
+    }
+    return gl;
 }


### PR DESCRIPTION
closes #971 

Displays a simple error message indicating that CARTA requires a WebGL-compatible browser. If the user continues after this, no hard-crashes occur, but images and contours are not displayed.