### PR TITLE
fixed platformInfo typo

### DIFF
--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -820,7 +820,7 @@ export class BackendService {
         this.serverFeatureFlags = ack.serverFeatureFlags;
         this.grpcPort = ack.grpcPort;
 
-        TelemetryService.Instance.addTelemetryEntry(TelemetryAction.Connection, {serverFeatureFlags: ack.serverFeatureFlags, plaformInfo: ack.platformStrings});
+        TelemetryService.Instance.addTelemetryEntry(TelemetryAction.Connection, {serverFeatureFlags: ack.serverFeatureFlags, platformInfo: ack.platformStrings});
         this.onDeferredResponse(eventId, ack);
     }
 


### PR DESCRIPTION
@veggiesaurus can't spell `platform` :see_no_evil: 