### PR TITLE
Angus/1613 toolbar

### DIFF
--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -188,137 +188,148 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
 
         return (
             <ButtonGroup className={className} style={styleProps}>
-                <Tooltip2
-                    position={tooltipPosition}
-                    content={
-                        <span>
-                            Measure distance
-                            <br />
-                            <i>
-                                <small>Click to create geodesic curves.</small>
-                            </i>
-                        </span>
-                    }
-                >
-                    <AnchorButton icon={<CustomIcon icon="distanceMeasuring" />} active={appStore.activeLayer === ImageViewLayer.DistanceMeasuring} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.DistanceMeasuring)} />
-                </Tooltip2>
-                <Tooltip2
-                    position={tooltipPosition}
-                    content={
-                        <span>
-                            Catalog selection
-                            <br />
-                            <i>
-                                <small>Click to select single catalog source</small>
-                            </i>
-                        </span>
-                    }
-                >
-                    <AnchorButton icon={"locate"} active={catalogOverlayEnabled} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.Catalog)} disabled={catalogSelectionDisabled} />
-                </Tooltip2>
-                {frame.regionSet.mode === RegionMode.CREATING && (
-                    <Tooltip2
-                        position={tooltipPosition}
-                        content={
-                            <span>
-                                Create region
-                                <br />
-                                <i>
-                                    <small>Click to select region type</small>
-                                </i>
-                            </span>
-                        }
-                    >
-                        <Popover2 popoverClassName="region-menu" content={regionMenu} position={Position.TOP} minimal={true}>
-                            <AnchorButton icon={regionIcon} active={appStore.activeLayer === ImageViewLayer.RegionCreating} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionCreating)} />
-                        </Popover2>
-                    </Tooltip2>
-                )}
-                {frame.regionSet.mode === RegionMode.MOVING && (
-                    <Tooltip2
-                        position={tooltipPosition}
-                        content={
-                            <span>
-                                Create region
-                                <br />
-                                <i>
-                                    <small>
-                                        Double-click to select region type.
+                {appStore.toolbarExpanded && (
+                    <React.Fragment>
+                        <Tooltip2
+                            position={tooltipPosition}
+                            content={
+                                <span>
+                                    Measure distance
+                                    <br />
+                                    <i>
+                                        <small>Click to create geodesic curves.</small>
+                                    </i>
+                                </span>
+                            }
+                        >
+                            <AnchorButton icon={<CustomIcon icon="distanceMeasuring" />} active={appStore.activeLayer === ImageViewLayer.DistanceMeasuring} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.DistanceMeasuring)} />
+                        </Tooltip2>
+                        <Tooltip2
+                            position={tooltipPosition}
+                            content={
+                                <span>
+                                    Catalog selection
+                                    <br />
+                                    <i>
+                                        <small>Click to select single catalog source</small>
+                                    </i>
+                                </span>
+                            }
+                        >
+                            <AnchorButton icon={"locate"} active={catalogOverlayEnabled} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.Catalog)} disabled={catalogSelectionDisabled} />
+                        </Tooltip2>
+                        {frame.regionSet.mode === RegionMode.CREATING && (
+                            <Tooltip2
+                                position={tooltipPosition}
+                                content={
+                                    <span>
+                                        Create region
                                         <br />
-                                        Press C to enter creation mode.
+                                        <i>
+                                            <small>Click to select region type</small>
+                                        </i>
+                                    </span>
+                                }
+                            >
+                                <Popover2 popoverClassName="region-menu" content={regionMenu} position={Position.TOP} minimal={true}>
+                                    <AnchorButton icon={regionIcon} active={appStore.activeLayer === ImageViewLayer.RegionCreating} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionCreating)} />
+                                </Popover2>
+                            </Tooltip2>
+                        )}
+                        {frame.regionSet.mode === RegionMode.MOVING && (
+                            <Tooltip2
+                                position={tooltipPosition}
+                                content={
+                                    <span>
+                                        Create region
+                                        <br />
+                                        <i>
+                                            <small>
+                                                Double-click to select region type.
+                                                <br />
+                                                Press C to enter creation mode.
+                                            </small>
+                                        </i>
+                                    </span>
+                                }
+                            >
+                                <AnchorButton icon={regionIcon} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionCreating)} />
+                            </Tooltip2>
+                        )}
+                        <Tooltip2 position={tooltipPosition} content="Select and pan mode">
+                            <AnchorButton
+                                icon={"hand"}
+                                onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionMoving)}
+                                active={frame.regionSet.mode === RegionMode.MOVING && appStore.activeLayer === ImageViewLayer.RegionMoving}
+                            />
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom in (Scroll wheel up){currentZoomSpan}</span>}>
+                            <AnchorButton icon={"zoom-in"} onClick={this.handleZoomInClicked} />
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom out (Scroll wheel down){currentZoomSpan}</span>}>
+                            <AnchorButton icon={"zoom-out"} onClick={this.handleZoomOutClicked} />
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom to 1.0x{currentZoomSpan}</span>}>
+                            <AnchorButton className={"full-zoom-button"} onClick={this.handleZoomToActualSizeClicked}>
+                                1.0x
+                            </AnchorButton>
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
+                            <AnchorButton icon="zoom-to-fit" onClick={frame.fitZoom} />
+                        </Tooltip2>
+                        <Tooltip2
+                            position={tooltipPosition}
+                            content={
+                                <span>
+                                    WCS Matching <br />
+                                    <small>
+                                        <i>Current: {wcsButtonTooltip}</i>
                                     </small>
-                                </i>
-                            </span>
-                        }
-                    >
-                        <AnchorButton icon={regionIcon} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionCreating)} />
-                    </Tooltip2>
+                                </span>
+                            }
+                        >
+                            <Popover2 content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
+                                <AnchorButton icon="link" className="link-button">
+                                    {wcsButtonSuperscript}
+                                </AnchorButton>
+                            </Popover2>
+                        </Tooltip2>
+                        <Tooltip2
+                            position={tooltipPosition}
+                            content={
+                                <span>
+                                    Overlay Coordinate <br />
+                                    <small>
+                                        <i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i>
+                                    </small>
+                                </span>
+                            }
+                        >
+                            <Popover2 content={coordinateSystemMenu} position={Position.TOP} minimal={true}>
+                                <AnchorButton disabled={!frame.validWcs} text={ToolbarComponent.CoordinateSystemName.get(coordinateSystem)} />
+                            </Popover2>
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content="Toggle grid">
+                            <AnchorButton icon="grid" active={grid.visible} onClick={() => grid.setVisible(!grid.visible)} />
+                        </Tooltip2>
+                        <Tooltip2 position={tooltipPosition} content="Toggle labels">
+                            <AnchorButton icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels} />
+                        </Tooltip2>
+                        <Tooltip2
+                            position={tooltipPosition}
+                            content={
+                                <span>
+                                    {`Export image (${appStore.modifierString}E)`}
+                                    {this.exportImageTooltip()}
+                                </span>
+                            }
+                        >
+                            <AnchorButton icon="floppy-disk" onClick={appStore.exportImage} />
+                        </Tooltip2>
+                    </React.Fragment>
                 )}
