### PR TITLE
Yuhsuan/1572 region unit size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Circular/linear polarizations are supported in polarization dropdowns for saving subimages and generating hypercubes.
 * The ability to export high resolution png images for publication quality in journals.
 * The ability to use a custom rest freqency for spectral matching, spectral axis display, and PV image x/y axis display.
-
+### Changed
+* Applied a new approach to calculate the sizes and lengths of a region ([#1572](https://github.com/CARTAvis/carta-frontend/issues/1572)).
 ### Fixed
 * Fixed crash when opening the image view configuration dialog before opening an image [(#1705)](https://github.com/CARTAvis/carta-frontend/issues/1705).
 * Fixed panning and zooming when opening a new image in distance measuring mode [(#1665)](https://github.com/CARTAvis/carta-frontend/issues/1665).
-* Fixed incorrent color gradient of the colorbar ([#1717](https://github.com/CARTAvis/carta-frontend/issues/1717) and [#1718](https://github.com/CARTAvis/carta-frontend/issues/1718)).
+* Fixed incorrect color gradient of the colorbar ([#1717](https://github.com/CARTAvis/carta-frontend/issues/1717) and [#1718](https://github.com/CARTAvis/carta-frontend/issues/1718)).
 
 ## [3.0.0-beta.1b]
 

--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -143,7 +143,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
         if (wcsString === this.sizeWCS.x) {
             return;
         }
-        const value = this.props.frame.getImageValueFromArcsec(getValueFromArcsecString(wcsString));
+        const value = this.props.frame.getImageXValueFromArcsec(getValueFromArcsecString(wcsString));
         const existingValue = this.props.region.size.x;
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, EllipticalRegionForm.REGION_PIXEL_EPS)) {
             this.props.region.setSize({x: value, y: this.props.region.size.y});
@@ -180,7 +180,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
         if (wcsString === this.sizeWCS.y) {
             return;
         }
-        const value = this.props.frame.getImageValueFromArcsec(getValueFromArcsecString(wcsString));
+        const value = this.props.frame.getImageYValueFromArcsec(getValueFromArcsecString(wcsString));
         const existingValue = this.props.region.size.y;
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, EllipticalRegionForm.REGION_PIXEL_EPS)) {
             this.props.region.setSize({x: this.props.region.size.x, y: value});

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -167,7 +167,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
             return;
         }
         const existingValue = length2D(this.props.region.size);
-        const value = existingValue * getValueFromArcsecString(wcsString) / length2D(this.props.frame.getWcsSizeInArcsec(this.props.region.size));
+        const value = (existingValue * getValueFromArcsecString(wcsString)) / length2D(this.props.frame.getWcsSizeInArcsec(this.props.region.size));
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const rotation = (region.rotation * Math.PI) / 180.0;

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -166,8 +166,8 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (wcsString === this.lengthWCS) {
             return;
         }
-        const value = this.props.frame.getImageValueFromArcsec(getValueFromArcsecString(wcsString));
         const existingValue = length2D(this.props.region.size);
+        const value = existingValue * getValueFromArcsecString(wcsString) / length2D(this.props.frame.getWcsSizeInArcsec(this.props.region.size));
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const rotation = (region.rotation * Math.PI) / 180.0;

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -165,7 +165,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
         if (wcsString === this.sizeWCS.x) {
             return;
         }
-        const value = this.props.frame.getImageValueFromArcsec(getValueFromArcsecString(wcsString));
+        const value = this.props.frame.getImageXValueFromArcsec(getValueFromArcsecString(wcsString));
         const existingValue = this.props.region.size.x;
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, RectangularRegionForm.REGION_PIXEL_EPS)) {
             this.props.region.setSize({x: value, y: this.props.region.size.y});
@@ -202,7 +202,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
         if (wcsString === this.sizeWCS.y) {
             return;
         }
-        const value = this.props.frame.getImageValueFromArcsec(getValueFromArcsecString(wcsString));
+        const value = this.props.frame.getImageYValueFromArcsec(getValueFromArcsecString(wcsString));
         const existingValue = this.props.region.size.y;
         if (isFinite(value) && value > 0 && !closeTo(value, existingValue, RectangularRegionForm.REGION_PIXEL_EPS)) {
             this.props.region.setSize({x: this.props.region.size.x, y: value});

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1205,15 +1205,19 @@ export class FrameStore {
     };
 
     private getRegionUnitSize = () => {
+        if (this.isPVImage || this.isUVImage) {
+            return null;
+        }
         const crpix1 = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf("CRPIX1") !== -1);
         const crpix2 = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf("CRPIX2") !== -1);
         if (crpix1 && crpix2) {
             const crpix1Val = getHeaderNumericValue(crpix1);
             const crpix2Val = getHeaderNumericValue(crpix2);
-            return {
-                x: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val + 1, crpix2Val) * 1e6) / 1e6,
-                y: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val, crpix2Val + 1) * 1e6) / 1e6
-            };
+            const xUnitSize = Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val + 1, crpix2Val) * 1e6) / 1e6;
+            const yUnitSize = Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val, crpix2Val + 1) * 1e6) / 1e6;
+            if (isFinite(xUnitSize) && isFinite(yUnitSize)) {
+                return {x: xUnitSize, y: yUnitSize};
+            }
         }
         return null;
     };

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1210,8 +1210,10 @@ export class FrameStore {
         if (crpix1 && crpix2) {
             const crpix1Val = getHeaderNumericValue(crpix1);
             const crpix2Val = getHeaderNumericValue(crpix2);
-            return {x: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val + 1, crpix2Val) * 1e6) / 1e6,
-                    y: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val, crpix2Val + 1) * 1e6) / 1e6};
+            return {
+                x: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val + 1, crpix2Val) * 1e6) / 1e6,
+                y: Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val, crpix2Val + 1) * 1e6) / 1e6
+            };
         }
         return null;
     };

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -508,6 +508,19 @@ EMSCRIPTEN_KEEPALIVE double axDistance(AstFrameSet* wcsinfo, int axis, double v1
     return astAxDistance(wcsinfo, axis, v1, v2);
 }
 
