### PR TITLE
Yuhsuan/issue 48 header search

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -471,6 +471,7 @@ export class FileBrowserDialogComponent extends React.Component {
                                 isLoading={fileBrowserStore.loadingInfo}
                                 errorMessage={fileBrowserStore.responseErrorMessage}
                                 catalogHeaderTable={tableProps}
+                                selectedFile={fileBrowserStore.selectedFile}
                             />
                         </div>
                     </div>

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -44,7 +44,7 @@
             }
 
             .header-comment {
-                opacity: 0.5;
+                color: rgba(0, 0, 0, 0.5);
                 font-style: italic;
             }
         }
@@ -76,6 +76,10 @@
 
     .info-highlight {
         background-color: yellow;
+    }
+
+    .info-highlight-selected {
+        background-color: $gold5;
     }
 }
 

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -32,6 +32,7 @@
         unicode-bidi: embed;
         font-family: monospace;
         white-space: pre;
+        user-select: text;
         cursor: text;
 
         .header-entry {

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -67,6 +67,11 @@
         bottom: -40px;
         right: 0;
         margin: 0 10px 10px 0;
+        
+        .bp3-button {
+            transition: opacity 400ms;
+            user-select: none;
+        }
     }
 }
 

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -38,6 +38,7 @@
             padding-right: 15px;
             margin-top: 10px;
             padding-left: 15px;
+
             .header-name {
                 color: $blue2;
                 font-weight: bold;
@@ -46,6 +47,14 @@
             .header-comment {
                 color: rgba(0, 0, 0, 0.5);
                 font-style: italic;
+            }
+
+            .info-highlight {
+                background-color: yellow;
+            }
+        
+            .info-highlight-selected {
+                background-color: $gold5;
             }
         }
     }
@@ -73,17 +82,10 @@
             user-select: none;
         }
     }
-
-    .info-highlight {
-        background-color: yellow;
-    }
-
-    .info-highlight-selected {
-        background-color: $gold5;
-    }
 }
 
-.header-search {
+.bp3-popover {
+    width: 250px;
 
     .header-search-iter {
         color: $gray1;

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -62,7 +62,7 @@
         font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
     }
 
-    .header-search {
+    .header-search-button {
         position: absolute;
         bottom: -40px;
         right: 0;
@@ -79,7 +79,10 @@
     }
 }
 
-.header-search-iter {
-    color: $gray1;
-    padding-top: 6px;
+.header-search {
+
+    .header-search-iter {
+        color: $gray1;
+        padding-top: 6px;
+    }
 }

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -61,4 +61,16 @@
         padding: 1px;
         font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
     }
+
+    .header-search {
+        position: absolute;
+        bottom: -40px;
+        right: 0;
+        margin: 0 10px 10px 0;
+    }
+}
+
+.header-search-iter {
+    color: $gray1;
+    padding-top: 6px;
 }

--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -73,6 +73,10 @@
             user-select: none;
         }
     }
