### PR TITLE
adjust padding-bottom in histogram-container in HistogramComponent.scss

### DIFF
--- a/src/components/Histogram/HistogramComponent.scss
+++ b/src/components/Histogram/HistogramComponent.scss
@@ -11,7 +11,7 @@
     .histogram-container {
         flex: 3 3 auto;
         min-width: 0;
-        padding-bottom: 5px;
+        padding-bottom: 15px;
         margin-right: 5px;
 
         .histogram-plot {


### PR DESCRIPTION
Fixed #1682 
![histogram container padding bottom](https://user-images.githubusercontent.com/34430648/150629304-047a38a4-4460-4971-8df3-c3f632552215.png)

I just modified the padding-bottom from 5px to 15px in order to show the padding between the tool bar and the histogram container.

I have checked with chrome, firefox, and safari browser, they looks ok!