### PR TITLE
pass header string as ptr instead of stack variable

### DIFF
--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -92,7 +92,6 @@ Module.setCanvas = function (canvas) {
 };
 
 Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string"]);
-Module.initFrame = Module.cwrap("initFrame", "number", ["string"]);
 Module.getSpectralFrame = Module.cwrap("getSpectralFrame", "number", ["number"]);
 Module.getSkyFrameSet = Module.cwrap("getSkyFrameSet", "number", ["number"]);
 Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);
@@ -118,6 +117,15 @@ Module.createTransformedFrameset = Module.cwrap("createTransformedFrameset", "nu
 Module.fillTransformGrid = Module.cwrap("fillTransformGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number"]);
 
 Module.currentFormatStrings = [];
+
+Module.initFrame = function(wcsString: string) {
+    const stringSize = Module.lengthBytesUTF8(wcsString);
+    const stringPtr = Module._malloc(stringSize + 1);
+    Module.stringToUTF8(wcsString, stringPtr, stringSize + 1);
+    const retVal = Module.ccall("initFrame", "number", ["number"], [stringPtr]);
+    Module._free(stringPtr);
+    return retVal;
+}
 
 Module.getFormattedCoordinates = function (wcsInfo: number, x: number, y: number, formatString: string, tempFormat: boolean) {
     let prevString;

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -8,7 +8,7 @@ npx tsc pre.ts --outFile build/pre.js
 npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/built/include -L../../wasm_libs/built/lib -last -last_pal -lm -g0 -O2 \
-    -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
+    -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "lengthBytesUTF8", "stringToUTF8","UTF8ToString"]' \
     -s EXPORTED_FUNCTIONS='["_malloc", "_free", "_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."


### PR DESCRIPTION
Closes #1347

We were simply wrapping the `initFrame` function using `cwrap` with a string argument. This meant that the string was sent to WebAssembly as a stack variable. The test image in CARTAvis/carta-backend#768 has a 4MB header string, which naturally causes a problem. 

The solution is to `malloc` a string in the WebAssembly heap first, copy the string into that memory and then pass the string as a pointer.