### PR TITLE
mylin/1648 toolbar backgroundColor

### DIFF
--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -101,7 +101,8 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             bottom: overlay.padding.bottom,
             right: overlay.padding.right,
             left: overlay.padding.left,
-            opacity: this.props.visible ? 1 : 0
+            opacity: this.props.visible ? 1 : 0,
+            backgroundColor: 'transparent'
         };
 
         const className = classNames("image-toolbar", {docked: this.props.docked, "bp3-dark": appStore.darkTheme});

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -102,7 +102,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
             right: overlay.padding.right,
             left: overlay.padding.left,
             opacity: this.props.visible ? 1 : 0,
-            backgroundColor: 'transparent'
+            backgroundColor: "transparent"
         };
 
         const className = classNames("image-toolbar", {docked: this.props.docked, "bp3-dark": appStore.darkTheme});


### PR DESCRIPTION
Fixed #1648 .
let backgroundColor to be transparent, the image view toolbar in dark mode will not show additional length.