### PR TITLE
fix highlighting when data lies outside of scale bounds

### DIFF
--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -16,6 +16,7 @@ export class RasterViewComponentProps {
 export class RasterViewComponent extends React.Component<RasterViewComponentProps> {
     private canvas: HTMLCanvasElement;
     private gl: WebGLRenderingContext;
+    private static readonly Float32Max = 3.402823466e38;
 
     componentDidMount() {
         this.gl = TileWebGLService.Instance.gl;
@@ -86,7 +87,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             if (isFinite(this.props.pixelHighlightValue)) {
                 this.gl.uniform1f(shaderUniforms.PixelHighlightVal, this.props.pixelHighlightValue);
             } else {
-                this.gl.uniform1f(shaderUniforms.PixelHighlightVal, renderConfig.scaleMinVal);
+                this.gl.uniform1f(shaderUniforms.PixelHighlightVal, -RasterViewComponent.Float32Max);
             }
         }
     }


### PR DESCRIPTION
Minor fix for situations where the image becomes saturated unnecessarily because the scale bounds are smaller than the data bounds (introduced in #1521)