### PR TITLE
Thchang/adding transparent image background option in preference

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -167,8 +167,8 @@ export class PreferenceDialogComponent extends React.Component {
                         {SPECTRAL_MATCHING_TYPES.map(type => <option key={type} value={type}>{SPECTRAL_TYPE_STRING.get(type)}</option>)}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Tranparent Exported Images">
-                    <Switch checked={preference.transparentExportedImage} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE, ev.currentTarget.checked)}/>
+                <FormGroup inline={true} label="Tranparent Image Background">
+                    <Switch checked={preference.transparentImageBackground} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND, ev.currentTarget.checked)}/>
                 </FormGroup>
             </React.Fragment>
         );

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -167,6 +167,9 @@ export class PreferenceDialogComponent extends React.Component {
                         {SPECTRAL_MATCHING_TYPES.map(type => <option key={type} value={type}>{SPECTRAL_TYPE_STRING.get(type)}</option>)}
                     </HTMLSelect>
                 </FormGroup>
+                <FormGroup inline={true} label="Tranparent Exported Images">
+                    <Switch checked={preference.transparentExportedImage} onChange={(ev) => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE, ev.currentTarget.checked)}/>
+                </FormGroup>
             </React.Fragment>
         );
 

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -69,6 +69,15 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         }
     }
 
+    exportImageTooltip = () => {
+        return (
+            <span><br/><i><small>
+                Background color is {AppStore.Instance.preferenceStore.transparentImageBackground ? "transparent" : "filled"}.<br/>
+                {AppStore.Instance.preferenceStore.transparentImageBackground ? "Disable" : "Enable"} transparent image background in Preferences.<br/>
+            </small></i></span>
+        );
+    };
+
     render() {
         const appStore = AppStore.Instance;
         const preferenceStore = appStore.preferenceStore;
@@ -232,7 +241,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 <Tooltip position={tooltipPosition} content="Toggle labels">
                     <AnchorButton icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels}/>
                 </Tooltip>
-                <Tooltip position={tooltipPosition} content={`Export image (${appStore.modifierString}E)`}>
+                <Tooltip position={tooltipPosition} content={<span>{`Export image (${appStore.modifierString}E)`}{this.exportImageTooltip()}</span>}>
                     <AnchorButton icon="floppy-disk" onClick={appStore.exportImage}/>
                 </Tooltip>
             </ButtonGroup>

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -13,6 +13,7 @@ import {StokesCoordinate} from "stores/widgets/StokesAnalysisWidgetStore";
 import {Point2D} from "models";
 import {clamp, toExponential, getTimestamp, exportTsvFile} from "utilities";
 import {PlotType} from "components/Shared";
