### PR TITLE
file menu style

### DIFF
--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -53,7 +53,7 @@
     }
 }
 
-.bp3-menu .bp3-popover-target {
+.bp3-menu .bp3-popover2-target {
     // for menu items with tooltips
     display: block;
 }


### PR DESCRIPTION
Closes #1533. The issue is caused by the migration of `tooltip2`.