### PR TITLE
Jason/multiprofile checkbox

### DIFF
--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -22,9 +22,9 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return {
             id: "spectral-profiler",
             type: "spectral-profiler",
-            minWidth: 780,
+            minWidth: 875,
             minHeight: 300,
-            defaultWidth: 780,
+            defaultWidth: 875,
             defaultHeight: 300,
             title: "Z Profile: Cursor",
             isCloseable: true,

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -22,9 +22,9 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return {
             id: "spectral-profiler",
             type: "spectral-profiler",
-            minWidth: 875,
+            minWidth: 870,
             minHeight: 300,
-            defaultWidth: 875,
+            defaultWidth: 870,
             defaultHeight: 300,
             title: "Z Profile: Cursor",
             isCloseable: true,

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
@@ -13,26 +13,27 @@
         flex-direction: row;
 
         .category-set {
-            padding-right: 5px;
-
-            .bp3-button {
-                padding-left: 8px;
-                padding-right: 8px;
-
-                .bp3-button-text {
-                    margin-right: 0;
-                }
-            }
+            display: flex;
+            align-items: center;
+            margin-right: 15px;
 
             .category-checkbox {
-                margin-right: 5px;
+                margin: 0 5px 0 0;
                 font-weight: bold;
             }
 
             .dropdown-button {
-                margin-right: 5px;
-                padding: 0;
-                width: 100px;
+                padding: 0 0 0 5px;
+                width: 90px;
+
+                .bp3-button {
+                    padding-left: 8px;
+                    padding-right: 8px;
+
+                    .bp3-button-text {
+                        margin-right: 0;
+                    }
+                }
 
                 .overflow-text {
                     max-width: 60px;

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
@@ -24,7 +24,14 @@
                 }
             }
 
+            .category-checkbox {
+                margin-right: 5px;
+                font-weight: bold;
+            }
+
             .dropdown-button {
+                margin-right: 5px;
+                padding: 0;
                 width: 100px;
 
                 .overflow-text {

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -1,7 +1,7 @@
 import {observer} from "mobx-react";
 import * as React from "react";
 import {CARTA} from "carta-protobuf";
-import {AnchorButton, ButtonGroup, Intent, Menu, MenuItem, Popover, Position, Tooltip} from "@blueprintjs/core";
+import {AnchorButton, ButtonGroup, Checkbox, Intent, Menu, MenuItem, Popover, Position, Tooltip} from "@blueprintjs/core";
 import {AppStore} from "stores";
 import {MultiProfileCategory, SpectralProfileWidgetStore, SpectralProfileSelectionStore} from "stores/widgets";
 import {SpectralProfilerComponent, SpectralProfilerSettingsTabs} from "components";
@@ -57,12 +57,13 @@ class ProfileSelectionButtonComponent extends React.Component<ProfileSelectionBu
         }
 
         return (
-            <ButtonGroup fill={true} className={className}>
+            <div className={className}>
                 <Tooltip content={this.props.categoryTooltip} position={Position.TOP}>
-                    <AnchorButton
-                        text={<span className={this.props.disableOptions ? "bp3-text-disabled" : ""}>{this.props.categoryName}</span>}
-                        active={this.props.isActiveCategory}
-                        onClick={(ev) => this.props.onCategorySelect()}
+                    <Checkbox
+                        className={"category-checkbox"}
+                        labelElement={<span>{this.props.categoryName}:</span>}
+                        checked={this.props.isActiveCategory}
+                        onChange={(ev) => this.props.onCategorySelect()}
                         disabled={this.props.disabled}
                     />
                 </Tooltip>
@@ -95,7 +96,7 @@ class ProfileSelectionButtonComponent extends React.Component<ProfileSelectionBu
                         />
                     </Tooltip>
                 </Popover>
-            </ButtonGroup>
+            </div>
         );
     }
 }

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -61,7 +61,7 @@ class ProfileSelectionButtonComponent extends React.Component<ProfileSelectionBu
                 <Tooltip content={this.props.categoryTooltip} position={Position.TOP}>
                     <Checkbox
                         className={"category-checkbox"}
-                        labelElement={<span>{this.props.categoryName}:</span>}
+                        label={`${this.props.categoryName}:`}
                         checked={this.props.isActiveCategory}
                         onChange={(ev) => this.props.onCategorySelect()}
                         disabled={this.props.disabled}

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -61,7 +61,7 @@ class ProfileSelectionButtonComponent extends React.Component<ProfileSelectionBu
                 <Tooltip content={this.props.categoryTooltip} position={Position.TOP}>
                     <Checkbox
                         className={"category-checkbox"}
-                        label={`${this.props.categoryName}:`}
+                        label={this.props.categoryName}
                         checked={this.props.isActiveCategory}
                         onChange={(ev) => this.props.onCategorySelect()}
                         disabled={this.props.disabled}


### PR DESCRIPTION
comments from beta user:

> Clarifying the "turn on multiple profiles" User Interaction would be helpful. It took me a while to realize I just needed to click on the "Images" button or "Regions" button to select / plot multiple profiles. Maybe just allowing the drop-downs to be multiselect with check marks and have a "Select all" at the bottom. Now that I know about it, it's fine, so maybe this doesn't need to change but it was confusing at first.

make sense & replace button with checkbox