### PR TITLE
Thchang/1546 exporting full resolution data in the spatial profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Added missing vector overlay and image fitting options in the View menu ([#1848](https://github.com/CARTAvis/carta-frontend/issues/1848))
 * Hide code snippet option in the View menu when code snippet is disabled in the preferences ([#1856](https://github.com/CARTAvis/carta-frontend/issues/1856))
+* Fixed issue with exporting decimated data instead of original data in spatial profiler ([#1546](https://github.com/CARTAvis/carta-frontend/issues/1546))
 
 ## [3.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Added missing vector overlay and image fitting options in the View menu ([#1848](https://github.com/CARTAvis/carta-frontend/issues/1848))
 * Hide code snippet option in the View menu when code snippet is disabled in the preferences ([#1856](https://github.com/CARTAvis/carta-frontend/issues/1856))
-* Fixed issue with exporting decimated data instead of original data in spatial profiler ([#1546](https://github.com/CARTAvis/carta-frontend/issues/1546))
+* Fixed issue with exporting decimated data instead of full resolution data in spatial profiler ([#1546](https://github.com/CARTAvis/carta-frontend/issues/1546))
 
 ## [3.0.0-beta.3]
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -122,7 +122,7 @@ export class LinePlotComponentProps {
     insideTexts?: LinePlotInsideTextMarker[];
     order?: number;
     multiPlotPropsMap?: Map<string, MultiPlotProps>;
-    exportData?: {x: number; y: number; z?: number}[];
+    fullResolutionData?: {x: number; y: number; z?: number}[];
 }
 
 // Maximum time between double clicks
@@ -661,7 +661,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             // data part
             rows.push("# x\ty");
             const useScientificForm = plotName === "histogram" || this.props.tickTypeX === TickType.Scientific;
-            const data = this.props.exportData?.length > 0 ? this.props.exportData : this.props.data;
+            const data = this.props.fullResolutionData?.length > 0 ? this.props.fullResolutionData : this.props.data;
             rows = rows.concat(data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
 
             exportTsvFile(imageName, plotName, `${comment}\n${rows.join("\n")}\n`);

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -122,6 +122,7 @@ export class LinePlotComponentProps {
     insideTexts?: LinePlotInsideTextMarker[];
     order?: number;
     multiPlotPropsMap?: Map<string, MultiPlotProps>;
+    exportData?: {x: number; y: number; z?: number}[];
 }
 
 // Maximum time between double clicks
@@ -660,7 +661,8 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             // data part
             rows.push("# x\ty");
             const useScientificForm = plotName === "histogram" || this.props.tickTypeX === TickType.Scientific;
-            rows = rows.concat(this.props.data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
+            const data = this.props.exportData?.length > 0 ? this.props.exportData : this.props.data;
+            rows = rows.concat(data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
 
             exportTsvFile(imageName, plotName, `${comment}\n${rows.join("\n")}\n`);
         }

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -70,7 +70,7 @@ export interface LinePlotInsideTextMarker {
 export class LinePlotComponentProps {
     width?: number;
     height?: number;
-    data?: {x: number; y: number; z?: number}[];
+    data?: Point2D[];
     comments?: string[];
     xMin?: number;
     xMax?: number;
@@ -122,7 +122,7 @@ export class LinePlotComponentProps {
     insideTexts?: LinePlotInsideTextMarker[];
     order?: number;
     multiPlotPropsMap?: Map<string, MultiPlotProps>;
-    fullResolutionData?: {x: number; y: number; z?: number}[];
+    fullResolutionData?: Point2D[];
 }
 
 // Maximum time between double clicks

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -73,7 +73,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
     }
 
-    @computed get plotData(): {values: Array<Point2D>; exportValues: Array<Point2D>; smoothingValues: Array<Point2D>; xMin: number; xMax: number; yMin: number; yMax: number; yMean: number; yRms: number} {
+    @computed get plotData(): {values: Array<Point2D>; fullResolutionValues: Array<Point2D>; smoothingValues: Array<Point2D>; xMin: number; xMax: number; yMin: number; yMax: number; yMean: number; yRms: number} {
         if (!this.frame || !this.width || !this.profileStore) {
             return null;
         }
@@ -116,14 +116,14 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
             let yCount = 0;
 
             let values: Array<{x: number; y: number}>;
-            let exportValues: Array<{x: number; y: number}>;
+            let fullResolutionValues: Array<{x: number; y: number}>;
             let smoothingValues: Array<{x: number; y: number}>;
             let N: number;
 
             if (this.lineAxis) {
                 N = coordinateData.values.length;
                 values = new Array(N);
-                exportValues = new Array(N);
+                fullResolutionValues = new Array(N);
                 let xArray: number[] = new Array(N);
                 const numPixels = this.width;
                 const decimationFactor = Math.round(N / numPixels);
@@ -147,7 +147,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                     if (decimationFactor <= 1) {
                         values[i] = {x, y};
                     } else {
-                        exportValues[i] = {x, y};
+                        fullResolutionValues[i] = {x, y};
                     }
                 }
                 if (decimationFactor > 1) {
@@ -196,7 +196,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                         }
                     } else {
                         // Decimated data
-                        exportValues = new Array(N);
+                        fullResolutionValues = new Array(N);
                         for (let i = 0; i < N; i++) {
                             const val = coordinateData.values[i + xMin];
                             const x = coordinateData.start + i + xMin;
@@ -207,7 +207,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                                 ySum += val;
                                 ySum2 += val * val;
                             }
-                            exportValues[i] = {x, y: val};
+                            fullResolutionValues[i] = {x, y: val};
                         }
                         values = this.widgetStore.smoothingStore.getDecimatedPoint2DArray(xArray, coordinateData.values, decimationFactor, xMin, xMax);
                     }
@@ -230,7 +230,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                 yMax += range * VERTICAL_RANGE_PADDING;
             }
 
-            return {values: values, exportValues, smoothingValues, xMin, xMax, yMin, yMax, yMean, yRms};
+            return {values: values, fullResolutionValues, smoothingValues, xMin, xMax, yMin, yMax, yMean, yRms};
         }
     }
 
@@ -495,7 +495,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                 const currentPlotData = this.plotData;
                 if (currentPlotData) {
                     linePlotProps.data = currentPlotData.values;
-                    linePlotProps.exportData = currentPlotData.exportValues;
+                    linePlotProps.fullResolutionData = currentPlotData.fullResolutionValues;
 
                     // set line color
                     let primaryLineColor = getColorForTheme(widgetStore.primaryLineColor);

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -115,8 +115,8 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
             let ySum2 = 0;
             let yCount = 0;
 
-            let values: Array<{x: number; y: number}>;
-            let fullResolutionValues: Array<{x: number; y: number}>;
+            let values: Array<Point2D>;
+            let fullResolutionValues: Array<Point2D>;
             let smoothingValues: Array<{x: number; y: number}>;
             let N: number;
 

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -73,7 +73,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
     }
 
-    @computed get plotData(): {values: Array<Point2D>; smoothingValues: Array<Point2D>; xMin: number; xMax: number; yMin: number; yMax: number; yMean: number; yRms: number} {
+    @computed get plotData(): {values: Array<Point2D>; exportValues: Array<Point2D>; smoothingValues: Array<Point2D>; xMin: number; xMax: number; yMin: number; yMax: number; yMean: number; yRms: number} {
         if (!this.frame || !this.width || !this.profileStore) {
             return null;
         }
@@ -116,12 +116,14 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
             let yCount = 0;
 
             let values: Array<{x: number; y: number}>;
+            let exportValues: Array<{x: number; y: number}>;
             let smoothingValues: Array<{x: number; y: number}>;
             let N: number;
 
             if (this.lineAxis) {
                 N = coordinateData.values.length;
                 values = new Array(N);
+                exportValues = new Array(N);
                 let xArray: number[] = new Array(N);
                 const numPixels = this.width;
                 const decimationFactor = Math.round(N / numPixels);
@@ -144,6 +146,8 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                     xArray[i] = x;
                     if (decimationFactor <= 1) {
                         values[i] = {x, y};
+                    } else {
+                        exportValues[i] = {x, y};
                     }
                 }
                 if (decimationFactor > 1) {
@@ -192,8 +196,10 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                         }
                     } else {
                         // Decimated data
+                        exportValues = new Array(N);
                         for (let i = 0; i < N; i++) {
                             const val = coordinateData.values[i + xMin];
+                            const x = coordinateData.start + i + xMin;
                             if (isFinite(val)) {
                                 yMin = Math.min(yMin, val);
                                 yMax = Math.max(yMax, val);
@@ -201,6 +207,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                                 ySum += val;
                                 ySum2 += val * val;
                             }
+                            exportValues[i] = {x, y: val};
                         }
                         values = this.widgetStore.smoothingStore.getDecimatedPoint2DArray(xArray, coordinateData.values, decimationFactor, xMin, xMax);
                     }
@@ -223,7 +230,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                 yMax += range * VERTICAL_RANGE_PADDING;
             }
 
-            return {values: values, smoothingValues, xMin, xMax, yMin, yMax, yMean, yRms};
+            return {values: values, exportValues, smoothingValues, xMin, xMax, yMin, yMax, yMean, yRms};
         }
     }
 
@@ -488,6 +495,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
                 const currentPlotData = this.plotData;
                 if (currentPlotData) {
                     linePlotProps.data = currentPlotData.values;
+                    linePlotProps.exportData = currentPlotData.exportValues;
 
                     // set line color
                     let primaryLineColor = getColorForTheme(widgetStore.primaryLineColor);


### PR DESCRIPTION
closes #1546: exporting full resolution data when showing decimated data in the plotting of the spatial profiler

changes:
- added `exportData` in LinePlotComponentProps to export data which are different from the plotting `data`.
- applied `exportData` to contain full resolution(un-decimated) data in the spatial profiler.

