### PR TITLE
populate FITS header cards individually

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -829,7 +829,8 @@ export class FrameStore {
     private initFrame = (): number => {
         const dimension = this.frameInfo.fileInfoExtended.depth > 1 ? "3" : "2";
 
-        let headerString = "";
+        const fitsChan = AST.emptyFitsChan();
+
         for (let entry of this.frameInfo.fileInfoExtended.headerEntries) {
             let name = entry.name;
 
@@ -869,12 +870,10 @@ export class FrameStore {
             }
 
             let entryString = `${name}=  ${value}`;
-            while (entryString.length < 80) {
-                entryString += " ";
-            }
-            headerString += entryString;
+
+            AST.putFits(fitsChan, entryString);
         }
-        return AST.initFrame(headerString);
+        return AST.getFrameFromFitsChan(fitsChan);
     };
 
     private sanitizeChannelNumber(channel: number) {

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -32,23 +32,19 @@ using namespace std;
 
 extern "C" {
 
-EMSCRIPTEN_KEEPALIVE AstFrameSet* initFrame(const char* header)
+EMSCRIPTEN_KEEPALIVE AstFitsChan* emptyFitsChan()
 {
-     if (!header)
-    {
-        cout << "Missing header argument." << endl;
-        return nullptr;
-    }
+    return astFitsChan(nullptr, nullptr, "");
+}
 
-    AstFitsChan* fitschan = astFitsChan(nullptr, nullptr, "");
-    if (!fitschan)
-    {
-        cout << "astFitsChan returned null :(" << endl;
-        return nullptr;
-    }
+EMSCRIPTEN_KEEPALIVE void putFits(AstFitsChan* fitschan, const char* card)
+{
+    astPutFits(fitschan, card, true);
+}
+
+EMSCRIPTEN_KEEPALIVE AstFrameSet* getFrameFromFitsChan(AstFitsChan* fitschan)
+{
     astClear(fitschan, "Card");
-    astPutCards(fitschan, header);
-
     AstFrameSet* frameSet = static_cast<AstFrameSet*>(astRead(fitschan));
     if (!frameSet || !astIsAFrameSet(frameSet))
     {

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -92,7 +92,9 @@ Module.setCanvas = function (canvas) {
 };
 
 Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string"]);
-Module.initFrame = Module.cwrap("initFrame", "number", ["string"]);
+Module.emptyFitsChan = Module.cwrap("emptyFitsChan", "number");
+Module.putFits = Module.cwrap("putFits", null, ["number", "string"])
+Module.getFrameFromFitsChan = Module.cwrap("getFrameFromFitsChan", "number", ["number"]);
 Module.getSpectralFrame = Module.cwrap("getSpectralFrame", "number", ["number"]);
 Module.getSkyFrameSet = Module.cwrap("getSkyFrameSet", "number", ["number"]);
 Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);

--- a/wasm_src/build_ast_wrapper.sh
+++ b/wasm_src/build_ast_wrapper.sh
@@ -9,7 +9,7 @@ npx tsc post.ts --outFile build/post.js
 emcc -std=c++11 -o build/ast_wrapper.js ast_wrapper.cc grf_debug.cc --pre-js build/pre.js --post-js build/post.js \
     -I../../wasm_libs/built/include -L../../wasm_libs/built/lib -last -last_pal -lm -g0 -O2 \
     -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_EXIT_RUNTIME=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString"]' \
-    -s EXPORTED_FUNCTIONS='["_malloc", "_free", "_plotGrid", "_initFrame", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
+    -s EXPORTED_FUNCTIONS='["_malloc", "_free", "_plotGrid", "_emptyFitsChan", "_putFits", "_getFrameFromFitsChan", "_initDummyFrame", "_format", "_set", "_clear", "_transform", "_transform3D", "_getString", "_norm", "_axDistance", "_deleteObject", "_copy", "_invert", "_convert", "_createTransformedFrameset", "_fillTransformGrid"]'
 
 printf "Checking for AST wrapper WASM..."
 if [[ $(find build/ast_wrapper.js -type f -size +1000c 2>/dev/null) ]]; then


### PR DESCRIPTION
Closes #1347

This is a different approach to that of #1348. Instead of passing the header string as a pointer, we use `astPutFits` to populate individual FITS cards. This has two advantages:
- We can safely use the stack, since the individual cards are 80 characters or less
- We don't have to build up a giant string

This seems to be quite a bit faster than #1348 for situations where you have lots of header entries