-                <Tooltip2 position={tooltipPosition} content="Select and pan mode">
-                    <AnchorButton icon={"hand"} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionMoving)} active={frame.regionSet.mode === RegionMode.MOVING && appStore.activeLayer === ImageViewLayer.RegionMoving} />
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content={<span>Zoom in (Scroll wheel up){currentZoomSpan}</span>}>
-                    <AnchorButton icon={"zoom-in"} onClick={this.handleZoomInClicked} />
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content={<span>Zoom out (Scroll wheel down){currentZoomSpan}</span>}>
-                    <AnchorButton icon={"zoom-out"} onClick={this.handleZoomOutClicked} />
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content={<span>Zoom to 1.0x{currentZoomSpan}</span>}>
-                    <AnchorButton className={"full-zoom-button"} onClick={this.handleZoomToActualSizeClicked}>
-                        1.0x
-                    </AnchorButton>
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
-                    <AnchorButton icon="zoom-to-fit" onClick={frame.fitZoom} />
-                </Tooltip2>
-                <Tooltip2
-                    position={tooltipPosition}
-                    content={
-                        <span>
-                            WCS Matching <br />
-                            <small>
-                                <i>Current: {wcsButtonTooltip}</i>
-                            </small>
-                        </span>
-                    }
-                >
-                    <Popover2 content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
-                        <AnchorButton icon="link" className="link-button">
-                            {wcsButtonSuperscript}
-                        </AnchorButton>
-                    </Popover2>
-                </Tooltip2>
-                <Tooltip2
-                    position={tooltipPosition}
-                    content={
-                        <span>
-                            Overlay Coordinate <br />
-                            <small>
-                                <i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i>
-                            </small>
-                        </span>
-                    }
-                >
-                    <Popover2 content={coordinateSystemMenu} position={Position.TOP} minimal={true}>
-                        <AnchorButton disabled={!frame.validWcs} text={ToolbarComponent.CoordinateSystemName.get(coordinateSystem)} />
-                    </Popover2>
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content="Toggle grid">
-                    <AnchorButton icon="grid" active={grid.visible} onClick={() => grid.setVisible(!grid.visible)} />
-                </Tooltip2>
-                <Tooltip2 position={tooltipPosition} content="Toggle labels">
-                    <AnchorButton icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels} />
-                </Tooltip2>
-                <Tooltip2
-                    position={tooltipPosition}
-                    content={
-                        <span>
-                            {`Export image (${appStore.modifierString}E)`}
-                            {this.exportImageTooltip()}
-                        </span>
-                    }
-                >
-                    <AnchorButton icon="floppy-disk" onClick={appStore.exportImage} />
+                <Tooltip2 position={tooltipPosition} content={appStore.toolbarExpanded ? "Hide toolbar" : "Show toolbar"}>
+                    <AnchorButton icon={appStore.toolbarExpanded ? "double-chevron-right" : "double-chevron-left"} onClick={appStore.toggleToolbarExpanded} />
                 </Tooltip2>
             </ButtonGroup>
         );

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -329,7 +329,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     </React.Fragment>
                 )}
                 <Tooltip2 position={tooltipPosition} content={appStore.toolbarExpanded ? "Hide toolbar" : "Show toolbar"}>
