### PR TITLE
ajm/adding ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,5 +13,17 @@ pipeline {
                 }
             }
         }
+        stage('WebAssembly compilation') {
+            agent {
+                label "macos-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh "git submodule update --init --recursive"
+                    sh "npm run build-libs-docker"
+                    stash includes: "carta_frontend", name: "carta_frontend_with_built_libs"
+                }
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,22 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "npm run build-libs-docker"
-                    stash includes: "carta_frontend", name: "carta_frontend_with_built_libs"
+                    stash includes: "carta-frontend", name: "carta_frontend_with_built_libs"
+                }
+            }
+        }
+        stage('node v12') {
+            agent {
+                label "macos-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "carta_frontend_with_built_libs"
+                    sh "rm -rf node_modules"
+                    sh "nvm use 12"
+                    sh "node -v"
+                    sh "npm install"
+                    sh "npm run build-docker"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Format check') {
             agent {
-                label "macos-1"
+                label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -15,7 +15,7 @@ pipeline {
         }
         stage('WebAssembly compilation') {
             agent {
-                label "macos-1"
+                label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -29,15 +29,15 @@ pipeline {
         }
         stage('node v12') {
             agent {
-                label "macos-1"
+                label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     unstash 'built_wasm_libs'
                     sh 'rm -rf node_modules'
-                    sh 'export NVM_DIR=/Users/acdc/.nvm'
-                    sh '[ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"'
-                    sh '[ -s "/usr/local/opt/nvm/etc/bash_completion.d/nvm" ] && . "/usr/local/opt/nvm/etc/bash_completion.d/nvm"'
+                    sh 'export NVM_DIR="/home/acdc/.nvm"'
+                    sh '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
+                    sh '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"'
                     sh 'nvm install 12 && nvm use 12'
                     sh 'node -v'
                     sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,7 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh 'rm -rf node_modules'
-                    sh 'bash && nvm --version'
-                    sh 'nvm install 12 && nvm use 12'
+                    sh 'n 12'
                     sh 'node -v'
                     sh 'npm install'
                     sh 'npm run build-docker'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     sh "npm run build-libs-docker"
                     sh "pwd"
                     sh "ls -sort"
-                    stash includes: "wasm_libs", name: "built_wasm_libs"
+                    stash name: "built_wasm_libs", includes: "wasm_libs/"
                 }
             }
         }
@@ -35,7 +35,7 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     unstash 'built_wasm_libs'
                     sh 'rm -rf node_modules'
-                    sh 'bash && . /home/acdc/.nvm/nvm.sh'
+                    sh 'bash && nvm --version'
                     sh 'nvm install 12 && nvm use 12'
                     sh 'node -v'
                     sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,11 @@ pipeline {
                 label "macos-1"
             }
             steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                sh "git submodule update --init --recursive"
-                sh "npm install"
-                sh "npm run checkformat"
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh "git submodule update --init --recursive"
+                    sh "npm install"
+                    sh "npm run checkformat"
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,14 +33,15 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash "built_wasm_libs"
-                    sh "pwd"
-                    sh "ls -sort"
-                    sh "rm -rf node_modules"
-                    sh "export NVM_DIR=/Users/acdc/.nvm && nvm install 12 && nvm use 12"
-                    sh "node -v"
-                    sh "npm install"
-                    sh "npm run build-docker"
+                    unstash 'built_wasm_libs'
+                    sh 'rm -rf node_modules'
+                    sh 'export NVM_DIR=/Users/acdc/.nvm'
+                    sh '[ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"'
+                    sh '[ -s "/usr/local/opt/nvm/etc/bash_completion.d/nvm" ] && . "/usr/local/opt/nvm/etc/bash_completion.d/nvm"'
+                    sh 'nvm install 12 && nvm use 12'
+                    sh 'node -v'
+                    sh 'npm install'
+                    sh 'npm run build-docker'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,58 +22,5 @@ pipeline {
                 sh "npm run checkformat"
             }
         }
-        stage('WebAssembly compilation') {
-            agent {
-                label "macos-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                sh "git submodule update --init --recursive"
-                sh "npm run build-libs-docker"
-                stash includes: "carta_frontend", name: "carta_frontend_with_built_libs"
-            }
-        }
-        stage('node v12') {
-            agent {
-                label "macos-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                unstash "carta_frontend_with_built_libs"
-                sh "rm -rf node_modules"
-                sh "nvm use 12"
-                sh "node -v"
-                sh "npm install"
-                sh "npm run build-docker"
-            }
-        }
-        stage('node v14') {
-            agent {
-                label "macos-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                unstash "carta_frontend_with_built_libs"
-                sh "rm -rf node_modules"
-                sh "nvm use 14"
-                sh "node -v"
-                sh "npm install"
-                sh "npm run build-docker"
-            }
-        }
-        stage('node v16') {
-            agent {
-                label "macos-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                unstash "carta_frontend_with_built_libs"
-                sh "rm -rf node_modules"
-                sh "nvm use 16"
-                sh "node -v"
-                sh "npm install"
-                sh "npm run build-docker"
-            }
-        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "npm run build-libs-docker"
-                    stash includes: "carta-frontend", name: "carta_frontend_with_built_libs"
+                    stash includes: "wasm_libs", name: "built_wasm_libs"
                 }
             }
         }
@@ -31,9 +31,9 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash "carta_frontend_with_built_libs"
+                    unstash "built_wasm_libs"
                     sh "rm -rf node_modules"
-                    sh "nvm use 12"
+                    sh "export NVM_DIR="/Users/acdc/.nvm" && nvm install 12 && nvm use 12"
                     sh "node -v"
                     sh "npm install"
                     sh "npm run build-docker"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,8 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "npm run build-libs-docker"
+                    sh "pwd"
+                    sh "ls -sort"
                     stash includes: "wasm_libs", name: "built_wasm_libs"
                 }
             }
