### PR TITLE
Yuhsuan/1041 line boundary input

### DIFF
--- a/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.scss
+++ b/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.scss
@@ -35,7 +35,7 @@
     .line-boundary {
         .bp3-input-group {
             input {
-                width: 90px;
+                width: 10em;
             }
         }
     }


### PR DESCRIPTION
Closes #1041: one-line change for the width of `X/Y Max/Min` inputs to show the significant figures.
Note that Blueprint `NumericInput` automatically converts the value to scientific notation when it's >=1e21 or <=1e-7.