### PR TITLE
Angus/additional preferences

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -11,7 +11,7 @@ import {CARTA} from "carta-protobuf";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {ScalingSelectComponent} from "components/Shared/ScalingSelectComponent/ScalingSelectComponent";
 import {ColormapComponent, ColorPickerComponent, AutoColorPickerComponent, SafeNumericInput} from "components/Shared";
-import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {AppStore, BeamType, ContourGeneratorType, FrameScaling, HelpType, PreferenceKeys, PreferenceStore, RegionStore, RenderConfigStore} from "stores";
 import {SWATCH_COLORS} from "utilities";
 import "./PreferenceDialogComponent.scss";
@@ -304,14 +304,22 @@ export class PreferenceDialogComponent extends React.Component {
 
         const overlayConfigPanel = (
             <React.Fragment>
-                <FormGroup inline={true} label="AST Color">
+                <FormGroup inline={true} label="Color">
                     <AutoColorPickerComponent color={preference.astColor} presetColors={SWATCH_COLORS} setColor={(color: string) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_COLOR, color)} disableAlpha={true} />
                 </FormGroup>
-                <FormGroup inline={true} label="AST Grid Visible">
+                <FormGroup inline={true} label="WCS Grid Visible">
                     <Switch checked={preference.astGridVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_GRID_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="AST Label Visible">
+                <FormGroup inline={true} label="Labels Visible">
                     <Switch checked={preference.astLabelsVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE, ev.currentTarget.checked)} />
+                </FormGroup>
+                <FormGroup inline={true} label="Cursor Info Visible">
+                    <HTMLSelect value={preference.cursorInfoVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_CURSOR_INFO, ev.currentTarget.value)}>
+                        <option value={CursorInfoVisibility.Always}>Always</option>
+                        <option value={CursorInfoVisibility.ActiveImage}>Active image only</option>
+                        <option value={CursorInfoVisibility.HideTiled}>Hide when tiled</option>
+                        <option value={CursorInfoVisibility.Never}>Never</option>
+                    </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="WCS Format">
                     <HTMLSelect
