### PR TITLE
Thchang/issue 1456: multiple tsv files exported when the profile fitting result presents 

### DIFF
--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -381,7 +381,8 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                     type: PlotType.LINES,
                     borderColor: appStore.darkTheme ? Colors.GRAY5 : Colors.GRAY1,
                     borderWidth: 0.5,
-                    opacity: 0.5
+                    opacity: 0.5,
+                    noExport: true
                 };
                 linePlotProps.multiPlotPropsMap.set("colormapScaling", colormapScalingProps);
             }

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -659,7 +659,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         }
 
         this.props.multiPlotPropsMap?.forEach((multiPlotProp, key) => {
-            if (key === "colormapScaling" || multiPlotProp.noExport) { // TODO: remove (key === "colormapScaling") to fully support multiple lines
+            if (multiPlotProp.noExport) {
                 return;
             }
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -662,6 +662,9 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             if (key === "colormapScaling") { // TODO: remove this to fully support multiple lines
                 return;
             }
+            if (multiPlotProp.noExport) {
+                return;
+            }
 
             let rows = [];
             const plotName = multiPlotProp.imageName;
@@ -679,9 +682,30 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             multiPlotProp.comments?.forEach(comment => rows.push(`# ${comment}\t`));
 
             // data part
-            rows.push("# x\ty");
-            multiPlotProp.data?.forEach(o => {
-                rows.push(`${o.x}\t${toExponential(o.y, 10)}`);
+            let columnsHeader = "# x\ty";
+            if (multiPlotProp.followingData) {
+                multiPlotProp.followingData.forEach(dataName => {
+                    columnsHeader = columnsHeader + `\t${dataName}`;
+                });
+            }
+            rows.push(columnsHeader);
+
+            multiPlotProp.data.forEach((o) => {
+                let rowData = `${o.x}\t${toExponential(o.y, 10)}`;
+                // append following data
+                if (multiPlotProp.followingData) {
+                    multiPlotProp.followingData.forEach(dataName => {
+                        const followingData = this.props.multiPlotPropsMap.get(dataName);
+                        if (followingData?.data) {
+                            followingData.data.forEach(obj => {
+                                if (obj.x === o.x) {
+                                    rowData = rowData + `\t${toExponential(obj.y, 10)}`;
+                                }
+                            });
+                        }
+                    });
+                }
+                rows.push(rowData);
             });
 
             exportTsvFile(multiPlotProp.imageName, multiPlotProp.plotName, `${comment}\n${rows.join("\n")}\n`);

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -699,7 +699,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                         if (followingData?.data) {
                             followingData.data.forEach(obj => {
                                 if (obj.x === o.x) {
-                                    rowData = rowData + `\t${toExponential(obj.y, 10)}`;
+                                    rowData = rowData + `\t${toExponential(obj.y, 6)}`;
                                 }
                             });
                         }

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -659,10 +659,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         }
 
         this.props.multiPlotPropsMap?.forEach((multiPlotProp, key) => {
-            if (key === "colormapScaling") { // TODO: remove this to fully support multiple lines
-                return;
-            }
-            if (multiPlotProp.noExport) {
+            if (key === "colormapScaling" || multiPlotProp.noExport) { // TODO: remove (key === "colormapScaling") to fully support multiple lines
                 return;
             }
 

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -65,6 +65,8 @@ export class MultiPlotProps {
     order?: number;
     comments?: string[];
     hidden?: boolean;
+    followingData?: string[];
+    noExport?: boolean;
 }
 
 interface MulticolorLineChartDatasets extends ChartDataSets {

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -307,6 +307,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             }
 
             const currentPlotData = this.plotData;
+            const fittingStore = this.widgetStore.fittingStore;
             if (currentPlotData?.numProfiles > 0) {
                 linePlotProps.imageName = currentPlotData.plotName?.image;
                 linePlotProps.plotName = currentPlotData.plotName?.plot;
@@ -324,7 +325,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             borderColor: currentPlotData.colors[i],
                             comments: currentPlotData.comments[i],
                             order: 1,
-                            hidden: smoothingStore.type !== SmoothingType.NONE && !smoothingStore.isOverlayOn
+                            hidden: smoothingStore.type !== SmoothingType.NONE && !smoothingStore.isOverlayOn,
+                            followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult && smoothingStore.type === SmoothingType.NONE ? ["fittingModel", "fittingResidual"] : null
                         });
                     }
 
@@ -338,7 +340,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             borderWidth: currentPlotData.numProfiles > 1 ? this.widgetStore.lineWidth + 1 : smoothingStore.lineWidth,
                             pointRadius: smoothingStore.pointRadius,
                             order: 0,
-                            comments: [...currentPlotData.comments[i], ...smoothingStore.comments]
+                            comments: [...currentPlotData.comments[i], ...smoothingStore.comments],
+                            followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult ? ["fittingModel", "fittingResidual"] : null
                         });
                     }
                 }
@@ -350,7 +353,6 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 let primaryLineColor = getColorForTheme(this.widgetStore.primaryLineColor);
                 linePlotProps.lineColor = primaryLineColor;
 
-                const fittingStore = this.widgetStore.fittingStore;
                 if (this.widgetStore.profileNum === 1) {
                     if (fittingStore.continuum !== FittingContinuum.NONE && !fittingStore.hasResult) {
                         let fittingPlotProps: MultiPlotProps = {
@@ -361,7 +363,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             borderColor: getColorForTheme("auto-lime"),
                             borderWidth: 1,
                             pointRadius: 1,
-                            order: 0
+                            order: 0,
+                            noExport: true
                         };
                         linePlotProps.multiPlotPropsMap.set("fittingBaseline", fittingPlotProps);
                     }
@@ -369,28 +372,30 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                         let fittingPlotProps: MultiPlotProps = {
                             imageName: currentPlotData.plotName.image,
                             plotName: currentPlotData.plotName.plot,
-                            data: fittingStore.resultPoint2DArray,
+                            data: fittingStore.modelPoint2DArray,
                             type: PlotType.LINES,
                             borderColor: getColorForTheme("auto-orange"),
                             borderWidth: 1,
                             pointRadius: 1,
-                            order: 0
+                            order: 0,
+                            noExport: true
                         };
-                        linePlotProps.multiPlotPropsMap.set("fittingResult", fittingPlotProps);
+                        linePlotProps.multiPlotPropsMap.set("fittingModel", fittingPlotProps);
 
-                        for (let i = 0; i < fittingStore.singleResultsPoint2DArrays.length; i++) {
+                        for (let i = 0; i < fittingStore.individualModelPoint2DArrays.length; i++) {
                             const individualPlotProps: MultiPlotProps = {
                                 imageName: currentPlotData.plotName.image,
                                 plotName: currentPlotData.plotName.plot,
-                                data: fittingStore.singleResultsPoint2DArrays[i],
+                                data: fittingStore.individualModelPoint2DArrays[i],
                                 type: PlotType.LINES,
                                 borderColor: getColorForTheme("auto-orange"),
                                 borderWidth: 1,
                                 pointRadius: 1,
                                 order: 0,
-                                opacity: 0.6
+                                opacity: 0.6,
+                                noExport: true
                             };
-                            linePlotProps.multiPlotPropsMap.set(`fittingIndividual(${i + 1})`, individualPlotProps);
+                            linePlotProps.multiPlotPropsMap.set(`fittingModel(${i + 1})`, individualPlotProps);
                         }
 
                         if (fittingStore.enableResidual) {
@@ -402,7 +407,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                                 borderColor: getColorForTheme("auto-orange"),
                                 borderWidth: 1,
                                 pointRadius: 1,
-                                order: 0
+                                order: 0,
+                                noExport: true
                             };
                             linePlotProps.multiPlotPropsMap.set("fittingResidual", fittingResidualPlotProps);
                         }

--- a/src/stores/ProfileFittingStore.ts
+++ b/src/stores/ProfileFittingStore.ts
@@ -188,10 +188,10 @@ export class ProfileFittingStore {
         return [];
     }
 
-    @computed get resultPoint2DArray(): Point2D[] {
+    @computed get modelPoint2DArray(): Point2D[] {
         if (this.components && this.hasResult) {
             const x = this.originData.x;
-            const resultPoint2DArray = new Array<Point2D>(x.length);
+            const modelPoint2DArray = new Array<Point2D>(x.length);
             for (let i = 0; i < x.length; i++) {
                 let yi = 0;
                 for (const component of this.components) {
@@ -201,26 +201,26 @@ export class ProfileFittingStore {
                         yi += lorentzian(x[i], component.resultAmp, component.resutlCenter, component.resultFwhm);
                     }
                 }
-                resultPoint2DArray.push({x: x[i], y: yi + (this.resultSlope * x[i] + this.resultYIntercept)});
+                modelPoint2DArray.push({x: x[i], y: yi + (this.resultSlope * x[i] + this.resultYIntercept)});
             }
-            return resultPoint2DArray;
+            return modelPoint2DArray;
         }
         return [];
     }
 
-    @computed get singleResultsPoint2DArrays(): Array<Point2D[]> {
+    @computed get individualModelPoint2DArrays(): Array<Point2D[]> {
         if (this.components && this.hasResult) {
             const x = this.originData.x;
-            const individualResultPoint2DArrays = new Array<Point2D[]>(this.components.length);
+            const individualModelPoint2DArrays = new Array<Point2D[]>(this.components.length);
             for (const component of this.components) {
                 let individualResultPoint2DArray: Point2D[] = [];
                 for (let i = 0; i < x.length; i++) {
                     const yi = this.function === FittingFunction.GAUSSIAN ? gaussian(x[i], component.resultAmp, component.resutlCenter, component.resultFwhm) : lorentzian(x[i], component.resultAmp, component.resutlCenter, component.resultFwhm);
                     individualResultPoint2DArray.push({x: x[i], y: yi + (this.resultSlope * x[i] + this.resultYIntercept)});
                 }
-                individualResultPoint2DArrays.push(individualResultPoint2DArray);
+                individualModelPoint2DArrays.push(individualResultPoint2DArray);
             }
-            return individualResultPoint2DArrays;
+            return individualModelPoint2DArrays;
         }
         return [];
     }


### PR DESCRIPTION
closes #1456. multiple tsv files exported when the profile fitting result presents.

Root cause was the extra tsv files were the data of fitting result, baseline, residual.
Fixed this issue by add `noExport` and `followingData` in _MultiPlotProps_ to remove unneeded tsv files and add columns(fittingModel, fittingResidual) in the main exported file.