### PR TITLE
Mylin/set the cursor type to be default when only cursor region

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -639,6 +639,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             cursor = "crosshair";
         } else if (regionSet.selectedRegion && regionSet.selectedRegion.editing) {
             cursor = "move";
+        } else if (regionSet.selectedRegion === regionSet.regions[0] || !regionSet.selectedRegion) {
+            cursor = "default";
         }
 
         return (


### PR DESCRIPTION
Fixed #1599 
I set the cursor type to be "default" when the selectedRegion only remain the cursor region itself or the selectedRegion to be null.

