### PR TITLE
Angus/socket url changes

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+GENERATE_SOURCEMAP=false

--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ protobuf
 wasm_src
 wasm_libs
 config
-build/**/*.js.map
 tsconfig*.json
 tslint.json
 *.sh

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -45,7 +45,12 @@ export class ApiService {
 
     @action setToken = (tokenString: string, tokenLifetime: number = Number.MAX_VALUE) => {
         if (isFinite(tokenLifetime) && tokenLifetime > 0) {
-            console.log(`Token updated and valid for ${tokenLifetime.toFixed()} seconds`);
+            // Store tokens from URL parameters as session cookie
+            if (tokenLifetime === Number.MAX_VALUE) {
+                document.cookie = `carta-auth-token=${tokenString}`
+            } else {
+                console.log(`Token updated and valid for ${tokenLifetime.toFixed()} seconds`);
+            }
             this._accessToken = tokenString;
             this.axiosInstance.defaults.headers.common["Authorization"] = `Bearer ${tokenString}`;
             this._tokenLifetime = tokenLifetime;

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -43,7 +43,7 @@ export class ApiService {
     private axiosInstance: AxiosInstance;
     private authInstance: gapi.auth2.GoogleAuth;
 
-    @action private setToken = (tokenString: string, tokenLifetime: number) => {
+    @action setToken = (tokenString: string, tokenLifetime: number = Number.MAX_VALUE) => {
         if (isFinite(tokenLifetime) && tokenLifetime > 0) {
             console.log(`Token updated and valid for ${tokenLifetime.toFixed()} seconds`);
             this._accessToken = tokenString;
@@ -74,7 +74,7 @@ export class ApiService {
     }
 
     constructor() {
-        makeObservable<ApiService, "_accessToken" | "setToken" | "clearToken">(this);
+        makeObservable(this);
         this.axiosInstance = axios.create();
         if (ApiService.RuntimeConfig.googleClientId) {
             gapi.load("auth2", () => {

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -161,7 +161,7 @@ export class BackendService {
         this.connectionDropped = false;
         this.connectionStatus = ConnectionStatus.PENDING;
         this.serverUrl = url;
-        this.connection = new WebSocket(apiService.accessToken ? url + `?token=${apiService.accessToken}` : url);
+        this.connection = new WebSocket(apiService.accessToken ? url + `/token/${apiService.accessToken}` : url);
         this.connection.binaryType = "arraybuffer";
         this.connection.onmessage = this.messageHandler.bind(this);
         this.connection.onclose = (ev: CloseEvent) => runInAction(()=>{
@@ -172,7 +172,7 @@ export class BackendService {
             // Reconnect to the same URL if Websocket is closed
             if (!ev.wasClean && this.autoReconnect) {
                 setTimeout(() => {
-                    const newConnection = new WebSocket(apiService.accessToken ? url + `?token=${apiService.accessToken}` : url);
+                    const newConnection = new WebSocket(apiService.accessToken ? url + `/token/${apiService.accessToken}` : url);
                     newConnection.binaryType = "arraybuffer";
                     newConnection.onopen = this.connection.onopen;
                     newConnection.onerror = this.connection.onerror;

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -2,7 +2,6 @@ import {action, observable, makeObservable, runInAction} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {Observable, Observer, Subject, throwError} from "rxjs";
 import {AppStore, PreferenceStore, RegionStore} from "stores";
-import {ApiService} from "./ApiService";
 import {mapToObject} from "utilities";
 
 export enum ConnectionStatus {
@@ -156,12 +155,11 @@ export class BackendService {
             this.connection.close();
         }
 
-        const apiService = ApiService.Instance;
         this.autoReconnect = autoConnect;
         this.connectionDropped = false;
         this.connectionStatus = ConnectionStatus.PENDING;
         this.serverUrl = url;
-        this.connection = new WebSocket(apiService.accessToken ? url + `/token/${apiService.accessToken}` : url);
+        this.connection = new WebSocket(url);
         this.connection.binaryType = "arraybuffer";
         this.connection.onmessage = this.messageHandler.bind(this);
         this.connection.onclose = (ev: CloseEvent) => runInAction(()=>{
@@ -172,7 +170,7 @@ export class BackendService {
             // Reconnect to the same URL if Websocket is closed
             if (!ev.wasClean && this.autoReconnect) {
                 setTimeout(() => {
-                    const newConnection = new WebSocket(apiService.accessToken ? url + `/token/${apiService.accessToken}` : url);
+                    const newConnection = new WebSocket(url);
                     newConnection.binaryType = "arraybuffer";
                     newConnection.onopen = this.connection.onopen;
                     newConnection.onerror = this.connection.onerror;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -135,10 +135,9 @@ export class AppStore {
         this.username = username;
     };
 
-    @action connectToServer = (socketName: string = "socket") => {
+    @action connectToServer = () => {
         // Remove query parameters, replace protocol and remove trailing /
-        const baseUrl = window.location.href.replace(window.location.search, "").replace(/^http/, "ws").replace(/\/$/, "");
-        let wsURL = `${baseUrl}/${socketName}`;
+        let wsURL = window.location.href.replace(window.location.search, "").replace(/^http/, "ws").replace(/\/$/, "");
         if (process.env.NODE_ENV === "development") {
             wsURL = process.env.REACT_APP_DEFAULT_ADDRESS ? process.env.REACT_APP_DEFAULT_ADDRESS : wsURL;
         } else {
@@ -168,6 +167,11 @@ export class AppStore {
                 this.loadFile(folderSearchParam, fileSearchParam, "");
             }
         }));
+
+        const authTokenParam = url.searchParams.get("token");
+        if (authTokenParam) {
+            ApiService.Instance.setToken(authTokenParam);
+        }
 
         this.backendService.connect(wsURL).subscribe(ack => {
             console.log(`Connected with session ID ${ack.sessionId}`);


### PR DESCRIPTION
Companion PR of https://github.com/CARTAvis/carta-backend/pull/691

This PR adjusts the default socket URL when building in production mode. Tokens are now passed to the server either via a cookie (when using carta-node-server) or via the WebSocket URL itself (e.g. `ws://myserver/token/<auth_token>`).

PR also properly prevents generation of source maps when building in production mode, rather than just ignoring them when packing.