### PR TITLE
skip Stokes options calculation if headers are missing

### DIFF
--- a/src/components/Animator/AnimatorComponent.scss
+++ b/src/components/Animator/AnimatorComponent.scss
@@ -82,7 +82,7 @@
             min-width: 180px;
             flex: 1 1 180px;
             .bp3-html-select {
-                width: 115px
+                width: 115px;
             }
             .bp3-numeric-input {
                 .bp3-input-group {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -801,6 +801,12 @@ export class FrameStore {
                 const crpixHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${index}`) !== -1);
                 const crvalHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRVAL${index}`) !== -1);
                 const cdeltHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CDELT${index}`) !== -1);
+
+                // Skip if any headers are missing
+                if (!naxisHeader || !crpixHeader || !crvalHeader || !cdeltHeader) {
+                    return [];
+                }
+
                 for (let i = 0; i < parseInt(naxisHeader.value); i++) {
                     const stokesVal = getHeaderNumericValue(crvalHeader) + (i + 1 - getHeaderNumericValue(crpixHeader)) * getHeaderNumericValue(cdeltHeader);
                     if (STANDARD_POLARIZATIONS.has(stokesVal)) {


### PR DESCRIPTION
Closes #1769 by just bailing out of the `stokesOptions` calculation gracefully if headers are missing.