### PR TITLE
add active style

### DIFF
--- a/src/components/Shared/ScalingSelectComponent/ScalingSelectComponent.scss
+++ b/src/components/Shared/ScalingSelectComponent/ScalingSelectComponent.scss
@@ -3,5 +3,5 @@
 }
 
 .bp3-active .equation-div {
-    filter: invert(1) brightness(2) drop-shadow(0 0 0.3px white);
+    filter: invert(1) brightness(2);
 }

--- a/src/components/Shared/ScalingSelectComponent/ScalingSelectComponent.scss
+++ b/src/components/Shared/ScalingSelectComponent/ScalingSelectComponent.scss
@@ -1,5 +1,7 @@
-.bp3-dark {
-    .equation-div {
-        filter: invert(1);
-    }
+.bp3-dark .equation-div {
+    filter: invert(1);
+}
+
+.bp3-active .equation-div {
+    filter: invert(1) brightness(2) drop-shadow(0 0 0.3px white);
 }


### PR DESCRIPTION
This PR extends PR https://github.com/CARTAvis/carta-frontend/pull/1371.
Added a style for the selected scaling for both light and dark mode:
![image](https://user-images.githubusercontent.com/43841102/113097028-d8e27900-9228-11eb-995d-23ab7b11d964.png)
![image](https://user-images.githubusercontent.com/43841102/113097048-e0a21d80-9228-11eb-80a8-3188410834ef.png)