+
+    .info-highlight {
+        background-color: yellow;
+    }
 }
 
 .header-search-iter {

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -61,7 +61,7 @@ export class FileInfoComponent extends React.Component<{
     };
 
     @action setSearchString = (inputSearchString: string) => {
-        this.searchString = inputSearchString.replace("\b","");
+        this.searchString = inputSearchString.replace("\b", "");
     };
 
     @action resetMatchedNums = () => {
@@ -121,7 +121,7 @@ export class FileInfoComponent extends React.Component<{
         this.setSearchString(ev.target.value);
         this.resetMatchedNums();
         
-        if (this.searchString !== "" && this.searchString !== "\b") {
+        if (this.searchString !== "") {
             // RegExp ignores the difference of lettercase; use special characters as normal strings by putting \ in the front
             const searchStringRegExp = new RegExp(this.searchString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
             this.splitLengthArray = [];

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -61,7 +61,7 @@ export class FileInfoComponent extends React.Component<{
     };
 
     @action setSearchString = (inputSearchString: string) => {
-        this.searchString = inputSearchString;
+        this.searchString = inputSearchString.replace("\b","");
     };
 
     @action resetMatchedNums = () => {
@@ -123,7 +123,7 @@ export class FileInfoComponent extends React.Component<{
         
         if (this.searchString !== "" && this.searchString !== "\b") {
             // RegExp ignores the difference of lettercase; use special characters as normal strings by putting \ in the front
-            const searchStringRegExp = new RegExp(this.searchString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace("\b", ""), 'i');
+            const searchStringRegExp = new RegExp(this.searchString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
             this.splitLengthArray = [];
             this.matchedLocationArray = [];
 

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -263,22 +263,22 @@ export class FileInfoComponent extends React.Component<{
         const nameValueLength = name.length + 3 + value.length;
         let highlightedString = [];
         let keyIter = 0; // add unique keys to span to avoid warning
-        let highlighClassName = "";
+        let highlightClassName = "";
         let typeClassName = "header-name";
         let usedLength = 0; 
 
-        function addHighlightedString(sliceStart: number, sliceEnd: number) {
+        let addHighlightedString = (sliceStart: number, sliceEnd: number) => {
             if(!isFinite(sliceStart) || !isFinite(sliceEnd)) {
                 return;
             }
-            highlightedString.push(<span className={typeClassName + highlighClassName} key={keyIter.toString()}>
+            highlightedString.push(<span className={typeClassName + highlightClassName} key={keyIter.toString()}>
                 {((name !== "END") ? `${name} = ${value}${comment && " / " + comment}` : name).slice(sliceStart, sliceEnd)}</span>);
             keyIter += 1;
             return;
-        }
+        };
 
         splitLength.forEach((arrayValue, arrayIndex) => {
-            highlighClassName = "";
+            highlightClassName = "";
             for (const addLength of [arrayValue, this.searchString.length]) {
                 const formerUsedLength = usedLength;
                 usedLength += addLength;
@@ -307,9 +307,9 @@ export class FileInfoComponent extends React.Component<{
                 }
 
                 if (index === this.matchedIterLocation.line && arrayIndex === this.matchedIterLocation.num) {
-                    highlighClassName = " info-highlight-selected";
+                    highlightClassName = " info-highlight-selected";
                 } else {
-                    highlighClassName = " info-highlight";
+                    highlightClassName = " info-highlight";
                 }
             }
         });

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -40,6 +40,7 @@ export class FileInfoComponent extends React.Component<{
     private matchedLocationArray: Array<{line: number, num: number}> = [];
     private listRef = React.createRef<any>();
     private clickMatchedTimer;
+    private clickMatchedTimerStart;
 
     @action onMouseEnter = () => {
         this.isMouseEntered = true;
@@ -153,6 +154,7 @@ export class FileInfoComponent extends React.Component<{
             return;
         }
         if (mode === 0) {
+            clearTimeout(this.clickMatchedTimerStart);
             clearInterval(this.clickMatchedTimer);
         } else {
             let clickMatched = () => {
@@ -167,7 +169,9 @@ export class FileInfoComponent extends React.Component<{
 
             if (mode === 99 || mode === -99) {
                 clickMatched();
-                this.clickMatchedTimer = setInterval(clickMatched, 100);
+                this.clickMatchedTimerStart = setTimeout(() => {
+                    this.clickMatchedTimer = setInterval(clickMatched, 100);
+                }, 500);
             } else if (mode === 1 || mode === -1) {
                 clickMatched();
             } else {
@@ -395,7 +399,7 @@ export class FileInfoComponent extends React.Component<{
                 >
                     <Button icon="search-text" style={{opacity: (this.isMouseEntered || this.isSearchOpened) ? 1 : 0}}></Button>
                     <InputGroup
-                        autoFocus={false}
+                        autoFocus={true}
                         placeholder={"Search text"}
                         leftIcon="search-text"
                         rightElement={searchIter}

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -129,37 +129,43 @@ export class FileInfoComponent extends React.Component<{
     private highlightString(searchString: string, name: string, value?: string, comment?: string) {
         let testSubString = searchString;
         let splitString = (name !== "END") ? `${name} = ${value}${comment && " / "+comment}`.split(testSubString) : name.split(testSubString);
-
+        
         let highlightedString = [];
         let highlighClassName = "";
         if (name !== "END") {
             let classNameType = ["header-name", "header-value", "header-comment"];
             let classNameTypeIter = 0;
             let usedString = 0; 
+            function addHighlightedString(addString: string, sliceStart: number, sliceEnd?: number): void {
+                highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{isFinite(sliceEnd) ? addString.slice(sliceStart, sliceEnd) : addString.slice(sliceStart)}</span>);
+                return;
+            }
             splitString.forEach((arrayValue) => {
 
                 highlighClassName = "";
-                for (const string of [arrayValue,this.searchString]) {
-
-                    usedString += string.length;;
-                    if (classNameTypeIter === 0 && usedString >= name.length + 3 + value.length) {
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(0, name.length - usedString + string.length)}</span>);
+                for (const addString of [arrayValue,this.searchString]) {
+                    const formerUsedString = usedString;
+                    const nameValueLength = name.length + 3 + value.length;
+                    usedString += addString.length;;
+                    if (comment && classNameTypeIter === 0 && usedString >= nameValueLength) {
+                        addHighlightedString(addString, 0, name.length - formerUsedString);
                         classNameTypeIter += 1;
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(name.length - usedString + string.length, name.length - usedString + string.length + value.length + 3)}</span>);
+                        addHighlightedString(addString, name.length - formerUsedString, nameValueLength - formerUsedString);
                         classNameTypeIter += 1;
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(name.length - usedString + string.length + value.length + 3)}</span>);
+                        addHighlightedString(addString, nameValueLength - formerUsedString);
 
                     } else if (classNameTypeIter === 0 && usedString >= name.length ) {
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(0, name.length - usedString + string.length)}</span>);
+                        addHighlightedString(addString, 0, name.length - formerUsedString);
                         classNameTypeIter += 1;
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(name.length - usedString + string.length)}</span>);
+                        addHighlightedString(addString, name.length - formerUsedString);
 
-                    } else if (classNameTypeIter === 1 && usedString > name.length + 3 + value.length) {
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(0, name.length + 3 + value.length - usedString + string.length)}</span>);
+                    } else if (comment && classNameTypeIter === 1 && usedString > nameValueLength) {
+                        addHighlightedString(addString, 0, nameValueLength - formerUsedString);
                         classNameTypeIter += 1;
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string.slice(name.length + 3 + value.length - usedString + string.length)}</span>);
+                        addHighlightedString(addString, nameValueLength - formerUsedString);
+
                     } else {
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{string}</span>);
+                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{addString}</span>);
                     }
     
                     highlighClassName = " info-highlight";
@@ -181,7 +187,6 @@ export class FileInfoComponent extends React.Component<{
     }
 
     private renderImageHeaderList(entries: CARTA.IHeaderEntry[], searchString?: string) {
-        //console.log(this.props.selectedTab, this.searchString);
         const renderHeaderRow = ({index, style}) => {
             if (index < 0 || index >= entries?.length) {
                 return null;

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
+import {action, makeObservable, observable} from "mobx";
 import {ControlGroup, Divider, FormGroup, HTMLSelect, IOptionProps, NonIdealState, Pre, Spinner, Tab, TabId, Tabs, Text, Popover, PopperModifiers, Position, Button, InputGroup, ButtonGroup} from "@blueprintjs/core";
 import {FixedSizeList as List} from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -28,6 +29,32 @@ export class FileInfoComponent extends React.Component<{
     errorMessage: string,
     catalogHeaderTable?: TableComponentProps
 }> {
+
+    @observable isMouseEntered = false;
+    @observable isSearchOpened = false;
+
+    @action onMouseEnter = () => {
+        this.isMouseEntered = true;
+    };
+
+    @action onMouseLeave = () => {
+        if (!this.isSearchOpened) {
+            this.isMouseEntered = false;
+        }
+    };
+
+    @action searchOpened = () => {
+        this.isSearchOpened = true;
+    }
+
+    @action searchClosed = () => {
+        this.isSearchOpened = false;
+    }
+
+    constructor(props) {
+        super(props);
+        makeObservable(this);
+    }
 
     private renderInfoTabs = () => {
         const infoTypes = this.props.infoTypes;
@@ -151,8 +178,11 @@ export class FileInfoComponent extends React.Component<{
                 className="header-search"
                 position={Position.LEFT}
                 modifiers={popoverModifiers}
+                onOpening={this.searchOpened}
+                onClosing={this.searchClosed}
+                defaultIsOpen={this.isSearchOpened ? true : false}
             >
-                <Button icon="search-text"></Button>
+                <Button icon="search-text" style={{opacity: (this.isMouseEntered) ? 1 : 0}}></Button>
                 <InputGroup
                     autoFocus={false}
                     placeholder={"Search text"}
@@ -165,7 +195,7 @@ export class FileInfoComponent extends React.Component<{
 
     render() {
         return (
-            <div className="file-info">
+            <div className="file-info" onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <div className="file-info-panel-top">
                     {this.renderInfoTabs()}
                     {this.renderHDUList()}

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -109,12 +109,8 @@ export class FileInfoComponent extends React.Component<{
         const height = listRefCurrent.props.height;
         const itemSize = listRefCurrent.props.itemSize;
         const targetPosition = 10 + this.matchedIterLocation.line * itemSize;
-        if (this.matchedIterLocation.line === 0) {
-            this.listRef.current.scrollTo(0);
-        } else if (targetPosition > origOffset + height - itemSize) {
-            this.listRef.current.scrollTo(targetPosition - height + itemSize);
-        } else if (targetPosition < origOffset) {
-            this.listRef.current.scrollTo(targetPosition);
+        if (targetPosition > origOffset + height - itemSize || targetPosition < origOffset) {
+            this.listRef.current.scrollTo(targetPosition - height / 2);
         }
     };
 

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {action, computed, makeObservable, observable} from "mobx";
+import {action, makeObservable, observable} from "mobx";
 import {ControlGroup, Divider, FormGroup, HTMLSelect, IOptionProps, NonIdealState, Pre, Spinner, Tab, TabId, Tabs, Text, Popover, PopperModifiers, Position, Button, InputGroup, ButtonGroup} from "@blueprintjs/core";
 import {FixedSizeList as List} from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -31,8 +31,9 @@ export class FileInfoComponent extends React.Component<{
 }> {
 
     @observable searchString: string = "";
-    @observable isMouseEntered = false;
-    @observable isSearchOpened = false;
+    @observable matchedTotal: number = 0;
+    @observable isMouseEntered: boolean = false;
+    @observable isSearchOpened: boolean = false;
 
     @action onMouseEnter = () => {
         this.isMouseEntered = true;
@@ -52,6 +53,10 @@ export class FileInfoComponent extends React.Component<{
         this.isSearchOpened = false;
         this.searchString = "";
     }
+
+    @action addMatchedTotal = (matchedNum: number) => {
+        this.matchedTotal += matchedNum;
+    };
 
     constructor(props) {
         super(props);
@@ -91,7 +96,7 @@ export class FileInfoComponent extends React.Component<{
         ) : undefined;
     };
 
-    @computed get renderInfoPanel() {
+    private renderInfoPanel = () => {
         if (this.props.isLoading) {
             return <NonIdealState className="non-ideal-state-file" icon={<Spinner className="astLoadingSpinner"/>} title="Loading file info..."/>;
         } else if (this.props.errorMessage) {
@@ -124,7 +129,7 @@ export class FileInfoComponent extends React.Component<{
             default:
                 return "";
         }
-    }
+    };
 
     private highlightString(searchString: string, name: string, value?: string, comment?: string) {
         let testSubString = searchString;
@@ -132,7 +137,7 @@ export class FileInfoComponent extends React.Component<{
         
         let highlightedString = [];
         let highlighClassName = "";
-        let keyIter = 0;
+        let keyIter = 0; // add unique keys to span to avoid warning
         if (name !== "END") {
             let classNameType = ["header-name", "header-value", "header-comment"];
             let classNameTypeIter = 0;
@@ -241,7 +246,7 @@ export class FileInfoComponent extends React.Component<{
 
     private renderHeaderSearch = () => {
         const popoverModifiers: PopperModifiers = {arrow: {enabled: false}, offset: {offset: '0, 10px, 0, 0'}};
-        let iterText = "0 of 0"
+        let iterText = `0 of ${this.matchedTotal}`;
         const searchIter = (
             <ButtonGroup>
                 <span className="header-search-iter">&nbsp;{iterText}&nbsp;</span>
@@ -278,7 +283,7 @@ export class FileInfoComponent extends React.Component<{
                     {this.renderInfoTabs()}
                     {this.renderHDUList()}
                 </div>
-                {this.renderInfoPanel}
+                {this.renderInfoPanel()}
                 {this.renderHeaderSearch()}
             </div>
         );

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -132,18 +132,20 @@ export class FileInfoComponent extends React.Component<{
         
         let highlightedString = [];
         let highlighClassName = "";
+        let keyIter = 0;
         if (name !== "END") {
             let classNameType = ["header-name", "header-value", "header-comment"];
             let classNameTypeIter = 0;
             let usedString = 0; 
             function addHighlightedString(addString: string, sliceStart: number, sliceEnd?: number): void {
-                highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{isFinite(sliceEnd) ? addString.slice(sliceStart, sliceEnd) : addString.slice(sliceStart)}</span>);
+                highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName} key={keyIter.toString()}>{isFinite(sliceEnd) ? addString.slice(sliceStart, sliceEnd) : addString.slice(sliceStart)}</span>);
+                keyIter += 1;
                 return;
             }
             splitString.forEach((arrayValue) => {
 
                 highlighClassName = "";
-                for (const addString of [arrayValue,this.searchString]) {
+                for (const addString of [arrayValue, this.searchString]) {
                     const formerUsedString = usedString;
                     const nameValueLength = name.length + 3 + value.length;
                     usedString += addString.length;;
@@ -165,7 +167,8 @@ export class FileInfoComponent extends React.Component<{
                         addHighlightedString(addString, nameValueLength - formerUsedString);
 
                     } else {
-                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName}>{addString}</span>);
+                        highlightedString.push(<span className={classNameType[classNameTypeIter]+highlighClassName} key={keyIter.toString()}>{addString}</span>);
+                        keyIter += 1;
                     }
     
                     highlighClassName = " info-highlight";
@@ -176,7 +179,8 @@ export class FileInfoComponent extends React.Component<{
 
                 highlighClassName = "";
                 for (const string of [value,this.searchString]) {
-                    highlightedString.push(<span className={"header-name"+highlighClassName}>{string}</span>);
+                    highlightedString.push(<span className={"header-name"+highlighClassName} key={keyIter.toString()}>{string}</span>);
+                    keyIter += 1;
                 }
                 highlighClassName = " info-highlight";
             });

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {ControlGroup, Divider, FormGroup, HTMLSelect, IOptionProps, NonIdealState, Pre, Spinner, Tab, TabId, Tabs, Text} from "@blueprintjs/core";
+import {ControlGroup, Divider, FormGroup, HTMLSelect, IOptionProps, NonIdealState, Pre, Spinner, Tab, TabId, Tabs, Text, Popover, PopperModifiers, Position, Button, InputGroup, ButtonGroup} from "@blueprintjs/core";
 import {FixedSizeList as List} from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import {CARTA} from "carta-protobuf";
@@ -134,6 +134,34 @@ export class FileInfoComponent extends React.Component<{
         );
     }
 
+    private renderHeaderSearch = () => {
+        const popoverModifiers: PopperModifiers = {arrow: {enabled: false}, offset: {offset: '0, 10px, 0, 0'}};
+        let iterText = "0 of 0"
+        const searchIter = (
+            <ButtonGroup>
+                <span className="header-search-iter">&nbsp;{iterText}&nbsp;</span>
+                <Button icon="caret-left" minimal={true}></Button>
+                <Button icon="caret-right" minimal={true}></Button>
+            </ButtonGroup>
+        );
+
+        return (this.props.selectedTab === FileInfoType.IMAGE_HEADER) ? (
+            <Popover
+                className="header-search"
+                position={Position.LEFT}
+                modifiers={popoverModifiers}
+            >
+                <Button icon="search-text"></Button>
+                <InputGroup
+                    autoFocus={false}
+                    placeholder={"Search text"}
+                    leftIcon="search-text"
+                    rightElement={searchIter}
+                />
+            </Popover>
+        ) : null;
+    };
+
     render() {
         return (
             <div className="file-info">
@@ -142,6 +170,7 @@ export class FileInfoComponent extends React.Component<{
                     {this.renderHDUList()}
                 </div>
                 {this.renderInfoPanel()}
+                {this.renderHeaderSearch()}
             </div>
         );
     }

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -98,12 +98,32 @@ export class FileInfoComponent extends React.Component<{
         this.matchedIterLocation = (this.matchedTotal > 0) ? this.matchedLocationArray[this.matchedIter - 1] : {line: -1, num: -1};
     };
 
+    private scrollToPosition = () => {
+        if (!this.listRef.current) {
+            return;
+        }
+
+        // scrollToItem() scroll to positions without the effect of padding
+        // calculate the correct positions and use scrollTo() instead
+        const origOffset = this.listRef.current.state.scrollOffset;
+        const height = this.listRef.current.props.height;
+        const itemSize = this.listRef.current.props.itemSize;
+        const targetPosition = 10 + this.matchedIterLocation.line * itemSize
+        if (this.matchedIterLocation.line === 0) {
+            this.listRef.current.scrollTo(0);
+        } else if (targetPosition > origOffset + height - itemSize) {
+            this.listRef.current.scrollTo(targetPosition - height + itemSize);
+        } else if (targetPosition < origOffset) {
+            this.listRef.current.scrollTo(targetPosition);
+        }
+    };
+
     private handleSearchStringChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
         this.setSearchString(ev.target.value);
         this.resetMatchedNums();
         
         if (this.searchString !== "") {
-            const searchStringRegExp = new RegExp(this.searchString, 'i');
+            const searchStringRegExp = new RegExp(this.searchString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
             this.splitLengthArray = [];
             this.matchedLocationArray = [];
 
@@ -123,20 +143,20 @@ export class FileInfoComponent extends React.Component<{
 
             this.initMatchedIter();
             this.updateMatchedIterLocation();
-            this.listRef.current.scrollToItem(this.matchedIterLocation.line, "start");
+            this.scrollToPosition();
         }
     };
 
     private handleClickMatchedNext = () => {
         this.addMatchedIter();
         this.updateMatchedIterLocation();
-        this.listRef.current.scrollToItem(this.matchedIterLocation.line, "start");
+        this.scrollToPosition();
     };
 
     private handleClickMatchedPrev = () => {
         this.minusMatchedIter();
         this.updateMatchedIterLocation();
-        this.listRef.current.scrollToItem(this.matchedIterLocation.line, "start");
+        this.scrollToPosition();
     };
 
     constructor(props) {

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -145,7 +145,8 @@ export class FileInfoComponent extends React.Component<{
             </ButtonGroup>
         );
 
-        return (this.props.selectedTab === FileInfoType.IMAGE_HEADER) ? (
+        return (!this.props.isLoading && !this.props.errorMessage && this.props.fileInfoExtended &&
+            this.props.selectedTab === FileInfoType.IMAGE_HEADER) ? (
             <Popover
                 className="header-search"
                 position={Position.LEFT}


### PR DESCRIPTION
This PR is for new feature requested in https://github.com/CARTAvis/carta/issues/48.
Some details:
- The button becomes visible when hovering on the information panel.
- The search panel can be easily closed by clicking anywhere outside.
- Pressing enter moves to the next matched string.
- The style of highlighting and scrolling is similar to the text search in Chrome browser, but other suggestions are welcome.