### PR TITLE
ksw/fix fitting icon rendering issue with Firefox on ubuntu

### DIFF
--- a/src/icons/CustomIcons.tsx
+++ b/src/icons/CustomIcons.tsx
@@ -274,7 +274,7 @@ const imageFittingSvg = (
             clipRule="evenodd"
             fillRule="evenodd"
         />
-        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" fontSize="10" id="svg_3" y="5.21879" x="6.26874" strokeWidth="0" stroke="#000">
+        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" font-size="9.44322px" id="svg_3" y="5.3225346" x="5.1441765" strokeWidth="0" stroke="#000">
             xy
         </text>
     </>
@@ -289,7 +289,7 @@ const lineFittingSvg = (
             clipRule="evenodd"
             fillRule="evenodd"
         />
-        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" fontSize="10" id="svg_3" y="5.71879" x="6.96874" strokeWidth="0" stroke="#000">
+        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" font-size="10px" id="svg_3" y="5.7571483" x="7.3132892" strokeWidth="0" stroke="#000">
             {" "}
             z
         </text>

--- a/src/icons/fitting_xy.svg
+++ b/src/icons/fitting_xy.svg
@@ -1,14 +1,66 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 16 16"
+   enable-background="new 0 0 16 16"
+   xml:space="preserve"
+   sodipodi:docname="fitting_xy.svg"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs65" /><sodipodi:namedview
+   id="namedview63"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="46.4375"
+   inkscape:cx="8"
+   inkscape:cy="7.9892328"
+   inkscape:window-width="1738"
+   inkscape:window-height="1210"
+   inkscape:window-x="2227"
+   inkscape:window-y="92"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="g60" />
 
- <g>
-  <title>Layer 1</title>
-  <g stroke="null" id="regression_chart_1_">
-   <g stroke="null" id="svg_1">
-    <path stroke="null" id="svg_2" d="m9.68361,10.28122c0,0.60521 0.48941,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm0.36524,3.28126c0,0.60521 0.48942,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm7.66994,2.91667l-8.57572,0l8.78756,-6.26356l-0.42367,-0.59063l-9.28428,6.61356l0,-6.32189c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917s-0.73047,0.32813 -0.73047,0.72917l0,7.29169c0,0.40104 0.32871,0.72917 0.73047,0.72917l10.22659,0c0.40176,0 0.73047,-0.32813 0.73047,-0.72917c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917z" clip-rule="evenodd" fill-rule="evenodd"/>
+ <g
+   id="g60">
+  <title
+   id="title54">Layer 1</title>
+  <g
+   stroke="null"
+   id="regression_chart_1_">
+   <g
+   stroke="null"
+   id="svg_1">
+    <path
+   stroke="null"
+   id="svg_2"
+   d="m9.68361,10.28122c0,0.60521 0.48941,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm0.36524,3.28126c0,0.60521 0.48942,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm7.66994,2.91667l-8.57572,0l8.78756,-6.26356l-0.42367,-0.59063l-9.28428,6.61356l0,-6.32189c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917s-0.73047,0.32813 -0.73047,0.72917l0,7.29169c0,0.40104 0.32871,0.72917 0.73047,0.72917l10.22659,0c0.40176,0 0.73047,-0.32813 0.73047,-0.72917c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917z"
+   clip-rule="evenodd"
+   fill-rule="evenodd" />
    </g>
   </g>
-  <text xml:space="preserve" text-anchor="start" font-family="sans-serif" font-size="10" id="svg_3" y="5.21879" x="6.96874" stroke-width="0" stroke="#000" fill="#000000">xy</text>
+  <text
+   xml:space="preserve"
+   text-anchor="start"
+   font-family="sans-serif"
+   font-size="9.44322px"
+   id="svg_3"
+   y="5.3225346"
+   x="5.1441765"
+   stroke-width="0"
+   stroke="#000000"
+   fill="#000000"
+   transform="scale(0.99001168,1.0100891)">xy</text>
  </g>
 </svg>

--- a/src/icons/fitting_z.svg
+++ b/src/icons/fitting_z.svg
@@ -1,14 +1,65 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 16 16"
+   enable-background="new 0 0 16 16"
+   xml:space="preserve"
+   sodipodi:docname="fitting_z.svg"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs65" /><sodipodi:namedview
+   id="namedview63"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="46.4375"
+   inkscape:cx="8"
+   inkscape:cy="8"
+   inkscape:window-width="1312"
+   inkscape:window-height="969"
+   inkscape:window-x="2447"
+   inkscape:window-y="215"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="g60" />
 
- <g>
-  <title>Layer 1</title>
-  <g stroke="null" id="regression_chart_1_">
-   <g stroke="null" id="svg_1">
-    <path stroke="null" id="svg_2" d="m9.68361,10.28122c0,0.60521 0.48941,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm0.36524,3.28126c0,0.60521 0.48942,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm7.66994,2.91667l-8.57572,0l8.78756,-6.26356l-0.42367,-0.59063l-9.28428,6.61356l0,-6.32189c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917s-0.73047,0.32813 -0.73047,0.72917l0,7.29169c0,0.40104 0.32871,0.72917 0.73047,0.72917l10.22659,0c0.40176,0 0.73047,-0.32813 0.73047,-0.72917c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917z" clip-rule="evenodd" fill-rule="evenodd"/>
+ <g
+   id="g60">
+  <title
+   id="title54">Layer 1</title>
+  <g
+   stroke="null"
+   id="regression_chart_1_">
+   <g
+   stroke="null"
+   id="svg_1">
+    <path
+   stroke="null"
+   id="svg_2"
+   d="m9.68361,10.28122c0,0.60521 0.48941,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm0.36524,3.28126c0,0.60521 0.48942,1.09375 1.09571,1.09375s1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375zm-3.28712,-1.09375c0.60629,0 1.09571,-0.48854 1.09571,-1.09375s-0.48942,-1.09375 -1.09571,-1.09375s-1.09571,0.48854 -1.09571,1.09375s0.48942,1.09375 1.09571,1.09375zm7.66994,2.91667l-8.57572,0l8.78756,-6.26356l-0.42367,-0.59063l-9.28428,6.61356l0,-6.32189c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917s-0.73047,0.32813 -0.73047,0.72917l0,7.29169c0,0.40104 0.32871,0.72917 0.73047,0.72917l10.22659,0c0.40176,0 0.73047,-0.32813 0.73047,-0.72917c0,-0.40104 -0.32871,-0.72917 -0.73047,-0.72917z"
+   clip-rule="evenodd"
+   fill-rule="evenodd" />
    </g>
   </g>
-  <text xml:space="preserve" text-anchor="start" font-family="sans-serif" font-size="10" id="svg_3" y="5.21879" x="6.96874" stroke-width="0" stroke="#000" fill="#000000"> z</text>
+  <text
+   xml:space="preserve"
+   text-anchor="start"
+   font-family="sans-serif"
+   font-size="10px"
+   id="svg_3"
+   y="5.7571483"
+   x="7.3132892"
+   stroke-width="0"
+   stroke="#000000"
+   fill="#000000"> z</text>
  </g>
 </svg>


### PR DESCRIPTION
close #1845 

The root cause is the icons I provided had the text part slightly out of the boarder box. The Firefox on Ubuntu does what it's been told so it is not Firefox's fault (my fault). However, for some reasons, the icons are rendered properly with Safari, Firefox, and Chrome on macOS (too smart?).

The fixed icon looks like

macOS Safari
![mac_safari](https://user-images.githubusercontent.com/20819712/168587000-996584f6-22da-4af8-99bf-c9bbe8c5e277.png)

macOS Firefox
![mac_firefox](https://user-images.githubusercontent.com/20819712/168586979-f31859dd-7fe2-441a-b98f-1a4e063d1b7b.png)

macOS Chrome
![mac_chrome](https://user-images.githubusercontent.com/20819712/168586965-bfc46871-483e-403a-9af8-cd058008e95f.png)

ubuntu 20.04 Firefox
![ubuntu2004_firefox](https://user-images.githubusercontent.com/20819712/168586942-38e737de-dc56-4f2d-b2b8-0b999690cd86.png)
