### PR TITLE
Yuhsuan/issue 1218 file browser date

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -358,7 +358,7 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
         let dateString: string;
         if (unixDate > 0) {
             const t = moment.unix(unixDate);
-            const isToday = moment(0, "HH").diff(t, "days") === 0;
+            const isToday = moment(0, "HH").diff(t) <= 0;
             if (isToday) {
                 dateString = t.format("HH:mm");
             } else {


### PR DESCRIPTION
This fixed issue https://github.com/CARTAvis/carta-frontend/issues/1218.
`moment(0, "HH").diff(t, "days")` returns zero when the difference is shorter than 1 day. Changed to `moment(0, "HH").diff(t)`, which returns negative value when the created time of the file is after today 0 a.m.