### PR TITLE
set starting folder from URL query parameter

### DIFF
--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -212,6 +212,9 @@ export class AppStore {
                     this.autoFitImages(frames);
                 }
             } else if (this.preferenceStore.autoLaunch) {
+                if (folderSearchParam) {
+                    this.fileBrowserStore.setStartingDirectory(folderSearchParam);
+                }
                 this.fileBrowserStore.showFileBrowser(BrowserMode.File);
             }
         } catch (err) {
@@ -1188,7 +1191,7 @@ export class AppStore {
             try {
                 await this.connectToServer();
                 await this.preferenceStore.fetchPreferences();
-                await this.fileBrowserStore.setStartingDirectory();
+                await this.fileBrowserStore.restoreStartingDirectory();
                 await this.layoutStore.fetchLayouts();
                 await this.snippetStore.fetchSnippets();
 

--- a/src/stores/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore.ts
@@ -338,7 +338,16 @@ export class FileBrowserStore {
     }
 
     @action saveStartingDirectory(directory?: string) {
+        this.setStartingDirectory(directory);
         const preferenceStore = PreferenceStore.Instance;
+        if (preferenceStore.keepLastUsedFolder) {
+            preferenceStore.setPreference(PreferenceKeys.GLOBAL_SAVED_LAST_FOLDER, this.startingDirectory);
+        } else {
+            preferenceStore.setPreference(PreferenceKeys.GLOBAL_SAVED_LAST_FOLDER, "");
+        }
+    }
+
+    @action setStartingDirectory(directory?: string) {
         if (directory !== undefined) {
             this.startingDirectory = directory;
         } else {
@@ -348,14 +357,9 @@ export class FileBrowserStore {
                 this.startingDirectory = this.fileList.directory;
             }
         }
-        if (preferenceStore.keepLastUsedFolder) {
-            preferenceStore.setPreference(PreferenceKeys.GLOBAL_SAVED_LAST_FOLDER, this.startingDirectory);
-        } else {
-            preferenceStore.setPreference(PreferenceKeys.GLOBAL_SAVED_LAST_FOLDER, "");
-        }
     }
 
-    setStartingDirectory() {
+    @action restoreStartingDirectory() {
         const preferenceStore = PreferenceStore.Instance;
         if (preferenceStore.keepLastUsedFolder) {
             if (preferenceStore.lastUsedFolder?.length > 0) {


### PR DESCRIPTION
Closes https://github.com/CARTAvis/carta/issues/89.

The `folder=<folder_name>` query parameter can be  used to specify a starting folder. This allows users to bookmark URLs for different workspaces.