### PR TITLE
Yuhsuan/1397 world coord result

### DIFF
--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {observer} from "mobx-react";
-import {action, computed, makeObservable, observable} from "mobx";
+import {action, makeObservable, observable} from "mobx";
 import {AnchorButton, Classes, Dialog, FormGroup, HTMLSelect, Icon, IDialogProps, Intent, NonIdealState, Position, Pre, Slider, Tab, Tabs, Text} from "@blueprintjs/core";
 import {Tooltip2} from "@blueprintjs/popover2";
 import classNames from "classnames";
@@ -22,28 +22,6 @@ export class FittingDialogComponent extends React.Component {
     @action private setFittingResultTabId = (tabId: FittingResultTabs) => {
         this.fittingResultTabId = tabId;
     };
-
-    @computed get fittingResults(): string {
-        const frame = AppStore.Instance.imageFittingStore.effectiveFrame;
-        const values = frame?.fittingResultValues;
-        const errors = frame?.fittingResultErrors;
-        if (!values || !errors) {
-            return "";
-        }
-
-        let results = "";
-        const unitString = frame.unit ? ` (${frame.unit})` : "";
-        for (let i = 0; i < values.length; i++) {
-            results += `Component #${i + 1}:\n`;
-            results += `Center X  = ${values[i]?.center?.x?.toFixed(6)} +/- ${errors[i]?.center?.x?.toFixed(6)} (px)\n`;
-            results += `Center Y  = ${values[i]?.center?.y?.toFixed(6)} +/- ${errors[i]?.center?.y?.toFixed(6)} (px)\n`;
-            results += `Amplitude = ${values[i]?.amp?.toFixed(6)} +/- ${errors[i]?.amp?.toFixed(6)}${unitString}\n`;
-            results += `FWHM X    = ${values[i]?.fwhm?.x?.toFixed(6)} +/- ${errors[i]?.fwhm?.x?.toFixed(6)} (px)\n`;
-            results += `FWHM Y    = ${values[i]?.fwhm?.y?.toFixed(6)} +/- ${errors[i]?.fwhm?.y?.toFixed(6)} (px)\n`;
-            results += `P.A.      = ${values[i]?.pa?.toFixed(6)} +/- ${errors[i]?.pa?.toFixed(6)} (deg)\n\n`;
-        }
-        return results;
-    }
 
     constructor(props: any) {
         super(props);
@@ -81,7 +59,7 @@ export class FittingDialogComponent extends React.Component {
 
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
-                <Text className="fitting-result-text">{this.fittingResults}</Text>
+                <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
             </Pre>
         );
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1108,7 +1108,7 @@ export class AppStore {
         try {
             const ack = await this.backendService.requestFitting(message);
             if (ack.success) {
-                this.getFrame(message.fileId).setFittingResults(ack.resultValues, ack.resultErrors, ack.log);
+                this.getFrame(message.fileId).updateFittingResults(ack.resultValues, ack.resultErrors, ack.log);
             }
             if (ack.message) {
                 AppToaster.show(WarningToast(`Image fitting: ${ack.message}.`));

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1108,9 +1108,7 @@ export class AppStore {
         try {
             const ack = await this.backendService.requestFitting(message);
             if (ack.success) {
-                const frame = this.getFrame(message.fileId);
-                frame.setFittingResult(ack.resultValues, ack.resultErrors);
-                frame.setFittingLog(ack.log);
+                this.getFrame(message.fileId).setFittingResults(ack.resultValues, ack.resultErrors, ack.log);
             }
             if (ack.message) {
                 AppToaster.show(WarningToast(`Image fitting: ${ack.message}.`));

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1108,7 +1108,7 @@ export class AppStore {
         try {
             const ack = await this.backendService.requestFitting(message);
             if (ack.success) {
-                this.getFrame(message.fileId).updateFittingResults(ack.resultValues, ack.resultErrors, ack.log);
+                this.imageFittingStore.setResultString(ack.resultValues, ack.resultErrors, ack.log);
             }
             if (ack.message) {
                 AppToaster.show(WarningToast(`Image fitting: ${ack.message}.`));

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -137,8 +137,7 @@ export class FrameStore {
     @observable momentImages: FrameStore[];
     @observable pvImage: FrameStore;
     @observable generatedPVRegionId: number;
-    @observable fittingResultValues: CARTA.IGaussianComponent[];
-    @observable fittingResultErrors: CARTA.IGaussianComponent[];
+    @observable fittingResult: string;
     @observable fittingLog: string;
 
     @observable isRequestingMoments: boolean;
@@ -868,8 +867,7 @@ export class FrameStore {
         this.secondaryRasterScalingImages = [];
         this.momentImages = [];
         this.pvImage = null;
-        this.fittingResultValues = [];
-        this.fittingResultErrors = [];
+        this.fittingResult = "";
         this.fittingLog = "";
 
         this.isRequestingMoments = false;
@@ -2171,9 +2169,29 @@ export class FrameStore {
         this.isRequestPVCancelling = val;
     };
 
-    @action setFittingResult = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[]) => {
-        this.fittingResultValues = values;
-        this.fittingResultErrors = errors;
+    public setFittingResults = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[], log: string) => {
+        if (!values || !errors) {
+            return;
+        }
+
+        let results = "";
+        const unitString = this.unit ? ` (${this.unit})` : "";
+        for (let i = 0; i < values.length; i++) {
+            results += `Component #${i + 1}:\n`;
+            results += `Center X  = ${values[i]?.center?.x?.toFixed(6)} +/- ${errors[i]?.center?.x?.toFixed(6)} (px)\n`;
+            results += `Center Y  = ${values[i]?.center?.y?.toFixed(6)} +/- ${errors[i]?.center?.y?.toFixed(6)} (px)\n`;
+            results += `Amplitude = ${values[i]?.amp?.toFixed(6)} +/- ${errors[i]?.amp?.toFixed(6)}${unitString}\n`;
+            results += `FWHM X    = ${values[i]?.fwhm?.x?.toFixed(6)} +/- ${errors[i]?.fwhm?.x?.toFixed(6)} (px)\n`;
+            results += `FWHM Y    = ${values[i]?.fwhm?.y?.toFixed(6)} +/- ${errors[i]?.fwhm?.y?.toFixed(6)} (px)\n`;
+            results += `P.A.      = ${values[i]?.pa?.toFixed(6)} +/- ${errors[i]?.pa?.toFixed(6)} (deg)\n\n`;
+        }
+        
+        this.setFittingResult(results);
+        this.setFittingLog(log);
+    };
+
+    @action setFittingResult = (results: string) => {
+        this.fittingResult = results;
     };
 
     @action setFittingLog = (log: string) => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2170,7 +2170,7 @@ export class FrameStore {
         this.isRequestPVCancelling = val;
     };
 
-    public setFittingResults = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[], log: string) => {
+    public updateFittingResults = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[], log: string) => {
         if (!values || !errors) {
             return;
         }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2,7 +2,7 @@ import {action, autorun, computed, observable, makeObservable, runInAction, reac
 import {IOptionProps, NumberRange} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import * as AST from "ast_wrapper";
-import {AnimatorStore, AppStore, ASTSettingsString, LogStore, NumberFormatType, OverlayStore, PreferenceStore} from "stores";
+import {AnimatorStore, AppStore, ASTSettingsString, LogStore, OverlayStore, PreferenceStore} from "stores";
 import {ColorbarStore, ContourStore, ContourConfigStore, DistanceMeasuringStore, RegionStore, RegionSetStore, RestFreqStore, RenderConfigStore, OverlayBeamStore} from "stores/Frame";
 import {
     ChannelInfo,
@@ -44,8 +44,7 @@ import {
     getFormattedWCSPoint,
     getPixelSize,
     multiply2D,
-    isAstBadPoint,
-    toExponential
+    isAstBadPoint
 } from "utilities";
 import {BackendService, CatalogWebGLService, ContourWebGLService, TILE_SIZE} from "services";
 import {RegionId} from "stores/widgets";
@@ -2168,84 +2167,6 @@ export class FrameStore {
 
     @action setIsRequestPVCancelling = (val: boolean) => {
         this.isRequestPVCancelling = val;
-    };
-
-    public updateFittingResults = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[], log: string) => {
-        if (!values || !errors) {
-            return;
-        }
-
-        let results = "";
-        log += "\n";
-        const toFixFormat = (param: string, value: number | string, error: number, unit: string): string => {
-            return `${param} = ${typeof value === "string" ? value : value?.toFixed(6)} +/- ${error?.toFixed(6)}${unit ? ` (${unit})` : ""}\n`;
-        };
-        const toExpFormat = (param: string, value: number | string, error: number, unit: string): string => {
-            return `${param} = ${typeof value === "string" ? value : toExponential(value, 12)} +/- ${toExponential(error, 12)}${unit ? ` (${unit})` : ""}\n`;
-        };
-        const isFormatXDeg = this.overlayStore.numbers?.formatTypeX === NumberFormatType.Degrees;
-        const isFormatYDeg = this.overlayStore.numbers?.formatTypeY === NumberFormatType.Degrees;
-
-        for (let i = 0; i < values.length; i++) {
-            const value = values[i];
-            const error = errors[i];
-            if (!value || !error) {
-                continue;
-            }
-            results += `Component #${i + 1}:\n`;
-            log += `Component #${i + 1}:\n`;
-            if (!this.wcsInfoForTransformation || !this.pixelUnitSizeArcsec) {
-                results += toFixFormat("Center X ", value.center?.x, error.center?.x, "px");
-                results += toFixFormat("Center Y ", value.center?.y, error.center?.y, "px");
-                results += toFixFormat("Amplitude", value.amp, error.amp, this.unit);
-                results += toFixFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
-                results += toFixFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
-                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
-
-                log += toExpFormat("Center X ", value.center?.x, error.center?.x, "px");
-                log += toExpFormat("Center Y ", value.center?.y, error.center?.y, "px");
-                log += toExpFormat("Amplitude", value.amp, error.amp, this.unit);
-                log += toExpFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
-                log += toExpFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
-                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
-            } else {
-                const centerValueWCS = getFormattedWCSPoint(this.wcsInfoForTransformation, value.center as Point2D);
-                if (isFormatXDeg) {
-                    centerValueWCS.x += " (deg)";
-                }
-                if (isFormatYDeg) {
-                    centerValueWCS.y += " (deg)";
-                }
-                const centerErrorWCS = this.getWcsSizeInArcsec(error.center as Point2D);
-                const fwhmValueWCS = this.getWcsSizeInArcsec(value.fwhm as Point2D);
-                const fwhmErrorWCS = this.getWcsSizeInArcsec(error.fwhm as Point2D);
-
-                results += toFixFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
-                results += toFixFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
-                results += toFixFormat("Amplitude", value.amp, error.amp, this.unit);
-                results += toFixFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
-                results += toFixFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
-                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
-
-                log += toExpFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
-                log += toExpFormat("         ", value.center?.x, error.center?.x, "px");
-                log += toExpFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
-                log += toExpFormat("         ", value.center?.y, error.center?.y, "px");
-                log += toExpFormat("Amplitude", value.amp, error.amp, this.unit);
-                log += toExpFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
-                log += toExpFormat("         ", value.fwhm?.x, error.fwhm?.x, "px");
-                log += toExpFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
-                log += toExpFormat("         ", value.fwhm?.y, error.fwhm?.y, "px");
-                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
-            }
-            if (i !== values.length - 1) {
-                results += "\n";
-                log += "\n";
-            }
-        }
-
-        this.setFittingResult(results);
-        this.setFittingLog(log);
     };
 
     @action setFittingResult = (results: string) => {

--- a/src/stores/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore.ts
@@ -1,9 +1,10 @@
 import {action, observable, makeObservable, computed} from "mobx";
 import {CARTA} from "carta-protobuf";
-import {AppStore} from "stores";
+import {AppStore, NumberFormatType} from "stores";
 import {FrameStore} from "stores/Frame";
 import {ACTIVE_FILE_ID} from "stores/widgets";
 import {Point2D} from "models";
+import {getFormattedWCSPoint, toExponential} from "utilities";
 
 export class ImageFittingStore {
     private static staticInstance: ImageFittingStore;
@@ -94,21 +95,95 @@ export class ImageFittingStore {
                 center: c.center,
                 amp: c.amplitude,
                 fwhm: c.fwhm,
-                pa: c.pa,
-                fixedCenterX: false,
-                fixedCenterY: false,
-                fixedAmp: false,
-                fixedFwhmX: false,
-                fixedFwhmY: false,
-                fixedPa: false
+                pa: c.pa
             });
         }
 
         const message: CARTA.IFittingRequest = {
             fileId: this.effectiveFrame.frameInfo.fileId,
-            initialValues: initialValues
+            initialValues: initialValues,
+            fixedParams: []
         };
         AppStore.Instance.requestFitting(message);
+    };
+
+    setResultString = (values: CARTA.IGaussianComponent[], errors: CARTA.IGaussianComponent[], log: string) => {
+        const frame = this.effectiveFrame;
+        if (!frame || !values || !errors) {
+            return;
+        }
+
+        let results = "";
+        log += "\n";
+        const toFixFormat = (param: string, value: number | string, error: number, unit: string): string => {
+            return `${param} = ${typeof value === "string" ? value : value?.toFixed(6)} +/- ${error?.toFixed(6)}${unit ? ` (${unit})` : ""}\n`;
+        };
+        const toExpFormat = (param: string, value: number | string, error: number, unit: string): string => {
+            return `${param} = ${typeof value === "string" ? value : toExponential(value, 12)} +/- ${toExponential(error, 12)}${unit ? ` (${unit})` : ""}\n`;
+        };
+        const isFormatXDeg = AppStore.Instance.overlayStore.numbers?.formatTypeX === NumberFormatType.Degrees;
+        const isFormatYDeg = AppStore.Instance.overlayStore.numbers?.formatTypeY === NumberFormatType.Degrees;
+
+        for (let i = 0; i < values.length; i++) {
+            const value = values[i];
+            const error = errors[i];
+            if (!value || !error) {
+                continue;
+            }
+            results += `Component #${i + 1}:\n`;
+            log += `Component #${i + 1}:\n`;
+            if (!frame.wcsInfoForTransformation || !frame.pixelUnitSizeArcsec) {
+                results += toFixFormat("Center X ", value.center?.x, error.center?.x, "px");
+                results += toFixFormat("Center Y ", value.center?.y, error.center?.y, "px");
+                results += toFixFormat("Amplitude", value.amp, error.amp, frame.unit);
+                results += toFixFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
+                results += toFixFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
+                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
+
+                log += toExpFormat("Center X ", value.center?.x, error.center?.x, "px");
+                log += toExpFormat("Center Y ", value.center?.y, error.center?.y, "px");
+                log += toExpFormat("Amplitude", value.amp, error.amp, frame.unit);
+                log += toExpFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
+                log += toExpFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
+                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
+            } else {
+                const centerValueWCS = getFormattedWCSPoint(frame.wcsInfoForTransformation, value.center as Point2D);
+                if (isFormatXDeg) {
+                    centerValueWCS.x += " (deg)";
+                }
+                if (isFormatYDeg) {
+                    centerValueWCS.y += " (deg)";
+                }
+                const centerErrorWCS = frame.getWcsSizeInArcsec(error.center as Point2D);
+                const fwhmValueWCS = frame.getWcsSizeInArcsec(value.fwhm as Point2D);
+                const fwhmErrorWCS = frame.getWcsSizeInArcsec(error.fwhm as Point2D);
+
+                results += toFixFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
+                results += toFixFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
+                results += toFixFormat("Amplitude", value.amp, error.amp, frame.unit);
+                results += toFixFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
+                results += toFixFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
+                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
+
+                log += toExpFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
+                log += toExpFormat("         ", value.center?.x, error.center?.x, "px");
+                log += toExpFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
+                log += toExpFormat("         ", value.center?.y, error.center?.y, "px");
+                log += toExpFormat("Amplitude", value.amp, error.amp, frame.unit);
+                log += toExpFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
+                log += toExpFormat("         ", value.fwhm?.x, error.fwhm?.x, "px");
+                log += toExpFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
+                log += toExpFormat("         ", value.fwhm?.y, error.fwhm?.y, "px");
+                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
+            }
+            if (i !== values.length - 1) {
+                results += "\n";
+                log += "\n";
+            }
+        }
+
+        frame.setFittingResult(results);
+        frame.setFittingLog(log);
     };
 }
 


### PR DESCRIPTION
This PR is for the second item of #1397: adding fitting results in world coordinates.
* [Fitting Result] shows the result in world coordinates, while [Full Log] shows the result in both px and world coordinates and shows more digits.
* If world coordinate info in the header is not sufficient, [Fitting Result] and [Full Log] only show the result in px.
* The position format is either `XX:XX:XX.XX...` or `XXX... (deg)`; the size format is in arcsec.
* The size calculation follows the same approach for regions (unit size estimated by the geodesic distance near `[CRPIX1, CRPIX2]`, see PR #1719). We may set warnings when the projection effect is large in the future (see #1716). If such cases are common, we may also consider calculating the geodesic distance near the Gaussian center.