@@ -453,6 +461,9 @@ export class PreferenceDialogComponent extends React.Component {
             <React.Fragment>
                 <FormGroup inline={true} label="Low bandwidth mode">
                     <Switch checked={preference.lowBandwidthMode} onChange={ev => preference.setPreference(PreferenceKeys.PERFORMANCE_LOW_BAND_WIDTH_MODE, ev.currentTarget.checked)} />
+                </FormGroup>
+                <FormGroup inline={true} label="Limit overlay redraw">
+                    <Switch checked={preference.limitOverlayRedraw} onChange={ev => preference.setPreference(PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Compression Quality" labelInfo={"(Images)"}>
                     <SafeNumericInput

--- a/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
@@ -52,7 +52,7 @@ export class PreferencesHelpComponent extends React.Component {
                 <h3 id="overlay-configuration">Overlay configuration</h3>
                 <p>This section provides customization of the image overlay in the image viewer.</p>
                 <ul>
-                    <li>Color: the default color theme of the grid layers including the coordinate bound box</li>
+                    <li>Color: the default color of the grid layers including the coordinate bound box</li>
                     <li>WCS grid visible: grid line rendering</li>
                     <li>Label visible: grid x and y labels rendering</li>
                     <li>WCS format: show world coordinates in degrees or sexagesimal or auto-formatted</li>

--- a/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
+++ b/src/components/HelpDrawer/HelpContent/PreferencesHelpComponent.tsx
@@ -52,9 +52,9 @@ export class PreferencesHelpComponent extends React.Component {
                 <h3 id="overlay-configuration">Overlay configuration</h3>
                 <p>This section provides customization of the image overlay in the image viewer.</p>
                 <ul>
-                    <li>AST color: the default color theme of the grid layers including the coordinate bound box</li>
-                    <li>AST grid visible: grid line rendering</li>
-                    <li>AST label visible: grid x and y labels rendering</li>
+                    <li>Color: the default color theme of the grid layers including the coordinate bound box</li>
+                    <li>WCS grid visible: grid line rendering</li>
+                    <li>Label visible: grid x and y labels rendering</li>
                     <li>WCS format: show world coordinates in degrees or sexagesimal or auto-formatted</li>
                     <li>Beam visible: beam rendering at the bottom-left corner of the image viewer</li>
                     <li>Beam color: the color to render a beam element</li>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -14,7 +14,7 @@ import {RegionViewComponent} from "./RegionView/RegionViewComponent";
 import {ContourViewComponent} from "./ContourView/ContourViewComponent";
 import {CatalogViewGLComponent} from "./CatalogView/CatalogViewGLComponent";
 import {AppStore, RegionStore, DefaultWidgetConfig, WidgetProps, HelpType, Padding} from "stores";
-import {CursorInfo, Point2D} from "models";
+import {CursorInfo, CursorInfoVisibility, Point2D} from "models";
 import {toFixed} from "utilities";
 import "./ImageViewComponent.scss";
 
@@ -210,11 +210,13 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             const effectiveWidth = appStore.activeFrame.renderWidth * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
             const effectiveHeight = appStore.activeFrame.renderHeight * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
             const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
+            // This will be expanded when using multi-panel view
+            const cursorInfoRequired = appStore.preferenceStore.cursorInfoVisible !== CursorInfoVisibility.Never;
 
             divContents = (
                 <React.Fragment>
                     {appStore.activeFrame.valid && <OverlayComponent frame={appStore.activeFrame} overlaySettings={overlayStore} docked={this.props.docked} />}
-                    {appStore.activeFrame.cursorInfo && (
+                    {cursorInfoRequired && appStore.activeFrame.cursorInfo && (
                         <CursorOverlayComponent
                             cursorInfo={appStore.activeFrame.cursorInfo}
                             cursorValue={appStore.activeFrame.cursorInfo.isInsideImage ? appStore.activeFrame.cursorValue.value : undefined}

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as AST from "ast_wrapper";
 import * as _ from "lodash";
 import {observer} from "mobx-react";
-import {AppStore, FrameStore, OverlayStore} from "stores";
+import {AppStore, FrameStore, OverlayStore, PreferenceStore} from "stores";
 import {CursorInfo, SPECTRAL_TYPE_STRING} from "models";
 import "./OverlayComponent.scss";
 
@@ -20,13 +20,19 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
     componentDidMount() {
         if (this.canvas) {
-            this.renderCanvas();
+            if (PreferenceStore.Instance.limitOverlayRedraw) {
+                this.throttledRenderCanvas();
+            } else {
+                requestAnimationFrame(this.renderCanvas);
+            }
         }
     }
 
     componentDidUpdate() {
-        if (this.canvas) {
-            this.renderCanvas();
+        if (PreferenceStore.Instance.limitOverlayRedraw) {
+            this.throttledRenderCanvas();
+        } else {
+            requestAnimationFrame(this.renderCanvas);
         }
     }
 
@@ -35,7 +41,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio;
     }
 
-    renderCanvas = _.throttle(() => {
+    renderCanvas = () => {
         const settings = this.props.overlaySettings;
         const frame = this.props.frame;
         const pixelRatio = devicePixelRatio;
@@ -100,7 +106,9 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             AST.deleteObject(tempWcsInfo);
             AST.clearLastErrorMessage();
         }
-    }, 50);
+    };
+
+    throttledRenderCanvas = _.throttle(this.renderCanvas, 50);
 
     render() {
         const styleString = this.props.overlaySettings.styleString;

--- a/src/models/CursorInfo.ts
+++ b/src/models/CursorInfo.ts
@@ -1,5 +1,12 @@
 import {Point2D} from "./Point2D";
 
+export enum CursorInfoVisibility {
+    Always = "always",
+    Never = "never",
+    ActiveImage = "activeImage",
+    HideTiled = "hideTiled"
+}
+
 export interface CursorInfo {
     posImageSpace: Point2D;
     isInsideImage: boolean;

--- a/src/models/preferences_schema_2.json
+++ b/src/models/preferences_schema_2.json
@@ -261,6 +261,15 @@
         },
         "codeSnippetsEnabled": {
             "type": "boolean"
+        },
+        "limitOverlayRedraw": {
+            "type": "boolean",
+            "default": true
+        },
+        "cursorInfoVisible": {
+            "type": "string",
+            "enum": ["always", "activeImage", "hideTiled", "never"],
+            "default": "activeImage"
         }
     }
 }

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -2,7 +2,7 @@ import {action, computed, observable, makeObservable} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {BeamType, ContourGeneratorType, FileFilteringType, FrameScaling} from "stores";
-import {CompressionQuality, CursorPosition, Event, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {parseBoolean} from "utilities";
 import {ApiService} from "services";
 
@@ -54,6 +54,7 @@ export enum PreferenceKeys {
     WCS_OVERLAY_BEAM_COLOR = "beamColor",
     WCS_OVERLAY_BEAM_TYPE = "beamType",
     WCS_OVERLAY_BEAM_WIDTH = "beamWidth",
+    WCS_OVERLAY_CURSOR_INFO = "cursorInfoVisible",
 
     REGION_COLOR = "regionColor",
     REGION_LINE_WIDTH = "regionLineWidth",
@@ -73,6 +74,7 @@ export enum PreferenceKeys {
     PERFORMANCE_STREAM_CONTOURS_WHILE_ZOOMING = "streamContoursWhileZooming",
     PERFORMANCE_LOW_BAND_WIDTH_MODE = "lowBandwidthMode",
     PERFORMANCE_STOP_ANIMATION_PLAYBACK_MINUTES = "stopAnimationPlaybackMinutes",
+    PERFORMANCE_LIMIT_OVERLAY_REDRAW = "limitOverlayRedraw",
 
     LOG_EVENT = "logEventList",
 
@@ -137,7 +139,8 @@ const DEFAULTS = {
         beamVisible: true,
         beamColor: "auto-gray",
         beamType: BeamType.Open,
-        beamWidth: 1
+        beamWidth: 1,
+        cursorInfoVisible: CursorInfoVisibility.ActiveImage
     },
     REGION: {
         regionColor: "#2EE6D6",
@@ -158,7 +161,8 @@ const DEFAULTS = {
         contourControlMapWidth: 256,
         streamContoursWhileZooming: false,
         lowBandwidthMode: false,
-        stopAnimationPlaybackMinutes: 5
+        stopAnimationPlaybackMinutes: 5,
+        limitOverlayRedraw: true
     },
     LOG_EVENT: {
         eventLoggingEnabled: []
@@ -370,6 +374,10 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.WCS_OVERLAY_BEAM_WIDTH) ?? DEFAULTS.WCS_OVERLAY.beamWidth;
     }
 
+    @computed get cursorInfoVisible(): string {
+        return this.preferences.get(PreferenceKeys.WCS_OVERLAY_CURSOR_INFO) ?? DEFAULTS.WCS_OVERLAY.cursorInfoVisible;
+    }
+
     // getters for region
     @computed get regionColor(): string {
         return this.preferences.get(PreferenceKeys.REGION_COLOR) ?? DEFAULTS.REGION.regionColor;
@@ -479,6 +487,10 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.PIXEL_GRID_COLOR) ?? DEFAULTS.SILENT.pixelGridColor;
     }
 
+    @computed get limitOverlayRedraw(): boolean {
+        return this.preferences.get(PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW) ?? DEFAULTS.PERFORMANCE.limitOverlayRedraw;
+    }
+
     @action setPreference = async (key: PreferenceKeys, value: any) => {
         if (!key) {
             return false;
@@ -576,7 +588,8 @@ export class PreferenceStore {
             PreferenceKeys.WCS_OVERLAY_BEAM_TYPE,
             PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE,
             PreferenceKeys.WCS_OVERLAY_BEAM_WIDTH,
-            PreferenceKeys.WCS_OVERLAY_WCS_TYPE
+            PreferenceKeys.WCS_OVERLAY_WCS_TYPE,
+            PreferenceKeys.WCS_OVERLAY_CURSOR_INFO
         ]);
     };
 
@@ -596,7 +609,8 @@ export class PreferenceStore {
             PreferenceKeys.PERFORMANCE_LOW_BAND_WIDTH_MODE,
             PreferenceKeys.PERFORMANCE_STOP_ANIMATION_PLAYBACK_MINUTES,
             PreferenceKeys.PERFORMANCE_STREAM_CONTOURS_WHILE_ZOOMING,
-            PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE
+            PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE,
+            PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW
         ]);
     };
 
@@ -657,7 +671,8 @@ export class PreferenceStore {
                 PreferenceKeys.REGION_CREATION_MODE,
                 PreferenceKeys.WCS_OVERLAY_AST_COLOR,
                 PreferenceKeys.CATALOG_TABLE_SEPARATOR_POSITION,
-                PreferenceKeys.PIXEL_GRID_COLOR
+                PreferenceKeys.PIXEL_GRID_COLOR,
+                PreferenceKeys.WCS_OVERLAY_CURSOR_INFO
             ];
 
             const intKeys = [

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -648,7 +648,7 @@ export class PreferenceStore {
 
     private upgradePreferences = async () => {
         if (!localStorage.getItem("preferences")) {
-            // perform localstorage upgrade
+            // perform localstorage upgrade by iterating over the old keys. This list consists of keys that were present when CARTA used a single localStorage entry per key
 
             // Strings
             const stringKeys = [

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -671,8 +671,7 @@ export class PreferenceStore {
                 PreferenceKeys.REGION_CREATION_MODE,
                 PreferenceKeys.WCS_OVERLAY_AST_COLOR,
                 PreferenceKeys.CATALOG_TABLE_SEPARATOR_POSITION,
-                PreferenceKeys.PIXEL_GRID_COLOR,
-                PreferenceKeys.WCS_OVERLAY_CURSOR_INFO
+                PreferenceKeys.PIXEL_GRID_COLOR
             ];
 
             const intKeys = [


### PR DESCRIPTION
Adds the following preferences:

- Performance -> Limit overlay redraw (defaults to `true`): This controls whether or not we throttle AST overlay redraws to 20 fps.
- Overlay -> Cursor info visible (defaults to `"always"`): This controls visibility of the cursor overlay. There are four options: `always` and `never` are selft-explanatory. `activeImage` only displays the cursor info on the active image, and `hideTiled` hides the cursor overaly whenever you use a tiled view. The last two options will only make a difference once #1259 is implemented.

Also adjusted the preferences text slightly, to remove reference to AST.