### PR TITLE
Upgrade chart-js to 3.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "@types/tinycolor2": "^1.4.2",
                 "ajv": "^8.6.1",
                 "axios": "^0.21.1",
-                "chart.js": "^3.5.1",
+                "chart.js": "^3.7.1",
                 "classnames": "^2.3.1",
                 "fuzzy-search": "^3.2.1",
                 "glob-to-regexp": "^0.4.1",
@@ -6632,9 +6632,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.5.1.tgz",
-            "integrity": "sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.1.tgz",
+            "integrity": "sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==",
             "dev": true
         },
         "node_modules/check-types": {
@@ -33593,9 +33593,9 @@
             "dev": true
         },
         "chart.js": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.5.1.tgz",
-            "integrity": "sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.1.tgz",
+            "integrity": "sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==",
             "dev": true
         },
         "check-types": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@types/tinycolor2": "^1.4.2",
         "ajv": "^8.6.1",
         "axios": "^0.21.1",
-        "chart.js": "^3.5.1",
+        "chart.js": "^3.7.1",
         "classnames": "^2.3.1",
         "fuzzy-search": "^3.2.1",
         "glob-to-regexp": "^0.4.1",


### PR DESCRIPTION
Fixed #1752 
I found the problem after migrate the chart-js from 2.9 to 3.5.1: the NaN in Stoke will be plotted in the widget.

Then I used the newer version (3.7.1) and found the behavior back to 2.9 version, the NaN will not be plotted in the Stoke widget.

So far, I have tested that the chart-js related plots (Histogram, Spectral, Spatial in X, Y) of 3.7.1 working fine and NaN will not be plotted in Stokes, Spectral and Spatial (X,Y).