### PR TITLE
1705_title_text_crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The ability to export high resolution png images for publication quality in journals.
 
 ### Fixed
+* Fixed crash when opening the image view configuration dialog before opening an image [(#1705)](https://github.com/CARTAvis/carta-frontend/issues/1705).
 * Fixed panning and zooming when opening a new image in distance measuring mode [(#1665)](https://github.com/CARTAvis/carta-frontend/issues/1665).
 
 ## [3.0.0-beta.1b]

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -213,7 +213,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                 </FormGroup>
                 <Collapse isOpen={title.customText}>
                     <FormGroup inline={true} label="Text" labelInfo="(Current image only)" disabled={!title.visible}>
-                        <InputGroup disabled={!title.visible} value={appStore.activeFrame.titleCustomText} placeholder="Enter title text" onChange={ev => appStore.activeFrame.setTitleCustomText(ev.currentTarget.value)} />
+                        <InputGroup disabled={!title.visible} value={appStore.activeFrame?.titleCustomText} placeholder="Enter title text" onChange={ev => appStore.activeFrame?.setTitleCustomText(ev.currentTarget.value)} />
                     </FormGroup>
                 </Collapse>
                 <FormGroup inline={true} label="Custom color" disabled={!title.visible}>


### PR DESCRIPTION
Closes the hard frontend crash described in #1705 by using optional chaining when `activeFrame` is not defined.