### PR TITLE
Yuhsuan/1653 save restfreq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* The ability to set a custom rest frequency for saving subimages. ([#1653](https://github.com/CARTAvis/carta-frontend/issues/1653)).
+
 ## [3.0.0-beta.2]
 
 ### Added
@@ -12,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added two spectral matching types "Vacuum wavelength" and "Air wavelength."
 * Circular/linear polarizations are supported in polarization dropdowns for saving subimages and generating hypercubes.
 * The ability to export high resolution png images for publication quality in journals.
-* The ability to use a custom rest freqency for spectral matching, spectral axis display, and PV image x/y axis display.
+* The ability to use a custom rest frequency for spectral matching, spectral axis display, and PV image x/y axis display.
 * Added new feature: ability to generate a position-velocity (PV) image from a line region on images with a supported coordinate system. The generated images are loaded as separate images, similar to generated moment maps.
 
 ### Changed

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -148,8 +148,7 @@ export class FileBrowserDialogComponent extends React.Component {
         }
         const saveStokes = fileBrowserStore.saveStokesRange;
 
-        const headerRestFreq = activeFrame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name === "RESTFRQ")?.numericValue;
-        const restFreq = headerRestFreq === fileBrowserStore.saveRestFreq ? NaN : fileBrowserStore.saveRestFreq;
+        const restFreq = activeFrame.headerRestFreq === fileBrowserStore.saveRestFreqInHz ? NaN : fileBrowserStore.saveRestFreqInHz;
         await appStore.saveFile(fileBrowserStore.fileList.directory, filename, fileBrowserStore.saveFileType, fileBrowserStore.saveRegionId, saveChannels, saveStokes, fileBrowserStore.shouldDropDegenerateAxes, restFreq);
     };
 

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -147,7 +147,10 @@ export class FileBrowserDialogComponent extends React.Component {
             saveChannels = [Math.max(saveChannelStart, 0), Math.min(saveChannelEnd, activeFrame.numChannels - 1), 1];
         }
         const saveStokes = fileBrowserStore.saveStokesRange;
-        await appStore.saveFile(fileBrowserStore.fileList.directory, filename, fileBrowserStore.saveFileType, fileBrowserStore.saveRegionId, saveChannels, saveStokes, fileBrowserStore.shouldDropDegenerateAxes);
+
+        const headerRestFreq = activeFrame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name === "RESTFRQ")?.numericValue;
+        const restFreq = headerRestFreq === fileBrowserStore.saveRestFreq ? NaN : fileBrowserStore.saveRestFreq;
+        await appStore.saveFile(fileBrowserStore.fileList.directory, filename, fileBrowserStore.saveFileType, fileBrowserStore.saveRegionId, saveChannels, saveStokes, fileBrowserStore.shouldDropDegenerateAxes, restFreq);
     };
 
     private handleSaveFileClicked = () => {

--- a/src/components/Dialogs/FileBrowser/ImageSaveComponent.scss
+++ b/src/components/Dialogs/FileBrowser/ImageSaveComponent.scss
@@ -89,4 +89,24 @@
         margin-top: 1em;
         width: 14em;
     }
+
+    .freq-input {
+        display: flex;
+
+        .bp3-form-group .bp3-label {
+            margin-top: 0.7em;
+        }
+
+        .bp3-html-select {
+            margin-top: 0.7em;
+        }
+
+        .bp3-form-group {
+            margin-right: 7px;
+
+            .bp3-input-group {
+                width: 13em;
+            }
+        }
+    }
 }

