### PR TITLE
Angus/scripting serialisation

### DIFF
--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -163,8 +163,8 @@ export class ScriptingService {
             }
 
             // Adjust the response to just the specified field if it exists
-            if (typeof response === "object" && requestMessage.responseField) {
-                response = _.get(response, requestMessage.responseField);
+            if (typeof response === "object" && requestMessage.returnPath) {
+                response = _.get(response, requestMessage.returnPath);
             }
 
             return {

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import {toJS} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {AppStore} from "stores";
@@ -160,10 +161,16 @@ export class ScriptingService {
             } else {
                 response = await entry.execute();
             }
+
+            // Adjust the response to just the specified field if it exists
+            if (typeof response === "object" && requestMessage.responseField) {
+                response = _.get(response, requestMessage.responseField);
+            }
+
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: true,
-                response: JSON.stringify(toJS(response))
+                response: toJS(response)
             };
         } catch (err) {
             return {

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -1,3 +1,4 @@
+import {toJS} from "mobx";
 import {CARTA} from "carta-protobuf";
 import {AppStore} from "stores";
 
@@ -162,7 +163,7 @@ export class ScriptingService {
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: true,
-                response: JSON.stringify(response)
+                response: JSON.stringify(toJS(response))
             };
         } catch (err) {
             return {

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -170,7 +170,7 @@ export class ScriptingService {
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: true,
-                response: toJS(response)
+                response: JSON.stringify(toJS(response))
             };
         } catch (err) {
             return {

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -162,7 +162,7 @@ export class ScriptingService {
                 response = await entry.execute();
             }
 
-            // Adjust the response to just the specified field if it exists
+            // Adjust the response to just the specified path if it is non-empty
             if (typeof response === "object" && requestMessage.returnPath) {
                 response = _.get(response, requestMessage.returnPath);
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -547,7 +547,7 @@ export class AppStore {
      * @param path - path to the parent directory of the file to open, or of the file itself
      * @param {string=} filename - filename of the file to open
      * @param {string=} hdu - HDU to open. If left blank, the first image HDU will be opened
-     * @return {Promise<number>} [async] the file ID of the opened file
+     * @return {Promise<FrameStore>} [async] the FrameStore the opened file
      */
     @action appendFile = async (path: string, filename: string, hdu: string) => {
         // Stop animations playing before loading a new frame
@@ -560,7 +560,7 @@ export class AppStore {
      * @param path - path to the parent directory of the file to open, or of the file itself
      * @param {string=} filename - filename of the file to open
      * @param {string=} hdu - HDU to open. If left blank, the first image HDU will be opened
-     * @return {Promise<number>} [async] the file ID of the opened file
+     * @return {Promise<FrameStore>} [async] the FrameStore of the opened file
      */
     @action openFile = (path: string, filename?: string, hdu?: string) => {
         this.removeAllFrames();


### PR DESCRIPTION
Minor adjustment to fix scripting interface issues raised by @confluence. The backend can now pass a `return_path` parameter to the frontend. If this is not empty, the frontend uses lodash to form a response object based on the return path. If it is empty, the full object is returned.

Companion PR for https://github.com/CARTAvis/carta-backend/pull/879