### PR TITLE
updates to official emscripten 2.0.14 docker container

### DIFF
--- a/build_wasm_libs_docker.sh
+++ b/build_wasm_libs_docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Building WebAssembly libraries inside Docker container"
-docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src trzeci/emscripten:1.39.18-upstream /src/wasm_libs/build_libs.sh
+docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh

--- a/build_wasm_wrappers_docker.sh
+++ b/build_wasm_wrappers_docker.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Building WebAssembly wrappers inside Docker container"
-docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src trzeci/emscripten:1.39.18-upstream /src/wasm_src/build_wrappers.sh
+docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh


### PR DESCRIPTION
closes #1307 

Turns out this PR was simpler than expected. Just need a quick check that everything AST or GSL related still functions, so @kswang1029 and @ajm-asiaa will need to review.

Note: I had to make sure my old build files were removed before the build succeeded.