### PR TITLE
Yuhsuan/1397 size unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0-beta.4]
 
+### Added
+* Size conversion in the image fitting results ([#1397](https://github.com/CARTAvis/carta-frontend/issues/1397)).
 ### Fixed
 * Added missing vector overlay and image fitting options in the View menu ([#1848](https://github.com/CARTAvis/carta-frontend/issues/1848))
 * Hide code snippet option in the View menu when code snippet is disabled in the preferences ([#1856](https://github.com/CARTAvis/carta-frontend/issues/1856))

--- a/src/models/AngularSize.ts
+++ b/src/models/AngularSize.ts
@@ -1,0 +1,47 @@
+export enum AngularSizeUnit {
+    MILLIARCSEC = "marcsec",
+    ARCSEC = "arcsec",
+    ARCMIN = "arcmin",
+    DEG = "deg"
+}
+
+export class AngularSize {
+    value: number;
+    unit: AngularSizeUnit;
+
+    public static convertValueFromArcsec = (arcsec: number, dstUnit: AngularSizeUnit): number => {
+        if (!isFinite(arcsec)) {
+            return undefined;
+        }
+
+        switch (dstUnit) {
+            case AngularSizeUnit.MILLIARCSEC:
+                return arcsec * 1e3;
+            case AngularSizeUnit.ARCMIN:
+                return arcsec / 60.0;
+            case AngularSizeUnit.DEG:
+                return arcsec / 3600.0;
+            case AngularSizeUnit.ARCSEC:
+            default:
+                return arcsec;
+        }
+    }
+
+    public static convertFromArcsec = (arcsec: number, supportMilliarcsec: boolean = false): AngularSize => {
+        if (!isFinite(arcsec)) {
+            return {value: undefined, unit: AngularSizeUnit.ARCSEC};
+        }
+
+        let unit;
+        if (supportMilliarcsec && arcsec < 0.002) {
+            unit = AngularSizeUnit.MILLIARCSEC;
+        } else if (arcsec < 120) {
+            unit = AngularSizeUnit.ARCSEC;
+        } else if (arcsec >= 120 && arcsec < 7200) {
+            unit = AngularSizeUnit.ARCMIN;
+        } else {
+            unit = AngularSizeUnit.DEG;
+        }
+        return {value: AngularSize.convertValueFromArcsec(arcsec, unit), unit: unit};
+    }
+}

--- a/src/models/AngularSize.ts
+++ b/src/models/AngularSize.ts
@@ -25,7 +25,7 @@ export class AngularSize {
             default:
                 return arcsec;
         }
-    }
+    };
 
     public static convertFromArcsec = (arcsec: number, supportMilliarcsec: boolean = false): AngularSize => {
         if (!isFinite(arcsec)) {
@@ -43,5 +43,5 @@ export class AngularSize {
             unit = AngularSizeUnit.DEG;
         }
         return {value: AngularSize.convertValueFromArcsec(arcsec, unit), unit: unit};
-    }
+    };
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -30,3 +30,4 @@ export * from "./ImagePanelMode";
 export * from "./PolarizationDefinition";
 export * from "./FileFilterMode";
 export * from "./Freq";
+export * from "./AngularSize";

--- a/src/stores/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore.ts
@@ -3,7 +3,7 @@ import {CARTA} from "carta-protobuf";
 import {AppStore, NumberFormatType} from "stores";
 import {FrameStore} from "stores/Frame";
 import {ACTIVE_FILE_ID} from "stores/widgets";
-import {Point2D} from "models";
+import {AngularSize, AngularSizeUnit, Point2D} from "models";
 import {getFormattedWCSPoint, toExponential} from "utilities";
 
 export class ImageFittingStore {
@@ -155,14 +155,22 @@ export class ImageFittingStore {
                     centerValueWCS.y += " (deg)";
                 }
                 const centerErrorWCS = frame.getWcsSizeInArcsec(error.center as Point2D);
-                const fwhmValueWCS = frame.getWcsSizeInArcsec(value.fwhm as Point2D);
-                const fwhmErrorWCS = frame.getWcsSizeInArcsec(error.fwhm as Point2D);
 
+                let fwhmValueWCS = frame.getWcsSizeInArcsec(value.fwhm as Point2D);
+                let fwhmErrorWCS = frame.getWcsSizeInArcsec(error.fwhm as Point2D);
+                let fwhmUnit = {x: AngularSizeUnit.ARCSEC, y: AngularSizeUnit.ARCSEC};
+                if (fwhmValueWCS && fwhmErrorWCS) {
+                    ({value: fwhmValueWCS.x, unit: fwhmUnit.x} = AngularSize.convertFromArcsec(fwhmValueWCS.x, true));
+                    fwhmErrorWCS.x = AngularSize.convertValueFromArcsec(fwhmErrorWCS.x, fwhmUnit.x);
+                    ({value: fwhmValueWCS.y, unit: fwhmUnit.y} = AngularSize.convertFromArcsec(fwhmValueWCS.y, true));
+                    fwhmErrorWCS.y = AngularSize.convertValueFromArcsec(fwhmErrorWCS.y, fwhmUnit.y);
+                }
+                
                 results += toFixFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
                 results += toFixFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
                 results += toFixFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                results += toFixFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
-                results += toFixFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
+                results += toFixFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
+                results += toFixFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
                 results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
 
                 log += toExpFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
@@ -170,9 +178,9 @@ export class ImageFittingStore {
                 log += toExpFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
                 log += toExpFormat("         ", value.center?.y, error.center?.y, "px");
                 log += toExpFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                log += toExpFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, "arcsec");
+                log += toExpFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
                 log += toExpFormat("         ", value.fwhm?.x, error.fwhm?.x, "px");
-                log += toExpFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS.y, "arcsec");
+                log += toExpFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
                 log += toExpFormat("         ", value.fwhm?.y, error.fwhm?.y, "px");
                 log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
             }

--- a/src/stores/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore.ts
@@ -133,19 +133,19 @@ export class ImageFittingStore {
             results += `Component #${i + 1}:\n`;
             log += `Component #${i + 1}:\n`;
             if (!frame.wcsInfoForTransformation || !frame.pixelUnitSizeArcsec) {
-                results += toFixFormat("Center X ", value.center?.x, error.center?.x, "px");
-                results += toFixFormat("Center Y ", value.center?.y, error.center?.y, "px");
-                results += toFixFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                results += toFixFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
-                results += toFixFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
-                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
+                results += toFixFormat("Center X       ", value.center?.x, error.center?.x, "px");
+                results += toFixFormat("Center Y       ", value.center?.y, error.center?.y, "px");
+                results += toFixFormat("Amplitude      ", value.amp, error.amp, frame.requiredUnit);
+                results += toFixFormat("FWHM Major Axis", value.fwhm?.x, error.fwhm?.x, "px");
+                results += toFixFormat("FWHM Minor Axis", value.fwhm?.y, error.fwhm?.y, "px");
+                results += toFixFormat("P.A.           ", value.pa, error.pa, "deg");
 
-                log += toExpFormat("Center X ", value.center?.x, error.center?.x, "px");
-                log += toExpFormat("Center Y ", value.center?.y, error.center?.y, "px");
-                log += toExpFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                log += toExpFormat("FWHM X   ", value.fwhm?.x, error.fwhm?.x, "px");
-                log += toExpFormat("FWHM Y   ", value.fwhm?.y, error.fwhm?.y, "px");
-                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
+                log += toExpFormat("Center X       ", value.center?.x, error.center?.x, "px");
+                log += toExpFormat("Center Y       ", value.center?.y, error.center?.y, "px");
+                log += toExpFormat("Amplitude      ", value.amp, error.amp, frame.requiredUnit);
+                log += toExpFormat("FWHM Major Axis", value.fwhm?.x, error.fwhm?.x, "px");
+                log += toExpFormat("FWHM Minor Axis", value.fwhm?.y, error.fwhm?.y, "px");
+                log += toExpFormat("P.A.           ", value.pa, error.pa, "deg");
             } else {
                 const centerValueWCS = getFormattedWCSPoint(frame.wcsInfoForTransformation, value.center as Point2D);
                 if (isFormatXDeg) {
@@ -165,24 +165,24 @@ export class ImageFittingStore {
                     ({value: fwhmValueWCS.y, unit: fwhmUnit.y} = AngularSize.convertFromArcsec(fwhmValueWCS.y, true));
                     fwhmErrorWCS.y = AngularSize.convertValueFromArcsec(fwhmErrorWCS.y, fwhmUnit.y);
                 }
-                
-                results += toFixFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
-                results += toFixFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
-                results += toFixFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                results += toFixFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
-                results += toFixFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
-                results += toFixFormat("P.A.     ", value.pa, error.pa, "deg");
 
-                log += toExpFormat("Center X ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
-                log += toExpFormat("         ", value.center?.x, error.center?.x, "px");
-                log += toExpFormat("Center Y ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
-                log += toExpFormat("         ", value.center?.y, error.center?.y, "px");
-                log += toExpFormat("Amplitude", value.amp, error.amp, frame.requiredUnit);
-                log += toExpFormat("FWHM X   ", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
-                log += toExpFormat("         ", value.fwhm?.x, error.fwhm?.x, "px");
-                log += toExpFormat("FWHM Y   ", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
-                log += toExpFormat("         ", value.fwhm?.y, error.fwhm?.y, "px");
-                log += toExpFormat("P.A.     ", value.pa, error.pa, "deg");
+                results += toFixFormat("Center X       ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
+                results += toFixFormat("Center Y       ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
+                results += toFixFormat("Amplitude      ", value.amp, error.amp, frame.requiredUnit);
+                results += toFixFormat("FWHM Major Axis", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
+                results += toFixFormat("FWHM Minor Axis", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
+                results += toFixFormat("P.A.           ", value.pa, error.pa, "deg");
+
+                log += toExpFormat("Center X       ", centerValueWCS?.x, centerErrorWCS?.x, "arcsec");
+                log += toExpFormat("               ", value.center?.x, error.center?.x, "px");
+                log += toExpFormat("Center Y       ", centerValueWCS?.y, centerErrorWCS?.y, "arcsec");
+                log += toExpFormat("               ", value.center?.y, error.center?.y, "px");
+                log += toExpFormat("Amplitude      ", value.amp, error.amp, frame.requiredUnit);
+                log += toExpFormat("FWHM Major Axis", fwhmValueWCS?.x, fwhmErrorWCS?.x, fwhmUnit.x);
+                log += toExpFormat("               ", value.fwhm?.x, error.fwhm?.x, "px");
+                log += toExpFormat("FWHM Minor Axis", fwhmValueWCS?.y, fwhmErrorWCS?.y, fwhmUnit.y);
+                log += toExpFormat("               ", value.fwhm?.y, error.fwhm?.y, "px");
+                log += toExpFormat("P.A.           ", value.pa, error.pa, "deg");
             }
             if (i !== values.length - 1) {
                 results += "\n";

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -363,8 +363,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
             }
 
             if (isFinite(frame.pixelUnitSizeArcsec?.x) && isFinite(frame.pixelUnitSizeArcsec?.y)) {
-                config["cdelta1"] = getAngleInRad(frame.pixelUnitSizeArcsec.x, "arcsec");
-                config["cdelta2"] = getAngleInRad(frame.pixelUnitSizeArcsec.y, "arcsec");
+                config["cdelta1"] = getAngleInRad(frame.pixelUnitSizeArcsec.x);
+                config["cdelta2"] = getAngleInRad(frame.pixelUnitSizeArcsec.y);
             }
             return config;
         }

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -85,23 +85,8 @@ export function formattedFrequency(freqGHz: number): string {
     return freqString;
 }
 
-export function getAngleInRad(value: number, unit: string): number {
-    if (isFinite(value) && unit) {
-        const trimmedUnit = unit.trim()?.toLowerCase();
-        if (trimmedUnit === "rad") {
-            return value;
-        } else if (trimmedUnit === "deg") {
-            return (value * Math.PI) / 180;
-        } else if (trimmedUnit === "arcmin") {
-            return (value * Math.PI) / 10800;
-        } else if (trimmedUnit === "arcsec") {
-            return (value * Math.PI) / 648000;
-        } else if (trimmedUnit === "mas") {
-            return (value * Math.PI) / 648000000;
-        }
-        return undefined;
-    }
-    return undefined;
+export function getAngleInRad(arcsec: number): number {
+    return isFinite(arcsec) ? (arcsec * Math.PI) / 648000 : undefined;
 }
 
 // TODO: possibly move to region class since they are the only callers

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -1,3 +1,5 @@
+import {AngularSize, AngularSizeUnit} from "models";
+
 export const SPEED_OF_LIGHT = 299792458;
 
 export function velocityFromFrequency(freq: number, refFreq: number): number {
@@ -108,13 +110,20 @@ export function formattedArcsec(arcsec: number, decimals: number = -1): string {
         return null;
     }
 
-    let arcString = "";
-    if (arcsec < 120) {
-        arcString = `${decimals < 0 ? toFixed(arcsec, 6) : toFixed(arcsec, decimals)}"`;
-    } else if (arcsec >= 120 && arcsec < 7200) {
-        arcString = `${decimals < 0 ? toFixed(arcsec / 60.0, 3) : toFixed(arcsec / 60.0, decimals)}'`;
-    } else {
-        arcString = `${decimals < 0 ? toFixed(arcsec / 3600.0, 3) : toFixed(arcsec / 3600.0, decimals)} deg`;
+    const angularSize = AngularSize.convertFromArcsec(arcsec);
+    let arcString = decimals < 0 ? toFixed(angularSize.value, 6) : toFixed(angularSize.value, decimals);
+    switch (angularSize.unit) {
+        case AngularSizeUnit.ARCSEC:
+            arcString += "\"";
+            break;
+        case AngularSizeUnit.ARCMIN:
+            arcString += "'";
+            break;
+        case AngularSizeUnit.DEG:
+            arcString += " deg";
+            break;
+        default:
+            break;
     }
     return arcString;
 }

--- a/src/utilities/units.ts
+++ b/src/utilities/units.ts
@@ -99,7 +99,7 @@ export function formattedArcsec(arcsec: number, decimals: number = -1): string {
     let arcString = decimals < 0 ? toFixed(angularSize.value, 6) : toFixed(angularSize.value, decimals);
     switch (angularSize.unit) {
         case AngularSizeUnit.ARCSEC:
-            arcString += "\"";
+            arcString += '"';
             break;
         case AngularSizeUnit.ARCMIN:
             arcString += "'";


### PR DESCRIPTION
This PR is for the third item in #1397: convert output FWHM size to arcmin or degree.

changes:
* added angular size conversion to marcsec/arcmin/deg in the fitting results
* changed `FWHM X/Y` to `FWHM Major/Minor Axis` to match the terms used in initial value setting
* refactored `formattedArcsec` to reuse the conversion
* removed unused conversion in `getAngleInRad`. It was implemented for reading header entries in #1707, but then became  unused after we changed the approach in the same branch.

to be tested:
* size conversions in the fitting results
* region inputs work as usual; tsv file headers unchanged
* the spectral profile intensity `/beam` and `/arcsec^2` conversion works as usual