@@ -32,6 +34,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     unstash "built_wasm_libs"
+                    sh "pwd"
+                    sh "ls -sort"
                     sh "rm -rf node_modules"
                     sh "export NVM_DIR=/Users/acdc/.nvm && nvm install 12 && nvm use 12"
                     sh "node -v"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,3 @@
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-frontend"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
-}
-
 pipeline {
     agent none
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,7 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     unstash 'built_wasm_libs'
                     sh 'rm -rf node_modules'
-                    sh 'export NVM_DIR="/home/acdc/.nvm"'
-                    sh '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
-                    sh '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"'
+                    sh 'bash && . /home/acdc/.nvm/nvm.sh'
                     sh 'nvm install 12 && nvm use 12'
                     sh 'node -v'
                     sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,6 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "npm run build-libs-docker"
-                    sh "pwd"
-                    sh "ls -sort"
-                    stash name: "built_wasm_libs", includes: "wasm_libs/"
                 }
             }
         }
@@ -33,7 +30,6 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash 'built_wasm_libs'
                     sh 'rm -rf node_modules'
                     sh 'bash && nvm --version'
                     sh 'nvm install 12 && nvm use 12'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     unstash "built_wasm_libs"
                     sh "rm -rf node_modules"
-                    sh "export NVM_DIR="/Users/acdc/.nvm" && nvm install 12 && nvm use 12"
+                    sh "export NVM_DIR=/Users/acdc/.nvm && nvm install 12 && nvm use 12"
                     sh "node -v"
                     sh "npm install"
                     sh "npm run build-docker"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,14 +24,42 @@ pipeline {
                 }
             }
         }