-                    <AnchorButton icon={appStore.toolbarExpanded ? "double-chevron-right" : "double-chevron-left"} onClick={appStore.toggleToolbarExpanded} />
+                    <AnchorButton active={appStore.toolbarExpanded} icon={appStore.toolbarExpanded ? "double-chevron-right" : "double-chevron-left"} onClick={appStore.toggleToolbarExpanded} />
                 </Tooltip2>
             </ButtonGroup>
         );

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -112,6 +112,7 @@ export class AppStore {
     // ImageViewer
     @observable activeLayer: ImageViewLayer;
     @observable cursorFrozen: boolean;
+    @observable toolbarExpanded: boolean;
 
     private appContainer: HTMLElement;
     private fileCounter = 0;
@@ -1085,6 +1086,14 @@ export class AppStore {
         this.cursorFrozen = val;
     };
 
+    @action toggleToolbarExpanded = () => {
+        this.toolbarExpanded = !this.toolbarExpanded;
+    };
+
+    @action setToolbarExpanded = (val: boolean) => {
+        this.toolbarExpanded = val;
+    };
+
     @action updateActiveLayer = (layer: ImageViewLayer) => {
         this.activeLayer = layer;
     };
@@ -1237,6 +1246,7 @@ export class AppStore {
         this.syncContourToFrame = true;
         this.initRequirements();
         this.activeLayer = ImageViewLayer.RegionMoving;
+        this.toolbarExpanded = true;
 
         AST.onReady.then(
             action(() => {


### PR DESCRIPTION
closes #1613 by making the toolbar expandable/shrinkable. Expanded by default when the user starts CARTA.

![image](https://user-images.githubusercontent.com/592504/128829448-b050a517-b123-4d39-a749-215afc0c68b9.png)

![image](https://user-images.githubusercontent.com/592504/128829595-852cc18b-9ab4-4573-a326-f80433a7513a.png)

(note: hide whitespace changes in the "Files changed" tab to get rid of the annoying indentation changes from Prettier)