### PR TITLE
Thchang/preserve file browser dialogue size after resizing

### DIFF
--- a/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
+++ b/src/components/Dialogs/DraggableDialog/DraggableDialogComponent.tsx
@@ -14,6 +14,7 @@ export class ResizableDialogComponentProps {
     minHeight?: number;
     enableResizing: boolean;
     helpType?: HelpType;
+    onResizeStop?: (newWidth: number, newHeight: number) => void;
 }
 
 export class DraggableDialogComponent extends React.Component<ResizableDialogComponentProps> {
@@ -40,6 +41,12 @@ export class DraggableDialogComponent extends React.Component<ResizableDialogCom
     private onClickHelpButton = () => {
         const centerX = this.rnd.draggable.state.x + this.rnd.resizable.size.width * 0.5;
         HelpStore.Instance.showHelpDrawer(this.props.helpType, centerX);
+    }
+
+    private onResizeStop = (e, direction, elementRef: HTMLDivElement) => {
+        if (this.props.onResizeStop) {
+            this.props.onResizeStop(elementRef.offsetWidth, elementRef.offsetHeight);
+        }
     }
 
     render() {
@@ -80,6 +87,7 @@ export class DraggableDialogComponent extends React.Component<ResizableDialogCom
                     minHeight={this.props.minHeight}
                     dragHandleClassName={"bp3-dialog-header"}
                     ref={c => { this.rnd = c; }}
+                    onResizeStop={this.onResizeStop}
                 >
                     <Dialog hasBackdrop={false} usePortal={false}  enforceFocus={false} autoFocus={true} {...this.props.dialogProps} children={this.props.children}/>
                 </Rnd>

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -16,10 +16,14 @@ export class FileBrowserDialogComponent extends React.Component {
     @observable overwriteExistingFileAlertVisible: boolean;
     @observable fileFilterString: string = "";
     @observable debouncedFilterString: string = "";
+    @observable defaultWidth: number;
+    @observable defaultHeight: number;
 
     constructor(props: any) {
         super(props);
         makeObservable(this);
+        this.defaultWidth = 1200;
+        this.defaultHeight = 600;
     }
 
     private handleTabChange = (newId: TabId) => {
@@ -429,6 +433,11 @@ export class FileBrowserDialogComponent extends React.Component {
         }
     };
 
+    @action private updateDefaultSize = (newWidth: number, newHeight: number) => {
+        this.defaultWidth = newWidth;
+        this.defaultHeight = newHeight;
+    };
+
     public render() {
         const appStore = AppStore.Instance;
         const fileBrowserStore = appStore.fileBrowserStore;
@@ -476,7 +485,7 @@ export class FileBrowserDialogComponent extends React.Component {
         const fileList = fileBrowserStore.getfileListByMode;
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.FILE_Browser} minWidth={400} minHeight={400} defaultWidth={1200} defaultHeight={600} enableResizing={true}>
+            <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.FILE_Browser} minWidth={400} minHeight={400} defaultWidth={this.defaultWidth} defaultHeight={this.defaultHeight} enableResizing={true} onResizeStop={this.updateDefaultSize}>
                 <div className="file-path">
                     {this.pathItems &&
                         <React.Fragment>


### PR DESCRIPTION
closes #1253. 
The size of file browser was still set to the fixed default size(width: 1200px, height: 600px) after users resizing the dialog for long filename. Now the default width and height of file browser dialog will be changed by the resized size.