### PR TITLE
add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,7 @@
+**Description**
+linked issues, what is implemented or fixed, how to test it, …
+
+**Checklist**
+- [ ] changelog updated / no changelog update needed
+- [ ] e2e test passing / added corresponding fix
+- [ ] protobuf updated to the latest dev commit / no protobuf update needed

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,5 +1,5 @@
 **Description**
-linked issues, what is implemented or fixed, how to test it, …
+linked issues and companion PRs (if there are), what is implemented or fixed, how to test it, …
 
 **Checklist**
 - [ ] changelog updated / no changelog update needed


### PR DESCRIPTION
Added a simple PR template:
* strikethrough the options when opening the PR, ex:
changelog updated / ~no changelog update needed~
* currently I don't include items already checked by Github, which are:
approved by reviewers, all CI checks passing, and no merge conflict