+EMSCRIPTEN_KEEPALIVE double geodesicDistance(AstFrameSet* wcsinfo, double x1, double y1, double x2, double y2)
+{
+    const double x[] = {x1, x2};
+    const double y[] = {y1, y2};
+    double xtran[2];
+    double ytran[2];
+    astTran2(wcsinfo, 2, x, y, 1, xtran, ytran);
+
+    double start[] = {xtran[0], ytran[0]};
+    double finish[] = {xtran[1], ytran[1]};
+    return astDistance(wcsinfo, start, finish) * 180.0 / M_PI * 3600.0;
+}
+
 EMSCRIPTEN_KEEPALIVE AstFrame* frame(int naxes, const char* options)
 {
     return astFrame(naxes, options);

--- a/wasm_src/ast_wrapper/index.d.ts
+++ b/wasm_src/ast_wrapper/index.d.ts
@@ -25,6 +25,7 @@ export function getString(obj: AstObject, attrib: string): string;
 export function dump(obj: AstObject): void;
 // Not exported norm()
 export function axDistance(frameSet: FrameSet, axis: number, v1: number, v2: number);
+export function geodesicDistance(frameSet: FrameSet, x1: number, y1: number, x2: number, y2: number): number;
 export function format(frameSet: FrameSet, axis: number, value: number): string;
 // Not exported unformat()
 // Not exported transform(), transform3D(), spectralTransform()

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -108,6 +108,7 @@ Module.getString = Module.cwrap("getString", "string", ["number", "string"]);
 Module.dump = Module.cwrap("dump", null, ["number"]);
 Module.norm = Module.cwrap("norm", "number", ["number", "number"]);
 Module.axDistance = Module.cwrap("axDistance", "number", ["number", "number", "number", "number"]);
+Module.geodesicDistance = Module.cwrap("geodesicDistance", "number", ["number", "number", "number", "number", "number"]);
 Module.format = Module.cwrap("format", "string", ["number", "number", "number"]);
 Module.unformat = Module.cwrap("unformat", "number", ["number", "number", "string", "number"]);
 Module.transform = Module.cwrap("transform", "number", ["number", "number", "number", "number", "number", "number", "number"]);


### PR DESCRIPTION
This PR closes #1572. Applied a new approach to calculate the unit size of a region:

* Calculate the geodesic distance of `(CRPIX1, CRPIX2), (CRPIX1 + 1, CRPIX2)` and `(CRPIX1, CRPIX2), (CRPIX1, CRPIX2 + 1)` by AST `astDistance` to obtain the x/y unit size
* The x/y unit size (in arcsec) is rounded to 6 digits
* The x/y unit size are used for wcs width/height (or major/minor-axis for ellipse, or delta x/y for line) respectively. No need to re-calculate the size after the regions are rotated because regions can not be rotated in a non square pixel image.
* The calculated sizes are used for numbers in the region dialog and region info in exported tsv/txt files