### PR TITLE
Angus/1571 raster image not updated

### DIFF
--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -243,7 +243,7 @@ export class TileService {
         }
     }
 
-    updateInactiveFileChannel(fileId: number, channel: number, stokes: number) {
+    updateHiddenFileChannels(fileId: number, channel: number, stokes: number) {
         this.clearCompressedCache(fileId);
         this.clearGPUCache(fileId);
         this.channelMap.set(fileId, {channel, stokes});

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -245,6 +245,7 @@ export class TileService {
 
     updateInactiveFileChannel(fileId: number, channel: number, stokes: number) {
         this.clearCompressedCache(fileId);
+        this.clearGPUCache(fileId);
         this.channelMap.set(fileId, {channel, stokes});
         this.backendService.setChannels(fileId, channel, stokes, {});
     }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1150,7 +1150,7 @@ export class AppStore {
                 const midPointTileCoords = {x: midPointImageCoords.x / tileSizeFullRes - 0.5, y: midPointImageCoords.y / tileSizeFullRes - 0.5};
                 this.tileService.requestTiles(tiles, frame.frameInfo.fileId, frame.channel, frame.stokes, midPointTileCoords, this.preferenceStore.imageCompressionQuality, true);
             } else {
-                this.tileService.updateInactiveFileChannel(frame.frameInfo.fileId, frame.channel, frame.stokes);
+                this.tileService.updateHiddenFileChannels(frame.frameInfo.fileId, frame.channel, frame.stokes);
             }
         }
     };


### PR DESCRIPTION
Closes #1571 by making sure hidden images' GPU cache is also cleared when changing channels. As @kswang1029 speculated, this was introduced by #1288.