### PR TITLE
ajm/jenkinsfile update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Format check') {
             agent {
-                label "ubuntu-1"
+                label "ubuntu-2004"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -16,61 +16,65 @@ pipeline {
                 }
             }
         }
-        stage('WebAssembly compilation') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh "git submodule update --init --recursive"
-                    sh "n exec 14 npm run build-libs-docker"
-                    stash includes: "protobuf/**/*", name: "protobuf" 
-                    stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl_math.h", name: "wasm_libs"
+        stage('Build') {
+            parallel {
+                stage('WebAssembly compilation') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "git submodule update --init --recursive"
+                            sh "n exec 14 npm run build-libs-docker"
+                            stash includes: "protobuf/**/*", name: "protobuf" 
+                            stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl/gsl_math.h", name: "wasm_libs"
+                        }
+                    }
                 }
-            }
-        }
-        stage('Build with node v12') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash "protobuf"
-                    unstash "wasm_libs"
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 12 node -v'
-                    sh 'n exec 12 npm install'
-                    sh 'n exec 12 npm run build-docker'
+                stage('Build with node v12') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "protobuf"
+                            unstash "wasm_libs"
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 12 node -v'
+                            sh 'n exec 12 npm install'
+                            sh 'n exec 12 npm run build-docker'
+                        }
+                    }
                 }
-            }
-        }
-        stage('Build with node v14') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash "protobuf"
-                    unstash "wasm_libs"
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 14 node -v'
-                    sh 'n exec 14 npm install'
-                    sh 'n exec 14 npm run build-docker'
+                stage('Build with node v14') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "protobuf"
+                            unstash "wasm_libs"
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 14 node -v'
+                            sh 'n exec 14 npm install'
+                            sh 'n exec 14 npm run build-docker'
+                        }
+                    }
                 }
-            }
-        }
-        stage('Build with node v16') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    unstash "protobuf"
-                    unstash "wasm_libs"
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 16 node -v'
-                    sh 'n exec 16 npm install'
-                    sh 'n exec 16 npm run build-docker'
+                stage('Build with node v16') {
+                    agent {
+                       label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "protobuf"
+                            unstash "wasm_libs"
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 16 node -v'
+                            sh 'n exec 16 npm install'
+                            sh 'n exec 16 npm run build-docker'
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,21 +16,21 @@ pipeline {
                 }
             }
         }
+        stage('WebAssembly compilation') {
+            agent {
+                label "ubuntu-2004"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh "git submodule update --init --recursive"
+                    sh "n exec 14 npm run build-libs-docker"
+                    stash includes: "protobuf/**/*", name: "protobuf" 
+                    stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl/gsl_math.h", name: "wasm_libs"
+                }
+            }
+        }
         stage('Build') {
             parallel {
-                stage('WebAssembly compilation') {
-                    agent {
-                        label "ubuntu-2004"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh "git submodule update --init --recursive"
-                            sh "n exec 14 npm run build-libs-docker"
-                            stash includes: "protobuf/**/*", name: "protobuf" 
-                            stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl/gsl_math.h", name: "wasm_libs"
-                        }
-                    }
-                }
                 stage('Build with node v12') {
                     agent {
                         label "ubuntu-2004"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                     sh "git submodule update --init --recursive"
                     sh "n exec 14 npm run build-libs-docker"
                     stash includes: "protobuf/**/*", name: "protobuf" 
-                    stash includes: "wasm_libs/built/**/*", name: "wasm_libs"
+                    stash includes: "wasm_libs/built/**/*,wasm_libs/zstd/build/standalone_zstd.bc", name: "wasm_libs"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "n exec 14 npm run build-libs-docker"
-                    stash includes: "wasm_libs/**/*", name: "wasm_libs"
+                    stash includes: "protobuf/**/*", name: "protobuf" 
+                    stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl_math.h", name: "wasm_libs"
                 }
             }
         }
@@ -34,6 +35,7 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "protobuf"
                     unstash "wasm_libs"
                     sh 'rm -rf node_modules build'
                     sh 'n exec 12 node -v'
