### PR TITLE
add certain className for popover width adjustment

### DIFF
--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -85,7 +85,7 @@
     }
 }
 
-.bp3-popover {
+.header-search-input {
     width: 250px;
 
     .header-search-iter {

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -408,6 +408,7 @@ export class FileInfoComponent extends React.Component<{
                 >
                     <Button icon="search-text" style={{opacity: (this.isMouseEntered || this.isSearchOpened) ? 1 : 0}}></Button>
                     <InputGroup
+                        className="header-search-input"
                         autoFocus={true}
                         placeholder={"Search text"}
                         leftIcon="search-text"


### PR DESCRIPTION
This PR fixed https://github.com/CARTAvis/carta-frontend/issues/1368.
Used a certain className `header-search-input` instead of `bp3-popover` to avoid changing all the popover widths.