### PR TITLE
rescale pixels appropriately before rounding in shader

### DIFF
--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -76,7 +76,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.uniform1i(shaderUniforms.UseSmoothedBiasContrast, appStore.preferenceStore.useSmoothedBiasContrast ? 1 : 0);
             this.gl.uniform1f(shaderUniforms.Gamma, renderConfig.gamma);
             this.gl.uniform1f(shaderUniforms.Alpha, renderConfig.alpha);
-            this.gl.uniform1f(shaderUniforms.CanvasWidth, (frame.renderWidth * pixelRatio) / frame.aspectRatio);
+            this.gl.uniform1f(shaderUniforms.CanvasWidth, frame.renderWidth * pixelRatio);
             this.gl.uniform1f(shaderUniforms.CanvasHeight, frame.renderHeight * pixelRatio);
 
             const nanColor = tinycolor(appStore.preferenceStore.nanColorHex).setAlpha(appStore.preferenceStore.nanAlpha);

--- a/src/services/GLSL/vertex_shader_raster.glsl
+++ b/src/services/GLSL/vertex_shader_raster.glsl
@@ -32,11 +32,11 @@ void main(void) {
     tilePosition = scaleAboutPoint2D(tilePosition, uRotationOrigin, uScaleAdjustment);
 
     // Handle pixel rounding while respecting pixel aspect ratios
-    vec2 roundindVector = vec2(1.0, 1.0);
+    vec2 roundingVector = vec2(1.0, 1.0);
     if (uPixelAspectRatio > 1.0) {
-        vec2 roundingVector = vec2(uPixelAspectRatio, 1.0);
+        roundingVector = vec2(uPixelAspectRatio, 1.0);
     } else if (uPixelAspectRatio < 1.0) {
-        vec2 roundingVector = vec2(1.0, 1.0/uPixelAspectRatio);
+        roundingVector = vec2(1.0, 1.0/uPixelAspectRatio);
     }
     tilePosition = floor(tilePosition * roundingVector) / roundingVector;
 


### PR DESCRIPTION
Closes #1708 by first scaling the smaller pixel dimension up before rounding (and then scaling back down).

This approach keeps the `floor` function which fixed the issues described in #1529.