### PR TITLE
Regression fix: Dynamic spatial matching

### DIFF
--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -39,8 +39,10 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     }
 
     updateImageDimensions() {
-        this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
-        this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
+        if (this.canvas) {
+            this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
+            this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
+        }
     }
 
     renderCanvas = () => {
@@ -50,7 +52,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
         const wcsInfo = frame.spatialReference ? frame.transformedWcsInfo : frame.wcsInfo;
         const frameView = frame.spatialReference ? frame.spatialReference.requiredFrameView : frame.requiredFrameView;
-        if (wcsInfo && frameView) {
+        if (wcsInfo && frameView && this.canvas) {
             // Take aspect ratio scaling into account
             const tempWcsInfo = AST.copy(wcsInfo);
             if (!tempWcsInfo) {

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -39,10 +39,8 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     }
 
     updateImageDimensions() {
-        if (this.canvas) {
-            this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
-            this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
-        }
+        this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
+        this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
     }
 
     renderCanvas = () => {
@@ -52,7 +50,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
         const wcsInfo = frame.spatialReference ? frame.transformedWcsInfo : frame.wcsInfo;
         const frameView = frame.spatialReference ? frame.spatialReference.requiredFrameView : frame.requiredFrameView;
-        if (wcsInfo && frameView && this.canvas) {
+        if (wcsInfo && frameView) {
             // Take aspect ratio scaling into account
             const tempWcsInfo = AST.copy(wcsInfo);
             if (!tempWcsInfo) {


### PR DESCRIPTION
Closes #1737 by reverting a change made in #1664.

@duidae, I'm not sure whether the changes were required somewhere else? [This commit](https://github.com/CARTAvis/carta-frontend/commit/2807546c636bebd59b5015796da8b69bcfa060bf) is where the changes occurred. 

The code was changed to always use the image center, rather than the `FrameView` center, as the reference point for spatial matching. I've reverted this change, so it now updates dynamically. But we will need to be sure that there are no other regressions with this change. @duidae can you remember why this change was originally neccessary?
