### PR TITLE
Thchang/overlapped y axis tick 163

### DIFF
--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -236,7 +236,7 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
             });
         }
         return newTicks;
-    }
+    };
 
     private static FormatTicksScientific = (value: number, index: number, values: number[]) => {
         return toExponential(value, 2);

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -179,15 +179,6 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         return null;
     };
 
-    private filterYLogTicks = (_axis, ticks: number[]) => {
-        if (this.props.data?.length === 1) {
-            const newTicks = ticks.filter(tick => tick !== this.props.data[0].y);
-            return this.filterLogTicks(_axis, newTicks);
-        }
-
-        return this.filterLogTicks(_axis, ticks);
-    };
-
     private filterLinearTicks = (_axis, ticks: number[]) => {
         let removeFirstTick = false;
         let removeLastTick = false;
@@ -223,14 +214,29 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         return ticks.slice(removeFirstTick ? 1 : 0, removeLastTick ? -1 : undefined);
     };
 
-    private filterYLinearTicks = (_axis, ticks: number[]) => {
-        if (this.props.data?.length === 1) {
-            const newTicks = ticks.filter(tick => tick !== this.props.data[0].y);
-            return this.filterLinearTicks(_axis, newTicks);
-        }
-
-        return this.filterLinearTicks(_axis, ticks);
+    private filterYLogTicks = (_axis, ticks: number[]) => {
+        return this.filterLogTicks(_axis, this.removeAdditionalTicks(ticks));
     };
+
+    private filterYLinearTicks = (_axis, ticks: number[]) => {
+        return this.filterLinearTicks(_axis, this.removeAdditionalTicks(ticks));
+    };
+
+    // remove the additional ticks, which are equal to the data value, when there is only one data
+    // otherwise the additional ticks could overlap other ticks
+    private removeAdditionalTicks = (ticks: number[]) => {
+        let newTicks: number[] = ticks;
+        if (this.props.data?.length === 1 && !this.props.multiPlotPropsMap?.size) {
+            newTicks = ticks.slice(1, ticks.length - 1);
+        } else if (!this.props.data?.length && this.props.multiPlotPropsMap?.size === 1) {
+            this.props.multiPlotPropsMap.forEach(props => {
+                if (props.data?.length === 1) {
+                    newTicks = ticks.slice(1, ticks.length - 1);
+                }
+            });
+        }
+        return newTicks;
+    }
 
     private static FormatTicksScientific = (value: number, index: number, values: number[]) => {
         return toExponential(value, 2);

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -179,6 +179,15 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         return null;
     };
 
+    private filterYLogTicks = (_axis, ticks: number[]) => {
+        if (this.props.data?.length === 1) {
+            const newTicks = ticks.filter(tick => tick !== this.props.data[0].y);
+            return this.filterLogTicks(_axis, newTicks);
+        }
+
+        return this.filterLogTicks(_axis, ticks);
+    };
+
     private filterLinearTicks = (_axis, ticks: number[]) => {
         let removeFirstTick = false;
         let removeLastTick = false;
@@ -212,6 +221,15 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         }
         // Remove first and last ticks if they've been flagged
         return ticks.slice(removeFirstTick ? 1 : 0, removeLastTick ? -1 : undefined);
+    };
+
+    private filterYLinearTicks = (_axis, ticks: number[]) => {
+        if (this.props.data?.length === 1) {
+            const newTicks = ticks.filter(tick => tick !== this.props.data[0].y);
+            return this.filterLinearTicks(_axis, newTicks);
+        }
+
+        return this.filterLinearTicks(_axis, ticks);
     };
 
     private static FormatTicksScientific = (value: number, index: number, values: number[]) => {
@@ -425,10 +443,10 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
         }
 
         if (this.props.logY) {
-            plotOptions.scales.yAxes[0].afterBuildTicks = this.filterLogTicks;
+            plotOptions.scales.yAxes[0].afterBuildTicks = this.filterYLogTicks;
             plotOptions.scales.yAxes[0].type = "logarithmic";
         } else {
-            plotOptions.scales.yAxes[0].afterBuildTicks = this.filterLinearTicks;
+            plotOptions.scales.yAxes[0].afterBuildTicks = this.filterYLinearTicks;
             plotOptions.scales.yAxes[0].type = "linear";
         }
 


### PR DESCRIPTION
closes #163.

Two additional y axis ticks would be added when there was only one data point in the plot area, and the value of the additional ticks will equal to the data point value. Not sure it is an expected behavior in Chart.js or is a bug. It happens when we zoom into empty space(still having an end point from data, since we use `clamp` to set plotData() in all `LinePlotComponent`), or we zoom in till there is only one data point.

The overlapping situation will happen when the additional y axis tick is too close to other ticks. Therefore, I removed the additional ticks in `PlotContainerComponent` to avoid ticks overlapping.

two identical ticks equal to value were in the `ticks` of `afterBuildTicks`
![Screenshot 2021-08-20 15:38:59](https://user-images.githubusercontent.com/20379662/130202497-2d85fcec-8efc-4d56-96e9-0dc87a2f0a0e.png)

this was the overlapping situation before

https://user-images.githubusercontent.com/20379662/130204857-3a6c68bd-fd61-48e8-9d44-9a587decbec7.mp4