--- a/src/components/Dialogs/FileBrowser/ImageSaveComponent.scss
+++ b/src/components/Dialogs/FileBrowser/ImageSaveComponent.scss
@@ -7,106 +7,72 @@
     margin-top: 1em;
 
     .file-name {
-        margin: 0em;
-        margin-bottom: 0em;
-
-        .label {
-            width: 22%;
+        .bp3-label {
+            width: 7em;
         }
+
         .text {
-            margin-left: 0;
-            width: 72%;
+            height: 30px;
+            line-height: 30px;
         }
     }
 
-    .region-select {
-        margin: 0em;
-
-        .label {
-            margin-top: 0.5em;
-            width: 22%;
-        }
-        .bp3-html-select {
-            margin-left: 0;
-            width: auto;
-        }
+    .region-select .bp3-label {
+        width: 7em;
     }
 
     .coordinate-select {
-        margin: 0em;
-        margin-top: 0em;
+        .bp3-label {
+            width: 7em;
+        }
 
-        .bp3-form-group {
-            margin: 0;
-            margin-top: 0.5em;
-
-            .bp3-label {
-                width: 20%;
-            }
-            .bp3-select {
-                margin-left: 0;
-            }
+        .bp3-html-select {
+            margin-right: 7px;
         }
     }
 
     .range-select {
-        margin: 0em;
-        margin-top: 0.5em;
+        .bp3-label {
+            width: 7em;
+        }
 
-        .bp3-control-group {
-            margin: 0;
+        .bp3-form-content {
+            display: flex;
+
+            .bp3-input-group {
+                margin: 0;
+                width: 13em;
+            }
 
             .bp3-label {
-                margin-top: 1em;
-                width: 21%;
-            }
-            .bp3-numeric-input {
-                margin: 0em;
-                width: 14em;
-                .bp3-input {
-                    width: 13em;
-                }
+                margin-left: 7px;
             }
         }
     }
 
-    .stokes-select {
-        margin-top: 0.5em;
-
-        .bp3-form-group {
-            margin: 0em;
-
-            .bp3-label {
-                width: 20%;
-            }
-            .bp3-select {
-                margin-left: 0;
-            }
-        }
+    .stokes-select .bp3-label {
+        width: 7em;
     }
 
     .drop-degenerate {
-        margin-top: 1em;
+        margin-top: 0.5em;
         width: 14em;
     }
 
     .freq-input {
         display: flex;
 
-        .bp3-form-group .bp3-label {
-            margin-top: 0.7em;
+        .bp3-input-group {
+            margin: 0;
+            width: 13em;
+        }
+
+        .bp3-input-group {
+            width: 13em;
         }
 
         .bp3-html-select {
-            margin-top: 0.7em;
-        }
-
-        .bp3-form-group {
-            margin-right: 7px;
-
-            .bp3-input-group {
-                width: 13em;
-            }
+            margin-left: 7px;
         }
     }
 }

--- a/src/components/Dialogs/FileBrowser/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSaveComponent.tsx
@@ -228,16 +228,16 @@ export class ImageSaveComponent extends React.Component {
                             <div className="freq-input">
                                 <ClearableNumericInputComponent
                                     label="Rest frequency"
-                                    value={fileBrowser.saveRestFreqVal}
+                                    value={fileBrowser.saveRestFreq.value}
                                     placeholder="rest frequency"
                                     selectAllOnFocus={true}
-                                    onValueChanged={fileBrowser.setRestFreqVal}
-                                    onValueCleared={fileBrowser.resetRestFreq}
+                                    onValueChanged={fileBrowser.setSaveRestFreqVal}
+                                    onValueCleared={fileBrowser.resetSaveRestFreq}
                                     resetDisabled={activeFrame.restFreqStore.resetDisable}
                                     tooltipContent={activeFrame.restFreqStore.defaultInfo}
                                     tooltipPlacement={"bottom"}
                                 />
-                                <HTMLSelect options={Object.values(FrequencyUnit)} value={fileBrowser.saveRestFreqUnit} onChange={ev => fileBrowser.setRestFreqUnit(ev.currentTarget.value as FrequencyUnit)} />
+                                <HTMLSelect options={Object.values(FrequencyUnit)} value={fileBrowser.saveRestFreq.unit} onChange={ev => fileBrowser.setSaveRestFreqUnit(ev.currentTarget.value as FrequencyUnit)} />
                             </div>
                         )}
                         <Switch className="drop-degenerate" checked={fileBrowser.shouldDropDegenerateAxes} label="Drop degenerate axes" onChange={this.onChangeShouldDropDegenerateAxes} />

--- a/src/components/Dialogs/FileBrowser/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSaveComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {action, autorun, computed, makeObservable} from "mobx";
-import {Text, Label, FormGroup, IOptionProps, HTMLSelect, ControlGroup, Switch, NumericInput, Intent} from "@blueprintjs/core";
+import {Text, Label, FormGroup, IOptionProps, HTMLSelect, Switch, NumericInput, Intent} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {AppStore, FileBrowserStore} from "stores";
 import {FrequencyUnit, SpectralSystem} from "models";
@@ -161,16 +161,14 @@ export class ImageSaveComponent extends React.Component {
             <React.Fragment>
                 {activeFrame && (
                     <div className="file-save">
-                        <ControlGroup className="file-name" vertical={false}>
-                            <Label className="label">{"Source"}</Label>
+                        <FormGroup className="file-name" label={"Source"} inline={true}>
                             <Text className="text" ellipsize={true} title={activeFrame.frameInfo.fileInfo.name}>
                                 {activeFrame.frameInfo.fileInfo.name}
                             </Text>
-                        </ControlGroup>
-                        <ControlGroup className="region-select" vertical={false}>
-                            <Label className="label">{"Region"}</Label>
+                        </FormGroup>
+                        <FormGroup className="region-select" label={"Region"} inline={true}>
                             <HTMLSelect value={fileBrowser.saveRegionId} onChange={this.handleRegionChanged} options={regionOptions} />
-                        </ControlGroup>
+                        </FormGroup>
                         {numChannels > 1 && (
                             <React.Fragment>
                                 <div className="coordinate-select">
@@ -188,8 +186,7 @@ export class ImageSaveComponent extends React.Component {
                                     </FormGroup>
                                 </div>
                                 <div className="range-select">
-                                    <ControlGroup>
-                                        <Label>{"Range from"}</Label>
+                                    <FormGroup label={"Range from"} inline={true}>
                                         <NumericInput
                                             value={fileBrowser.saveSpectralRange[0]}
                                             buttonPosition="none"
@@ -202,9 +199,8 @@ export class ImageSaveComponent extends React.Component {
                                             intent={this.validSaveSpectralRangeStart ? Intent.NONE : Intent.DANGER}
                                         />
                                         <Label>{activeFrame.spectralUnit ? `(${activeFrame.spectralUnit})` : ""}</Label>
-                                    </ControlGroup>
-                                    <ControlGroup>
-                                        <Label>{"Range to"}</Label>
+                                    </FormGroup>
+                                    <FormGroup label={"Range to"} inline={true}>
                                         <NumericInput
                                             value={fileBrowser.saveSpectralRange[1]}
                                             buttonPosition="none"
@@ -217,7 +213,7 @@ export class ImageSaveComponent extends React.Component {
                                             intent={this.validSaveSpectralRangeEnd ? Intent.NONE : Intent.DANGER}
                                         />
                                         <Label>{activeFrame.spectralUnit ? `(${activeFrame.spectralUnit})` : ""}</Label>
-                                    </ControlGroup>
+                                    </FormGroup>
                                 </div>
                             </React.Fragment>
                         )}

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -167,7 +167,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 `${frame.spectralType ? `System(2)=${frame.spectralType},` : ""}` +
                     `${frame.spectralUnit ? `Unit(2)=${frame.spectralUnit},` : ""}` +
                     `${frame.spectralSystem ? `StdOfRest=${frame.spectralSystem},` : ""}` +
-                    `${frame.restFreqStore.restFreq ? `RestFreq=${frame.restFreqStore.restFreq} Hz,` : ""}` +
+                    `${frame.restFreqStore.restFreqInHz ? `RestFreq=${frame.restFreqStore.restFreqInHz} Hz,` : ""}` +
                     `${frame.spectralType && frame.spectralSystem ? `Label(2)=[${frame.spectralSystem}] ${SPECTRAL_TYPE_STRING.get(frame.spectralType)},` : ""}`
             );
         }

--- a/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
+++ b/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
@@ -58,7 +58,7 @@ export class LayerListSettingsPanelComponent extends React.Component<WidgetProps
             <div className="freq-input">
                 <ClearableNumericInputComponent
                     label="Rest frequency"
-                    value={restFreqStore.customVal}
+                    value={restFreqStore.customRestFreq.value}
                     disabled={frameOption.disable}
                     placeholder="rest frequency"
                     selectAllOnFocus={true}
@@ -74,7 +74,7 @@ export class LayerListSettingsPanelComponent extends React.Component<WidgetProps
                     tooltipPlacement={"bottom"}
                     focused={frameOption.frameIndex === this.widgetStore.selectedFrameIndex}
                 />
-                <HTMLSelect disabled={frameOption.disable} options={Object.values(FrequencyUnit)} value={restFreqStore.customUnit} onChange={ev => restFreqStore.setCustomUnit(ev.currentTarget.value as FrequencyUnit)} />
+                <HTMLSelect disabled={frameOption.disable} options={Object.values(FrequencyUnit)} value={restFreqStore.customRestFreq.unit} onChange={ev => restFreqStore.setCustomUnit(ev.currentTarget.value as FrequencyUnit)} />
             </div>
         );
     };

--- a/src/models/Freq.ts
+++ b/src/models/Freq.ts
@@ -1,0 +1,35 @@
+import {FrequencyUnit} from "./SpectralDefinition";
+
+export class Freq {
+    value: number;
+    unit: FrequencyUnit;
+
+    public static convertUnitFromHz = (freq: number): Freq => {
+        if (!isFinite(freq)) {
+            return {value: undefined, unit: FrequencyUnit.MHZ};
+        }
+
+        if (freq >= 1e9) {
+            return {value: freq / 1e9, unit: FrequencyUnit.GHZ};
+        } else if (freq >= 1e6) {
+            return {value: freq / 1e6, unit: FrequencyUnit.MHZ};
+        } else if (freq >= 1e3) {
+            return {value: freq / 1e3, unit: FrequencyUnit.KHZ};
+        } else {
+            return {value: freq, unit: FrequencyUnit.HZ};
+        }
+    };
+
+    public static convertUnitToHz = (freq: Freq): number => {
+        switch (freq.unit) {
+            case FrequencyUnit.GHZ:
+                return freq.value * 1e9;
+            case FrequencyUnit.MHZ:
+                return freq.value * 1e6;
+            case FrequencyUnit.KHZ:
+                return freq.value * 1e3;
+            default:
+                return freq.value;
+        }
+    };
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -29,3 +29,4 @@ export * from "./AbstractCatalogProfile";
 export * from "./ImagePanelMode";
 export * from "./PolarizationDefinition";
 export * from "./FileFilterMode";
+export * from "./Freq";

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -444,11 +444,11 @@ export class BackendService {
         return false;
     }
 
-    async saveFile(fileId: number, outputFileDirectory: string, outputFileName: string, outputFileType: CARTA.FileType, regionId?: number, channels?: number[], stokes?: number[], keepDegenerate?: boolean): Promise<CARTA.ISaveFileAck> {
+    async saveFile(fileId: number, outputFileDirectory: string, outputFileName: string, outputFileType: CARTA.FileType, regionId?: number, channels?: number[], stokes?: number[], keepDegenerate?: boolean, restFreq?: number): Promise<CARTA.ISaveFileAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {
-            const message = CARTA.SaveFile.create({fileId, outputFileDirectory, outputFileName, outputFileType, regionId, channels, stokes, keepDegenerate});
+            const message = CARTA.SaveFile.create({fileId, outputFileDirectory, outputFileName, outputFileType, regionId, channels, stokes, keepDegenerate, restFreq});
             const requestId = this.eventCounter;
             this.logEvent(CARTA.EventType.SAVE_FILE, this.eventCounter, message, false);
             if (this.sendEvent(CARTA.EventType.SAVE_FILE, CARTA.SaveFile.encode(message).finish())) {

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -444,7 +444,17 @@ export class BackendService {
         return false;
     }
 
-    async saveFile(fileId: number, outputFileDirectory: string, outputFileName: string, outputFileType: CARTA.FileType, regionId?: number, channels?: number[], stokes?: number[], keepDegenerate?: boolean, restFreq?: number): Promise<CARTA.ISaveFileAck> {
+    async saveFile(
+        fileId: number,
+        outputFileDirectory: string,
+        outputFileName: string,
+        outputFileType: CARTA.FileType,
+        regionId?: number,
+        channels?: number[],
+        stokes?: number[],
+        keepDegenerate?: boolean,
+        restFreq?: number
+    ): Promise<CARTA.ISaveFileAck> {
         if (this.connectionStatus !== ConnectionStatus.ACTIVE) {
             throw new Error("Not connected");
         } else {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -608,14 +608,14 @@ export class AppStore {
         return this.loadFile(path, filename, hdu, imageArithmetic);
     };
 
-    saveFile = async (directory: string, filename: string, fileType: CARTA.FileType, regionId?: number, channels?: number[], stokes?: number[], shouldDropDegenerateAxes?: boolean) => {
+    saveFile = async (directory: string, filename: string, fileType: CARTA.FileType, regionId?: number, channels?: number[], stokes?: number[], shouldDropDegenerateAxes?: boolean, restFreq?: number) => {
         if (!this.activeFrame) {
             throw new Error("No active image");
         }
         this.startFileSaving();
         const fileId = this.activeFrame.frameInfo.fileId;
         try {
-            const ack = await this.backendService.saveFile(fileId, directory, filename, fileType, regionId, channels, stokes, !shouldDropDegenerateAxes);
+            const ack = await this.backendService.saveFile(fileId, directory, filename, fileType, regionId, channels, stokes, !shouldDropDegenerateAxes, restFreq);
             AppToaster.show({icon: "saved", message: `${filename} saved.`, intent: "success", timeout: 3000});
             this.fileBrowserStore.hideFileBrowser();
             this.endFileSaving();

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -477,7 +477,7 @@ export class FrameStore {
                 if (spectralType.code === "FREQ") {
                     // dummy variable to update velocity when the rest freq for spectral transform is changed
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const restFreq = this.restFreqStore.restFreq;
+                    const restFreq = this.restFreqStore.restFreqInHz;
 
                     const freqVal = channelInfo.rawValues[this.channel];
                     // convert frequency value to unit in GHz
@@ -817,6 +817,10 @@ export class FrameStore {
         return this.requiredStokes >= 0 && this.requiredStokes < this.stokesInfo?.length ? this.stokesInfo[this.requiredStokes] : String(this.requiredStokes);
     }
 
+    get headerRestFreq(): number {
+        return this.frameInfo?.fileInfoExtended?.headerEntries?.find(entry => entry.name === "RESTFRQ")?.numericValue;
+    }
+
     constructor(frameInfo: FrameInfo) {
         makeObservable(this);
         this.overlayStore = OverlayStore.Instance;
@@ -994,7 +998,7 @@ export class FrameStore {
             }
         }
 
-        const headerRestFreq = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name === "RESTFRQ")?.numericValue;
+        const headerRestFreq = this.headerRestFreq;
         this.restFreqStore = new RestFreqStore(headerRestFreq);
         this.initSupportedSpectralConversion();
         this.initCenter();
@@ -1020,7 +1024,7 @@ export class FrameStore {
         this.cursorMoving = false;
 
         reaction(
-            () => this.restFreqStore.restFreq,
+            () => this.restFreqStore.restFreqInHz,
             restFreq => {
                 if (this.restFreqStore.inValidInput || !isFinite(restFreq)) {
                     return;
@@ -1067,7 +1071,7 @@ export class FrameStore {
             const unit = this.spectralUnit;
             /* eslint-disable @typescript-eslint/no-unused-vars */
             const specsys = this.spectralSystem;
-            const restFreq = this.restFreqStore.restFreq;
+            const restFreq = this.restFreqStore.restFreqInHz;
             /* eslint-enable @typescript-eslint/no-unused-vars */
             if (this.channelInfo) {
                 if (!type && !unit) {
@@ -1540,7 +1544,7 @@ export class FrameStore {
         const spectralType = this.spectralAxis.type.code;
         if (IsSpectralTypeSupported(spectralType)) {
             // check RESTFRQ
-            if (isFinite(this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name === "RESTFRQ")?.numericValue)) {
+            if (isFinite(this.headerRestFreq)) {
                 this.spectralCoordsSupported = SPECTRAL_COORDS_SUPPORTED;
             } else {
                 this.spectralCoordsSupported = new Map<string, {type: SpectralType; unit: SpectralUnit}>();

--- a/src/stores/Frame/RestFreqStore.ts
+++ b/src/stores/Frame/RestFreqStore.ts
@@ -1,80 +1,45 @@
 import {action, computed, observable, makeObservable} from "mobx";
-import {FrequencyUnit} from "models";
+import {FrequencyUnit, Freq} from "models";
 
 export class RestFreqStore {
-    readonly headerVal: number;
-    readonly headerUnit: FrequencyUnit;
+    readonly headerRestFreq: Freq;
+    @observable customRestFreq: Freq;
 
-    @observable customVal: number;
-    @observable customUnit: FrequencyUnit;
-
-    @computed get restFreq(): number {
+    @computed get restFreqInHz(): number {
         if (this.inValidInput) {
             return undefined;
         }
-        return RestFreqStore.convertUnitInverse(this.customVal, this.customUnit);
+        return Freq.convertUnitToHz(this.customRestFreq);
     }
 
     @computed get inValidInput(): boolean {
-        return !isFinite(this.customVal);
+        return !isFinite(this.customRestFreq.value);
     }
 
     @computed get resetDisable(): boolean {
-        return !isFinite(this.headerVal);
+        return !isFinite(this.headerRestFreq.value);
     }
 
     @computed get defaultInfo(): string {
-        return isFinite(this.headerVal) ? `Header: ${this.headerVal} ${this.headerUnit}` : undefined;
+        return isFinite(this.headerRestFreq.value) ? `Header: ${this.headerRestFreq.value} ${this.headerRestFreq.unit}` : undefined;
     }
 
     constructor(headerRestFreq: number) {
         makeObservable(this);
-        const defaultRestFreq = RestFreqStore.convertUnit(headerRestFreq);
-        this.headerVal = defaultRestFreq.value;
-        this.headerUnit = defaultRestFreq.unit;
-        this.customVal = defaultRestFreq.value;
-        this.customUnit = defaultRestFreq.unit;
+        const defaultRestFreq = Freq.convertUnitFromHz(headerRestFreq);
+        this.headerRestFreq = defaultRestFreq;
+        this.customRestFreq = defaultRestFreq;
     }
 
     @action setCustomVal = (val: number) => {
-        this.customVal = val;
+        this.customRestFreq.value = val;
     };
 
     @action setCustomUnit = (val: FrequencyUnit) => {
-        this.customUnit = val;
+        this.customRestFreq.unit = val;
     };
 
     @action restoreDefaults = () => {
-        this.customVal = this.headerVal;
-        this.customUnit = this.headerUnit;
-    };
-
-    private static convertUnit = (restFreq: number) => {
-        if (!isFinite(restFreq)) {
-            return {value: undefined, unit: FrequencyUnit.MHZ};
-        }
-
-        if (restFreq >= 1e9) {
-            return {value: restFreq / 1e9, unit: FrequencyUnit.GHZ};
-        } else if (restFreq >= 1e6) {
-            return {value: restFreq / 1e6, unit: FrequencyUnit.MHZ};
-        } else if (restFreq >= 1e3) {
-            return {value: restFreq / 1e3, unit: FrequencyUnit.KHZ};
-        } else {
-            return {value: restFreq, unit: FrequencyUnit.HZ};
-        }
-    };
-
-    static convertUnitInverse = (value: number, unit: FrequencyUnit) => {
-        switch (unit) {
-            case FrequencyUnit.GHZ:
-                return value * 1e9;
-            case FrequencyUnit.MHZ:
-                return value * 1e6;
-            case FrequencyUnit.KHZ:
-                return value * 1e3;
-            default:
-                return value;
-        }
+        this.customRestFreq = this.headerRestFreq;
     };
 }

--- a/src/stores/Frame/RestFreqStore.ts
+++ b/src/stores/Frame/RestFreqStore.ts
@@ -2,8 +2,8 @@ import {action, computed, observable, makeObservable} from "mobx";
 import {FrequencyUnit} from "models";
 
 export class RestFreqStore {
-    private readonly headerVal: number;
-    private readonly headerUnit: FrequencyUnit;
+    readonly headerVal: number;
+    readonly headerUnit: FrequencyUnit;
 
     @observable customVal: number;
     @observable customUnit: FrequencyUnit;
@@ -65,7 +65,7 @@ export class RestFreqStore {
         }
     };
 
-    private static convertUnitInverse = (value: number, unit: FrequencyUnit) => {
+    static convertUnitInverse = (value: number, unit: FrequencyUnit) => {
         switch (unit) {
             case FrequencyUnit.GHZ:
                 return value * 1e9;


### PR DESCRIPTION
Closes #1653 with some code maintenance:

* Add rest frequency input in the image save panel
    * update the value after adjusting custom rest freq in the image layer settings
    * set to header rest freq by the reset button
* Add `Freq` model for `FileBrowserStore` and `RestFreqStore`
* Refactor `ImageSaveComponent`
    * Remove `renderSaveImageControl` and `const stokesOptions`
    * change to `Formgroup` to avoid manually setting margins in CSS
* Add `headerRestFreq` in `FrameStore`

Companion PRs:
https://github.com/CARTAvis/carta-backend/pull/1088
https://github.com/CARTAvis/carta-protobuf/pull/69