### PR TITLE
ensure canvas ref is defined before resizing or assigning to AST

### DIFF
--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -39,8 +39,10 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     }
 
     updateImageDimensions() {
-        this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
-        this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
+        if (this.canvas) {
+            this.canvas.width = this.props.overlaySettings.viewWidth * devicePixelRatio * AppStore.Instance.imageRatio;
+            this.canvas.height = this.props.overlaySettings.viewHeight * devicePixelRatio * AppStore.Instance.imageRatio;
+        }
     }
 
     renderCanvas = () => {
@@ -50,7 +52,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
         const wcsInfo = frame.spatialReference ? frame.transformedWcsInfo : frame.wcsInfo;
         const frameView = frame.spatialReference ? frame.spatialReference.requiredFrameView : frame.requiredFrameView;
-        if (wcsInfo && frameView) {
+        if (wcsInfo && frameView && this.canvas) {
             // Take aspect ratio scaling into account
             const tempWcsInfo = AST.copy(wcsInfo);
             if (!tempWcsInfo) {


### PR DESCRIPTION
Closes #1746 by checking that the `canvas` ref is defined.