### PR TITLE
hide regions from raster view / list while loading

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -535,12 +535,15 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     };
 
     render() {
+        const appStore = AppStore.Instance;
         const frame = this.props.frame;
         const regionSet = frame.regionSet;
         const className = classNames("region-stage", {docked: this.props.docked});
         let regionComponents = null;
 
-        if (regionSet && regionSet.regions.length) {
+        if (appStore.fileBrowserStore.isLoadingDialogOpen) {
+            regionComponents = [];
+        } else if (regionSet && regionSet.regions.length) {
             regionComponents = regionSet.regions
                 .filter(r => r.isValid && r.regionId !== 0)
                 .sort((a, b) => (a.boundingBoxArea > b.boundingBoxArea ? -1 : 1))
@@ -556,7 +559,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                                 selected={r === regionSet.selectedRegion}
                                 onSelect={regionSet.selectRegion}
                                 onDoubleClick={this.handleRegionDoubleClick}
-                                listening={regionSet.mode !== RegionMode.CREATING && AppStore.Instance?.activeLayer !== ImageViewLayer.DistanceMeasuring}
+                                listening={regionSet.mode !== RegionMode.CREATING && appStore?.activeLayer !== ImageViewLayer.DistanceMeasuring}
                                 isRegionCornerMode={this.props.isRegionCornerMode}
                             />
                         );
@@ -584,7 +587,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                                 selected={r === regionSet.selectedRegion}
                                 onSelect={regionSet.selectRegion}
                                 onDoubleClick={this.handleRegionDoubleClick}
-                                listening={regionSet.mode !== RegionMode.CREATING && AppStore.Instance?.activeLayer !== ImageViewLayer.DistanceMeasuring}
+                                listening={regionSet.mode !== RegionMode.CREATING && appStore?.activeLayer !== ImageViewLayer.DistanceMeasuring}
                                 isRegionCornerMode={this.props.isRegionCornerMode}
                             />
                         );
@@ -642,7 +645,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
 
         let cursor: string;
 
-        if (regionSet.mode === RegionMode.CREATING || AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring) {
+        if (regionSet.mode === RegionMode.CREATING || appStore?.activeLayer === ImageViewLayer.DistanceMeasuring) {
             cursor = "crosshair";
         } else if (regionSet.selectedRegion && regionSet.selectedRegion.editing) {
             cursor = "move";

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
-import {HTMLTable, Icon, NonIdealState, Position} from "@blueprintjs/core";
+import {HTMLTable, Icon, NonIdealState, Position, Spinner} from "@blueprintjs/core";
 import {Tooltip2} from "@blueprintjs/popover2";
 import ReactResizeDetector from "react-resize-detector";
 import {CARTA} from "carta-protobuf";
@@ -89,7 +89,17 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         if (!frame) {
             return (
                 <div className="region-list-widget">
-                    <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />;<ReactResizeDetector handleWidth handleHeight onResize={this.onResize}></ReactResizeDetector>
+                    <NonIdealState icon={"folder-open"} title={"No file loaded"} description={"Load a file using the menu"} />
+                    <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
+                </div>
+            );
+        }
+
+        if (appStore.fileBrowserStore.isLoadingDialogOpen) {
+            return (
+                <div className="region-list-widget">
+                    <NonIdealState icon={<Spinner />} title={"Loading regions"} description={"Region list with be shown when regions have been loaded"} />
+                    <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} />
                 </div>
             );
         }


### PR DESCRIPTION
Adjusts batched imports as follows:
- increased batch size to 100
- wrap batch import in `@action` decorator to limit O(N^2) behaviour.
- hide regions from region list and image view while loading