### PR TITLE
Disable plotting spectral lines when showing multiple profiles of dif…

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -551,6 +551,10 @@ export class FrameStore {
         return this.spectralType === SpectralType.CHANNEL;
     }
 
+    @computed get isCoordVelocity(): boolean {
+        return this.spectralType === SpectralType.VRAD || this.spectralType === SpectralType.VOPT;
+    }
+
     @computed get nativeSpectralCoordinate(): string {
         return this.spectralAxis ? `${this.spectralAxis.type.name} (${this.spectralAxis.type.unit})` : undefined;
     }

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -393,6 +393,10 @@ export class SpectralProfileSelectionStore {
         return this.activeProfileCategory === MultiProfileCategory.NONE;
     }
 
+    @computed get isShowingProfilesOfMultiImages(): boolean {
+        return this.activeProfileCategory === MultiProfileCategory.IMAGE && this.profiles?.length > 1;
+    }
+
     @action private switchToSingleModeHandily = (profileCategory: MultiProfileCategory) => {
         if (profileCategory === MultiProfileCategory.REGION) {
             this.selectSingleRegionHandily();

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -438,14 +438,19 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     }
 
     @computed get transformedSpectralLines(): SpectralLine[] {
-        // transform to corresponding value according to current widget's spectral settings
-        let transformedSpectralLines: SpectralLine[] = [];
         const frame = this.effectiveFrame;
-        if (frame && this.spectralLinesMHz) {
-            this.spectralLinesMHz.forEach(spectralLine => {
-                const transformedValue = frame.convertFreqMHzToSettingWCS(spectralLine.value);
+
+        // Ignoring plotting lines when:
+        // 1. x cooridnate is channel
+        // 2. showing multiple profiles of different images in radio/optical velocity.(observation sources are not aligned now)
+        const disablePlot = frame?.isCoordChannel || (frame?.isCoordVelocity && this.profileSelectionStore.isShowingProfilesOfMultiImages);
+
+        let transformedSpectralLines: SpectralLine[] = [];
+        if (frame && !disablePlot) {
+            this.spectralLinesMHz?.forEach(spectralLine => {
+                const transformedValue = frame.convertFreqMHzToSettingWCS(spectralLine?.value);
                 if (isFinite(transformedValue)) {
-                    transformedSpectralLines.push({species: spectralLine.species, value: transformedValue, qn: spectralLine.qn});
+                    transformedSpectralLines.push({species: spectralLine?.species, value: transformedValue, qn: spectralLine?.qn});
                 }
             });
         }


### PR DESCRIPTION
closes #1435 and temporarily fixes #1428: 
not showing spectral lines when
1. x-axis is coordinate
2. x-axis is radio/optical velocity & profiles are from different images

full support for #1428 may need observation source alignment feature.