### PR TITLE
hide the whole toolbar when no image loaded

### DIFF
--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -1024,12 +1024,14 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     </Layer>
                 </Stage>
                 }
+                {(this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0)) &&
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
-                    visible={this.isMouseEntered && (this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0))}
+                    visible={this.isMouseEntered}
                     exportImage={this.exportImage}
                     exportData={this.exportData}
                 />
+                }
             </div>
         );
     }

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -1024,7 +1024,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     </Layer>
                 </Stage>
                 }
-                {(this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0)) &&
+                {(this.props.data !== undefined || this.props.multiPlotPropsMap?.size > 0) &&
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
                     visible={this.isMouseEntered}

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -607,12 +607,14 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
                     </Layer>
                 </Stage>
                 }
+                {(this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0)) &&
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
-                    visible={this.isMouseEntered && (this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0))}
+                    visible={this.isMouseEntered}
                     exportImage={this.exportImage}
                     exportData={this.exportData}
                 />
+                }
             </div>
         );
     }

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -607,7 +607,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
                     </Layer>
                 </Stage>
                 }
-                {(this.props.data !== undefined || (this.props.multiPlotPropsMap && this.props.multiPlotPropsMap.size > 0)) &&
+                {(this.props.data !== undefined || this.props.multiPlotPropsMap?.size > 0) &&
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
                     visible={this.isMouseEntered}


### PR DESCRIPTION
This fixed issue https://github.com/CARTAvis/carta-frontend/issues/1330.
Hide the whole toolbar when no image loaded on x/y/z/ profile and stokes analysis dialogs.