### PR TITLE
fix play button for image and image animation order

### DIFF
--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -168,7 +168,7 @@ export class RootMenuComponent extends React.Component {
             </Menu>
         );
 
-        let layerItems = appStore.frames.slice().sort((a, b) => a.frameInfo.fileId <= b.frameInfo.fileId ? -1 : 1).map(frame => {
+        let layerItems = appStore.frames.map(frame => {
             return (
                 <Menu.Item
                     text={frame.filename}

--- a/src/stores/AnimatorStore.ts
+++ b/src/stores/AnimatorStore.ts
@@ -63,7 +63,7 @@ export class AnimatorStore {
 
         if (this.animationMode === AnimationMode.FRAME) {
             clearInterval(this.animateHandle);
-            this.animationActive = false;
+            this.animationActive = true;
             this.animate();
             this.animateHandle = setInterval(this.animate, this.frameInterval);
             return;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -597,7 +597,7 @@ export class AppStore {
 
     @action shiftFrame = (delta: number) => {
         if (this.activeFrame && this.frames.length > 1) {
-            const frameIds = this.frames.map(f => f.frameInfo.fileId).sort((a, b) => a - b);
+            const frameIds = this.frames.map(f => f.frameInfo.fileId)
             const currentIndex = frameIds.indexOf(this.activeFrame.frameInfo.fileId);
             const requiredIndex = (this.frames.length + currentIndex + delta) % this.frames.length;
             this.setActiveFrame(frameIds[requiredIndex]);


### PR DESCRIPTION
This PR fixes 
1. https://github.com/CARTAvis/carta-frontend/issues/1329 the animation state when animation playback is triggered is not set correctly.
2. https://github.com/CARTAvis/carta-frontend/issues/1270 the frame order is managed by `handleFileReordered` in LayerListComponent so there is no need to sort the frame list first when determining which frame to show next in AppStore. 