### PR TITLE
Yuhsuan/1605_colorbar_tick_num

### DIFF
--- a/src/stores/ColorbarStore.ts
+++ b/src/stores/ColorbarStore.ts
@@ -21,18 +21,17 @@ export class ColorbarStore {
         } else {
             let dy = (scaleMaxVal - scaleMinVal) / tickNum; // estimate the step
             let precision = -ColorbarStore.GetPrecision(dy); // estimate precision
-            const roundBase = Math.pow(10, precision);
-            const min = Math.round(scaleMinVal * roundBase) / roundBase;
-            dy = Math.ceil(dy * roundBase) / roundBase; // the exact step
+            let roundBase = Math.pow(10, precision);
+            dy = Math.round(dy * roundBase) / roundBase; // the exact step
             precision = -ColorbarStore.GetPrecision(dy); // the exact precision of the step
+            roundBase = Math.pow(10, precision);
+            const min = Math.round(scaleMinVal * roundBase) / roundBase;
 
-            const indexArray = Array.from(Array(tickNum).keys());
-            let numbers = indexArray.map(x => min + dy * (x + (min <= scaleMinVal ? 1 : 0)));
-
-            const isOutofBound = (element: number) => element >= scaleMaxVal;
-            const outofBoundIndex = numbers.findIndex(isOutofBound);
-            if (outofBoundIndex !== -1) {
-                numbers = numbers.slice(0, outofBoundIndex);
+            let numbers = [];
+            let val = min > scaleMinVal ? min : min + dy;
+            while (val < scaleMaxVal) {
+                numbers.push(val);
+                val += dy;
             }
             return {numbers: numbers, precision: precision};
         }

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -891,7 +891,7 @@ export class OverlayColorbarSettings {
 
     @computed get tickNum(): number {
         const tickNum = Math.round((this.height / 100.0) * this.tickDensity);
-        return this.height && tickNum > 1 ? tickNum : 1;
+        return this.height && tickNum > 3 ? tickNum : 3;
     }
 
     @computed get rightBorderPos(): number {

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -5,6 +5,7 @@ import {WCSType} from "models";
 import {toFixed, clamp, getColorForTheme} from "utilities";
 
 const AST_DEFAULT_COLOR = "auto-blue";
+const COLORBAR_TICK_NUM_MIN = 3;
 
 export enum AstColorsIndex {
     GLOBAL = 0,
@@ -891,7 +892,7 @@ export class OverlayColorbarSettings {
 
     @computed get tickNum(): number {
         const tickNum = Math.round((this.height / 100.0) * this.tickDensity);
-        return this.height && tickNum > 3 ? tickNum : 3;
+        return this.height && tickNum > COLORBAR_TICK_NUM_MIN ? tickNum : COLORBAR_TICK_NUM_MIN;
     }
 
     @computed get rightBorderPos(): number {


### PR DESCRIPTION
This PR closes #1605:
* Changed the min of tick number to 3. The exact ticks may become 2-4 due to the algorithm of obtaining rounded numbers

Also adjusted the algorithm of obtaining rounded numbers, so please test the correctness of the numbers:
* avoid one tick
* fixed one bug: calculate the smallest number by the exact precision