### PR TITLE
Yuhsuan/1588_hide_image_coord

### DIFF
--- a/src/components/CursorInfo/CursorInfoComponent.tsx
+++ b/src/components/CursorInfo/CursorInfoComponent.tsx
@@ -86,15 +86,17 @@ export class CursorInfoComponent extends React.Component<WidgetProps> {
     };
 
     private genImageCoordContent = (frame: FrameStore): React.ReactNode => {
-        if (!frame) {
+        const x = frame?.cursorInfo?.posImageSpace?.x;
+        const y = frame?.cursorInfo?.posImageSpace?.y;
+        if (!isFinite(x) || !isFinite(y) || (x === -Number.MAX_VALUE && y === -Number.MAX_VALUE)) {
             return "-";
         }
 
         return (
             <React.Fragment>
-                {toFixed(frame.cursorInfo?.posImageSpace?.x, 3)}
+                {toFixed(x, 3)}
                 <br />
-                {toFixed(frame.cursorInfo?.posImageSpace?.y, 3)}
+                {toFixed(y, 3)}
             </React.Fragment>
         );
     };

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -36,7 +36,7 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
         if (this.props.showWCS && cursorInfo.infoWCS) {
             infoStrings.push(`WCS:\u00a0(${cursorInfo.infoWCS.x},\u00a0${cursorInfo.infoWCS.y})`);
         }
-        if (this.props.showImage) {
+        if (this.props.showImage && (cursorInfo.posImageSpace?.x !== -Number.MAX_VALUE || cursorInfo.posImageSpace?.y !== -Number.MAX_VALUE)) {
             infoStrings.push(`Image:\u00a0(${toFixed(cursorInfo.posImageSpace.x)},\u00a0${toFixed(cursorInfo.posImageSpace.y)})`);
         }
         if (this.props.showValue && this.props.cursorValue !== undefined) {
@@ -93,7 +93,7 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
         }
         return (
             <div className={className} style={styleProps}>
-                {infoStrings.join("; ")}
+                {infoStrings.length ? infoStrings.join("; ") : "\u00a0"}
             </div>
         );
     }


### PR DESCRIPTION
This PR closes #1588:
* hide the image coordinate value`-Number.MAX_VALUE` in the cursor overlay and the cursor info widget
* remain the cursor overlay when cursor information is empty