### PR TITLE
Mylin/1762 add cursor info to histogram widget

### DIFF
--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -194,7 +194,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             if (this.widgetStore.isMouseMoveIntoLinePlots) {
                 let numberString;
                 // Switch between standard and scientific notation
-                if (this.widgetStore.cursorX < 1e-2) {
+                if (this.widgetStore.cursorX < 1e-5) {
                     numberString = toExponential(this.widgetStore.cursorX, 5);
                 } else {
                     numberString = toFixed(this.widgetStore.cursorX, 5);

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -7,11 +7,11 @@ import {observer} from "mobx-react";
 import {NonIdealState} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {HistogramToolbarComponent} from "./HistogramToolbarComponent/HistogramToolbarComponent";
-import {LinePlotComponent, LinePlotComponentProps} from "components/Shared";
+import {LinePlotComponent, LinePlotComponentProps, ProfilerInfoComponent} from "components/Shared";
 import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 import {HistogramWidgetStore} from "stores/widgets";
 import {FrameStore, WidgetProps, HelpType, WidgetsStore, AppStore, DefaultWidgetConfig} from "stores";
-import {clamp, getColorForTheme} from "utilities";
+import {clamp, getColorForTheme, toExponential, toFixed, formattedExponential} from "utilities";
 import {Point2D} from "models";
 import "./HistogramComponent.scss";
 
@@ -188,6 +188,33 @@ export class HistogramComponent extends React.Component<WidgetProps> {
         this.widgetStore.setCursor(x);
     }, 100);
 
+    private genProfilerInfo = (): string[] => {
+        let profilerInfo: string[] = [];
+        if (this.widgetStore.isMouseMoveIntoLinePlots) {
+            let numberString;
+            // Switch between standard and scientific notation
+            if (this.widgetStore.cursorX < 1e-2) {
+                numberString = toExponential(this.widgetStore.cursorX, 2);
+            } else {
+                numberString = toFixed(this.widgetStore.cursorX, 2);
+            }
+
+            const frame = AppStore.Instance.activeFrame;
+            if (frame.unit) {
+                numberString += ` ${frame.unit}`;
+            }
+            profilerInfo.push(`Cursor: ${numberString}`);
+        } else {
+            // get value directly from cursor Value
+            const frame = AppStore.Instance.activeFrame;
+            const cursorX = `${frame.cursorValue.position.x} px`;
+            const cursorY = `${frame.cursorValue.position.y} px`;
+            const cursorValue = `${formattedExponential(frame.cursorValue.value, 5)}`;
+            profilerInfo.push("Data: (" + cursorX + ", " + cursorY + ", " + cursorValue + ")");
+        }
+        return profilerInfo;
+    };
+
     render() {
         const appStore = AppStore.Instance;
         const frame = this.widgetStore.effectiveFrame;
@@ -222,6 +249,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             graphZoomReset: this.widgetStore.clearXYBounds,
             graphCursorMoved: this.onGraphCursorMoved,
             scrollZoom: true,
+            mouseEntered: this.widgetStore.setMouseMoveIntoLinePlots,
             borderWidth: this.widgetStore.lineWidth,
             pointRadius: this.widgetStore.linePlotPointSize,
             zeroLineWidth: 2
@@ -269,6 +297,9 @@ export class HistogramComponent extends React.Component<WidgetProps> {
                     <HistogramToolbarComponent widgetStore={this.widgetStore} />
                     <div className="histogram-plot">
                         <LinePlotComponent {...linePlotProps} />
+                    </div>
+                    <div>
+                        <ProfilerInfoComponent info={this.genProfilerInfo()} />
                     </div>
                 </div>
                 <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"}></ReactResizeDetector>

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -208,9 +208,9 @@ export class HistogramComponent extends React.Component<WidgetProps> {
                         numberString += ` ${frame.unit}`;
                     }
                     if (nearest.point.y <= 1) {
-                        valueLabel += ` Count`
+                        valueLabel += ` Count`;
                     } else {
-                        valueLabel += ` Counts`
+                        valueLabel += ` Counts`;
                     }
                     profilerInfo.push(`Cursor: ${numberString}, ${valueLabel}`);
                 }

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -212,6 +212,10 @@ export class HistogramComponent extends React.Component<WidgetProps> {
                     } else {
                         valueLabel += ` Counts`;
                     }
+
+                    if (this.widgetStore.cursorX > this.plotData.xMax || this.widgetStore.cursorX < this.plotData.xMin) {
+                        valueLabel = `NaN`;
+                    }
                     profilerInfo.push(`Cursor: ${numberString}, ${valueLabel}`);
                 }
             }

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -12,7 +12,6 @@ import {TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent"
 import {HistogramWidgetStore} from "stores/widgets";
 import {FrameStore, WidgetProps, HelpType, WidgetsStore, AppStore, DefaultWidgetConfig} from "stores";
 import {binarySearchByX, clamp, getColorForTheme, toExponential, toFixed} from "utilities";
-
 import {Point2D} from "models";
 import "./HistogramComponent.scss";
 

--- a/src/stores/widgets/HistogramWidgetStore.ts
+++ b/src/stores/widgets/HistogramWidgetStore.ts
@@ -13,6 +13,7 @@ export class HistogramWidgetStore extends RegionWidgetStore {
     @observable minY: number;
     @observable maxY: number;
     @observable cursorX: number;
+    @observable isMouseMoveIntoLinePlots: boolean;
 
     // settings
     @observable logScaleY: boolean;
@@ -76,6 +77,10 @@ export class HistogramWidgetStore extends RegionWidgetStore {
 
     @action setCursor = (cursorVal: number) => {
         this.cursorX = cursorVal;
+    };
+
+    @action setMouseMoveIntoLinePlots = (val: boolean) => {
+        this.isMouseMoveIntoLinePlots = val;
     };
 
     @computed get isAutoScaledX() {


### PR DESCRIPTION
Fixed #1762 
I follow the spatial and spectral widget method to add the cursor information to the left bottom of the histogram widget.