### PR TITLE
Angus/1774 million channels

### DIFF
--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1114,7 +1114,7 @@ export class FrameStore {
 
     private convertSpectral = (values: Array<number>): Array<number> => {
         const N = values?.length;
-        if (!N) {
+        if (!N || !this.spectralFrame) {
             return null;
         }
 

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1113,7 +1113,17 @@ export class FrameStore {
     };
 
     private convertSpectral = (values: Array<number>): Array<number> => {
-        return values && values.length > 0 ? values.map(value => this.astSpectralTransform(this.spectralType, this.spectralUnit, this.spectralSystem, value)) : null;
+        const N = values?.length;
+        if (!N) {
+            return null;
+        }
+
+        console.log(`Converting ${N} spectral values`);
+        const spectralArray = new Array<number>(N);
+        for (let i = 0; i < N; i++) {
+            spectralArray[i] = this.astSpectralTransform(this.spectralType, this.spectralUnit, this.spectralSystem, values[i]);
+        }
+        return spectralArray;
     };
 
     private astSpectralTransform = (type: SpectralType, unit: SpectralUnit, system: SpectralSystem, value: number): number => {

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -1118,12 +1118,8 @@ export class FrameStore {
             return null;
         }
 
-        console.log(`Converting ${N} spectral values`);
-        const spectralArray = new Array<number>(N);
-        for (let i = 0; i < N; i++) {
-            spectralArray[i] = this.astSpectralTransform(this.spectralType, this.spectralUnit, this.spectralSystem, values[i]);
-        }
-        return spectralArray;
+        const convertedArray = AST.transformSpectralPointArray(this.spectralFrame, this.spectralType, this.spectralUnit, this.spectralSystem, values);
+        return Array.from(convertedArray);
     };
 
     private astSpectralTransform = (type: SpectralType, unit: SpectralUnit, system: SpectralSystem, value: number): number => {

--- a/wasm_src/ast_wrapper/index.d.ts
+++ b/wasm_src/ast_wrapper/index.d.ts
@@ -51,6 +51,7 @@ export function transformPointArrays(frameSet: FrameSet, xIn: Float64Array, yIn:
 export function transformPoint(frameSet: FrameSet, x: number, y: number, forward?: boolean): {x: number, y: number};
 export function transform3DPoint(frameSet: FrameSet, x: number, y: number, z: number, forward?: boolean): {x: number, y: number, z: number};
 export function transformSpectralPoint(specFrame: SpecFrame, specType: string, specUnit: string, specSys: string, z: number, forward?: boolean);
+export function transformSpectralPointArray(specFrame: SpecFrame, specType: string, specUnit: string, specSys: string, zIn: Float64Array | Array<number>, forward?: boolean): Float64Array;
 export function normalizeCoordinates(frameSet: FrameSet, x: number, y: number): {x: number, y: number};
 export function getTransformGrid(transformFrameSet: FrameSet, xMin: number, xMax: number, numX: number, yMin: number, yMax: number, numY: number, forward: boolean);
 


### PR DESCRIPTION
Closes #1774 by adding a new function to the AST wrapper `transformSpectralPointArray`, which converts an entire array between spectral configs, rather than calling `transformSpectralPoint` a million times.

@kswang1029 can you please test to ensure the following:
1. The loading time is now almost instant.
2. The spectral values in normal files are still the same.