### PR TITLE
Angus/1259 multi panel

### DIFF
--- a/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
+++ b/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
@@ -105,7 +105,7 @@ export class BeamProfileOverlayComponent extends React.Component<BeamProfileOver
 
         const appStore = AppStore.Instance;
         const baseFrame = appStore.activeFrame;
-        const contourFrames = appStore.contourFrames.filter(frame => frame.frameInfo.fileId !== appStore.activeFrame.frameInfo.fileId && frame.hasVisibleBeam);
+        const contourFrames = appStore.contourFrames.get(baseFrame)?.filter(frame => frame.frameInfo.fileId !== appStore.activeFrame.frameInfo.fileId && frame.hasVisibleBeam);
 
         if (!baseFrame.hasVisibleBeam && !contourFrames.length) {
             return null;

--- a/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
+++ b/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
@@ -9,6 +9,7 @@ import "./BeamProfileOverlayComponent.scss";
 
 interface BeamProfileOverlayComponentProps {
     docked: boolean;
+    frame: FrameStore;
     top: number;
     left: number;
     padding?: number;
@@ -104,8 +105,8 @@ export class BeamProfileOverlayComponent extends React.Component<BeamProfileOver
         }
 
         const appStore = AppStore.Instance;
-        const baseFrame = appStore.activeFrame;
-        const contourFrames = appStore.contourFrames.get(baseFrame)?.filter(frame => frame.frameInfo.fileId !== appStore.activeFrame.frameInfo.fileId && frame.hasVisibleBeam);
+        const baseFrame = this.props.frame;
+        const contourFrames = appStore.contourFrames.get(baseFrame)?.filter(frame => frame !== baseFrame && frame.hasVisibleBeam);
 
         if (!baseFrame.hasVisibleBeam && !contourFrames.length) {
             return null;

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -279,7 +279,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.ControlMapEnabled, 0);
                     this.gl.uniform1i(shaderUniforms.ControlMapTexture, 0);
                 } else {
-                    const controlMap = frame.getCatalogControlMap(appStore.activeFrame);
+                    const controlMap = frame.getCatalogControlMap(destinationFrame);
                     if (controlMap) {
                         controlMap.updateCatalogBoundary();
                         this.gl.uniform1i(shaderUniforms.ControlMapEnabled, 1);

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -44,8 +44,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
         }
 
         const catalogStore = appStore.catalogStore;
-        // TODO: Render catalogs for current image, not active image
-        const catalogFileIds = catalogStore.activeCatalogFiles;
+        const catalogFileIds = catalogStore.visibleCatalogFiles.get(baseFrame);
         catalogStore.catalogGLData.forEach((catalog, fileId) => {
             const catalogWidgetStore = catalogStore.getCatalogWidgetStore(fileId);
             const numVertices = catalog.x.length;
@@ -168,7 +167,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
         let rotationAngle = 0.0;
         let scaleAdjustment = 1.0;
         const destinationFrame = this.props.frame;
-        catalogStore.activeCatalogFiles?.forEach(fileId => {
+        catalogStore.visibleCatalogFiles.get(destinationFrame)?.forEach(fileId => {
             const frame = appStore.getFrame(catalogStore.getFrameIdByCatalogId(fileId));
             const isActive = frame === destinationFrame;
             const catalog = catalogStore.catalogGLData.get(fileId);

--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -61,7 +61,7 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
 
     private handleMouseMove = event => {
         const appStore = AppStore.Instance;
-        const renderConfig = appStore?.activeFrame?.renderConfig;
+        const renderConfig = this.props.frame?.renderConfig;
         const colorbarSettings = appStore?.overlayStore?.colorbar;
         if (!renderConfig || !colorbarSettings) {
             return;

--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -3,14 +3,19 @@ import {observer} from "mobx-react";
 import {action, observable, makeObservable} from "mobx";
 import {Layer, Line, Rect, Stage, Text} from "react-konva";
 import {ProfilerInfoComponent} from "components/Shared";
-import {AppStore} from "stores";
+import {AppStore, FrameStore} from "stores";
 import {fonts} from "ast_wrapper";
 import {Font} from "../ImageViewSettingsPanel/ImageViewSettingsPanelComponent";
 import {clamp, getColorForTheme} from "utilities";
 import "./ColorbarComponent.scss";
 
+export interface ColorbarComponentProps {
+    onCursorHoverValueChanged: (number) => void;
+    frame: FrameStore;
+}
+
 @observer
-export class ColorbarComponent extends React.Component<{onCursorHoverValueChanged: (number) => void}> {
+export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
     @observable hoverInfoText: string = "";
     @observable isHovering: boolean = false;
     @observable cursorY: number = -1;
@@ -83,7 +88,7 @@ export class ColorbarComponent extends React.Component<{onCursorHoverValueChange
 
     render() {
         const appStore = AppStore.Instance;
-        const frame = appStore.activeFrame;
+        const frame = this.props.frame;
         const colorbarSettings = appStore.overlayStore.colorbar;
 
         let getColor = (customColor: boolean, color: string): string => {
@@ -155,8 +160,8 @@ export class ColorbarComponent extends React.Component<{onCursorHoverValueChange
         let ticks = [];
         let numbers = [];
         if (colorbarSettings.tickVisible || colorbarSettings.numberVisible) {
-            const texts = colorbarSettings.texts;
-            const positions = colorbarSettings.positions;
+            const texts = frame.colorbarStore.texts;
+            const positions = frame.colorbarStore.positions;
 
             for (let i = 0; i < positions.length; i++) {
                 if (colorbarSettings.tickVisible) {

--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -34,17 +34,21 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
         this.hoverInfoText = text;
     };
 
+    @action setMouseHovering = (val: boolean) => {
+        this.isHovering = val;
+    };
+
     @action onMouseEnter = () => {
         if (this.mouseEnterHandle) {
             clearTimeout(this.mouseEnterHandle);
         }
         this.mouseEnterHandle = setTimeout(() => {
-            this.isHovering = true;
+            this.setMouseHovering(true);
         }, ColorbarComponent.HoverDelay);
     };
 
     @action onMouseLeave = () => {
-        this.isHovering = false;
+        this.setMouseHovering(false);
         if (this.mouseEnterHandle) {
             clearTimeout(this.mouseEnterHandle);
         }

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -46,7 +46,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.canvas.height = requiredHeight;
         }
         // Resize and clear the shared WebGL canvas if required
-        this.contourWebGLService.setCanvasSize(requiredWidth * appStore.numColumns, requiredHeight * appStore.numRows);
+        this.contourWebGLService.setCanvasSize(requiredWidth * appStore.numImageColumns, requiredHeight * appStore.numImageRows);
 
         // Resize canvas if necessary
         if (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight) {
@@ -56,7 +56,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         // Otherwise just clear it
         const xOffset = this.props.column * frame.renderWidth * devicePixelRatio;
         // y-axis is inverted
-        const yOffset = (appStore.numRows - 1 - this.props.row) * frame.renderHeight * devicePixelRatio;
+        const yOffset = (appStore.numImageRows - 1 - this.props.row) * frame.renderHeight * devicePixelRatio;
         this.gl.viewport(xOffset, yOffset, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
         this.gl.clearColor(0, 0, 0, 0);
         // Clear a scissored rectangle limited to the current frame

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -41,7 +41,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         const requiredHeight = Math.max(1, frame.renderHeight * devicePixelRatio);
 
         // Resize and clear the canvas if needed
-        if (frame && frame.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
+        if (frame?.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
             this.canvas.width = requiredWidth;
             this.canvas.height = requiredHeight;
         }

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -8,6 +8,8 @@ import "./ContourViewComponent.scss";
 export interface ContourViewComponentProps {
     docked: boolean;
     frame: FrameStore;
+    row: number;
+    column: number;
 }
 
 @observer
@@ -34,36 +36,55 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             return;
         }
 
-        const reqWidth = Math.round(Math.max(1, frame.renderWidth * devicePixelRatio));
-        const reqHeight = Math.round(Math.max(1, frame.renderHeight * devicePixelRatio));
+        const appStore = AppStore.Instance;
+        const requiredWidth = Math.max(1, frame.renderWidth * devicePixelRatio);
+        const requiredHeight = Math.max(1, frame.renderHeight * devicePixelRatio);
+
+        // Resize and clear the canvas if needed
+        if (frame && frame.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
+            this.canvas.width = requiredWidth;
+            this.canvas.height = requiredHeight;
+        }
+        // Resize and clear the shared WebGL canvas if required
+        this.contourWebGLService.setCanvasSize(requiredWidth * appStore.numColumns, requiredHeight * appStore.numRows);
+
         // Resize canvas if necessary
-        if (this.canvas.width !== reqWidth || this.canvas.height !== reqHeight) {
-            this.canvas.width = reqWidth;
-            this.canvas.height = reqHeight;
-            this.contourWebGLService.setCanvasSize(reqWidth, reqHeight);
+        if (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight) {
+            this.canvas.width = requiredWidth;
+            this.canvas.height = requiredHeight;
         }
         // Otherwise just clear it
+        const xOffset = this.props.column * frame.renderWidth * devicePixelRatio;
+        // y-axis is inverted
+        const yOffset = (appStore.numRows - 1 - this.props.row) * frame.renderHeight * devicePixelRatio;
+        this.gl.viewport(xOffset, yOffset, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
         this.gl.clearColor(0, 0, 0, 0);
+        // Clear a scissored rectangle limited to the current frame
+        this.gl.enable(WebGLRenderingContext.SCISSOR_TEST);
+        this.gl.scissor(xOffset, yOffset, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
         const clearMask = WebGLRenderingContext.COLOR_BUFFER_BIT | WebGLRenderingContext.DEPTH_BUFFER_BIT | WebGLRenderingContext.STENCIL_BUFFER_BIT;
         this.gl.clear(clearMask);
+        this.gl.disable(WebGLRenderingContext.SCISSOR_TEST);
     }
 
     private updateCanvas = () => {
         const appStore = AppStore.Instance;
         const baseFrame = this.props.frame;
-        // TODO: Get contour frames for the current frame, rather than the active one
-        const contourFrames = appStore.contourFrames;
         if (baseFrame && this.canvas && this.gl && this.contourWebGLService.shaderUniforms) {
+            const contourFrames = appStore.contourFrames.get(baseFrame);
             this.resizeAndClearCanvas();
-
-            // Render back-to-front to preserve ordering
-            for (let i = contourFrames.length - 1; i >= 0; --i) {
-                this.renderFrameContours(contourFrames[i], baseFrame);
+            if (contourFrames) {
+                // Render back-to-front to preserve ordering
+                for (let i = contourFrames.length - 1; i >= 0; --i) {
+                    this.renderFrameContours(contourFrames[i], baseFrame);
+                }
             }
             // draw in 2d canvas
             const ctx = this.canvas.getContext("2d");
-            ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-            ctx.drawImage(this.gl.canvas, 0, 0, this.canvas.width, this.canvas.height);
+            const w = this.canvas.width;
+            const h = this.canvas.height;
+            ctx.clearRect(0, 0, w, h);
+            ctx.drawImage(this.gl.canvas, this.props.column * w, this.props.row * h, w, h, 0, 0, w, h);
         }
     };
 
@@ -195,17 +216,19 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             const view = baseFrame.requiredFrameView;
         }
 
-        const contourFrames = appStore.contourFrames;
-        for (const frame of contourFrames) {
-            const config = frame.contourConfig;
-            const thickness = config.thickness;
-            const color = config.colormapEnabled ? config.colormap : config.color;
-            const dashMode = config.dashMode;
-            const bias = config.colormapBias;
-            const contrast = config.colormapContrast;
-            frame.contourStores.forEach(contourStore => {
-                const numVertices = contourStore.vertexCount;
-            });
+        const contourFrames = appStore.contourFrames.get(baseFrame);
+        if (contourFrames) {
+            for (const frame of contourFrames) {
+                const config = frame.contourConfig;
+                const thickness = config.thickness;
+                const color = config.colormapEnabled ? config.colormap : config.color;
+                const dashMode = config.dashMode;
+                const bias = config.colormapBias;
+                const contrast = config.colormapContrast;
+                frame.contourStores.forEach(contourStore => {
+                    const numVertices = contourStore.vertexCount;
+                });
+            }
         }
         /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
@@ -1,0 +1,17 @@
+.image-view-div {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    user-select: none;
+
+    .tag-image-ratio {
+        transition: opacity 0.5s;
+        position: absolute;
+        z-index: 5;
+        pointer-events: none;
+
+        .bp3-tag {
+            left: -50%;
+        }
+    }
+}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
@@ -1,6 +1,14 @@
+@import "~@blueprintjs/core/lib/scss/variables.scss";
+
 .image-panel-div {
     width: 100%;
     height: 100%;
     position: relative;
     user-select: none;
+    border: 1px solid transparent;
+    border-radius: $pt-border-radius;
+
+    &.active {
+        border: 1px solid $red3;
+    }
 }

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
@@ -3,15 +3,4 @@
     height: 100%;
     position: relative;
     user-select: none;
-
-    .tag-image-ratio {
-        transition: opacity 0.5s;
-        position: absolute;
-        z-index: 5;
-        pointer-events: none;
-
-        .bp3-tag {
-            left: -50%;
-        }
-    }
 }

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.scss
@@ -1,4 +1,4 @@
-.image-view-div {
+.image-panel-div {
     width: 100%;
     height: 100%;
     position: relative;

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -1,0 +1,194 @@
+import * as React from "react";
+import {observer} from "mobx-react";
+import {action, autorun, makeObservable, observable, runInAction} from "mobx";
+import {NonIdealState, Spinner, Tag} from "@blueprintjs/core";
+import ReactResizeDetector from "react-resize-detector";
+import {OverlayComponent} from "../Overlay/OverlayComponent";
+import {CursorOverlayComponent} from "../CursorOverlay/CursorOverlayComponent";
+import {ColorbarComponent} from "../Colorbar/ColorbarComponent";
+import {RasterViewComponent} from "../RasterView/RasterViewComponent";
+import {ToolbarComponent} from "../Toolbar/ToolbarComponent";
+import {BeamProfileOverlayComponent} from "../BeamProfileOverlay/BeamProfileOverlayComponent";
+import {RegionViewComponent} from "../RegionView/RegionViewComponent";
+import {ContourViewComponent} from "../ContourView/ContourViewComponent";
+import {CatalogViewGLComponent} from "../CatalogView/CatalogViewGLComponent";
+import {ImageViewLayer} from "../ImageViewComponent";
+import {AppStore, RegionStore, FrameStore} from "stores";
+import {CursorInfo, CursorInfoVisibility, Point2D} from "models";
+import {toFixed} from "utilities";
+import "./ImagePanelComponent.scss";
+
+interface ImagePanelComponentProps {
+    docked: boolean;
+    frame: FrameStore;
+}
+
+@observer
+export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
+    private ratioIndicatorTimeoutHandle;
+    private cachedImageSize: Point2D;
+
+    @observable showRatioIndicator: boolean;
+    @observable pixelHighlightValue: number = NaN;
+    readonly activeLayer: ImageViewLayer;
+
+    @action setPixelHighlightValue = (val: number) => {
+        this.pixelHighlightValue = val;
+    };
+
+    constructor(props: ImagePanelComponentProps) {
+        super(props);
+        makeObservable(this);
+
+        this.activeLayer = AppStore.Instance.activeLayer;
+        autorun(() => {
+            const frame = props.frame;
+            if (frame) {
+                const imageSize = {x: frame.renderWidth, y: frame.renderHeight};
+                // Compare to cached image size to prevent duplicate events when changing frames
+                if (!this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y) {
+                    this.cachedImageSize = imageSize;
+                    clearTimeout(this.ratioIndicatorTimeoutHandle);
+                    runInAction(() => (this.showRatioIndicator = true));
+                    this.ratioIndicatorTimeoutHandle = setTimeout(
+                        () =>
+                            runInAction(() => {
+                                this.showRatioIndicator = false;
+                            }),
+                        1000
+                    );
+                }
+            }
+        });
+    }
+
+    onResize = (width: number, height: number) => {
+        if (width > 0 && height > 0) {
+            AppStore.Instance.setImageViewDimensions(width, height);
+        }
+    };
+
+    onClicked = (cursorInfo: CursorInfo) => {
+        const frame = this.props.frame;
+        if (frame) {
+            frame.setCenter(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y);
+        }
+    };
+
+    onZoomed = (cursorInfo: CursorInfo, delta: number) => {
+        const frame = this.props.frame;
+        if (frame) {
+            const zoomSpeed = 1 + Math.abs(delta / 750.0);
+
+            // If frame is spatially matched, apply zoom to the reference frame, rather than the active frame
+            if (frame.spatialReference) {
+                const newZoom = frame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+                frame.zoomToPoint(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y, newZoom, true);
+            } else {
+                const newZoom = frame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
+                frame.zoomToPoint(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y, newZoom, true);
+            }
+        }
+    };
+
+    onMouseEnter = () => {
+        AppStore.Instance.showImageToolbar();
+    };
+
+    onMouseLeave = () => {
+        AppStore.Instance.hideImageToolbar();
+    };
+
+    private handleRegionDoubleClicked = (region: RegionStore) => {
+        const appStore = AppStore.Instance;
+        if (region) {
+            const frame = appStore.getFrame(region.fileId);
+            if (frame) {
+                frame.regionSet.selectRegion(region);
+                appStore.dialogStore.showRegionDialog();
+            }
+        }
+    };
+
+    render() {
+        const appStore = AppStore.Instance;
+        const overlayStore = appStore.overlayStore;
+        let divContents;
+
+        const frame = this.props.frame;
+        if (frame && frame.isRenderable && appStore.astReady) {
+            const effectiveWidth = frame.renderWidth * (frame.renderHiDPI ? devicePixelRatio : 1);
+            const effectiveHeight = frame.renderHeight * (frame.renderHiDPI ? devicePixelRatio : 1);
+            const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
+            // This will be expanded when using multi-panel view
+            const cursorInfoRequired = appStore.preferenceStore.cursorInfoVisible !== CursorInfoVisibility.Never;
+
+            divContents = (
+                <React.Fragment>
+                    {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
+                    {cursorInfoRequired && frame.cursorInfo && (
+                        <CursorOverlayComponent
+                            cursorInfo={frame.cursorInfo}
+                            cursorValue={frame.cursorInfo.isInsideImage ? frame.cursorValue.value : undefined}
+                            isValueCurrent={frame.isCursorValueCurrent}
+                            spectralInfo={frame.spectralInfo}
+                            width={overlayStore.viewWidth}
+                            left={overlayStore.padding.left}
+                            right={overlayStore.padding.right}
+                            docked={this.props.docked}
+                            unit={frame.unit}
+                            top={overlayStore.padding.top}
+                            currentStokes={frame.hasStokes ? frame.stokesInfo[frame.requiredStokes] : ""}
+                            showImage={true}
+                            showWCS={true}
+                            showValue={true}
+                            showChannel={false}
+                            showSpectral={true}
+                            showStokes={true}
+                        />
+                    )}
+                    {frame && overlayStore.colorbar.visible && <ColorbarComponent onCursorHoverValueChanged={this.setPixelHighlightValue} />}
+                    {frame && <BeamProfileOverlayComponent top={overlayStore.padding.top} left={overlayStore.padding.left} docked={this.props.docked} padding={10} />}
+                    {frame && <CatalogViewGLComponent frame={frame} docked={this.props.docked} onZoomed={this.onZoomed} />}
+                    {frame && (
+                        <RegionViewComponent
+                            frame={frame}
+                            width={frame.renderWidth}
+                            height={frame.renderHeight}
+                            top={overlayStore.padding.top}
+                            left={overlayStore.padding.left}
+                            onClicked={this.onClicked}
+                            onRegionDoubleClicked={this.handleRegionDoubleClicked}
+                            onZoomed={this.onZoomed}
+                            overlaySettings={overlayStore}
+                            isRegionCornerMode={appStore.preferenceStore.isRegionCornerMode}
+                            dragPanningEnabled={appStore.preferenceStore.dragPanning}
+                            cursorFrozen={appStore.cursorFrozen}
+                            cursorPoint={frame.cursorInfo.posImageSpace}
+                            docked={this.props.docked && (this.activeLayer === ImageViewLayer.RegionMoving || this.activeLayer === ImageViewLayer.RegionCreating)}
+                        />
+                    )}
+                    <ToolbarComponent docked={this.props.docked} visible={appStore.imageToolbarVisible} vertical={false} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
+                    <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>
+                        <Tag large={true}>
+                            {effectiveWidth} x {effectiveHeight} ({toFixed(effectiveWidth / effectiveHeight, 2)})
+                        </Tag>
+                    </div>
+                </React.Fragment>
+            );
+        } else if (!appStore.astReady) {
+            divContents = <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
+        } else {
+            divContents = <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;
+        }
+
+        return (
+            <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+                <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
+                <ContourViewComponent frame={frame} docked={this.props.docked} />
+                {divContents}
+                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
+            </div>
+        );
+    }
+}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -171,7 +171,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                             showStokes={true}
                         />
                     )}
-                    {frame && overlayStore.colorbar.visible && <ColorbarComponent onCursorHoverValueChanged={this.setPixelHighlightValue} />}
+                    {frame && overlayStore.colorbar.visible && <ColorbarComponent frame={frame} onCursorHoverValueChanged={this.setPixelHighlightValue} />}
                     {frame && <BeamProfileOverlayComponent frame={frame} top={overlayStore.padding.top} left={overlayStore.padding.left} docked={this.props.docked} padding={10} />}
                     {frame && <CatalogViewGLComponent frame={frame} docked={this.props.docked} onZoomed={this.onZoomed} />}
                     {frame && (

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -119,9 +119,6 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         if (frame?.isRenderable && appStore.astReady) {
             const isActive = frame === appStore.activeFrame && appStore.numImageRows * appStore.numImageColumns > 1;
 
-            // Left-align toolbar if we have multiple columns and this panel is in the left-most
-            const leftAlignToolbar = this.props.column === 0 && appStore.numImageColumns > 1;
-
             let className = "image-panel-div";
             let style: React.CSSProperties = {width: overlayStore.viewWidth, height: overlayStore.viewHeight};
             if (isActive) {
@@ -193,7 +190,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                             docked={this.props.docked && (this.activeLayer === ImageViewLayer.RegionMoving || this.activeLayer === ImageViewLayer.RegionCreating)}
                         />
                     )}
-                    <ToolbarComponent docked={this.props.docked} visible={this.imageToolbarVisible} leftAlign={leftAlignToolbar} frame={frame} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
+                    <ToolbarComponent docked={this.props.docked} visible={this.imageToolbarVisible} frame={frame} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
                 </div>
             );
         } else {

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {observer} from "mobx-react";
 import {action, autorun, makeObservable, observable, runInAction} from "mobx";
 import {NonIdealState, Spinner, Tag} from "@blueprintjs/core";
-import ReactResizeDetector from "react-resize-detector";
 import {OverlayComponent} from "../Overlay/OverlayComponent";
 import {CursorOverlayComponent} from "../CursorOverlay/CursorOverlayComponent";
 import {ColorbarComponent} from "../Colorbar/ColorbarComponent";
@@ -28,7 +27,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
     private ratioIndicatorTimeoutHandle;
     private cachedImageSize: Point2D;
 
-    @observable showRatioIndicator: boolean;
+    @observable showRatioIndicator: boolean = false;
     @observable pixelHighlightValue: number = NaN;
     readonly activeLayer: ImageViewLayer;
 
@@ -61,12 +60,6 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             }
         });
     }
-
-    onResize = (width: number, height: number) => {
-        if (width > 0 && height > 0) {
-            AppStore.Instance.setImageViewDimensions(width, height);
-        }
-    };
 
     onClicked = (cursorInfo: CursorInfo) => {
         const frame = this.props.frame;
@@ -183,11 +176,10 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         }
 
         return (
-            <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+            <div className="image-panel-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                 <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
                 <ContourViewComponent frame={frame} docked={this.props.docked} />
                 {divContents}
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
             </div>
         );
     }

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -145,6 +145,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             const effectiveWidth = frame.renderWidth * (frame.renderHiDPI ? devicePixelRatio : 1);
             const effectiveHeight = frame.renderHeight * (frame.renderHiDPI ? devicePixelRatio : 1);
             const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
+            const isActive = frame === appStore.activeFrame && appStore.numRows * appStore.numColumns > 1;
 
             return (
                 <div
@@ -157,7 +158,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                 >
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
-                    {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
+                    {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} highlightFrame={isActive} />}
                     {this.cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent
                             cursorInfo={frame.cursorInfo}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -25,6 +25,7 @@ interface ImagePanelComponentProps {
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
     @observable pixelHighlightValue: number = NaN;
+    @observable imageToolbarVisible: boolean = false;
     readonly activeLayer: ImageViewLayer;
 
     @action setPixelHighlightValue = (val: number) => {
@@ -61,12 +62,12 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         }
     };
 
-    onMouseEnter = () => {
-        AppStore.Instance.showImageToolbar();
+    @action onMouseEnter = () => {
+        this.imageToolbarVisible = true;
     };
 
-    onMouseLeave = () => {
-        AppStore.Instance.hideImageToolbar();
+    @action onMouseLeave = () => {
+        this.imageToolbarVisible = false;
     };
 
     onMouseDown = ev => {
@@ -117,6 +118,10 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         const frame = this.props.frame;
         if (frame?.isRenderable && appStore.astReady) {
             const isActive = frame === appStore.activeFrame && appStore.numImageRows * appStore.numImageColumns > 1;
+
+            // Left-align toolbar if we have multiple columns and this panel is in the left-most
+            const leftAlignToolbar = this.props.column === 0 && appStore.numImageColumns > 1;
+
             let className = "image-panel-div";
             let style: React.CSSProperties = {width: overlayStore.viewWidth, height: overlayStore.viewHeight};
             if (isActive) {
@@ -187,7 +192,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                             docked={this.props.docked && (this.activeLayer === ImageViewLayer.RegionMoving || this.activeLayer === ImageViewLayer.RegionCreating)}
                         />
                     )}
-                    <ToolbarComponent docked={this.props.docked} visible={appStore.imageToolbarVisible} vertical={false} frame={frame} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
+                    <ToolbarComponent docked={this.props.docked} visible={this.imageToolbarVisible} leftAlign={leftAlignToolbar} frame={frame} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
                 </div>
             );
         } else {

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -172,7 +172,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                         />
                     )}
                     {frame && overlayStore.colorbar.visible && <ColorbarComponent onCursorHoverValueChanged={this.setPixelHighlightValue} />}
-                    {frame && <BeamProfileOverlayComponent top={overlayStore.padding.top} left={overlayStore.padding.left} docked={this.props.docked} padding={10} />}
+                    {frame && <BeamProfileOverlayComponent frame={frame} top={overlayStore.padding.top} left={overlayStore.padding.left} docked={this.props.docked} padding={10} />}
                     {frame && <CatalogViewGLComponent frame={frame} docked={this.props.docked} onZoomed={this.onZoomed} />}
                     {frame && (
                         <RegionViewComponent

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -42,6 +42,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         makeObservable(this);
 
         this.activeLayer = AppStore.Instance.activeLayer;
+        // TODO: this should be changed to show a single popup for the entire image view, rather than per-panel
         autorun(() => {
             const frame = props.frame;
             if (frame) {
@@ -94,6 +95,22 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         AppStore.Instance.hideImageToolbar();
     };
 
+    onMouseDown = ev => {
+        const appStore = AppStore.Instance;
+        if (this.props.frame !== appStore.activeFrame) {
+            appStore.setActiveFrame(this.props.frame);
+            ev.stopPropagation();
+        }
+    };
+
+    onMouseWheel = ev => {
+        const appStore = AppStore.Instance;
+        if (this.props.frame !== appStore.activeFrame) {
+            appStore.setActiveFrame(this.props.frame);
+            ev.stopPropagation();
+        }
+    };
+
     private handleRegionDoubleClicked = (region: RegionStore) => {
         const appStore = AppStore.Instance;
         if (region) {
@@ -130,7 +147,14 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
 
             return (
-                <div className="image-panel-div" style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+                <div
+                    className="image-panel-div"
+                    style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}}
+                    onWheel={this.onMouseWheel}
+                    onMouseDown={this.onMouseDown}
+                    onMouseOver={this.onMouseEnter}
+                    onMouseLeave={this.onMouseLeave}
+                >
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -102,7 +102,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             case CursorInfoVisibility.Always:
                 return true;
             case CursorInfoVisibility.HideTiled:
-                return appStore.numRows * appStore.numColumns === 1;
+                return appStore.numImageRows * appStore.numImageColumns === 1;
             case CursorInfoVisibility.ActiveImage:
                 return appStore.activeFrame === this.props.frame;
             default:
@@ -116,7 +116,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
         const frame = this.props.frame;
         if (frame && frame.isRenderable && appStore.astReady) {
-            const isActive = frame === appStore.activeFrame && appStore.numRows * appStore.numColumns > 1;
+            const isActive = frame === appStore.activeFrame && appStore.numImageRows * appStore.numImageColumns > 1;
 
             return (
                 <div

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -132,7 +132,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             return (
                 <div className="image-panel-div" style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
-                    <ContourViewComponent frame={frame} docked={this.props.docked} />
+                    <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
                     {this.cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -20,6 +20,8 @@ import "./ImagePanelComponent.scss";
 interface ImagePanelComponentProps {
     docked: boolean;
     frame: FrameStore;
+    row: number;
+    column: number;
 }
 
 @observer
@@ -129,7 +131,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
             return (
                 <div className="image-panel-div" style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
-                    <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
+                    <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
                     {this.cursorInfoRequired && frame.cursorInfo && (

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -117,19 +117,34 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         const frame = this.props.frame;
         if (frame && frame.isRenderable && appStore.astReady) {
             const isActive = frame === appStore.activeFrame && appStore.numImageRows * appStore.numImageColumns > 1;
+            let className = "image-panel-div";
+            let style: React.CSSProperties = {width: overlayStore.viewWidth, height: overlayStore.viewHeight};
+            if (isActive) {
+                className += " active";
 
+                // Disable border radius rounding in inner corners
+                if (this.props.row !== 0) {
+                    style.borderTopLeftRadius = 0;
+                    style.borderTopRightRadius = 0;
+                }
+                if (this.props.column !== 0) {
+                    style.borderTopLeftRadius = 0;
+                    style.borderBottomLeftRadius = 0;
+                }
+                if (this.props.row !== appStore.numImageRows - 1) {
+                    style.borderBottomLeftRadius = 0;
+                    style.borderBottomRightRadius = 0;
+                }
+                if (this.props.column !== appStore.numImageColumns - 1) {
+                    style.borderTopRightRadius = 0;
+                    style.borderBottomRightRadius = 0;
+                }
+            }
             return (
-                <div
-                    className="image-panel-div"
-                    style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}}
-                    onWheel={this.onMouseWheel}
-                    onMouseDown={this.onMouseDown}
-                    onMouseOver={this.onMouseEnter}
-                    onMouseLeave={this.onMouseLeave}
-                >
+                <div className={className} style={style} onWheel={this.onMouseWheel} onMouseDown={this.onMouseDown} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
-                    {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} highlightFrame={isActive} />}
+                    {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
                     {this.cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent
                             cursorInfo={frame.cursorInfo}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {action, autorun, makeObservable, observable, runInAction} from "mobx";
-import {NonIdealState, Spinner, Tag} from "@blueprintjs/core";
+import {Tag} from "@blueprintjs/core";
 import {OverlayComponent} from "../Overlay/OverlayComponent";
 import {CursorOverlayComponent} from "../CursorOverlay/CursorOverlayComponent";
 import {ColorbarComponent} from "../Colorbar/ColorbarComponent";
@@ -106,7 +106,6 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
     render() {
         const appStore = AppStore.Instance;
         const overlayStore = appStore.overlayStore;
-        let divContents;
 
         const frame = this.props.frame;
         if (frame && frame.isRenderable && appStore.astReady) {
@@ -116,8 +115,10 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             // This will be expanded when using multi-panel view
             const cursorInfoRequired = appStore.preferenceStore.cursorInfoVisible !== CursorInfoVisibility.Never;
 
-            divContents = (
-                <React.Fragment>
+            return (
+                <div className="image-panel-div" style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+                    <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
+                    <ContourViewComponent frame={frame} docked={this.props.docked} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
                     {cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent
@@ -161,26 +162,16 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                             docked={this.props.docked && (this.activeLayer === ImageViewLayer.RegionMoving || this.activeLayer === ImageViewLayer.RegionCreating)}
                         />
                     )}
-                    <ToolbarComponent docked={this.props.docked} visible={appStore.imageToolbarVisible} vertical={false} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
+                    <ToolbarComponent docked={this.props.docked} visible={appStore.imageToolbarVisible} vertical={false} frame={frame} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
                     <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>
                         <Tag large={true}>
                             {effectiveWidth} x {effectiveHeight} ({toFixed(effectiveWidth / effectiveHeight, 2)})
                         </Tag>
                     </div>
-                </React.Fragment>
+                </div>
             );
-        } else if (!appStore.astReady) {
-            divContents = <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
         } else {
-            divContents = <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;
+            return null;
         }
-
-        return (
-            <div className="image-panel-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
-                <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
-                <ContourViewComponent frame={frame} docked={this.props.docked} />
-                {divContents}
-            </div>
-        );
     }
 }

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -145,8 +145,9 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                     style.borderBottomRightRadius = 0;
                 }
             }
+
             return (
-                <div className={className} style={style} onWheel={this.onMouseWheel} onMouseDown={this.onMouseDown} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+                <div id={`image-panel-${this.props.column}-${this.props.row}`} className={className} style={style} onWheel={this.onMouseWheel} onMouseDown={this.onMouseDown} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {action, autorun, makeObservable, observable, runInAction} from "mobx";
+import {action, autorun, computed, makeObservable, observable, runInAction} from "mobx";
 import {Tag} from "@blueprintjs/core";
 import {OverlayComponent} from "../Overlay/OverlayComponent";
 import {CursorOverlayComponent} from "../CursorOverlay/CursorOverlayComponent";
@@ -103,6 +103,20 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         }
     };
 
+    @computed get cursorInfoRequired() {
+        const appStore = AppStore.Instance;
+        switch (appStore.preferenceStore.cursorInfoVisible) {
+            case CursorInfoVisibility.Always:
+                return true;
+            case CursorInfoVisibility.HideTiled:
+                return appStore.numRows * appStore.numColumns === 1;
+            case CursorInfoVisibility.ActiveImage:
+                return appStore.activeFrame === this.props.frame;
+            default:
+                return false;
+        }
+    }
+
     render() {
         const appStore = AppStore.Instance;
         const overlayStore = appStore.overlayStore;
@@ -112,15 +126,13 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             const effectiveWidth = frame.renderWidth * (frame.renderHiDPI ? devicePixelRatio : 1);
             const effectiveHeight = frame.renderHeight * (frame.renderHiDPI ? devicePixelRatio : 1);
             const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
-            // This will be expanded when using multi-panel view
-            const cursorInfoRequired = appStore.preferenceStore.cursorInfoVisible !== CursorInfoVisibility.Never;
 
             return (
                 <div className="image-panel-div" style={{width: overlayStore.viewWidth, height: overlayStore.viewHeight}} onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} />
                     {frame.valid && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
-                    {cursorInfoRequired && frame.cursorInfo && (
+                    {this.cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent
                             cursorInfo={frame.cursorInfo}
                             cursorValue={frame.cursorInfo.isInsideImage ? frame.cursorValue.value : undefined}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -115,7 +115,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         const overlayStore = appStore.overlayStore;
 
         const frame = this.props.frame;
-        if (frame && frame.isRenderable && appStore.astReady) {
+        if (frame?.isRenderable && appStore.astReady) {
             const isActive = frame === appStore.activeFrame && appStore.numImageRows * appStore.numImageColumns > 1;
             let className = "image-panel-div";
             let style: React.CSSProperties = {width: overlayStore.viewWidth, height: overlayStore.viewHeight};

--- a/src/components/ImageView/ImageViewComponent.scss
+++ b/src/components/ImageView/ImageViewComponent.scss
@@ -4,5 +4,4 @@
     position: relative;
     user-select: none;
     display: grid;
-    grid-template-columns: auto auto;
 }

--- a/src/components/ImageView/ImageViewComponent.scss
+++ b/src/components/ImageView/ImageViewComponent.scss
@@ -1,17 +1,2 @@
 .image-view-div {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    user-select: none;
-
-    .tag-image-ratio {
-        transition: opacity 0.5s;
-        position: absolute;
-        z-index: 5;
-        pointer-events: none;
-
-        .bp3-tag {
-            left: -50%;
-        }
-    }
 }

--- a/src/components/ImageView/ImageViewComponent.scss
+++ b/src/components/ImageView/ImageViewComponent.scss
@@ -1,2 +1,8 @@
 .image-view-div {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    user-select: none;
+    display: grid;
+    grid-template-columns: auto auto;
 }

--- a/src/components/ImageView/ImageViewComponent.scss
+++ b/src/components/ImageView/ImageViewComponent.scss
@@ -1,7 +1,30 @@
+@import "~@blueprintjs/core/lib/scss/variables.scss";
+
 .image-view-div {
     width: 100%;
     height: 100%;
     position: relative;
     user-select: none;
     display: grid;
+
+    .image-ratio-popup {
+        transition: opacity 0.5s;
+        text-align: center;
+        border-radius: $pt-border-radius;
+        background-color: $blue2;
+        color: $light-gray5;
+        border: 1px solid $light-gray5;
+        padding: 5px;
+
+        position: absolute;
+        z-index: 5;
+        pointer-events: none;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+
+        p {
+            margin-bottom: 0;
+        }
+    }
 }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -1,22 +1,16 @@
+import "./ImageViewComponent.scss";
 import * as React from "react";
 import $ from "jquery";
 import {observer} from "mobx-react";
-import {action, autorun, makeObservable, observable, runInAction} from "mobx";
-import {NonIdealState, Spinner, Tag} from "@blueprintjs/core";
-import ReactResizeDetector from "react-resize-detector";
-import {OverlayComponent} from "./Overlay/OverlayComponent";
-import {CursorOverlayComponent} from "./CursorOverlay/CursorOverlayComponent";
-import {ColorbarComponent} from "./Colorbar/ColorbarComponent";
-import {RasterViewComponent} from "./RasterView/RasterViewComponent";
-import {ToolbarComponent} from "./Toolbar/ToolbarComponent";
-import {BeamProfileOverlayComponent} from "./BeamProfileOverlay/BeamProfileOverlayComponent";
-import {RegionViewComponent} from "./RegionView/RegionViewComponent";
-import {ContourViewComponent} from "./ContourView/ContourViewComponent";
-import {CatalogViewGLComponent} from "./CatalogView/CatalogViewGLComponent";
-import {AppStore, RegionStore, DefaultWidgetConfig, WidgetProps, HelpType, Padding} from "stores";
-import {CursorInfo, CursorInfoVisibility, Point2D} from "models";
-import {toFixed} from "utilities";
-import "./ImageViewComponent.scss";
+import {AppStore, DefaultWidgetConfig, HelpType, Padding, WidgetProps} from "stores";
+import {ImagePanelComponent} from "./ImagePanel/ImagePanelComponent";
+
+export enum ImageViewLayer {
+    RegionCreating = "regionCreating",
+    Catalog = "catalog",
+    RegionMoving = "regionMoving",
+    DistanceMeasuring = "distanceMeasuring"
+}
 
 export const getImageCanvas = (padding: Padding, colorbarPosition: string, backgroundColor: string = "rgba(255, 255, 255, 0)"): HTMLCanvasElement => {
     const rasterCanvas = document.getElementById("raster-canvas") as HTMLCanvasElement;
@@ -94,22 +88,8 @@ export const getImageCanvas = (padding: Padding, colorbarPosition: string, backg
     return composedCanvas;
 };
 
-export enum ImageViewLayer {
-    RegionCreating = "regionCreating",
-    Catalog = "catalog",
-    RegionMoving = "regionMoving",
-    DistanceMeasuring = "distanceMeasuring"
-}
-
 @observer
 export class ImageViewComponent extends React.Component<WidgetProps> {
-    private ratioIndicatorTimeoutHandle;
-    private cachedImageSize: Point2D;
-
-    @observable showRatioIndicator: boolean;
-    @observable pixelHighlightValue: number = NaN;
-    readonly activeLayer: ImageViewLayer;
-
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
             id: "image-view",
@@ -124,161 +104,8 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         };
     }
 
-    @action setPixelHighlightValue = (val: number) => {
-        this.pixelHighlightValue = val;
-    };
-
-    constructor(props: WidgetProps) {
-        super(props);
-        makeObservable(this);
-
-        this.activeLayer = AppStore.Instance.activeLayer;
-        autorun(() => {
-            const frame = AppStore.Instance.activeFrame;
-            if (frame) {
-                const imageSize = {x: frame.renderWidth, y: frame.renderHeight};
-                // Compare to cached image size to prevent duplicate events when changing frames
-                if (!this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y) {
-                    this.cachedImageSize = imageSize;
-                    clearTimeout(this.ratioIndicatorTimeoutHandle);
-                    runInAction(() => (this.showRatioIndicator = true));
-                    this.ratioIndicatorTimeoutHandle = setTimeout(
-                        () =>
-                            runInAction(() => {
-                                this.showRatioIndicator = false;
-                            }),
-                        1000
-                    );
-                }
-            }
-        });
-    }
-
-    onResize = (width: number, height: number) => {
-        if (width > 0 && height > 0) {
-            AppStore.Instance.setImageViewDimensions(width, height);
-        }
-    };
-
-    onClicked = (cursorInfo: CursorInfo) => {
-        const frame = AppStore.Instance.activeFrame;
-        if (frame) {
-            frame.setCenter(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y);
-        }
-    };
-
-    onZoomed = (cursorInfo: CursorInfo, delta: number) => {
-        const frame = AppStore.Instance.activeFrame;
-        if (frame) {
-            const zoomSpeed = 1 + Math.abs(delta / 750.0);
-
-            // If frame is spatially matched, apply zoom to the reference frame, rather than the active frame
-            if (frame.spatialReference) {
-                const newZoom = frame.spatialReference.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
-                frame.zoomToPoint(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y, newZoom, true);
-            } else {
-                const newZoom = frame.zoomLevel * (delta > 0 ? zoomSpeed : 1.0 / zoomSpeed);
-                frame.zoomToPoint(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y, newZoom, true);
-            }
-        }
-    };
-
-    onMouseEnter = () => {
-        AppStore.Instance.showImageToolbar();
-    };
-
-    onMouseLeave = () => {
-        AppStore.Instance.hideImageToolbar();
-    };
-
-    private handleRegionDoubleClicked = (region: RegionStore) => {
-        const appStore = AppStore.Instance;
-        if (region) {
-            const frame = appStore.getFrame(region.fileId);
-            if (frame) {
-                frame.regionSet.selectRegion(region);
-                appStore.dialogStore.showRegionDialog();
-            }
-        }
-    };
-
     render() {
-        const appStore = AppStore.Instance;
-        const overlayStore = appStore.overlayStore;
-        let divContents;
-        if (appStore.activeFrame && appStore.activeFrame.isRenderable && appStore.astReady) {
-            const effectiveWidth = appStore.activeFrame.renderWidth * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
-            const effectiveHeight = appStore.activeFrame.renderHeight * (appStore.activeFrame.renderHiDPI ? devicePixelRatio : 1);
-            const imageRatioTagOffset = {x: overlayStore.padding.left + overlayStore.viewWidth / 2.0, y: overlayStore.padding.top + overlayStore.viewHeight / 2.0};
-            // This will be expanded when using multi-panel view
-            const cursorInfoRequired = appStore.preferenceStore.cursorInfoVisible !== CursorInfoVisibility.Never;
-
-            divContents = (
-                <React.Fragment>
-                    {appStore.activeFrame.valid && <OverlayComponent frame={appStore.activeFrame} overlaySettings={overlayStore} docked={this.props.docked} />}
-                    {cursorInfoRequired && appStore.activeFrame.cursorInfo && (
-                        <CursorOverlayComponent
-                            cursorInfo={appStore.activeFrame.cursorInfo}
-                            cursorValue={appStore.activeFrame.cursorInfo.isInsideImage ? appStore.activeFrame.cursorValue.value : undefined}
-                            isValueCurrent={appStore.activeFrame.isCursorValueCurrent}
-                            spectralInfo={appStore.activeFrame.spectralInfo}
-                            width={overlayStore.viewWidth}
-                            left={overlayStore.padding.left}
-                            right={overlayStore.padding.right}
-                            docked={this.props.docked}
-                            unit={appStore.activeFrame.unit}
-                            top={overlayStore.padding.top}
-                            currentStokes={appStore.activeFrame.hasStokes ? appStore.activeFrame.stokesInfo[appStore.activeFrame.requiredStokes] : ""}
-                            showImage={true}
-                            showWCS={true}
-                            showValue={true}
-                            showChannel={false}
-                            showSpectral={true}
-                            showStokes={true}
-                        />
-                    )}
-                    {appStore.activeFrame && overlayStore.colorbar.visible && <ColorbarComponent onCursorHoverValueChanged={this.setPixelHighlightValue} />}
-                    {appStore.activeFrame && <BeamProfileOverlayComponent top={overlayStore.padding.top} left={overlayStore.padding.left} docked={this.props.docked} padding={10} />}
-                    {appStore.activeFrame && <CatalogViewGLComponent frame={appStore.activeFrame} docked={this.props.docked} onZoomed={this.onZoomed} />}
-                    {appStore.activeFrame && (
-                        <RegionViewComponent
-                            frame={appStore.activeFrame}
-                            width={appStore.activeFrame.renderWidth}
-                            height={appStore.activeFrame.renderHeight}
-                            top={overlayStore.padding.top}
-                            left={overlayStore.padding.left}
-                            onClicked={this.onClicked}
-                            onRegionDoubleClicked={this.handleRegionDoubleClicked}
-                            onZoomed={this.onZoomed}
-                            overlaySettings={overlayStore}
-                            isRegionCornerMode={appStore.preferenceStore.isRegionCornerMode}
-                            dragPanningEnabled={appStore.preferenceStore.dragPanning}
-                            cursorFrozen={appStore.cursorFrozen}
-                            cursorPoint={appStore.activeFrame.cursorInfo.posImageSpace}
-                            docked={this.props.docked && (this.activeLayer === ImageViewLayer.RegionMoving || this.activeLayer === ImageViewLayer.RegionCreating)}
-                        />
-                    )}
-                    <ToolbarComponent docked={this.props.docked} visible={appStore.imageToolbarVisible} vertical={false} onActiveLayerChange={appStore.updateActiveLayer} activeLayer={this.activeLayer} />
-                    <div style={{opacity: this.showRatioIndicator ? 1 : 0, left: imageRatioTagOffset.x, top: imageRatioTagOffset.y}} className={"tag-image-ratio"}>
-                        <Tag large={true}>
-                            {effectiveWidth} x {effectiveHeight} ({toFixed(effectiveWidth / effectiveHeight, 2)})
-                        </Tag>
-                    </div>
-                </React.Fragment>
-            );
-        } else if (!appStore.astReady) {
-            divContents = <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
-        } else {
-            divContents = <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;
-        }
-
-        return (
-            <div className="image-view-div" onMouseOver={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
-                <RasterViewComponent frame={appStore.activeFrame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} />
-                <ContourViewComponent frame={appStore.activeFrame} docked={this.props.docked} />
-                {divContents}
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
-            </div>
-        );
+        const frame = AppStore.Instance.activeFrame;
+        return <ImagePanelComponent docked={this.props.docked} frame={frame} />;
     }
 }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -171,33 +171,37 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         } else if (!appStore.astReady) {
             divContents = <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
         } else {
-            divContents = this.panels;
-        }
+            const effectiveImageSize = {x: Math.floor(appStore.overlayStore.renderWidth), y: Math.floor(appStore.overlayStore.renderHeight)};
+            const ratio = effectiveImageSize.x / effectiveImageSize.y;
+            const gridSize = {x: appStore.numImageColumns, y: appStore.numImageRows};
 
-        const effectiveImageSize = {x: Math.floor(appStore.overlayStore.renderWidth), y: Math.floor(appStore.overlayStore.renderHeight)};
-        const ratio = effectiveImageSize.x / effectiveImageSize.y;
-        const gridSize = {x: appStore.numImageColumns, y: appStore.numImageRows};
-
-        let gridSizeNode: React.ReactNode;
-        if (gridSize.x * gridSize.y > 1) {
-            gridSizeNode = (
-                <p>
-                    {gridSize.x} &times; {gridSize.y}
-                </p>
+            let gridSizeNode: React.ReactNode;
+            if (gridSize.x * gridSize.y > 1) {
+                gridSizeNode = (
+                    <p>
+                        {gridSize.x} &times; {gridSize.y}
+                    </p>
+                );
+            }
+            divContents = (
+                <React.Fragment>
+                    {this.panels}
+                    <div style={{opacity: this.showRatioIndicator ? 1 : 0}} className={"image-ratio-popup"}>
+                        <p>
+                            {effectiveImageSize.x} &times; {effectiveImageSize.y} ({toFixed(ratio, 2)})
+                        </p>
+                        {gridSizeNode}
+                    </div>
+                </React.Fragment>
             );
         }
 
         return (
-            <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`}}>
-                {divContents}
-                <div style={{opacity: this.showRatioIndicator ? 1 : 0}} className={"image-ratio-popup"}>
-                    <p>
-                        {effectiveImageSize.x} &times; {effectiveImageSize.y} ({toFixed(ratio, 2)})
-                    </p>
-                    {gridSizeNode}
+            <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}>
+                <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`}}>
+                    {divContents}
                 </div>
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33} />
-            </div>
+            </ReactResizeDetector>
         );
     }
 }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -121,15 +121,18 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     render() {
         const appStore = AppStore.Instance;
 
+        let divContents: React.ReactNode | React.ReactNode[];
         if (!this.panels.length) {
-            return <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;
+            divContents = <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;
         } else if (!appStore.astReady) {
-            return <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
+            divContents = <NonIdealState icon={<Spinner className="astLoadingSpinner" />} title={"Loading AST Library"} />;
+        } else {
+            divContents = this.panels;
         }
 
         return (
             <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numColumns}, auto)`}}>
-                {this.panels}
+                {divContents}
                 <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
             </div>
         );

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -21,8 +21,8 @@ export enum ImageViewLayer {
 export function getImageViewCanvas(padding: Padding, colorbarPosition: string, backgroundColor: string = "rgba(255, 255, 255, 0)") {
     const appStore = AppStore.Instance;
     const imageViewCanvas = document.createElement("canvas") as HTMLCanvasElement;
-    imageViewCanvas.width = appStore.overlayStore.fullViewWidth;
-    imageViewCanvas.height = appStore.overlayStore.fullViewHeight;
+    imageViewCanvas.width = appStore.overlayStore.fullViewWidth * devicePixelRatio;
+    imageViewCanvas.height = appStore.overlayStore.fullViewHeight * devicePixelRatio;
     const ctx = imageViewCanvas.getContext("2d");
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, imageViewCanvas.width, imageViewCanvas.height);
@@ -31,7 +31,7 @@ export function getImageViewCanvas(padding: Padding, colorbarPosition: string, b
         const row = Math.floor(index / appStore.numImageColumns);
         const panelCanvas = getPanelCanvas(column, row, padding, colorbarPosition, backgroundColor);
         if (panelCanvas) {
-            ctx.drawImage(panelCanvas, appStore.overlayStore.viewWidth * column, appStore.overlayStore.viewHeight * row);
+            ctx.drawImage(panelCanvas, appStore.overlayStore.viewWidth * column * devicePixelRatio, appStore.overlayStore.viewHeight * row * devicePixelRatio);
         }
     });
 

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -134,7 +134,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
         autorun(() => {
             const imageSize = {x: appStore.overlayStore.renderWidth, y: appStore.overlayStore.renderHeight};
-            const imageGridSize = {x: appStore.numColumns, y: appStore.numRows};
+            const imageGridSize = {x: appStore.numImageColumns, y: appStore.numImageRows};
             // Compare to cached image size to prevent duplicate events when changing frames
             const imageSizeChanged = !this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y;
             const gridSizeChanged = !this.cachedGridSize || this.cachedGridSize.x !== imageGridSize.x || this.cachedGridSize.y !== imageGridSize.y;
@@ -155,8 +155,8 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             return [];
         }
         return visibleFrames.map((frame, index) => {
-            const column = index % appStore.numColumns;
-            const row = Math.floor(index / appStore.numColumns);
+            const column = index % appStore.numImageColumns;
+            const row = Math.floor(index / appStore.numImageColumns);
 
             return <ImagePanelComponent key={frame.frameInfo.fileId} docked={this.props.docked} frame={frame} row={row} column={column} />;
         });
@@ -176,7 +176,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
         const effectiveImageSize = {x: Math.floor(appStore.overlayStore.renderWidth), y: Math.floor(appStore.overlayStore.renderHeight)};
         const ratio = effectiveImageSize.x / effectiveImageSize.y;
-        const gridSize = {x: appStore.numColumns, y: appStore.numRows};
+        const gridSize = {x: appStore.numImageColumns, y: appStore.numImageRows};
 
         let gridSizeNode: React.ReactNode;
         if (gridSize.x * gridSize.y > 1) {
@@ -188,7 +188,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         }
 
         return (
-            <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numColumns}, auto)`}}>
+            <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`}}>
                 {divContents}
                 <div style={{opacity: this.showRatioIndicator ? 1 : 0}} className={"image-ratio-popup"}>
                     <p>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -128,7 +128,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         }
 
         return (
-            <div className="image-view-div">
+            <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numColumns}, auto)`}}>
                 {this.panels}
                 <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
             </div>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -114,8 +114,17 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     };
 
     @computed get panels() {
-        const visibleFrames = AppStore.Instance.visibleFrames;
-        return visibleFrames?.map(frame => <ImagePanelComponent key={frame.frameInfo.fileId} docked={this.props.docked} frame={frame} />) ?? [];
+        const appStore = AppStore.Instance;
+        const visibleFrames = appStore.visibleFrames;
+        if (!visibleFrames) {
+            return [];
+        }
+        return visibleFrames.map((frame, index) => {
+            const column = index % appStore.numColumns;
+            const row = Math.floor(index / appStore.numColumns);
+
+            return <ImagePanelComponent key={frame.frameInfo.fileId} docked={this.props.docked} frame={frame} row={row} column={column} />;
+        });
     }
 
     render() {

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -2,8 +2,9 @@ import "./ImageViewComponent.scss";
 import * as React from "react";
 import $ from "jquery";
 import {observer} from "mobx-react";
-import {AppStore, DefaultWidgetConfig, HelpType, Padding, WidgetProps} from "stores";
+import ReactResizeDetector from "react-resize-detector";
 import {ImagePanelComponent} from "./ImagePanel/ImagePanelComponent";
+import {AppStore, DefaultWidgetConfig, HelpType, Padding, WidgetProps} from "stores";
 
 export enum ImageViewLayer {
     RegionCreating = "regionCreating",
@@ -104,8 +105,18 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         };
     }
 
+    onResize = (width: number, height: number) => {
+        if (width > 0 && height > 0) {
+            AppStore.Instance.setImageViewDimensions(width, height);
+        }
+    };
+
     render() {
         const frame = AppStore.Instance.activeFrame;
-        return <ImagePanelComponent docked={this.props.docked} frame={frame} />;
+        return (
+            <div className="image-panel-div">
+                <ImagePanelComponent docked={this.props.docked} frame={frame} />;<ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
+            </div>
+        );
     }
 }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -133,7 +133,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         return (
             <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numColumns}, auto)`}}>
                 {divContents}
-                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>
+                <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33} />
             </div>
         );
     }

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -150,11 +150,27 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                         <option value={ImagePanelMode.Fixed}>Fixed grid size</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Panel columns">
-                    <SafeNumericInput placeholder="Columns" min={1} value={preferences.imagePanelColumns} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_COLUMNS, value)} />
+                <FormGroup inline={true} label="Columns" labelInfo={preferences.imagePanelMode === ImagePanelMode.Dynamic ? "(Maximum)" : "(Fixed)"} disabled={preferences.imagePanelMode === ImagePanelMode.None}>
+                    <SafeNumericInput
+                        placeholder="Columns"
+                        min={1}
+                        value={preferences.imagePanelColumns}
+                        disabled={preferences.imagePanelMode === ImagePanelMode.None}
+                        stepSize={1}
+                        minorStepSize={null}
+                        onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_COLUMNS, value)}
+                    />
                 </FormGroup>
-                <FormGroup inline={true} label="Panel rows">
-                    <SafeNumericInput placeholder="Rows" min={1} value={preferences.imagePanelRows} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_ROWS, value)} />
+                <FormGroup inline={true} label="Rows" labelInfo={preferences.imagePanelMode === ImagePanelMode.Dynamic ? "(Maximum)" : "(Fixed)"} disabled={preferences.imagePanelMode === ImagePanelMode.None}>
+                    <SafeNumericInput
+                        placeholder="Rows"
+                        min={1}
+                        disabled={preferences.imagePanelMode === ImagePanelMode.None}
+                        value={preferences.imagePanelRows}
+                        stepSize={1}
+                        minorStepSize={null}
+                        onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_ROWS, value)}
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Overlay color">
                     <AutoColorPickerComponent color={global.color} presetColors={SWATCH_COLORS} setColor={global.setColor} disableAlpha={true} />

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -6,9 +6,9 @@ import {ItemRenderer, Select} from "@blueprintjs/select";
 import {Button, Collapse, Divider, FormGroup, HTMLSelect, InputGroup, MenuItem, Switch, Tab, TabId, Tabs} from "@blueprintjs/core";
 import {AutoColorPickerComponent, SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
 import {AppStore, BeamType, DefaultWidgetConfig, HelpType, LabelType, NUMBER_FORMAT_LABEL, NumberFormatType, PreferenceKeys, SystemType, WidgetProps} from "stores";
+import {ImagePanelMode} from "models";
 import {SWATCH_COLORS} from "utilities";
 import "./ImageViewSettingsPanelComponent.scss";
-import {ImageTileMode} from "../../../models";
 
 enum ImageViewSettingsPanelTabs {
     GLOBAL = "Global",
@@ -143,18 +143,18 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
 
         const globalPanel = (
             <div className="panel-container">
-                <FormGroup inline={true} label="Image Tiling">
-                    <HTMLSelect
-                        options={Object.keys(ImageTileMode).map(key => ({label: key, value: ImageTileMode[key]}))}
-                        value={preferences.imageTileMode}
-                        onChange={(event: React.FormEvent<HTMLSelectElement>) => preferences.setPreference(PreferenceKeys.IMAGE_TILE_MODE, event.currentTarget.value as ImageTileMode)}
-                    />
+                <FormGroup inline={true} label="Multi-panel mode">
+                    <HTMLSelect value={preferences.imagePanelMode} onChange={event => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_MODE, event.currentTarget.value as ImagePanelMode)}>
+                        <option value={ImagePanelMode.None}>Single panel only</option>
+                        <option value={ImagePanelMode.Dynamic}>Dynamic grid size</option>
+                        <option value={ImagePanelMode.Fixed}>Fixed grid size</option>
+                    </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Tile Columns">
-                    <SafeNumericInput placeholder="Columns" min={1} value={preferences.imageTileColumns} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_TILE_COLUMNS, value)} />
+                <FormGroup inline={true} label="Panel columns">
+                    <SafeNumericInput placeholder="Columns" min={1} value={preferences.imagePanelColumns} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_COLUMNS, value)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Tile Rows">
-                    <SafeNumericInput placeholder="Rows" min={1} value={preferences.imageTileRows} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_TILE_ROWS, value)} />
+                <FormGroup inline={true} label="Panel rows">
+                    <SafeNumericInput placeholder="Rows" min={1} value={preferences.imagePanelRows} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_PANEL_ROWS, value)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Overlay color">
                     <AutoColorPickerComponent color={global.color} presetColors={SWATCH_COLORS} setColor={global.setColor} disableAlpha={true} />

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -8,6 +8,7 @@ import {AutoColorPickerComponent, SafeNumericInput, SpectralSettingsComponent} f
 import {AppStore, BeamType, DefaultWidgetConfig, HelpType, LabelType, NUMBER_FORMAT_LABEL, NumberFormatType, PreferenceKeys, SystemType, WidgetProps} from "stores";
 import {SWATCH_COLORS} from "utilities";
 import "./ImageViewSettingsPanelComponent.scss";
+import {ImageTileMode} from "../../../models";
 
 enum ImageViewSettingsPanelTabs {
     GLOBAL = "Global",
@@ -142,7 +143,20 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
 
         const globalPanel = (
             <div className="panel-container">
-                <FormGroup inline={true} label="Color">
+                <FormGroup inline={true} label="Image Tiling">
+                    <HTMLSelect
+                        options={Object.keys(ImageTileMode).map(key => ({label: key, value: ImageTileMode[key]}))}
+                        value={preferences.imageTileMode}
+                        onChange={(event: React.FormEvent<HTMLSelectElement>) => preferences.setPreference(PreferenceKeys.IMAGE_TILE_MODE, event.currentTarget.value as ImageTileMode)}
+                    />
+                </FormGroup>
+                <FormGroup inline={true} label="Tile Columns">
+                    <SafeNumericInput placeholder="Columns" min={1} value={preferences.imageTileColumns} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_TILE_COLUMNS, value)} />
+                </FormGroup>
+                <FormGroup inline={true} label="Tile Rows">
+                    <SafeNumericInput placeholder="Rows" min={1} value={preferences.imageTileRows} stepSize={1} minorStepSize={null} onValueChange={value => preferences.setPreference(PreferenceKeys.IMAGE_TILE_ROWS, value)} />
+                </FormGroup>
+                <FormGroup inline={true} label="Overlay color">
                     <AutoColorPickerComponent color={global.color} presetColors={SWATCH_COLORS} setColor={global.setColor} disableAlpha={true} />
                 </FormGroup>
                 <FormGroup inline={true} label="Tolerance" labelInfo="(%)">

--- a/src/components/ImageView/Overlay/OverlayComponent.scss
+++ b/src/components/ImageView/Overlay/OverlayComponent.scss
@@ -1,5 +1,4 @@
 .overlay-canvas {
-    width: 100%;
     position: absolute;
 
     &.docked {

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -102,6 +102,11 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 currentStyleString += `, Width(Border)=${this.props.overlaySettings.border.width * 2}`;
             }
 
+            if (!this.props.frame.validWcs) {
+                //Remove system and format entries
+                currentStyleString = currentStyleString.replace(/System=.*?,/, "").replaceAll(/Format\(\d\)=.*?,/g, "");
+            }
+
             plot(currentStyleString);
 
             if (/No grid curves can be drawn for axis/.test(AST.getLastErrorMessage())) {

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -154,6 +154,6 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         if (this.props.docked) {
             className += " docked";
         }
-        return <canvas className={className} id="overlay-canvas" key={styleString} ref={ref => (this.canvas = ref)} />;
+        return <canvas className={className} style={{width: w, height: h}} id="overlay-canvas" key={styleString} ref={ref => (this.canvas = ref)} />;
     }
 }

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -10,7 +10,6 @@ export class OverlayComponentProps {
     overlaySettings: OverlayStore;
     frame: FrameStore;
     docked: boolean;
-    highlightFrame: boolean;
     onClicked?: (cursorInfo: CursorInfo) => void;
     onZoomed?: (cursorInfo: CursorInfo, delta: number) => void;
 }
@@ -95,11 +94,6 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             if (frame.moving) {
                 const tolVal = Math.max((settings.global.tolerance * 2) / 100.0, 0.1);
                 currentStyleString += `, Tol=${tolVal}`;
-            }
-
-            // Double the border width to highlight this frame
-            if (this.props.highlightFrame && this.props.overlaySettings.border.visible) {
-                currentStyleString += `, Width(Border)=${this.props.overlaySettings.border.width * 2}`;
             }
 
             if (!this.props.frame.validWcs) {

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -10,6 +10,7 @@ export class OverlayComponentProps {
     overlaySettings: OverlayStore;
     frame: FrameStore;
     docked: boolean;
+    highlightFrame: boolean;
     onClicked?: (cursorInfo: CursorInfo) => void;
     onZoomed?: (cursorInfo: CursorInfo, delta: number) => void;
 }
@@ -94,6 +95,11 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             if (frame.moving) {
                 const tolVal = Math.max((settings.global.tolerance * 2) / 100.0, 0.1);
                 currentStyleString += `, Tol=${tolVal}`;
+            }
+
+            // Double the border width to highlight this frame
+            if (this.props.highlightFrame && this.props.overlaySettings.border.visible) {
+                currentStyleString += `, Width(Border)=${this.props.overlaySettings.border.width * 2}`;
             }
 
             plot(currentStyleString);

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -36,6 +36,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private updateCanvas = () => {
         const frame = this.props.frame;
         const tileRenderService = TileWebGLService.Instance;
+        console.log(`Updating canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
         if (frame && this.canvas && this.gl && tileRenderService.cmapTexture) {
             const histStokes = frame.renderConfig.stokes;
             const histChannel = frame.renderConfig.histogram ? frame.renderConfig.histogram.channel : undefined;
@@ -106,12 +107,12 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
     private renderCanvas() {
         const frame = this.props.frame;
+        console.log(`Rendering canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
         // Only clear and render if we're in animation or tiled mode
         if (frame && frame.isRenderable && frame.renderType !== RasterRenderType.NONE) {
             this.gl.viewport(0, 0, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
             this.gl.enable(WebGLRenderingContext.DEPTH_TEST);
             this.gl.clear(WebGLRenderingContext.COLOR_BUFFER_BIT | WebGLRenderingContext.DEPTH_BUFFER_BIT);
-
             // Skip rendering if frame is hidden
             if (!frame.renderConfig.visible) {
                 return;
@@ -217,12 +218,23 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         }
     }
 
+    private get panelIndex() {
+        const panelElement = this.canvas?.parentElement?.parentElement;
+        const viewElement = panelElement?.parentElement;
+        const numPanels = (viewElement?.children?.length ?? 0) - 1;
+        for (let i = 0; i < numPanels; i++) {
+            if (viewElement.children[i] === panelElement) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     private renderTile(tile: TileCoordinate, rasterTile: RasterTile, mip: number) {
         const appStore = AppStore.Instance;
-        const frame = appStore.activeFrame;
+        const frame = this.props.frame;
         const shaderUniforms = TileWebGLService.Instance.shaderUniforms;
         const tileService = TileService.Instance;
-
         if (!rasterTile) {
             return;
         }

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import tinycolor from "tinycolor2";
 import {observer} from "mobx-react";
-import {AppStore, FrameStore, RasterRenderType} from "stores";
+import {AppStore, FrameStore} from "stores";
 import {FrameView, Point2D, TileCoordinate} from "models";
 import {GetRequiredTiles, GL, LayerToMip, add2D, scale2D, smoothStep, getColorForTheme} from "utilities";
 import {RasterTile, TILE_SIZE, TileService, TileWebGLService} from "services";
@@ -111,7 +111,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
         const tileRenderService = TileWebGLService.Instance;
         // Resize and clear the canvas if needed
-        if (frame && frame.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
+        if (frame?.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
             this.canvas.width = requiredWidth;
             this.canvas.height = requiredHeight;
         }
@@ -122,7 +122,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private renderCanvas() {
         const frame = this.props.frame;
         // Only clear and render if we're in animation or tiled mode
-        if (frame && frame.isRenderable && frame.renderType !== RasterRenderType.NONE) {
+        if (frame?.isRenderable) {
             const appStore = AppStore.Instance;
             const xOffset = this.props.column * frame.renderWidth * devicePixelRatio;
             // y-axis is inverted
@@ -137,10 +137,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.disable(WebGLRenderingContext.SCISSOR_TEST);
 
             // Skip rendering if frame is hidden
-            if (!frame.renderConfig.visible) {
-                return;
-            }
-            if (frame.renderType === RasterRenderType.TILED) {
+            if (frame.renderConfig.visible) {
                 this.renderTiledCanvas();
             }
         }
@@ -348,7 +345,6 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             const spatialReference = frame.spatialReference || frame;
             const frameView = spatialReference.requiredFrameView;
             const currentView = spatialReference.currentFrameView;
-            const renderType = frame.renderType;
 
             const colorMapping = {
                 min: frame.renderConfig.scaleMinVal,
@@ -375,6 +371,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         if (this.props.docked) {
             className += " docked";
         }
+
         return (
             <div className={className}>
                 <canvas

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -107,7 +107,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
 
     private renderCanvas() {
         const frame = this.props.frame;
-        console.log(`Rendering canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
+        // console.log(`Rendering canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
         // Only clear and render if we're in animation or tiled mode
         if (frame && frame.isRenderable && frame.renderType !== RasterRenderType.NONE) {
             this.gl.viewport(0, 0, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -106,8 +106,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         }
 
         const appStore = AppStore.Instance;
-        const requiredWidth = frame.renderWidth * devicePixelRatio;
-        const requiredHeight = frame.renderHeight * devicePixelRatio;
+        const requiredWidth = Math.max(1, frame.renderWidth * devicePixelRatio);
+        const requiredHeight = Math.max(1, frame.renderHeight * devicePixelRatio);
 
         const tileRenderService = TileWebGLService.Instance;
         // Resize and clear the canvas if needed

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -116,7 +116,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.canvas.height = requiredHeight;
         }
         // Resize and clear the shared WebGL canvas if required
-        tileRenderService.setCanvasSize(requiredWidth * appStore.numColumns, requiredHeight * appStore.numRows);
+        tileRenderService.setCanvasSize(requiredWidth * appStore.numImageColumns, requiredHeight * appStore.numImageRows);
     }
 
     private renderCanvas() {
@@ -126,7 +126,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             const appStore = AppStore.Instance;
             const xOffset = this.props.column * frame.renderWidth * devicePixelRatio;
             // y-axis is inverted
-            const yOffset = (appStore.numRows - 1 - this.props.row) * frame.renderHeight * devicePixelRatio;
+            const yOffset = (appStore.numImageRows - 1 - this.props.row) * frame.renderHeight * devicePixelRatio;
             this.gl.viewport(xOffset, yOffset, frame.renderWidth * devicePixelRatio, frame.renderHeight * devicePixelRatio);
             this.gl.enable(WebGLRenderingContext.DEPTH_TEST);
 

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -384,8 +384,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                     style={{
                         top: padding.top,
                         left: padding.left,
-                        width: frame && frame.isRenderable ? frame.renderWidth || 1 : 1,
-                        height: frame && frame.isRenderable ? frame.renderHeight || 1 : 1
+                        width: frame?.isRenderable ? frame.renderWidth || 1 : 1,
+                        height: frame?.isRenderable ? frame.renderHeight || 1 : 1
                     }}
                 />
             </div>

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -52,7 +52,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             const h = this.canvas.height;
             ctx.clearRect(0, 0, w, h);
 
-            ctx.drawImage(this.gl.canvas, this.props.column * w, this.props.row * h, w, h, 0, 0, w, h);
+            ctx.drawImage(this.gl.canvas, this.props.column * w, this.props.row * h + 1, w, h, 0, 0, w, h);
         }
     };
 

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -51,8 +51,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             const w = this.canvas.width;
             const h = this.canvas.height;
             ctx.clearRect(0, 0, w, h);
-
-            ctx.drawImage(this.gl.canvas, this.props.column * w, this.props.row * h + 1, w, h, 0, 0, w, h);
+            ctx.drawImage(this.gl.canvas, this.props.column * w, this.props.row * h, w, h, 0, 0, w, h);
         }
     };
 

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -36,7 +36,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private updateCanvas = () => {
         const frame = this.props.frame;
         const tileRenderService = TileWebGLService.Instance;
-        console.log(`Updating canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
+        // console.log(`Updating canvas for frame ${frame.frameInfo.fileId}, panel ${this.panelIndex}`);
         if (frame && this.canvas && this.gl && tileRenderService.cmapTexture) {
             const histStokes = frame.renderConfig.stokes;
             const histChannel = frame.renderConfig.histogram ? frame.renderConfig.histogram.channel : undefined;

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -1,4 +1,4 @@
-@import "../../../../node_modules/@blueprintjs/core/lib/scss/variables.scss";
+@import "~@blueprintjs/core/lib/scss/variables.scss";
 
 .image-toolbar {
     position: absolute;

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -5,6 +5,13 @@
     margin: 5px;
     transition: opacity 400ms;
 
+    flex-wrap: wrap;
+    justify-content: flex-end;
+
+    .bp3-popover2-target {
+        flex: none !important;
+    }
+
     &.docked {
         z-index: 4;
     }

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -4,7 +4,7 @@ import {observer} from "mobx-react";
 import {AnchorButton, ButtonGroup, IconName, Menu, MenuItem, PopoverPosition, Position} from "@blueprintjs/core";
 import {Popover2, Tooltip2} from "@blueprintjs/popover2";
 import {CARTA} from "carta-protobuf";
-import {AppStore, OverlayStore, RegionMode, RegionStore, SystemType} from "stores";
+import {AppStore, FrameStore, OverlayStore, RegionMode, RegionStore, SystemType} from "stores";
 import {ImageViewLayer} from "../ImageViewComponent";
 import {toFixed} from "utilities";
 import {CustomIcon} from "icons/CustomIcons";
@@ -14,6 +14,7 @@ export class ToolbarComponentProps {
     docked: boolean;
     visible: boolean;
     vertical: boolean;
+    frame: FrameStore;
     onActiveLayerChange: (layer: ImageViewLayer) => void;
     activeLayer: ImageViewLayer;
 }
@@ -39,25 +40,22 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
     ]);
 
     handleZoomToActualSizeClicked = () => {
-        AppStore.Instance.activeFrame.setZoom(1.0);
+        this.props.frame.setZoom(1.0);
     };
 
     handleZoomInClicked = () => {
-        const appStore = AppStore.Instance;
-        const frame = appStore.activeFrame.spatialReference || appStore.activeFrame;
+        const frame = this.props.frame.spatialReference || this.props.frame;
         frame.setZoom(frame.zoomLevel * 2.0, true);
     };
 
     handleZoomOutClicked = () => {
-        const appStore = AppStore.Instance;
-        const frame = appStore.activeFrame.spatialReference || appStore.activeFrame;
+        const frame = this.props.frame.spatialReference || this.props.frame;
         frame.setZoom(frame.zoomLevel / 2.0, true);
     };
 
     handleRegionTypeClicked = (type: CARTA.RegionType) => {
-        const appStore = AppStore.Instance;
-        appStore.activeFrame.regionSet.setNewRegionType(type);
-        appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
+        this.props.frame.regionSet.setNewRegionType(type);
+        this.props.frame.regionSet.setMode(RegionMode.CREATING);
     };
 
     handleCoordinateSystemClicked = (coordinateSystem: SystemType) => {
@@ -71,9 +69,9 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         }
         this.props.onActiveLayerChange(layer);
         if (layer === ImageViewLayer.RegionCreating) {
-            appStore.activeFrame.regionSet.setMode(RegionMode.CREATING);
+            this.props.frame.regionSet.setMode(RegionMode.CREATING);
         } else {
-            appStore.activeFrame.regionSet.setMode(RegionMode.MOVING);
+            this.props.frame.regionSet.setMode(RegionMode.MOVING);
         }
     };
 
@@ -96,7 +94,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const appStore = AppStore.Instance;
         const preferenceStore = appStore.preferenceStore;
         const overlay = appStore.overlayStore;
-        const frame = appStore.activeFrame;
+        const frame = this.props.frame;
         const grid = overlay.grid;
 
         let styleProps: CSSProperties = {

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -13,7 +13,7 @@ import "./ToolbarComponent.scss";
 export class ToolbarComponentProps {
     docked: boolean;
     visible: boolean;
-    vertical: boolean;
+    leftAlign: boolean;
     frame: FrameStore;
     onActiveLayerChange: (layer: ImageViewLayer) => void;
     activeLayer: ImageViewLayer;
@@ -97,11 +97,16 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const frame = this.props.frame;
         const grid = overlay.grid;
 
-        let styleProps: CSSProperties = {
+        const styleProps: CSSProperties = {
             bottom: overlay.padding.bottom,
-            right: overlay.padding.right,
             opacity: this.props.visible ? 1 : 0
         };
+
+        if (this.props.leftAlign) {
+            styleProps.left = overlay.padding.left;
+        } else {
+            styleProps.right = overlay.padding.right;
+        }
 
         let className = "image-toolbar";
 
@@ -122,7 +127,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                 </i>
             </span>
         );
-        const tooltipPosition: PopoverPosition = this.props.vertical ? "left" : "top";
+        const tooltipPosition: PopoverPosition = "top";
 
         const regionMenu = (
             <Menu>
@@ -186,7 +191,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const catalogSelectionDisabled = appStore.catalogNum === 0;
 
         return (
-            <ButtonGroup className={className} style={styleProps} vertical={this.props.vertical}>
+            <ButtonGroup className={className} style={styleProps}>
                 <Tooltip2
                     position={tooltipPosition}
                     content={

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -13,7 +13,6 @@ import "./ToolbarComponent.scss";
 export class ToolbarComponentProps {
     docked: boolean;
     visible: boolean;
-    leftAlign: boolean;
     frame: FrameStore;
     onActiveLayerChange: (layer: ImageViewLayer) => void;
     activeLayer: ImageViewLayer;
@@ -99,14 +98,9 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
 
         const styleProps: CSSProperties = {
             bottom: overlay.padding.bottom,
+            right: overlay.padding.right,
             opacity: this.props.visible ? 1 : 0
         };
-
-        if (this.props.leftAlign) {
-            styleProps.left = overlay.padding.left;
-        } else {
-            styleProps.right = overlay.padding.right;
-        }
 
         let className = "image-toolbar";
 

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -99,6 +99,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const styleProps: CSSProperties = {
             bottom: overlay.padding.bottom,
             right: overlay.padding.right,
+            left: overlay.padding.left,
             opacity: this.props.visible ? 1 : 0
         };
 

--- a/src/models/ImagePanelMode.ts
+++ b/src/models/ImagePanelMode.ts
@@ -1,0 +1,5 @@
+export enum ImagePanelMode {
+    None = "none",
+    Dynamic = "dynamic",
+    Fixed = "fixed"
+}

--- a/src/models/ImageTileMode.ts
+++ b/src/models/ImageTileMode.ts
@@ -1,0 +1,5 @@
+export enum ImageTileMode {
+    None = "none",
+    Dynamic = "dynamic",
+    Static = "static"
+}

--- a/src/models/ImageTileMode.ts
+++ b/src/models/ImageTileMode.ts
@@ -1,5 +1,0 @@
-export enum ImageTileMode {
-    None = "none",
-    Dynamic = "dynamic",
-    Static = "static"
-}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -26,4 +26,4 @@ export * from "./StatisticsDefinition";
 export * from "./TypeDefinition";
 export * from "./Snippet";
 export * from "./CatalogControlMap";
-export * from "./ImageTileMode";
+export * from "./ImagePanelMode";

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -26,3 +26,4 @@ export * from "./StatisticsDefinition";
 export * from "./TypeDefinition";
 export * from "./Snippet";
 export * from "./CatalogControlMap";
+export * from "./ImageTileMode";

--- a/src/models/preferences_schema_2.json
+++ b/src/models/preferences_schema_2.json
@@ -268,21 +268,12 @@
         },
         "cursorInfoVisible": {
             "type": "string",
-            "enum": [
-                "always",
-                "activeImage",
-                "hideTiled",
-                "never"
-            ],
+            "enum": ["always", "activeImage", "hideTiled", "never"],
             "default": "activeImage"
         },
         "imagePanelMode": {
             "type": "string",
-            "enum": [
-                "single",
-                "dynamic",
-                "fixed"
-            ],
+            "enum": ["single", "dynamic", "fixed"],
             "default": "none"
         },
         "imagePanelColumns": {

--- a/src/models/preferences_schema_2.json
+++ b/src/models/preferences_schema_2.json
@@ -276,21 +276,21 @@
             ],
             "default": "activeImage"
         },
-        "imageTileMode": {
+        "imagePanelMode": {
             "type": "string",
             "enum": [
-                "none",
+                "single",
                 "dynamic",
-                "static"
+                "fixed"
             ],
             "default": "none"
         },
-        "imageTileColumns": {
+        "imagePanelColumns": {
             "type": "number",
             "minimum": 1,
             "default": 2
         },
-        "imageTileRows": {
+        "imagePanelRows": {
             "type": "number",
             "minimum": 1,
             "default": 2

--- a/src/models/preferences_schema_2.json
+++ b/src/models/preferences_schema_2.json
@@ -268,8 +268,32 @@
         },
         "cursorInfoVisible": {
             "type": "string",
-            "enum": ["always", "activeImage", "hideTiled", "never"],
+            "enum": [
+                "always",
+                "activeImage",
+                "hideTiled",
+                "never"
+            ],
             "default": "activeImage"
+        },
+        "imageTileMode": {
+            "type": "string",
+            "enum": [
+                "none",
+                "dynamic",
+                "static"
+            ],
+            "default": "none"
+        },
+        "imageTileColumns": {
+            "type": "number",
+            "minimum": 1,
+            "default": 2
+        },
+        "imageTileRows": {
+            "type": "number",
+            "minimum": 1,
+            "default": 2
         }
     }
 }

--- a/src/services/ContourWebGLService.ts
+++ b/src/services/ContourWebGLService.ts
@@ -46,12 +46,12 @@ export class ContourWebGLService {
     }
 
     public setCanvasSize = (width: number, height: number) => {
-        if (!this.gl) {
+        // Skip if no update needed
+        if (!this.gl || (this.gl.canvas.width === width && this.gl.canvas.height === height)) {
             return;
         }
         this.gl.canvas.width = width;
         this.gl.canvas.height = height;
-        this.gl.viewport(0, 0, width, height);
     };
 
     private initShaders() {

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -280,7 +280,7 @@ export class TileService {
     }
 
     clearRequestQueue(fileId?: number) {
-        if (fileId === undefined) {
+        if (fileId !== undefined) {
             // Clear all requests with the given file ID
             const fileKey = `${fileId}`;
             this.pendingRequests.forEach((value, key) => {
@@ -421,6 +421,8 @@ export class TileService {
                     this.getCompressedCache(tileMessage.fileId).set(encodedCoordinate, {tile, compressionQuality: tileMessage.compressionQuality});
                     this.asyncDecompressTile(tileMessage.fileId, tileMessage.channel, tileMessage.stokes, tile, tileMessage.compressionQuality, encodedCoordinate);
                 }
+            } else {
+                console.warn(`No pending request for tile (${tile.x}, ${tile.y}, ${tile.layer}) and key=${key}`);
             }
         }
     };

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -81,6 +81,12 @@ export class TileService {
         return this.workersReady && this.workersReady.every(v => v);
     }
 
+    @action setWorkerReady(index: number) {
+        if (index >= 0 && index < this.workersReady.length) {
+            this.workersReady[index] = true;
+        }
+    }
+
     public setAnimationEnabled = (val: boolean) => {
         this.animationEnabled = val;
     };
@@ -128,8 +134,7 @@ export class TileService {
             this.workers[i] = new ZFPWorker();
             this.workers[i].onmessage = (event: MessageEvent) => {
                 if (event.data[0] === "ready") {
-                    this.workersReady[i] = true;
-                    console.log(`Tile Worker ${i} ready`);
+                    this.setWorkerReady(i);
                 } else if (event.data[0] === "decompress") {
                     const buffer = event.data[1];
                     const eventArgs = event.data[2] as TileMessageArgs;
@@ -192,8 +197,8 @@ export class TileService {
             }
             const encodedCoordinate = tile.encode();
             const gpuCacheCoordinate = TileCoordinate.AddFileId(encodedCoordinate, fileId);
-            const pendingRequestsMap = this.pendingRequests.get(key);
-            const tileCached = !channelsChanged && this.cachedTiles.has(gpuCacheCoordinate);
+            const pendingRequestsMap = this.pendingRequests?.get(key);
+            const tileCached = !channelsChanged && this.cachedTiles?.has(gpuCacheCoordinate);
             if (!tileCached && !(pendingRequestsMap && pendingRequestsMap.has(encodedCoordinate))) {
                 const compressedTile = !channelsChanged && this.getCompressedCache(fileId).get(encodedCoordinate);
                 const pendingCompressionMap = this.pendingDecompressions.get(key);

--- a/src/services/TileWebGLService.ts
+++ b/src/services/TileWebGLService.ts
@@ -62,9 +62,11 @@ export class TileWebGLService {
     }
 
     public setCanvasSize = (width: number, height: number) => {
-        if (!this.gl) {
+        // Skip if no update needed
+        if (!this.gl || (this.gl.canvas.width === width && this.gl.canvas.height === height)) {
             return;
         }
+
         this.gl.canvas.width = width;
         this.gl.canvas.height = height;
     };

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -201,8 +201,14 @@ export class AppStore {
 
         try {
             if (fileList?.length) {
+                const frames: FrameStore[] = [];
                 for (const file of fileList) {
-                    await this.loadFile(folderSearchParam, file, "");
+                    frames.push(await this.loadFile(folderSearchParam, file, ""));
+                }
+
+                // Auto-fit loaded frames after panel configuration has been updated.
+                if (this.preferenceStore.zoomMode === Zoom.FIT) {
+                    this.autoFitImages(frames);
                 }
             } else if (this.preferenceStore.autoLaunch) {
                 this.fileBrowserStore.showFileBrowser(BrowserMode.File);
@@ -211,6 +217,15 @@ export class AppStore {
             console.error(err);
         }
     };
+
+    @action autoFitImages(frames: FrameStore[]) {
+        // Frames that have a spatial reference are not auto-fitted.
+        for (const frame of frames) {
+            if (frame && !frame.spatialReference) {
+                frame.fitZoom();
+            }
+        }
+    }
 
     @action handleThemeChange = (darkMode: boolean) => {
         this.systemTheme = darkMode ? "dark" : "light";

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1100,12 +1100,12 @@ export class AppStore {
     private histogramRequirements: Map<number, Array<number>>;
     private pendingChannelHistograms: Map<string, CARTA.IRegionHistogramData>;
 
-    public updateChannels = (updates: ChannelUpdate[]) => {
+    @action updateChannels = (updates: ChannelUpdate[]) => {
         if (!updates || !updates.length) {
             return;
         }
 
-        updates.forEach(update => {
+        for (const update of updates) {
             const frame = update.frame;
             if (!frame) {
                 return;
@@ -1135,7 +1135,7 @@ export class AppStore {
             } else {
                 this.tileService.updateInactiveFileChannel(frame.frameInfo.fileId, frame.channel, frame.stokes);
             }
-        });
+        }
     };
 
     private updateViews = (updates: ViewUpdate[]) => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -100,7 +100,6 @@ export class AppStore {
     @observable activeLayer: ImageViewLayer;
     @observable cursorFrozen: boolean;
     @observable imageGridSize: Point2D;
-    @observable currentImagePage: number;
 
     private appContainer: HTMLElement;
     private fileCounter = 0;
@@ -1193,7 +1192,6 @@ export class AppStore {
         this.frames = [];
         this.activeFrame = null;
         this.imageGridSize = {x: 1, y: 1};
-        this.currentImagePage = 0;
         this.contourDataSource = null;
         this.syncFrameToContour = true;
         this.syncContourToFrame = true;
@@ -1989,8 +1987,14 @@ export class AppStore {
         this.imageGridSize = {x: Math.max(1, columns), y: Math.max(1, rows)};
     }
 
-    @action setImagePage(page: number) {
-        this.currentImagePage = clamp(page, 0, this.numImagePages);
+    @computed get currentImagePage() {
+        if (!this.frames?.length || !this.activeFrame) {
+            return 0;
+        }
+
+        const imagesPerPage = this.imageGridSize.x * this.imageGridSize.y;
+        const index = this.frames.indexOf(this.activeFrame);
+        return Math.floor(index / imagesPerPage);
     }
 
     @computed get visibleFrames(): FrameStore[] {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -28,7 +28,6 @@ import {
     OverlayStore,
     PreferenceKeys,
     PreferenceStore,
-    RasterRenderType,
     RegionFileType,
     RegionStore,
     SnippetStore,
@@ -1493,11 +1492,6 @@ export class AppStore {
                 updatedFrame.stokes = tileStreamDetails.stokes;
             }
             this.pendingChannelHistograms.delete(key);
-        }
-
-        // Switch to tiled rendering. TODO: ensure that the correct frame gets set to tiled
-        if (this.activeFrame) {
-            this.activeFrame.renderType = RasterRenderType.TILED;
         }
     };
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1333,7 +1333,7 @@ export class AppStore {
         autorun(() => {
             if (this.activeFrame) {
                 const updates: ChannelUpdate[] = [];
-                // Calculate if new data is required
+                // Calculate if new data is required for the active channel
                 const updateRequiredChannels = this.activeFrame.requiredChannel !== this.activeFrame.channel || this.activeFrame.requiredStokes !== this.activeFrame.stokes;
                 // Don't auto-update when animation is playing
                 if (!this.animatorStore.animationActive && updateRequiredChannels) {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -36,7 +36,7 @@ import {
     WidgetsStore,
     CURSOR_REGION_ID
 } from ".";
-import {clamp, distinct, divide2D, getColorForTheme, GetRequiredTiles, getTimestamp, mapToObject} from "utilities";
+import {clamp, distinct, getColorForTheme, GetRequiredTiles, getTimestamp, mapToObject} from "utilities";
 import {ApiService, BackendService, ConnectionStatus, ScriptingService, TileService, TileStreamDetails} from "services";
 import {FileId, FrameView, Point2D, PresetLayout, ProtobufProcessing, RegionId, Theme, TileCoordinate, WCSMatchingType} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore} from "./widgets";
@@ -1971,8 +1971,8 @@ export class AppStore {
 
     @action setImageGridSize(columns: number, rows: number) {
         this.imageGridSize = {x: Math.max(1, columns), y: Math.max(1, rows)};
-        const perPanelDimensions = divide2D(this.imageViewDimensions, this.imageGridSize);
-        this.overlayStore.setViewDimension(perPanelDimensions.x, perPanelDimensions.y);
+        this.overlayStore.setNumColumns(this.imageGridSize.x);
+        this.overlayStore.setNumRows(this.imageGridSize.y);
     }
 
     @action setImagePage(page: number) {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1971,8 +1971,6 @@ export class AppStore {
 
     @action setImageGridSize(columns: number, rows: number) {
         this.imageGridSize = {x: Math.max(1, columns), y: Math.max(1, rows)};
-        this.overlayStore.setNumColumns(this.imageGridSize.x);
-        this.overlayStore.setNumRows(this.imageGridSize.y);
     }
 
     @action setImagePage(page: number) {
@@ -1993,6 +1991,16 @@ export class AppStore {
             pageFrames.push(this.frames[i]);
         }
         return pageFrames;
+    }
+
+    @computed get numColumns() {
+        const numImages = this.frames?.length ?? 1;
+        return Math.min(numImages, this.imageGridSize.x);
+    }
+
+    @computed get numRows() {
+        const numImages = this.frames?.length ?? 1;
+        return Math.min(Math.ceil(numImages / this.imageGridSize.x), this.imageGridSize.y);
     }
 
     exportImage = (): boolean => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -37,7 +37,7 @@ import {
 } from ".";
 import {clamp, distinct, getColorForTheme, GetRequiredTiles, getTimestamp, mapToObject} from "utilities";
 import {ApiService, BackendService, ConnectionStatus, ScriptingService, TileService, TileStreamDetails} from "services";
-import {FileId, FrameView, ImagePanelMode, Point2D, PresetLayout, ProtobufProcessing, RegionId, Theme, TileCoordinate, WCSMatchingType} from "models";
+import {FileId, FrameView, ImagePanelMode, Point2D, PresetLayout, ProtobufProcessing, RegionId, Theme, TileCoordinate, WCSMatchingType, Zoom} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore} from "./widgets";
 import {getImageCanvas, ImageViewLayer} from "components";
 import {AppToaster, ErrorToast, SuccessToast, WarningToast} from "components/Shared";
@@ -122,7 +122,14 @@ export class AppStore {
 
     // Image view
     @action setImageViewDimensions = (w: number, h: number) => {
+        const requiresAutoFit = this.preferenceStore.zoomMode === Zoom.FIT && this.overlayStore.fullViewWidth <= 1 && this.overlayStore.fullViewHeight <= 1;
         this.overlayStore.setViewDimension(w, h);
+
+        if (requiresAutoFit) {
+            for (const frame of this.frames) {
+                frame.fitZoom();
+            }
+        }
     };
 
     // Auth

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -38,7 +38,7 @@ import {
 } from ".";
 import {clamp, distinct, getColorForTheme, GetRequiredTiles, getTimestamp, mapToObject} from "utilities";
 import {ApiService, BackendService, ConnectionStatus, ScriptingService, TileService, TileStreamDetails} from "services";
-import {FileId, FrameView, ImageTileMode, Point2D, PresetLayout, ProtobufProcessing, RegionId, Theme, TileCoordinate, WCSMatchingType} from "models";
+import {FileId, FrameView, ImagePanelMode, Point2D, PresetLayout, ProtobufProcessing, RegionId, Theme, TileCoordinate, WCSMatchingType} from "models";
 import {HistogramWidgetStore, RegionWidgetStore, SpatialProfileWidgetStore, SpectralProfileWidgetStore, StatsWidgetStore, StokesAnalysisWidgetStore} from "./widgets";
 import {getImageCanvas, ImageViewLayer} from "components";
 import {AppToaster, ErrorToast, SuccessToast, WarningToast} from "components/Shared";
@@ -2002,26 +2002,26 @@ export class AppStore {
     }
 
     @computed get numImageColumns() {
-        switch (this.preferenceStore.imageTileMode) {
-            case ImageTileMode.None:
+        switch (this.preferenceStore.imagePanelMode) {
+            case ImagePanelMode.None:
                 return 1;
-            case ImageTileMode.Static:
-                return Math.max(1, this.preferenceStore.imageTileColumns);
+            case ImagePanelMode.Fixed:
+                return Math.max(1, this.preferenceStore.imagePanelColumns);
             default:
                 const numImages = this.frames?.length ?? 0;
-                return clamp(numImages, 1, this.preferenceStore.imageTileColumns);
+                return clamp(numImages, 1, this.preferenceStore.imagePanelColumns);
         }
     }
 
     @computed get numImageRows() {
-        switch (this.preferenceStore.imageTileMode) {
-            case ImageTileMode.None:
+        switch (this.preferenceStore.imagePanelMode) {
+            case ImagePanelMode.None:
                 return 1;
-            case ImageTileMode.Static:
-                return Math.max(1, this.preferenceStore.imageTileRows);
+            case ImagePanelMode.Fixed:
+                return Math.max(1, this.preferenceStore.imagePanelRows);
             default:
                 const numImages = this.frames?.length ?? 0;
-                return clamp(Math.ceil(numImages / this.preferenceStore.imageTileColumns), 1, this.preferenceStore.imageTileRows);
+                return clamp(Math.ceil(numImages / this.preferenceStore.imagePanelColumns), 1, this.preferenceStore.imagePanelRows);
         }
     }
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -125,15 +125,6 @@ export class AppStore {
         this.overlayStore.setViewDimension(w, h);
     };
 
-    // Image toolbar
-    @observable imageToolbarVisible: boolean;
-    @action showImageToolbar = () => {
-        this.imageToolbarVisible = true;
-    };
-    @action hideImageToolbar = () => {
-        this.imageToolbarVisible = false;
-    };
-
     // Auth
     @observable username: string = "";
     @action setUsername = (username: string) => {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1994,13 +1994,13 @@ export class AppStore {
     }
 
     @computed get numColumns() {
-        const numImages = this.frames?.length ?? 1;
-        return Math.min(numImages, this.imageGridSize.x);
+        const numImages = this.frames?.length ?? 0;
+        return clamp(numImages, 1, this.imageGridSize.x);
     }
 
     @computed get numRows() {
-        const numImages = this.frames?.length ?? 1;
-        return Math.min(Math.ceil(numImages / this.imageGridSize.x), this.imageGridSize.y);
+        const numImages = this.frames?.length ?? 0;
+        return clamp(Math.ceil(numImages / this.imageGridSize.x), 1, this.imageGridSize.y);
     }
 
     exportImage = (): boolean => {

--- a/src/stores/ColorbarStore.ts
+++ b/src/stores/ColorbarStore.ts
@@ -1,0 +1,77 @@
+import {computed, makeObservable} from "mobx";
+import {FrameStore, OverlayStore} from "stores";
+import {clamp} from "utilities";
+
+export class ColorbarStore {
+    private static readonly TextRatio = [0.5, 0.45, 0.5, 0.45, 0.6];
+    private readonly frame: FrameStore;
+    private readonly overlayStore: OverlayStore;
+    constructor(frame: FrameStore) {
+        makeObservable(this);
+        this.frame = frame;
+        this.overlayStore = OverlayStore.Instance;
+    }
+
+    @computed get roundedNumbers(): {numbers: number[]; precision: number} {
+        const scaleMinVal = this.frame?.renderConfig?.scaleMinVal;
+        const scaleMaxVal = this.frame?.renderConfig?.scaleMaxVal;
+        const tickNum = this.overlayStore.colorbar.tickNum;
+        if (!isFinite(scaleMinVal) || !isFinite(scaleMaxVal) || scaleMinVal >= scaleMaxVal || !tickNum) {
+            return null;
+        } else {
+            let dy = (scaleMaxVal - scaleMinVal) / tickNum; // estimate the step
+            let precision = -ColorbarStore.GetPrecision(dy); // estimate precision
+            const roundBase = Math.pow(10, precision);
+            const min = Math.round(scaleMinVal * roundBase) / roundBase;
+            dy = Math.ceil(dy * roundBase) / roundBase; // the exact step
+            precision = -ColorbarStore.GetPrecision(dy); // the exact precision of the step
+
+            const indexArray = Array.from(Array(tickNum).keys());
+            let numbers = indexArray.map(x => min + dy * (x + (min <= scaleMinVal ? 1 : 0)));
+
+            const isOutofBound = (element: number) => element >= scaleMaxVal;
+            const outofBoundIndex = numbers.findIndex(isOutofBound);
+            if (outofBoundIndex !== -1) {
+                numbers = numbers.slice(0, outofBoundIndex);
+            }
+            return {numbers: numbers, precision: precision};
+        }
+    }
+
+    @computed get texts(): string[] {
+        if (!this.roundedNumbers) {
+            return [];
+        }
+        const orders = this.roundedNumbers.numbers.map(x => ColorbarStore.GetOrder(x));
+        const maxOrder = Math.max(...orders);
+        const minOrder = Math.min(...orders);
+        if (maxOrder >= 5.0 || minOrder <= -5.0) {
+            return this.roundedNumbers.numbers.map(x =>
+                x.toExponential(this.overlayStore.colorbar.numberCustomPrecision ? this.overlayStore.colorbar.numberPrecision : x === 0 ? 0 : clamp(this.roundedNumbers.precision + ColorbarStore.GetPrecision(x), 0, 50))
+            );
+        } else {
+            return this.roundedNumbers.numbers.map(x => x.toFixed(this.overlayStore.colorbar.numberCustomPrecision ? this.overlayStore.colorbar.numberPrecision : clamp(this.roundedNumbers.precision, 0, 50)));
+        }
+    }
+
+    @computed get positions(): number[] {
+        const scaleMinVal = this.frame?.renderConfig?.scaleMinVal;
+        const scaleMaxVal = this.frame?.renderConfig?.scaleMaxVal;
+        if (!this.roundedNumbers || !this.frame || !isFinite(this.overlayStore.colorbar.yOffset)) {
+            return [];
+        }
+        if (this.overlayStore.colorbar.position === "right") {
+            return this.roundedNumbers.numbers.map(x => this.overlayStore.colorbar.yOffset + (this.overlayStore.colorbar.height * (scaleMaxVal - x)) / (scaleMaxVal - scaleMinVal));
+        } else {
+            return this.roundedNumbers.numbers.map(x => this.overlayStore.colorbar.yOffset + (this.overlayStore.colorbar.height * (x - scaleMinVal)) / (scaleMaxVal - scaleMinVal));
+        }
+    }
+
+    private static GetOrder = (x: number): number => {
+        return x === 0 ? 0 : Math.log10(Math.abs(x));
+    };
+
+    private static GetPrecision = (x: number): number => {
+        return Math.floor(ColorbarStore.GetOrder(x));
+    };
+}

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -44,11 +44,6 @@ export interface FrameInfo {
     beamTable: CARTA.IBeam[];
 }
 
-export enum RasterRenderType {
-    NONE,
-    TILED
-}
-
 export const WCS_PRECISION = 10;
 
 export class FrameStore {
@@ -99,7 +94,6 @@ export class FrameStore {
     @observable requiredStokes: number;
     @observable requiredChannel: number;
     @observable animationChannelRange: NumberRange;
-    @observable renderType: RasterRenderType;
     @observable currentFrameView: FrameView;
     @observable currentCompressionQuality: number;
     @observable renderConfig: RenderConfigStore;
@@ -763,7 +757,6 @@ export class FrameStore {
         this.renderConfig = new RenderConfigStore(preferenceStore, this);
         this.contourConfig = new ContourConfigStore(preferenceStore);
         this.contourStores = new Map<number, ContourStore>();
-        this.renderType = RasterRenderType.NONE;
         this.moving = false;
         this.zooming = false;
         this.colorbarLabelCustomText = this.unit === undefined || !this.unit.length ? "arbitrary units" : this.unit;
@@ -1676,10 +1669,6 @@ export class FrameStore {
 
     @action setAnimationRange = (range: NumberRange) => {
         this.animationChannelRange = range;
-    };
-
-    @action setRasterRenderType = (renderType: RasterRenderType) => {
-        this.renderType = renderType;
     };
 
     @action startMoving = () => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -211,7 +211,6 @@ export class FrameStore {
             const mipLog2 = Math.log2(mipExact);
             const mipLog2Rounded = Math.round(mipLog2);
             const mipRoundedPow2 = Math.pow(2, mipLog2Rounded);
-
             return {
                 xMin: this.center.x - imageWidth / 2.0,
                 xMax: this.center.x + imageWidth / 2.0,

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -32,6 +32,7 @@ import {clamp, formattedFrequency, getHeaderNumericValue, getTransformedChannel,
 import {BackendService, CatalogWebGLService, ContourWebGLService, TILE_SIZE} from "services";
 import {RegionId} from "stores/widgets";
 import {formattedArcsec} from "utilities";
+import {ColorbarStore} from "./ColorbarStore";
 
 export interface FrameInfo {
     fileId: number;
@@ -68,6 +69,7 @@ export class FrameStore {
     public readonly wcsInfo3D: AST.FrameSet;
     public readonly validWcs: boolean;
     public readonly frameInfo: FrameInfo;
+    public readonly colorbarStore: ColorbarStore;
 
     public spectralCoordsSupported: Map<string, {type: SpectralType; unit: SpectralUnit}>;
     public spectralSystemsSupported: Array<SpectralSystem>;
@@ -755,6 +757,7 @@ export class FrameStore {
         this.requiredStokes = 0;
         this.requiredChannel = 0;
         this.renderConfig = new RenderConfigStore(preferenceStore, this);
+        this.colorbarStore = new ColorbarStore(this);
         this.contourConfig = new ContourConfigStore(preferenceStore);
         this.contourStores = new Map<number, ContourStore>();
         this.moving = false;

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -910,11 +910,11 @@ export class OverlayColorbarSettings {
     }
 
     @computed get numberWidth(): number {
-        const activeFrame = AppStore.Instance.activeFrame;
-        if (!activeFrame) {
-            return 0;
+        let textWidth = 0;
+        for (const frame of AppStore.Instance.visibleFrames) {
+            const frameTextWidth = Math.max(...frame.colorbarStore.texts.map(x => x.length)) * this.textRatio[clamp(Math.floor(this.numberFont / 4), 0, this.textRatio.length)];
+            textWidth = Math.max(textWidth, frameTextWidth);
         }
-        const textWidth = Math.max(...activeFrame.colorbarStore.texts.map(x => x.length)) * this.textRatio[clamp(Math.floor(this.numberFont / 4), 0, this.textRatio.length)];
         return this.numberVisible ? this.numberFontSize * (this.numberRotation || this.position !== "right" ? 1 : textWidth) + this.textGap : 0;
     }
 

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -1283,11 +1283,11 @@ export class OverlayStore {
     }
 
     @computed get viewWidth() {
-        return this.fullViewWidth / AppStore.Instance.numColumns;
+        return this.fullViewWidth / AppStore.Instance.numImageColumns;
     }
 
     @computed get viewHeight() {
-        return this.fullViewHeight / AppStore.Instance.numRows;
+        return this.fullViewHeight / AppStore.Instance.numImageRows;
     }
 
     @computed get renderWidth() {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -1283,11 +1283,11 @@ export class OverlayStore {
     }
 
     @computed get viewWidth() {
-        return this.fullViewWidth / (AppStore.Instance.numColumns);
+        return this.fullViewWidth / AppStore.Instance.numColumns;
     }
 
     @computed get viewHeight() {
-        return this.fullViewHeight / (AppStore.Instance.numRows);
+        return this.fullViewHeight / AppStore.Instance.numRows;
     }
 
     @computed get renderWidth() {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -1224,11 +1224,11 @@ export class OverlayStore {
     }
 
     @computed get viewWidth() {
-        return this.fullViewWidth / AppStore.Instance.numImageColumns;
+        return Math.floor(this.fullViewWidth / AppStore.Instance.numImageColumns);
     }
 
     @computed get viewHeight() {
-        return this.fullViewHeight / AppStore.Instance.numImageRows;
+        return Math.floor(this.fullViewHeight / AppStore.Instance.numImageRows);
     }
 
     @computed get renderWidth() {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -1075,8 +1075,11 @@ export class OverlayStore {
     }
 
     // View size options
-    @observable viewWidth: number;
-    @observable viewHeight: number;
+    @observable fullViewWidth: number;
+    @observable fullViewHeight: number;
+
+    @observable numRows: number;
+    @observable numColumns: number;
 
     // Individual settings
     @observable global: OverlayGlobalSettings;
@@ -1102,8 +1105,11 @@ export class OverlayStore {
         this.ticks = new OverlayTickSettings();
         this.colorbar = new OverlayColorbarSettings();
         this.beam = new OverlayBeamSettings();
-        this.viewHeight = 1;
-        this.viewWidth = 1;
+        this.fullViewWidth = 1;
+        this.fullViewHeight = 1;
+
+        this.numRows = 2;
+        this.numColumns = 2;
 
         // if the system is manually selected, set new default formats & update active frame's wcs settings
         autorun(() => {
@@ -1136,8 +1142,16 @@ export class OverlayStore {
     }
 
     @action setViewDimension = (width: number, height: number) => {
-        this.viewWidth = width;
-        this.viewHeight = height;
+        this.fullViewWidth = width;
+        this.fullViewHeight = height;
+    };
+
+    @action setNumColumns = (cols: number) => {
+        this.numColumns = cols;
+    };
+
+    @action setNumRows = (rows: number) => {
+        this.numRows = rows;
     };
 
     @action setFormatsFromSystem() {
@@ -1280,6 +1294,14 @@ export class OverlayStore {
             top: this.paddingTop,
             bottom: this.paddingBottom
         };
+    }
+
+    @computed get viewWidth() {
+        return this.fullViewWidth / this.numColumns;
+    }
+
+    @computed get viewHeight() {
+        return this.fullViewHeight / this.numRows;
     }
 
     @computed get renderWidth() {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -1078,9 +1078,6 @@ export class OverlayStore {
     @observable fullViewWidth: number;
     @observable fullViewHeight: number;
 
-    @observable numRows: number;
-    @observable numColumns: number;
-
     // Individual settings
     @observable global: OverlayGlobalSettings;
     @observable title: OverlayTitleSettings;
@@ -1107,9 +1104,6 @@ export class OverlayStore {
         this.beam = new OverlayBeamSettings();
         this.fullViewWidth = 1;
         this.fullViewHeight = 1;
-
-        this.numRows = 2;
-        this.numColumns = 2;
 
         // if the system is manually selected, set new default formats & update active frame's wcs settings
         autorun(() => {
@@ -1144,14 +1138,6 @@ export class OverlayStore {
     @action setViewDimension = (width: number, height: number) => {
         this.fullViewWidth = width;
         this.fullViewHeight = height;
-    };
-
-    @action setNumColumns = (cols: number) => {
-        this.numColumns = cols;
-    };
-
-    @action setNumRows = (rows: number) => {
-        this.numRows = rows;
     };
 
     @action setFormatsFromSystem() {
@@ -1297,11 +1283,11 @@ export class OverlayStore {
     }
 
     @computed get viewWidth() {
-        return this.fullViewWidth / this.numColumns;
+        return this.fullViewWidth / (AppStore.Instance.numColumns);
     }
 
     @computed get viewHeight() {
-        return this.fullViewHeight / this.numRows;
+        return this.fullViewHeight / (AppStore.Instance.numRows);
     }
 
     @computed get renderWidth() {

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -2,7 +2,7 @@ import {action, computed, observable, makeObservable} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {BeamType, ContourGeneratorType, FileFilteringType, FrameScaling} from "stores";
-import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, ImageTileMode, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, ImagePanelMode, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {parseBoolean} from "utilities";
 import {ApiService} from "services";
 
@@ -83,9 +83,9 @@ export enum PreferenceKeys {
 
     PIXEL_GRID_VISIBLE = "pixelGridVisible",
     PIXEL_GRID_COLOR = "pixelGridColor",
-    IMAGE_TILE_MODE = "imageTileMode",
-    IMAGE_TILE_COLUMNS = "imageTileColumns",
-    IMAGE_TILE_ROWS = "imageTileRows"
+    IMAGE_PANEL_MODE = "imagePanelMode",
+    IMAGE_PANEL_COLUMNS = "imagePanelColumns",
+    IMAGE_PANEL_ROWS = "imagePanelRows"
 }
 
 const DEFAULTS = {
@@ -94,9 +94,9 @@ const DEFAULTS = {
         fileFilteringType: FileFilteringType.Fuzzy,
         pixelGridVisible: false,
         pixelGridColor: "#FFFFFF",
-        imageTileMode: ImageTileMode.None,
-        imageTileColumns: 2,
-        imageTileRows: 2
+        imagePanelMode: ImagePanelMode.None,
+        imagePanelColumns: 2,
+        imagePanelRows: 2
     },
     GLOBAL: {
         theme: Theme.AUTO,
@@ -497,16 +497,16 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW) ?? DEFAULTS.PERFORMANCE.limitOverlayRedraw;
     }
 
-    @computed get imageTileMode(): ImageTileMode {
-        return this.preferences.get(PreferenceKeys.IMAGE_TILE_MODE) ?? DEFAULTS.SILENT.imageTileMode;
+    @computed get imagePanelMode(): ImagePanelMode {
+        return this.preferences.get(PreferenceKeys.IMAGE_PANEL_MODE) ?? DEFAULTS.SILENT.imagePanelMode;
     }
 
-    @computed get imageTileColumns(): number {
-        return this.preferences.get(PreferenceKeys.IMAGE_TILE_COLUMNS) ?? DEFAULTS.SILENT.imageTileColumns;
+    @computed get imagePanelColumns(): number {
+        return this.preferences.get(PreferenceKeys.IMAGE_PANEL_COLUMNS) ?? DEFAULTS.SILENT.imagePanelColumns;
     }
 
-    @computed get imageTileRows(): number {
-        return this.preferences.get(PreferenceKeys.IMAGE_TILE_ROWS) ?? DEFAULTS.SILENT.imageTileRows;
+    @computed get imagePanelRows(): number {
+        return this.preferences.get(PreferenceKeys.IMAGE_PANEL_ROWS) ?? DEFAULTS.SILENT.imagePanelRows;
     }
 
     @action setPreference = async (key: PreferenceKeys, value: any) => {
@@ -551,9 +551,9 @@ export class PreferenceStore {
             PreferenceKeys.SILENT_FILE_FILTERING_TYPE,
             PreferenceKeys.PIXEL_GRID_VISIBLE,
             PreferenceKeys.PIXEL_GRID_COLOR,
-            PreferenceKeys.IMAGE_TILE_MODE,
-            PreferenceKeys.IMAGE_TILE_COLUMNS,
-            PreferenceKeys.IMAGE_TILE_ROWS
+            PreferenceKeys.IMAGE_PANEL_MODE,
+            PreferenceKeys.IMAGE_PANEL_COLUMNS,
+            PreferenceKeys.IMAGE_PANEL_ROWS
         ]);
     };
 

--- a/src/stores/PreferenceStore.ts
+++ b/src/stores/PreferenceStore.ts
@@ -2,7 +2,7 @@ import {action, computed, observable, makeObservable} from "mobx";
 import {Colors} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {BeamType, ContourGeneratorType, FileFilteringType, FrameScaling} from "stores";
-import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, ImageTileMode, PresetLayout, RegionCreationMode, SpectralType, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {parseBoolean} from "utilities";
 import {ApiService} from "services";
 
@@ -82,7 +82,10 @@ export enum PreferenceKeys {
     CATALOG_TABLE_SEPARATOR_POSITION = "catalogTableSeparatorPosition",
 
     PIXEL_GRID_VISIBLE = "pixelGridVisible",
-    PIXEL_GRID_COLOR = "pixelGridColor"
+    PIXEL_GRID_COLOR = "pixelGridColor",
+    IMAGE_TILE_MODE = "imageTileMode",
+    IMAGE_TILE_COLUMNS = "imageTileColumns",
+    IMAGE_TILE_ROWS = "imageTileRows"
 }
 
 const DEFAULTS = {
@@ -90,7 +93,10 @@ const DEFAULTS = {
         fileSortingString: "-date",
         fileFilteringType: FileFilteringType.Fuzzy,
         pixelGridVisible: false,
-        pixelGridColor: "#FFFFFF"
+        pixelGridColor: "#FFFFFF",
+        imageTileMode: ImageTileMode.None,
+        imageTileColumns: 2,
+        imageTileRows: 2
     },
     GLOBAL: {
         theme: Theme.AUTO,
@@ -491,6 +497,18 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW) ?? DEFAULTS.PERFORMANCE.limitOverlayRedraw;
     }
 
+    @computed get imageTileMode(): ImageTileMode {
+        return this.preferences.get(PreferenceKeys.IMAGE_TILE_MODE) ?? DEFAULTS.SILENT.imageTileMode;
+    }
+
+    @computed get imageTileColumns(): number {
+        return this.preferences.get(PreferenceKeys.IMAGE_TILE_COLUMNS) ?? DEFAULTS.SILENT.imageTileColumns;
+    }
+
+    @computed get imageTileRows(): number {
+        return this.preferences.get(PreferenceKeys.IMAGE_TILE_ROWS) ?? DEFAULTS.SILENT.imageTileRows;
+    }
+
     @action setPreference = async (key: PreferenceKeys, value: any) => {
         if (!key) {
             return false;
@@ -528,7 +546,15 @@ export class PreferenceStore {
 
     // reset functions
     @action resetSilentSettings = () => {
-        this.clearPreferences([PreferenceKeys.SILENT_FILE_SORTING_STRING, PreferenceKeys.SILENT_FILE_FILTERING_TYPE, PreferenceKeys.PIXEL_GRID_VISIBLE, PreferenceKeys.PIXEL_GRID_COLOR]);
+        this.clearPreferences([
+            PreferenceKeys.SILENT_FILE_SORTING_STRING,
+            PreferenceKeys.SILENT_FILE_FILTERING_TYPE,
+            PreferenceKeys.PIXEL_GRID_VISIBLE,
+            PreferenceKeys.PIXEL_GRID_COLOR,
+            PreferenceKeys.IMAGE_TILE_MODE,
+            PreferenceKeys.IMAGE_TILE_COLUMNS,
+            PreferenceKeys.IMAGE_TILE_ROWS
+        ]);
     };
 
     @action resetGlobalSettings = () => {

--- a/src/utilities/math2d.ts
+++ b/src/utilities/math2d.ts
@@ -26,6 +26,14 @@ export function scale2D(a: Point2D, s: number): Point2D {
     return {x: a.x * s, y: a.y * s};
 }
 
+export function multiply2D(a: Point2D, b: Point2D): Point2D {
+    return {x: a.x * b.x, y: a.y * b.y};
+}
+
+export function divide2D(a: Point2D, b: Point2D): Point2D {
+    return {x: a.x / b.x, y: a.y / b.y};
+}
+
 export function normal2D(a: Point2D, b: Point2D): Point2D {
     const delta = normalize2D(subtract2D(a, b));
     return perpVector2D(delta);


### PR DESCRIPTION
Closes #1259. Some bugs will be solved in separate issues. The main aim of this PR is to add an experimental multi-panel view without breaking the existing single-panel view.

- [x] Handle image export in multi-panel view.
- [x] Required tiles are sometimes not updated when zooming in, resulting in pixelated images.
- [x] Beam profile overlays not implemented correctly yet
- [x] The image toolbar should only show up on one panel at a time, and be aligned correctly
- [x] Catalogs should be rendered correctly
- [x] Colorbar's colormap and values should be determined per-image
- [x] Active panel highlight needs to be adjusted to be more obvious
- [x] Disable columns/rows spinner when multi-panel is disabled. Adjust text when in dynamic grid mode
- [x] Align non-ideal state 
- [x] Images sometimes don't show up if you load them simultaneously.