### PR TITLE
Yuhsuan/issue 1458 save image filetype

### DIFF
--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -79,7 +79,12 @@ export class FileBrowserStore {
         autorun(() => {
             if (AppStore.Instance.activeFrame) {
                 FileBrowserStore.Instance.initialSaveSpectralRange();
-                this.setSaveFileType(AppStore.Instance.activeFrame?.frameInfo?.fileInfo.type);
+                const initialFileType = AppStore.Instance.activeFrame.frameInfo?.fileInfo.type;
+                if (initialFileType === CARTA.FileType.FITS || initialFileType === CARTA.FileType.CASA) {
+                    this.setSaveFileType(initialFileType);
+                } else {
+                    this.setSaveFileType(CARTA.FileType.FITS);
+                }
             }
         });
 

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -79,12 +79,7 @@ export class FileBrowserStore {
         autorun(() => {
             if (AppStore.Instance.activeFrame) {
                 FileBrowserStore.Instance.initialSaveSpectralRange();
-                const initialFileType = AppStore.Instance.activeFrame.frameInfo?.fileInfo.type;
-                if (initialFileType === CARTA.FileType.FITS || initialFileType === CARTA.FileType.CASA) {
-                    this.setSaveFileType(initialFileType);
-                } else {
-                    this.setSaveFileType(CARTA.FileType.FITS);
-                }
+                this.setSaveFileType(AppStore.Instance.activeFrame.frameInfo?.fileInfo.type === CARTA.FileType.CASA ? CARTA.FileType.CASA : CARTA.FileType.FITS);
             }
         });
 


### PR DESCRIPTION
This PR closes https://github.com/CARTAvis/carta-frontend/issues/1458: The initial export filetype is set to either FITS or CASA since we only have these two options. It is set to FITS if the image filetype is not CASA. Please check if all filetypes work fine (e.g. HDF5, MIRIAD).