### PR TITLE
adds WASM functions for converting int64 arrays to double

### DIFF
--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -309,20 +309,26 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         }
     }
 
-    private getDataType(type: CARTA.ColumnType) {
+    private static GetDataType(type: CARTA.ColumnType) {
         switch (type) {
             case CARTA.ColumnType.Bool:
                 return "bool";
             case CARTA.ColumnType.Int8:
+                return "byte";
             case CARTA.ColumnType.Int16:
+                return "short";
             case CARTA.ColumnType.Int32:
-            case CARTA.ColumnType.Int64:
                 return "int";
+            case CARTA.ColumnType.Int64:
+                return "long";
             case CARTA.ColumnType.Uint8:
+                return "unsigned byte";
             case CARTA.ColumnType.Uint16:
+                return "unsigned short";
             case CARTA.ColumnType.Uint32:
-            case CARTA.ColumnType.Uint64:
                 return "unsigned int";
+            case CARTA.ColumnType.Uint64:
+                return "unsigned long";
             case CARTA.ColumnType.Double:
                 return "double";
             case CARTA.ColumnType.Float:
@@ -347,7 +353,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
             headerNames.push(header.name);
             headerDescriptions.push(header.description);
             units.push(header.units);
-            types.push(this.getDataType(header.dataType));
+            types.push(CatalogOverlayComponent.GetDataType(header.dataType));
         }
         const columnName = this.renderDataColumn(HeaderTableColumnName.Name, headerNames);
         tableColumns.push(columnName);

--- a/src/models/Processed.ts
+++ b/src/models/Processed.ts
@@ -138,6 +138,12 @@ export class ProtobufProcessing {
             case CARTA.ColumnType.Double:
                 data = new Float64Array(column.binaryData.slice().buffer);
                 break;
+            case CARTA.ColumnType.Int64:
+                data = CARTACompute.ConvertInt64Array(column.binaryData, true);
+                break;
+            case CARTA.ColumnType.Uint64:
+                data = CARTACompute.ConvertInt64Array(column.binaryData, false);
+                break;
             case CARTA.ColumnType.Bool:
                 const array = new Uint8Array(column.binaryData.slice().buffer);
                 const boolData = new Array<boolean>(array.length);

--- a/wasm_src/build_carta_computation.sh
+++ b/wasm_src/build_carta_computation.sh
@@ -13,7 +13,7 @@ cp typings.d.ts build/index.d.ts
 
 emcc -o build/carta_computation.js carta_computation.cc Point2D.cc ../../wasm_libs/zstd/build/standalone_zstd.bc \
   --pre-js build/pre.js --post-js build/post.js -std=c++11 -g0 -O3 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
-  -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS='["_ZSTD_decompress", "_decodeArray", "_generateVertexData", "_calculateCatalogMap","_malloc", "_free"]' \
+  -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS='["_ZSTD_decompress", "_decodeArray", "_generateVertexData", "_calculateCatalogMap", "_convertInt64Array", "_convertUint64Array","_malloc", "_free"]' \
   -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "calledRun"]'
 
 printf "Checking for CARTA computation WASM..."

--- a/wasm_src/carta_computation/carta_computation.cc
+++ b/wasm_src/carta_computation/carta_computation.cc
@@ -317,4 +317,18 @@ void calculateCatalogMap(int mapType, float* data, size_t N, float dataMin, floa
     }
 }
 
+void convertInt64Array(std::int64_t* source, size_t length) {
+    double* dest = (double*) source;
+    for (auto i = 0; i < length; i++) {
+        dest[i] = source[i];
+    }
+}
+
+void convertUint64Array(std::uint64_t* source, size_t length) {
+    double* dest = (double*) source;
+    for (auto i = 0; i < length; i++) {
+        dest[i] = source[i];
+    }
+}
+
 }