-        stage('node v12') {
+        stage('Build with node v12') {
             agent {
                 label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh 'rm -rf node_modules'
+                    sh 'rm -rf node_modules build'
                     sh 'n 12'
+                    sh 'node -v'
+                    sh 'npm install'
+                    sh 'npm run build-docker'
+                }
+            }
+        }
+        stage('Build with node v14') {
+            agent {
+                label "ubuntu-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh 'rm -rf node_modules build'
+                    sh 'n 14'
+                    sh 'node -v'
+                    sh 'npm install'
+                    sh 'npm run build-docker'
+                }
+            }
+        }
+        stage('Build with node v16') {
+            agent {
+                label "ubuntu-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh 'rm -rf node_modules build'
+                    sh 'n 16'
                     sh 'node -v'
                     sh 'npm install'
                     sh 'npm run build-docker'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,12 @@ void setBuildStatus(String message, String state) {
 }
 
 pipeline {
-    agent "macos-1"
+    agent none
     stages {
         stage('Format check') {
+            agent {
+                label "macos-1"
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
                 sh "git submodule update --init --recursive"
@@ -19,14 +22,21 @@ pipeline {
                 sh "npm run checkformat"
             }
         }
-        stage('WebAssembly compilation')
+        stage('WebAssembly compilation') {
+            agent {
+                label "macos-1"
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
                 sh "git submodule update --init --recursive"
                 sh "npm run build-libs-docker"
                 stash includes: "carta_frontend", name: "carta_frontend_with_built_libs"
             }
+        }
         stage('node v12') {
+            agent {
+                label "macos-1"
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
                 unstash "carta_frontend_with_built_libs"
@@ -38,6 +48,9 @@ pipeline {
             }
         }
         stage('node v14') {
+            agent {
+                label "macos-1"
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
                 unstash "carta_frontend_with_built_libs"
@@ -49,6 +62,9 @@ pipeline {
             }
         }
         stage('node v16') {
+            agent {
+                label "macos-1"
+            }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
                 unstash "carta_frontend_with_built_libs"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,63 @@
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-frontend"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
+pipeline {
+    agent "macos-1"
+    stages {
+        stage('Format check') {
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                sh "git submodule update --init --recursive"
+                sh "npm install"
+                sh "npm run checkformat"
+            }
+        }
+        stage('WebAssembly compilation')
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                sh "git submodule update --init --recursive"
+                sh "npm run build-libs-docker"
+                stash includes: "carta_frontend", name: "carta_frontend_with_built_libs"
+            }
+        stage('node v12') {
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                unstash "carta_frontend_with_built_libs"
+                sh "rm -rf node_modules"
+                sh "nvm use 12"
+                sh "node -v"
+                sh "npm install"
+                sh "npm run build-docker"
+            }
+        }
+        stage('node v14') {
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                unstash "carta_frontend_with_built_libs"
+                sh "rm -rf node_modules"
+                sh "nvm use 14"
+                sh "node -v"
+                sh "npm install"
+                sh "npm run build-docker"
+            }
+        }
+        stage('node v16') {
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                unstash "carta_frontend_with_built_libs"
+                sh "rm -rf node_modules"
+                sh "nvm use 16"
+                sh "node -v"
+                sh "npm install"
+                sh "npm run build-docker"
+            }
+        }
+    }
+}

--- a/build_wasm_libs_docker.sh
+++ b/build_wasm_libs_docker.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 echo "Building WebAssembly libraries inside Docker container"
-if [ -t 0 ] && [ -t 1 ]; then
-  docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh
-else
-  # Non interactive version needed by Jenkins as no TTY is available 
-  docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh
-fi
+docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh

--- a/build_wasm_libs_docker.sh
+++ b/build_wasm_libs_docker.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 echo "Building WebAssembly libraries inside Docker container"
-docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh
+if [ -t 0 ] && [ -t 1 ]; then
+  docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh
+else
+  # Non interactive version needed by Jenkins as no TTY is available 
+  docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_libs/build_libs.sh
+fi

--- a/build_wasm_wrappers_docker.sh
+++ b/build_wasm_wrappers_docker.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 echo "Building WebAssembly wrappers inside Docker container"
-if [ -t 0 ] && [ -t 1 ]; then
-  docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh
-else
-  # Non interactive version needed by Jenkins as no TTY is available 
-  docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh
-fi
+docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh

--- a/build_wasm_wrappers_docker.sh
+++ b/build_wasm_wrappers_docker.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 echo "Building WebAssembly wrappers inside Docker container"
-docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh
+if [ -t 0 ] && [ -t 1 ]; then
+  docker run -it --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh
+else
+  # Non interactive version needed by Jenkins as no TTY is available 
+  docker run --rm -u $(id -u):$(id -g) -v `pwd`:/src emscripten/emsdk:2.0.14 /src/wasm_src/build_wrappers.sh
+fi


### PR DESCRIPTION
@veggiesaurus I almost have a basic version working now.
Some points to note:

1. It reports the green tick or red x back to Github. The developer can click on it to see a summary of each stage, or click "Details" to proceed to Jenkins for full build logs.

2. I needed to modify the `build_wasm_libs_docker.sh` and `build_wasm_wrappers_docker.sh` to remove the `-it` flag because Jenkins does not have a TTY. I found a handy way on StackOverflow to only run it with `-it` if a TTY is present. The scripts will behave just the same as before for users running it with a TTY.

3. I had a lot of trouble trying to get Jenkins to use `nvm`. In the end I have changed to `n` and it seems to work fine.

4. It is currently using our existing ubuntu server to run each stage sequentially. Once our Lustre system upgrade is complete, maybe I will be able to add more servers where we can have a dedicated server for each 'node' version and have them run in parallel.

5. You can see the stages and steps in the Jenkinsfile.
Stage 1: Checkout submodule folder, npm install, runs checkformat.
Stage 2: Runs the WebAssembly compilation in Docker.
Stage 3: Removes node_modules and build folder, switches to node v12, npm install, and then npm run build-docker.
Stage 4: Removes node_modules and build folder, switches to node v14, npm install, and then npm run build-docker.
Stage 5: Removes node_modules and build folder, switches to node v16, npm install, and then npm run build-docker.
Is that OK?

One issue remaining:
You can see there is a format check warning with `src/static/gitInfo.ts`.

> Checking formatting...
> [warn] src/static/gitInfo.ts
> [warn] Code style issues found in the above file(s). Forgot to run Prettier?

That file contains Github commit information:

> const info = {logMessage: "6e82e17 adding node v14 and v16 stages"}; export default info;

Should we do an `rm src/static/gitInfo.ts` before the checkformat command, or could we add that file to an ignore list?