### PR TITLE
using n exec to make sure the correct node version is used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
-                    sh "npm install"
-                    sh "npm run checkformat"
+                    sh "n exec 14 npm install"
+                    sh "n exec 14 npm run checkformat"
                 }
             }
         }
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
-                    sh "npm run build-libs-docker"
+                    sh "n exec 14 npm run build-libs-docker"
                 }
             }
         }
@@ -31,10 +31,9 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh 'rm -rf node_modules build'
-                    sh 'n 12'
-                    sh 'node -v'
-                    sh 'npm install'
-                    sh 'npm run build-docker'
+                    sh 'n exec 12 node -v'
+                    sh 'n exec 12 npm install'
+                    sh 'n exec 12 npm run build-docker'
                 }
             }
         }
@@ -45,10 +44,9 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh 'rm -rf node_modules build'
-                    sh 'n 14'
-                    sh 'node -v'
-                    sh 'npm install'
-                    sh 'npm run build-docker'
+                    sh 'n exec 14 node -v'
+                    sh 'n exec 14 npm install'
+                    sh 'n exec 14 npm run build-docker'
                 }
             }
         }
@@ -59,10 +57,9 @@ pipeline {
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh 'rm -rf node_modules build'
-                    sh 'n 16'
-                    sh 'node -v'
-                    sh 'npm install'
-                    sh 'npm run build-docker'
+                    sh 'n exec 16 node -v'
+                    sh 'n exec 16 npm install'
+                    sh 'n exec 16 npm run build-docker'
                 }
             }
         }


### PR DESCRIPTION
Using "n exec 12" etc. so that multiple branch can be built with the correct node version in parallel.