### PR TITLE
restore moment generator initial range update

### DIFF
--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -1,4 +1,4 @@
-import {action, autorun, computed, observable, makeObservable, override} from "mobx";
+import {action, autorun, computed, observable, makeObservable, override, reaction} from "mobx";
 import {IOptionProps, NumberRange} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings, VERTICAL_RANGE_PADDING, SmoothingType} from "components/Shared";
@@ -316,10 +316,19 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.intensityConversion = undefined;
         this.setIntensityUnit(this.effectiveFrame?.unit);
 
+        reaction(
+            () => this.effectiveFrame,
+            frame => {
+                if (frame) {
+                    this.setIntensityUnit(frame.unit);
+                }
+            }
+        );
+
         autorun(() => {
             if (this.effectiveFrame) {
                 this.updateRanges();
-                this.momentRegionId = RegionId.ACTIVE;
+                this.selectMomentRegion(RegionId.ACTIVE)
             }
         });
 

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -1,4 +1,4 @@
-import {action, autorun, computed, observable, makeObservable, override, reaction} from "mobx";
+import {action, autorun, computed, observable, makeObservable, override} from "mobx";
 import {IOptionProps, NumberRange} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {PlotType, LineSettings, VERTICAL_RANGE_PADDING, SmoothingType} from "components/Shared";
@@ -316,16 +316,12 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.intensityConversion = undefined;
         this.setIntensityUnit(this.effectiveFrame?.unit);
 
-        reaction(
-            () => this.effectiveFrame,
-            frame => {
-                if (frame) {
-                    this.momentRegionId = RegionId.ACTIVE;
-                    this.setIntensityUnit(frame.unit);
-                    this.updateRanges();
-                }
+        autorun(() => {
+            if (this.effectiveFrame) {
+                this.updateRanges();
+                this.momentRegionId = RegionId.ACTIVE;
             }
-        );
+        });
 
         // Update boundaries
         autorun(() => {

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -328,7 +328,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         autorun(() => {
             if (this.effectiveFrame) {
                 this.updateRanges();
-                this.selectMomentRegion(RegionId.ACTIVE)
+                this.selectMomentRegion(RegionId.ACTIVE);
             }
         });
 


### PR DESCRIPTION
This is to address https://github.com/CARTAvis/carta-frontend/issues/1749 by restoring the approach that v2.0 adopts. ~~This fix also fixes the issue that if there are two images loaded and if we change the intensity unit of the current one then switch to the other and switch back, we see the intensity unit resets to the default (undesired).~~ 