### PR TITLE
ksw/enable text selection in region info and catalog info

### DIFF
--- a/src/components/FileInfo/FileInfoComponent.scss
+++ b/src/components/FileInfo/FileInfoComponent.scss
@@ -25,6 +25,7 @@
         overflow: auto;
         height: 100%;
         flex: 2 2 auto;
+        user-select: text;
     }
 
     .header-list {


### PR DESCRIPTION
this is to address https://github.com/CARTAvis/carta-frontend/issues/1795 by enabling user-select in css. Tested with Safari, Chrome and Firefox and they all work fine. 