### PR TITLE
Yuhsuan/issue 1325 polygon region

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -668,7 +668,7 @@ export class FrameStore {
                 return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonWcsProperties = `polygon(wcs:${systemType})[`;
-                region.controlPoints.map((point) => {
+                region.controlPoints.forEach((point) => {
                     const wcsPoint = isFinite(point.x) && isFinite(point.y) ? getFormattedWCSPoint(this.wcsInfoForTransformation, point) : null;
                     polygonWcsProperties += wcsPoint ? `[${wcsPoint.x}, ${wcsPoint.y}], ` : "[Invalid], ";
                 });

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1065,9 +1065,9 @@ export class FrameStore {
             case CARTA.RegionType.POINT:
                 return `Point (wcs:${systemType}) [${center}]`;
             case CARTA.RegionType.RECTANGLE:
-                return `rotbox(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
+                return `rotbox(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation,6)}deg]`;
             case CARTA.RegionType.ELLIPSE:
-                return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
+                return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 6)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonWcsProperties = `poly(wcs:${systemType})[`;
                 region.controlPoints.forEach((point) => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1069,7 +1069,7 @@ export class FrameStore {
             case CARTA.RegionType.ELLIPSE:
                 return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
-                let polygonWcsProperties = `polygon(wcs:${systemType})[`;
+                let polygonWcsProperties = `poly(wcs:${systemType})[`;
                 region.controlPoints.forEach((point) => {
                     const wcsPoint = isFinite(point.x) && isFinite(point.y) ? getFormattedWCSPoint(this.wcsInfoForTransformation, point) : null;
                     polygonWcsProperties += wcsPoint ? `[${wcsPoint.x}, ${wcsPoint.y}], ` : "[Invalid], ";

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1070,11 +1070,11 @@ export class FrameStore {
                 return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 6)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonWcsProperties = `poly(wcs:${systemType})[`;
-                region.controlPoints.forEach((point) => {
+                region.controlPoints.forEach((point, index) => {
                     const wcsPoint = isFinite(point.x) && isFinite(point.y) ? getFormattedWCSPoint(this.wcsInfoForTransformation, point) : null;
-                    polygonWcsProperties += wcsPoint ? `[${wcsPoint.x}, ${wcsPoint.y}], ` : "[Invalid], ";
+                    polygonWcsProperties += wcsPoint ? `[${wcsPoint.x}, ${wcsPoint.y}]` : "[Invalid]";
+                    polygonWcsProperties += index !== region.controlPoints.length - 1 ? ", " : "]";
                 });
-                polygonWcsProperties = polygonWcsProperties.slice(0, -2) + "]";
                 return polygonWcsProperties;
             default:
                 return "Not Implemented";

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -667,7 +667,13 @@ export class FrameStore {
             case CARTA.RegionType.ELLIPSE:
                 return `ellipse(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
-                return `polygon(wcs:${systemType})[[${center}], [${size.x}, ${size.y}], ${toFixed(region.rotation, 1)}deg]`;
+                let polygonWcsProperties = `polygon(wcs:${systemType})[`;
+                region.controlPoints.map((point) => {
+                    const wcsPoint = isFinite(point.x) && isFinite(point.y) ? getFormattedWCSPoint(this.wcsInfoForTransformation, point) : null;
+                    polygonWcsProperties += wcsPoint ? `[${wcsPoint.x}, ${wcsPoint.y}], ` : "[Invalid], ";
+                });
+                polygonWcsProperties = polygonWcsProperties.slice(0, -2) + "]";
+                return polygonWcsProperties;
             default:
                 return "Not Implemented";
         }

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -199,7 +199,7 @@ export class RegionStore {
                     `[${toFixed(this.size.x, 1)}pix, ${toFixed(this.size.y, 1)}pix], ` +
                     `${toFixed(this.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
-                let polygonProperties = "polygon[";
+                let polygonProperties = "poly[";
                 this.controlPoints.forEach((point) => {
                     polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 1)}pix, ${toFixed(point.y, 1)}pix], ` : "[Invalid], ";
                 });

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -200,7 +200,7 @@ export class RegionStore {
                     `${toFixed(this.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonProperties = "polygon[";
-                this.controlPoints.map((point) => {
+                this.controlPoints.forEach((point) => {
                     polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 1)}pix, ${toFixed(point.y, 1)}pix], ` : "[Invalid], ";
                 });
                 polygonProperties = polygonProperties.slice(0, -2) + "]";

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -200,10 +200,10 @@ export class RegionStore {
                     `${toFixed(this.rotation, 6)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonProperties = "poly[";
-                this.controlPoints.forEach((point) => {
-                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix], ` : "[Invalid], ";
+                this.controlPoints.forEach((point, index) => {
+                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                    polygonProperties += index !== this.controlPoints.length - 1 ? ", " : "]";
                 });
-                polygonProperties = polygonProperties.slice(0, -2) + "]";
                 return polygonProperties;
             default:
                 return "Not Implemented";

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -199,11 +199,12 @@ export class RegionStore {
                     `[${toFixed(this.size.x, 1)}pix, ${toFixed(this.size.y, 1)}pix], ` +
                     `${toFixed(this.rotation, 1)}deg]`;
             case CARTA.RegionType.POLYGON:
-                // TODO: Region properties
-                const bounds = minMax2D(this.controlPoints);
-                return `polygon[[${center}], ` +
-                    `[${toFixed(bounds.maxPoint.x, 1)}pix, ${toFixed(bounds.maxPoint.y, 1)}pix], ` +
-                    `${toFixed(this.rotation, 1)}deg]`;
+                let polygonProperties = "polygon[";
+                this.controlPoints.map((point) => {
+                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 1)}pix, ${toFixed(point.y, 1)}pix], ` : "[Invalid], ";
+                });
+                polygonProperties = polygonProperties.slice(0, -2) + "]";
+                return polygonProperties;
             default:
                 return "Not Implemented";
         }

--- a/src/stores/RegionStore.ts
+++ b/src/stores/RegionStore.ts
@@ -185,23 +185,23 @@ export class RegionStore {
 
     @computed get regionProperties(): string {
         const point = this.center;
-        const center = isFinite(point.x) && isFinite(point.y) ? `${toFixed(point.x, 1)}pix, ${toFixed(point.y, 1)}pix` : "Invalid";
+        const center = isFinite(point.x) && isFinite(point.y) ? `${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix` : "Invalid";
 
         switch (this.regionType) {
             case CARTA.RegionType.POINT:
                 return `Point (pixel) [${center}]`;
             case CARTA.RegionType.RECTANGLE:
                 return `rotbox[[${center}], ` +
-                    `[${toFixed(this.size.x, 1)}pix, ${toFixed(this.size.y, 1)}pix], ` +
-                    `${toFixed(this.rotation, 1)}deg]`;
+                    `[${toFixed(this.size.x, 6)}pix, ${toFixed(this.size.y, 6)}pix], ` +
+                    `${toFixed(this.rotation, 6)}deg]`;
             case CARTA.RegionType.ELLIPSE:
                 return `ellipse[[${center}], ` +
-                    `[${toFixed(this.size.x, 1)}pix, ${toFixed(this.size.y, 1)}pix], ` +
-                    `${toFixed(this.rotation, 1)}deg]`;
+                    `[${toFixed(this.size.x, 6)}pix, ${toFixed(this.size.y, 6)}pix], ` +
+                    `${toFixed(this.rotation, 6)}deg]`;
             case CARTA.RegionType.POLYGON:
                 let polygonProperties = "poly[";
                 this.controlPoints.forEach((point) => {
-                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 1)}pix, ${toFixed(point.y, 1)}pix], ` : "[Invalid], ";
+                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix], ` : "[Invalid], ";
                 });
                 polygonProperties = polygonProperties.slice(0, -2) + "]";
                 return polygonProperties;


### PR DESCRIPTION
This PR fixed issue https://github.com/cartavis/carta-frontend/issues/1325.
The format of polygon regions in tsv files is changed to "poly[[x1, y1], [x2, y2], [x3, y3], ...]" for both world and pixel coordinates.