### PR TITLE
ksw/limit filename length before timestamp up to 200

### DIFF
--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -629,7 +629,8 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
 
         composedCanvas.toBlob(blob => {
             const link = document.createElement("a") as HTMLAnchorElement;
-            link.download = `${imageName}-${plotName.replace(" ", "-")}-${getTimestamp()}.png`;
+            // Trim filename before timestamp to 200 characters to prevent browser errors
+            link.download = `${imageName}-${plotName.replace(" ", "-")}`.substring(0, 200) + `-${getTimestamp()}.png`;
             link.href = URL.createObjectURL(blob);
             link.dispatchEvent(new MouseEvent("click"));
         }, "image/png");

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -304,7 +304,8 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
 
         composedCanvas.toBlob(blob => {
             const link = document.createElement("a") as HTMLAnchorElement;
-            link.download = `${imageName}-${plotName.replace(" ", "-")}-${getTimestamp()}.png`;
+            // Trim filename before timestamp to 200 characters to prevent browser errors
+            link.download = `${imageName}-${plotName.replace(" ", "-")}`.substring(0, 200) + `-${getTimestamp()}.png`;
             link.href = URL.createObjectURL(blob);
             link.dispatchEvent(new MouseEvent("click"));
         }, "image/png");

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -2237,8 +2237,8 @@ export class AppStore {
                     composedCanvas.toBlob(blob => {
                         const link = document.createElement("a") as HTMLAnchorElement;
                         const joinedNames = this.visibleFrames.map(f => f.filename).join("-");
-                        // Trim filename to 230 characters in total to prevent browser errors
-                        link.download = `${joinedNames}-image-${getTimestamp()}`.substring(0, 225) + ".png";
+                        // Trim filename before timestamp to 200 characters to prevent browser errors
+                        link.download = `${joinedNames}-image`.substring(0, 200) + `-${getTimestamp()}.png`;
                         link.href = URL.createObjectURL(blob);
                         link.dispatchEvent(new MouseEvent("click"));
                     }, "image/png");


### PR DESCRIPTION
This is to address https://github.com/CARTAvis/carta-frontend/issues/1501 by trimming the filename string before the timestamp up to 200 char. This applies to the spectral profiler when saving the profile plot as a png and image viewer when saving the image as a png.