+import {AppStore} from "stores";
 import "./LinePlotComponent.scss";
 
 export enum ZoomMode {
@@ -542,7 +543,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = "rgba(255, 255, 255, 0.0)";
+        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -543,7 +543,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
+        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentImageBackground ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 

--- a/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
+++ b/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {CSSProperties} from "react";
 import {observer} from "mobx-react";
 import {AnchorButton, ButtonGroup, Tooltip} from "@blueprintjs/core";
+import {AppStore} from "stores";
 import "./ToolbarComponent.scss";
 
 export class ToolbarComponentProps {
@@ -13,6 +14,15 @@ export class ToolbarComponentProps {
 
 @observer
 export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
+
+    exportImageTooltip = () => {
+        return (
+            <span><br/><i><small>
+                Background color is {AppStore.Instance.preferenceStore.transparentImageBackground ? "transparent" : "filled"}.<br/>
+                {AppStore.Instance.preferenceStore.transparentImageBackground ? "Disable" : "Enable"} transparent image background in Preferences.<br/>
+            </small></i></span>
+        );
+    };
 
     render() {
         let styleProps: CSSProperties = {
@@ -28,7 +38,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         return (
             <ButtonGroup className={className} style={styleProps}>
                 {(this.props.exportImage) ?
-                    <Tooltip content="Export image">
+                    <Tooltip content={<span>Export image {this.exportImageTooltip()}</span>}>
                         <AnchorButton icon="floppy-disk" onClick={this.props.exportImage}/>
                     </Tooltip> : null}
                 <Tooltip content="Export data">

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -13,6 +13,7 @@ import {ZoomMode, InteractionMode} from "components/Shared/LinePlot/LinePlotComp
 import {PlotType} from "../PlotTypeSelector/PlotTypeSelectorComponent";
 import {Point2D} from "models";
 import {clamp, toExponential, getTimestamp, exportTsvFile} from "utilities";
+import {AppStore} from "stores";
 import "./ScatterPlotComponent.scss";
 
 
@@ -299,7 +300,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = "rgba(255, 255, 255, 0.0)";
+        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -300,7 +300,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
         composedCanvas.height = canvas.height;
 
         const ctx = composedCanvas.getContext("2d");
-        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
+        ctx.fillStyle = AppStore.Instance.preferenceStore.transparentImageBackground ? "rgba(255, 255, 255, 0.0)" : (this.props.darkMode ?  Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
         ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
         ctx.drawImage(canvas, 0, 0);
 

--- a/src/models/preferences_schema_1.json
+++ b/src/models/preferences_schema_1.json
@@ -81,6 +81,9 @@
             "minimum": 0,
             "maximum": 3
         },
+        "transparentExportedImage": {
+            "type": "boolean"
+        },
         "scaling": {
             "type": "integer",
             "minimum": 0,

--- a/src/models/preferences_schema_1.json
+++ b/src/models/preferences_schema_1.json
@@ -81,7 +81,7 @@
             "minimum": 0,
             "maximum": 3
         },
-        "transparentExportedImage": {
+        "transparentImageBackground": {
             "type": "boolean"
         },
         "scaling": {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1726,7 +1726,7 @@ export class AppStore {
 
     exportImage = (): boolean => {
         if (this.activeFrame) {
-            const backgroundColor = this.preferenceStore.transparentExportedImage ? null : (this.darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
+            const backgroundColor = this.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0)" : (this.darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
             const composedCanvas = getImageCanvas(this.overlayStore.padding, backgroundColor);
             if (composedCanvas) {
                 composedCanvas.toBlob((blob) => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1726,7 +1726,8 @@ export class AppStore {
 
     exportImage = (): boolean => {
         if (this.activeFrame) {
-            const composedCanvas = getImageCanvas(this.overlayStore.padding);
+            const backgroundColor = this.preferenceStore.transparentExportedImage ? null : (this.darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
+            const composedCanvas = getImageCanvas(this.overlayStore.padding, backgroundColor);
             if (composedCanvas) {
                 composedCanvas.toBlob((blob) => {
                     const link = document.createElement("a") as HTMLAnchorElement;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1726,7 +1726,7 @@ export class AppStore {
 
     exportImage = (): boolean => {
         if (this.activeFrame) {
-            const backgroundColor = this.preferenceStore.transparentExportedImage ? "rgba(255, 255, 255, 0)" : (this.darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
+            const backgroundColor = this.preferenceStore.transparentImageBackground ? "rgba(255, 255, 255, 0)" : (this.darkTheme ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5);
             const composedCanvas = getImageCanvas(this.overlayStore.padding, backgroundColor);
             if (composedCanvas) {
                 composedCanvas.toBlob((blob) => {

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -19,7 +19,7 @@ export enum PreferenceKeys {
     GLOBAL_DRAG_PANNING = "dragPanning",
     GLOBAL_SPECTRAL_MATCHING_TYPE = "spectralMatchingType",
     GLOBAL_AUTO_WCS_MATCHING = "autoWCSMatching",
-    GLOBAL_TRANSPARENT_EXPORTED_IMAGE = "transparentExportedImage",
+    GLOBAL_TRANSPARENT_IMAGE_BACKGROUND = "transparentImageBackground",
 
     RENDER_CONFIG_SCALING = "scaling",
     RENDER_CONFIG_COLORMAP = "colormap",
@@ -87,7 +87,7 @@ const DEFAULTS = {
         dragPanning: true,
         spectralMatchingType: SpectralType.VRAD,
         autoWCSMatching: WCSMatchingType.NONE,
-        transparentExportedImage: true,
+        transparentImageBackground: true,
     },
     RENDER_CONFIG: {
         scaling: FrameScaling.LINEAR,
@@ -206,8 +206,8 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING) ?? DEFAULTS.GLOBAL.autoWCSMatching;
     }
 
-    @computed get transparentExportedImage(): boolean {
-        return this.preferences.get(PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE) ?? DEFAULTS.GLOBAL.transparentExportedImage;
+    @computed get transparentImageBackground(): boolean {
+        return this.preferences.get(PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND) ?? DEFAULTS.GLOBAL.transparentImageBackground;
     }
 
     // getters for render config
@@ -463,7 +463,7 @@ export class PreferenceStore {
             PreferenceKeys.GLOBAL_THEME, PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_LAYOUT,
             PreferenceKeys.GLOBAL_CURSOR_POSITION, PreferenceKeys.GLOBAL_ZOOM_MODE, PreferenceKeys.GLOBAL_ZOOM_POINT,
             PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING,
-            PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE
+            PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND
         ]);
     };
 
@@ -571,7 +571,7 @@ export class PreferenceStore {
             ];
 
             const booleanKeys = [
-                PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE, PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP_ENABLED,
+                PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND, PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP_ENABLED,
                 PreferenceKeys.WCS_OVERLAY_AST_GRID_VISIBLE, PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE, PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE,
                 PreferenceKeys.PERFORMANCE_STREAM_CONTOURS_WHILE_ZOOMING, PreferenceKeys.PERFORMANCE_LOW_BAND_WIDTH_MODE
             ];

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -87,7 +87,7 @@ const DEFAULTS = {
         dragPanning: true,
         spectralMatchingType: SpectralType.VRAD,
         autoWCSMatching: WCSMatchingType.NONE,
-        transparentImageBackground: true,
+        transparentImageBackground: false,
     },
     RENDER_CONFIG: {
         scaling: FrameScaling.LINEAR,

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -19,6 +19,7 @@ export enum PreferenceKeys {
     GLOBAL_DRAG_PANNING = "dragPanning",
     GLOBAL_SPECTRAL_MATCHING_TYPE = "spectralMatchingType",
     GLOBAL_AUTO_WCS_MATCHING = "autoWCSMatching",
+    GLOBAL_TRANSPARENT_EXPORTED_IMAGE = "transparentExportedImage",
 
     RENDER_CONFIG_SCALING = "scaling",
     RENDER_CONFIG_COLORMAP = "colormap",
@@ -86,6 +87,7 @@ const DEFAULTS = {
         dragPanning: true,
         spectralMatchingType: SpectralType.VRAD,
         autoWCSMatching: WCSMatchingType.NONE,
+        transparentExportedImage: true,
     },
     RENDER_CONFIG: {
         scaling: FrameScaling.LINEAR,
@@ -202,6 +204,10 @@ export class PreferenceStore {
 
     @computed get autoWCSMatching(): WCSMatchingType {
         return this.preferences.get(PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING) ?? DEFAULTS.GLOBAL.autoWCSMatching;
+    }
+
+    @computed get transparentExportedImage(): boolean {
+        return this.preferences.get(PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE) ?? DEFAULTS.GLOBAL.transparentExportedImage;
     }
 
     // getters for render config
@@ -456,7 +462,9 @@ export class PreferenceStore {
         this.clearPreferences([
             PreferenceKeys.GLOBAL_THEME, PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_LAYOUT,
             PreferenceKeys.GLOBAL_CURSOR_POSITION, PreferenceKeys.GLOBAL_ZOOM_MODE, PreferenceKeys.GLOBAL_ZOOM_POINT,
-            PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING]);
+            PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING,
+            PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE
+        ]);
     };
 
     @action resetRenderConfigSettings = () => {
@@ -563,7 +571,7 @@ export class PreferenceStore {
             ];
 
             const booleanKeys = [
-                PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP_ENABLED,
+                PreferenceKeys.GLOBAL_AUTOLAUNCH, PreferenceKeys.GLOBAL_DRAG_PANNING, PreferenceKeys.GLOBAL_TRANSPARENT_EXPORTED_IMAGE, PreferenceKeys.CONTOUR_CONFIG_CONTOUR_COLORMAP_ENABLED,
                 PreferenceKeys.WCS_OVERLAY_AST_GRID_VISIBLE, PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE, PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE,
                 PreferenceKeys.PERFORMANCE_STREAM_CONTOURS_WHILE_ZOOMING, PreferenceKeys.PERFORMANCE_LOW_BAND_WIDTH_MODE
             ];


### PR DESCRIPTION
closes #923 

Adding a controller in preference to export images with transparent or filled background.(default: filled) The color of filled background depends on the current theme.

Transparent background(light theme):
![HD163296_CO_2-1_bin3 image-X-profile-2021-03-04-12-03-07](https://user-images.githubusercontent.com/20379662/109911629-65128680-7ce5-11eb-8bcc-6e55376d8513.png)

Transparent background(dark theme):
![HD163296_CO_2-1_bin3 image-X-profile-2021-03-04-12-02-08](https://user-images.githubusercontent.com/20379662/109912291-b7a07280-7ce6-11eb-8726-b94b385e12c3.png)

Filled background(light theme):
![HD163296_CO_2-1_bin3 image-X-profile-2021-03-04-12-03-01](https://user-images.githubusercontent.com/20379662/109911633-6643b380-7ce5-11eb-8707-dd7fc045d1d1.png)

Filled background(dark theme):
![HD163296_CO_2-1_bin3 image-X-profile-2021-03-04-12-02-34](https://user-images.githubusercontent.com/20379662/109911635-6643b380-7ce5-11eb-9891-c16e6ec1c880.png)
