### PR TITLE
Yuhsuan/1624 distance tool disable click to pan

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -397,7 +397,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             return;
         }
 
-        if (frame.wcsInfo && AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring) {
+        if (frame.wcsInfo && AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring && !isSecondaryClick) {
             const imagePos = this.getDistanceMeasureImagePos(mouseEvent.offsetX, mouseEvent.offsetY);
             const wcsPos = transformPoint(frame.wcsInfo, imagePos);
             if (!isAstBadPoint(wcsPos)) {
@@ -422,7 +422,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             frame.regionSet.deselectRegion();
         }
 
-        if (frame.wcsInfo && this.props.onClicked && (!this.props.dragPanningEnabled || isSecondaryClick)) {
+        if (frame.wcsInfo && this.props.onClicked && ((!this.props.dragPanningEnabled && AppStore.Instance?.activeLayer !== ImageViewLayer.DistanceMeasuring) || isSecondaryClick)) {
             const cursorPosImageSpace = canvasToTransformedImagePos(mouseEvent.offsetX, mouseEvent.offsetY, frame, this.props.width, this.props.height);
             this.props.onClicked(frame.getCursorInfo(cursorPosImageSpace));
         }

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -197,11 +197,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                                     Measure distance
                                     <br />
                                     <i>
-                                        <small>
-                                            Click to create geodesic curves.
-                                            <br />
-                                            {AppStore.Instance.preferenceStore?.dragPanning ? "" : "Hold Ctrl/Cmd and click to pan the image."}
-                                        </small>
+                                        <small>Click to create geodesic curves.</small>
                                     </i>
                                 </span>
                             }

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -197,7 +197,11 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                                     Measure distance
                                     <br />
                                     <i>
-                                        <small>Click to create geodesic curves.</small>
+                                        <small>
+                                            Click to create geodesic curves.
+                                            <br />
+                                            {AppStore.Instance.preferenceStore?.dragPanning ? "" : "Hold Ctrl/Cmd and click to pan the image."}
+                                        </small>
                                     </i>
                                 </span>
                             }


### PR DESCRIPTION
This PR closes #1624:
* when drag-to-pan is disabled, disable click-to-pan in the distance measuring mode. We can still use ctrl/cmd clicks or middle clicks for panning
* avoid creating curves by ctrl/cmd clicks or middle clicks in the distance measuring mode