### PR TITLE
ksw/revise axes label of the ellipse region

### DIFF
--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -310,7 +310,7 @@ export class EllipticalRegionForm extends React.Component<{ region: RegionStore,
                             <td><span className="info-string">{infoString}</span></td>
                         </tr>
                         <tr>
-                            <td>Axes {pxUnitSpan}</td>
+                            <td>Semi-axes {pxUnitSpan}</td>
                             <td>{sizeWidthInput}</td>
                             <td>{sizeHeightInput}</td>
                             <td><span className="info-string">{sizeInfoString}</span></td>


### PR DESCRIPTION
trivial improvement of the axes label of the ellipse region in the region dialog.

Label "Axes" is changed to "Semi-axes".

<img width="769" alt="Screen Shot 2021-03-25 at 10 23 17 AM" src="https://user-images.githubusercontent.com/20819712/112409440-77b43480-8d54-11eb-9952-5af3b54e9b11.png">

@Jordatious please check if this fixes the issue https://github.com/CARTAvis/carta/issues/70