@@ -48,6 +50,7 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "protobuf"
                     unstash "wasm_libs"
                     sh 'rm -rf node_modules build'
                     sh 'n exec 14 node -v'
@@ -62,6 +65,7 @@ pipeline {
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "protobuf"
                     unstash "wasm_libs"
                     sh 'rm -rf node_modules build'
                     sh 'n exec 16 node -v'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                     sh "git submodule update --init --recursive"
                     sh "n exec 14 npm run build-libs-docker"
                     stash includes: "protobuf/**/*", name: "protobuf" 
-                    stash includes: "wasm_libs/ast/ast.h,wasm_libs/zfp/zfp.h,wasm_libs/gsl/gsl/gsl_math.h", name: "wasm_libs"
+                    stash includes: "wasm_libs/built/**/*", name: "wasm_libs"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Format check') {
             agent {
-                label "ubuntu-1"
+                label "ubuntu-2004"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -18,7 +18,7 @@ pipeline {
         }
         stage('WebAssembly compilation') {
             agent {
-                label "ubuntu-1"
+                label "ubuntu-2004"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -27,42 +27,44 @@ pipeline {
                 }
             }
         }
-        stage('Build with node v12') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 12 node -v'
-                    sh 'n exec 12 npm install'
-                    sh 'n exec 12 npm run build-docker'
+        parallel {
+            stage('Build with node v12') {
+                agent {
+                    label "ubuntu-2004"
+                }
+                steps {
+                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                        sh 'rm -rf node_modules build'
+                        sh 'n exec 12 node -v'
+                        sh 'n exec 12 npm install'
+                        sh 'n exec 12 npm run build-docker'
+                    }
                 }
             }
-        }
-        stage('Build with node v14') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 14 node -v'
-                    sh 'n exec 14 npm install'
-                    sh 'n exec 14 npm run build-docker'
+            stage('Build with node v14') {
+                agent {
+                    label "ubuntu-2004"
+                }
+                steps {
+                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                        sh 'rm -rf node_modules build'
+                        sh 'n exec 14 node -v'
+                        sh 'n exec 14 npm install'
+                        sh 'n exec 14 npm run build-docker'
+                    }
                 }
             }