--- a/wasm_src/carta_computation/carta_computation.cc
+++ b/wasm_src/carta_computation/carta_computation.cc
@@ -10,7 +10,6 @@
 
 extern size_t ZSTD_decompress(void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 
-
 union Block {
     int intValues[4];
     char byteValues[16];
@@ -50,7 +49,7 @@ void decodeArray(char* dst, size_t dstCapacity, int decimationFactor) {
     int v = 0;
 
     Block block;
-    
+
     // Un-shuffle data and convert from int to float based on decimation factor
     for (v = 0; v < blockedLength; v += 4) {
         const int i = 4 * v;
@@ -243,8 +242,7 @@ void generateVertexData(void* dst, size_t dstCapacity, float* srcVertices, int n
 }
 
 float clamp(float d, float min, float max) {
-    if (d!=d)
-    {
+    if (d != d) {
         return min;
     }
     const double t = d < min ? min : d;
@@ -252,68 +250,62 @@ float clamp(float d, float min, float max) {
 }
 
 float scaleValue(float x, int scaling, float alpha, float gamma) {
-    switch (scaling)
-    {
-    case SQUARE:
-        return x * x;
-    case SQRT:
-        return sqrt(x);
-    case LOG:
-        return clamp(log(alpha * x + 1.0) / log(alpha), 0.0, 1.0);
-    case POWER:
-        return (pow(alpha, x) - 1.0) / alpha;
-    case GAMMA:
-        return pow(x, gamma);
-    default:
-        return x;
+    switch (scaling) {
+        case SQUARE:
+            return x * x;
+        case SQRT:
+            return sqrt(x);
+        case LOG:
+            return clamp(log(alpha * x + 1.0) / log(alpha), 0.0, 1.0);
+        case POWER:
+            return (pow(alpha, x) - 1.0) / alpha;
+        case GAMMA:
+            return pow(x, gamma);
+        default:
+            return x;
     }
 }
 
-void calculateCatalogMap(int mapType, float* data, size_t N, float dataMin, float dataMax, int clipMin, int clipMax, int scaling, float alpha, float gamma, int devicePixelRatio, bool invert) {
+void calculateCatalogMap(int mapType, float* data, size_t N, float dataMin, float dataMax, int clipMin, int clipMax, int scaling, float alpha, float gamma, int devicePixelRatio,
+                         bool invert) {
     float columnMin = scaleValue(dataMin, scaling, alpha, gamma);
     float columnMax = scaleValue(dataMax, scaling, alpha, gamma);
     float range = columnMax - columnMin;
 
-    switch (mapType)
-    {
-    case SIZE_DIAMETER:
-        for (size_t i = 0; i < N; i++)
-        {
-            float v = clamp(data[i], dataMin, dataMax);
-            float value = scaleValue(v, scaling, alpha, gamma);
-            data[i] = ((value - columnMin) / range * (clipMax - clipMin) + clipMin) * devicePixelRatio;
-        }
-        break;
-    case SIZE_AREA:
-        for (size_t i = 0; i < N; i++)
-        {
-            float v = clamp(data[i], dataMin, dataMax);
-            float value = scaleValue(v, scaling, alpha, gamma);
-            data[i] = (sqrt((value - columnMin) / range) * (clipMax - clipMin) + clipMin) * devicePixelRatio;
-        }
-        break;
-    case COLOR:
-        for (size_t i = 0; i < N; i++)
-        {
-            float v = clamp(data[i], dataMin, dataMax);
-            float value = (scaleValue(v, scaling, alpha, gamma) - columnMin) / range;
-            if (invert)
-            {
-                value = 1 - value;
+    switch (mapType) {
+        case SIZE_DIAMETER:
+            for (size_t i = 0; i < N; i++) {
+                float v = clamp(data[i], dataMin, dataMax);
+                float value = scaleValue(v, scaling, alpha, gamma);
+                data[i] = ((value - columnMin) / range * (clipMax - clipMin) + clipMin) * devicePixelRatio;
             }
-            data[i] = value;
-        }
-        break;
-    case ORIENTATION:
-        for (size_t i = 0; i < N; i++)
-        {
-            float v = clamp(data[i], dataMin, dataMax);
-            float value = scaleValue(v, scaling, alpha, gamma);
-            data[i] = ((value - columnMin) / range * (clipMax - clipMin) + clipMin);
-        }
-        break;
-    default:
-        break;
+            break;
+        case SIZE_AREA:
+            for (size_t i = 0; i < N; i++) {
+                float v = clamp(data[i], dataMin, dataMax);
+                float value = scaleValue(v, scaling, alpha, gamma);
+                data[i] = (sqrt((value - columnMin) / range) * (clipMax - clipMin) + clipMin) * devicePixelRatio;
+            }
+            break;
+        case COLOR:
+            for (size_t i = 0; i < N; i++) {
+                float v = clamp(data[i], dataMin, dataMax);
+                float value = (scaleValue(v, scaling, alpha, gamma) - columnMin) / range;
+                if (invert) {
+                    value = 1 - value;
+                }
+                data[i] = value;
+            }
+            break;
+        case ORIENTATION:
+            for (size_t i = 0; i < N; i++) {
+                float v = clamp(data[i], dataMin, dataMax);
+                float value = scaleValue(v, scaling, alpha, gamma);
+                data[i] = ((value - columnMin) / range * (clipMax - clipMin) + clipMin);
+            }
+            break;
+        default:
+            break;
     }
 }
 

--- a/wasm_src/carta_computation/post.ts
+++ b/wasm_src/carta_computation/post.ts
@@ -7,6 +7,8 @@ const decompress = Module.cwrap("ZSTD_decompress", "number", ["number", "number"
 const decodeArray = Module.cwrap("decodeArray", "number", ["number", "number", "number"]);
 const generateVertexData = Module.cwrap("generateVertexData", "number", ["number", "number", "number", "number", "number", "number"]);
 const calculateCatalogMap = Module.cwrap("calculateCatalogMap", null, ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number"]);
+const convertInt64Array = Module.cwrap("convertInt64Array", null, ["number", "number"]);
+const convertUint64Array = Module.cwrap("convertUint64Array", null, ["number", "number"]);
 const VertexDataElements = 8;
 
 Module.srcAllocated = 0;
@@ -145,6 +147,22 @@ Module.CalculateCatalogOrientation = (data: Float32Array, min: number, max: numb
     const float32 = new Float32Array(Module.HEAPF32.buffer, dataOnWasmHeap, N);
     Module._free(dataOnWasmHeap);
     return float32.slice();
+}
+
+Module.ConvertInt64Array = (data: Uint8Array, signed: boolean): Float64Array => {
+    const N = data.byteLength / 8;
+    const srcPtr = Module._malloc(data.byteLength);
+    const srcHeap = new Uint8Array(Module.HEAPU8.buffer, srcPtr, data.byteLength);
+    srcHeap.set(data);
+    if (signed) {
+        convertInt64Array(srcPtr, N);
+    } else {
+        convertUint64Array(srcPtr, N);
+    }
+    const destHeap = new Float64Array(Module.HEAPF64.buffer, srcPtr, N);
+    const result = destHeap.slice();
+    Module._free(srcPtr);
+    return result;
 }
 
 module.exports = Module;

--- a/wasm_src/carta_computation/typings.d.ts
+++ b/wasm_src/carta_computation/typings.d.ts
@@ -6,4 +6,5 @@ export const Decode: (src: Uint8Array, destSize: number, decimationFactor: numbe
 export const GenerateVertexData: (sourceVertices: Float32Array, indexOffsets: Int32Array) => Float32Array;
 export const CalculateCatalogSize: (data: Float32Array, min: number, max: number, sizeMin: number, sizeMax: number, scaling: number, area: boolean, devicePixelRatio: number, alpha?: number, gamma?: number) => Float32Array;
 export const CalculateCatalogColor: (data: Float32Array, invert: boolean, min: number, max: number, scaling: number, alpha?: number, gamma?: number) => Float32Array;
-export const CalculateCatalogOrientation: (data: Float32Array, min: number, max: number, angleMin: number, angleMax: number, scaling: number, alpha?: number, gamma?: number)=> Float32Array; 
+export const CalculateCatalogOrientation: (data: Float32Array, min: number, max: number, angleMin: number, angleMax: number, scaling: number, alpha?: number, gamma?: number)=> Float32Array;
+export const ConvertInt64Array: (data: Uint8Array, signed: boolean) => Float64Array;


### PR DESCRIPTION
Adds proper handling of 64-bit integer types sent from the backend. A WebAssembly function handles converting of the data to `Float64Array`, which means we don't have to worry about unreliable `BigInt64` support in browsers.

Companion PR of https://github.com/CARTAvis/carta-backend/pull/911