### PR TITLE
ksw/refine label style for pv conversion

### DIFF
--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.scss
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.scss
@@ -4,10 +4,6 @@
     padding: 20px;
     height: 100%;
 
-    h3 {
-        margin: 10px 0 10px 5px;
-    }
-
     div.bp3-tabs.bp3-vertical {
         height: 100%;
     }

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -1053,9 +1053,9 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
         const isPVImage = frame?.isPVImage;
         const spectralPanel = isPVImage ? (
             <div className="panel-container">
-                <h3>For spatial-spectral image</h3>
+                <p>For spatial-spectral image</p>
                 <Divider/>
-                <h3>Spectral axis</h3>
+                <p>Spectral axis</p>
                 <SpectralSettingsComponent
                     frame={appStore.activeFrame}
                     onSpectralCoordinateChange={frame.setSpectralCoordinate}


### PR DESCRIPTION
This simply refines the labels for pv conversion in the image view settings. 
Was:
![Screen Shot 2021-04-02 at 4 30 13 PM](https://user-images.githubusercontent.com/20819712/113398247-db7fd280-93d0-11eb-9a0f-a5197ceb10fb.png)
Now:
![Screen Shot 2021-04-02 at 4 29 36 PM](https://user-images.githubusercontent.com/20819712/113398268-e5a1d100-93d0-11eb-985e-32686a4bd0e4.png)