-        }
-        stage('Build with node v16') {
-            agent {
-                label "ubuntu-1"
-            }
-            steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh 'rm -rf node_modules build'
-                    sh 'n exec 16 node -v'
-                    sh 'n exec 16 npm install'
-                    sh 'n exec 16 npm run build-docker'
+            stage('Build with node v16') {
+                agent {
+                    label "ubuntu-2004"
+                }
+                steps {
+                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                        sh 'rm -rf node_modules build'
+                        sh 'n exec 16 node -v'
+                        sh 'n exec 16 npm install'
+                        sh 'n exec 16 npm run build-docker'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Format check') {
             agent {
-                label "ubuntu-2004"
+                label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -18,55 +18,55 @@ pipeline {
         }
         stage('WebAssembly compilation') {
             agent {
-                label "ubuntu-2004"
+                label "ubuntu-1"
             }
             steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                     sh "git submodule update --init --recursive"
                     sh "n exec 14 npm run build-libs-docker"
+                    stash includes: "wasm_libs/**/*", name: "wasm_libs"
                 }
             }
         }
-        stage('Build') {
-            parallel {
-                stage('Build with node v12') {
-                    agent {
-                        label "ubuntu-2004"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh 'rm -rf node_modules build'
-                            sh 'n exec 12 node -v'
-                            sh 'n exec 12 npm install'
-                            sh 'n exec 12 npm run build-docker'
-                        }
-                    }
+        stage('Build with node v12') {
+            agent {
+                label "ubuntu-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "wasm_libs"
+                    sh 'rm -rf node_modules build'
+                    sh 'n exec 12 node -v'
+                    sh 'n exec 12 npm install'
+                    sh 'n exec 12 npm run build-docker'
                 }
-                stage('Build with node v14') {
-                    agent {
-                        label "ubuntu-2004"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh 'rm -rf node_modules build'
-                            sh 'n exec 14 node -v'
-                            sh 'n exec 14 npm install'
-                            sh 'n exec 14 npm run build-docker'
-                        }
-                    }
+            }
+        }
+        stage('Build with node v14') {
+            agent {
+                label "ubuntu-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "wasm_libs"
+                    sh 'rm -rf node_modules build'
+                    sh 'n exec 14 node -v'
+                    sh 'n exec 14 npm install'
+                    sh 'n exec 14 npm run build-docker'
                 }
-                stage('Build with node v16') {
-                    agent {
-                        label "ubuntu-2004"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh 'rm -rf node_modules build'
-                            sh 'n exec 16 node -v'
-                            sh 'n exec 16 npm install'
-                            sh 'n exec 16 npm run build-docker'
-                        }
-                    }
+            }
+        }
+        stage('Build with node v16') {
+            agent {
+                label "ubuntu-1"
+            }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    unstash "wasm_libs"
+                    sh 'rm -rf node_modules build'
+                    sh 'n exec 16 node -v'
+                    sh 'n exec 16 npm install'
+                    sh 'n exec 16 npm run build-docker'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,43 +27,45 @@ pipeline {
                 }
             }
         }
-        parallel {
-            stage('Build with node v12') {
-                agent {
-                    label "ubuntu-2004"
-                }
-                steps {
-                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                        sh 'rm -rf node_modules build'
-                        sh 'n exec 12 node -v'
-                        sh 'n exec 12 npm install'
-                        sh 'n exec 12 npm run build-docker'
+        stage('Build') {
+            parallel {
+                stage('Build with node v12') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 12 node -v'
+                            sh 'n exec 12 npm install'
+                            sh 'n exec 12 npm run build-docker'
+                        }
                     }
                 }
-            }
-            stage('Build with node v14') {
-                agent {
-                    label "ubuntu-2004"
-                }
-                steps {
-                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                        sh 'rm -rf node_modules build'
-                        sh 'n exec 14 node -v'
-                        sh 'n exec 14 npm install'
-                        sh 'n exec 14 npm run build-docker'
+                stage('Build with node v14') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 14 node -v'
+                            sh 'n exec 14 npm install'
+                            sh 'n exec 14 npm run build-docker'
+                        }
                     }
                 }
-            }
-            stage('Build with node v16') {
-                agent {
-                    label "ubuntu-2004"
-                }
-                steps {
-                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                        sh 'rm -rf node_modules build'
-                        sh 'n exec 16 node -v'
-                        sh 'n exec 16 npm install'
-                        sh 'n exec 16 npm run build-docker'
+                stage('Build with node v16') {
+                    agent {
+                        label "ubuntu-2004"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh 'rm -rf node_modules build'
+                            sh 'n exec 16 node -v'
+                            sh 'n exec 16 npm install'
+                            sh 'n exec 16 npm run build-docker'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
@veggiesaurus I have moved the carta-frontend CI to a new server, at least temporarily (Running Ubuntu 20.04, but not on SSDs yet). Now we can have multiple executors (I set it to 8) and that means we can build the different node versions stages in parallel. 

To do that, I noticed we need results of the WebAssembly stage for each parallel executor. Rather than building the WebAssembly stage on each executor, I have tried the stash/unstash feature.

I notice that we don't really need the entire contents of wasm_libs, so I am just stashing `wasm_libs/built`, and found we also needed `wasm_libs/zstd/build/standalone_zstd.bc`. I think we need to stash the `protobuf` folder too.
It appears to work. Is that acceptable? Do you think we would ever need other files from `wasm_libs`?

Regarding the WebAssembly stage; It is still built using node v14 for each commit. I was considering a persistent stash with `preserveStashes()` so that we could skip the WebAssembly stage. It would save ~2.5 minutes. But I guess it may be a good idea to keep the WebAssembly stage in case a commit has modified it? 