### PR TITLE
Yuhsuan/1725 frozen cursor fix

### DIFF
--- a/src/components/ImageView/RegionView/CursorRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/CursorRegionComponent.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import {observer} from "mobx-react";
-import {AppStore, FrameStore, RegionStore} from "stores";
+import {AppStore, FrameStore} from "stores";
 import {transformedImageToCanvasPos} from "./shared";
 import {CursorMarker} from "./InvariantShapes";
 
 interface CursorRegionComponentProps {
-    region: RegionStore;
     frame: FrameStore;
     width: number;
     height: number;
@@ -15,12 +14,12 @@ interface CursorRegionComponentProps {
 @observer
 export class CursorRegionComponent extends React.Component<CursorRegionComponentProps> {
     render() {
-        const region = this.props.region;
         const frame = this.props.frame;
+        const posImageSpace = frame?.cursorInfo?.posImageSpace;
 
-        if (AppStore.Instance.cursorFrozen && frame && region) {
+        if (AppStore.Instance.cursorFrozen && posImageSpace) {
             const rotation = frame.spatialReference ? (frame.spatialTransform.rotation * 180.0) / Math.PI : 0.0;
-            const cursorCanvasSpace = transformedImageToCanvasPos(region.center, frame, this.props.width, this.props.height, this.props.stageRef.current);
+            const cursorCanvasSpace = transformedImageToCanvasPos(posImageSpace, frame, this.props.width, this.props.height, this.props.stageRef.current);
             return <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} />;
         }
 

--- a/src/components/ImageView/RegionView/InvariantShapes.tsx
+++ b/src/components/ImageView/RegionView/InvariantShapes.tsx
@@ -157,7 +157,7 @@ export const CursorMarker = (props: CursorMarkerProps) => {
     };
 
     return (
-        <Group x={Math.floor(props.x) + 0.5} y={Math.floor(props.y) + 0.5} rotation={-props.rotation}>
+        <Group x={props.x} y={props.y} rotation={-props.rotation}>
             <Shape listening={false} strokeScaleEnabled={false} strokeWidth={1} stroke={"black"} sceneFunc={handleSquareDraw} />
             <Shape listening={false} strokeScaleEnabled={false} fill={"white"} strokeWidth={1} stroke={"black"} sceneFunc={handleCrossDraw} />
         </Group>

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -674,7 +674,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                 >
                     <Layer ref={this.layerRef}>
                         <RegionComponents frame={frame} regions={frame?.regionSet?.regionsForRender} width={this.props.width} height={this.props.height} stageRef={this.stageRef} />
-                        <CursorRegionComponent frame={frame} region={frame.regionSet?.cursorRegion} width={this.props.width} height={this.props.height} stageRef={this.stageRef} />
+                        <CursorRegionComponent frame={frame} width={this.props.width} height={this.props.height} stageRef={this.stageRef} />
                         {creatingLine}
                     </Layer>
                 </Stage>

--- a/src/stores/RegionSetStore.ts
+++ b/src/stores/RegionSetStore.ts
@@ -54,10 +54,6 @@ export class RegionSetStore {
         return regionId;
     };
 
-    @computed get cursorRegion(): RegionStore {
-        return this.regions?.length > 0 ? this.regions[0] : null;
-    }
-
     @computed get regionsForRender(): RegionStore[] {
         return this.regions?.filter(r => r.isValid && r.regionId !== 0)?.sort((a, b) => (a.boundingBoxArea > b.boundingBoxArea ? -1 : 1));
     }


### PR DESCRIPTION
Closes #1725:
* use `frame.cursorInfo.posImageSpace` (unrounded number) for `CursorMarker` instead of the center of the cursor region (rounded number; used for requesting new pixel value and profiles data)
* remove `Math.floor(x) + 0.5` calculation in `CursorMarker`, which was for avoiding blurry 1 px line on the canvas