### PR TITLE
prevent crash when plot data is empty

### DIFF
--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -232,6 +232,11 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
 
     // replace log(0) with log(0.5)
     private static ConvertLogData(data: {x: number; y: number; z?: number}[]) {
+        // Skip undefined or empty arrays
+        if (!data?.length) {
+            return data;
+        }
+
         for (let index = 0; index < data.length; index++) {
             const point = data[index];
             if (point.y === 0) {


### PR DESCRIPTION
Closes #1772 by adding a simple check to see if `data` is empty/undefined.