### PR TITLE
Yuhsuan/1739 rotation anchor offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.0.0-beta.4]
 
 ### Fixed
-* Added missing vector overlay and image fitting options in the View menu ([#1848](https://github.com/CARTAvis/carta-frontend/issues/1848))
-* Hide code snippet option in the View menu when code snippet is disabled in the preferences ([#1856](https://github.com/CARTAvis/carta-frontend/issues/1856))
+* Added missing vector overlay and image fitting options in the View menu ([#1848](https://github.com/CARTAvis/carta-frontend/issues/1848)).
+* Hide code snippet option in the View menu when code snippet is disabled in the preferences ([#1856](https://github.com/CARTAvis/carta-frontend/issues/1856)).
+* Fixed the rotation anchor offset of line regions ([#1739](https://github.com/CARTAvis/carta-frontend/issues/1739)).
 
 ## [3.0.0-beta.3]
 

--- a/src/components/ImageView/RegionView/InvariantShapes.tsx
+++ b/src/components/ImageView/RegionView/InvariantShapes.tsx
@@ -12,9 +12,9 @@ const CURSOR_CROSS_THICKNESS_WIDE = 3;
 const CURSOR_CROSS_CENTER_SQUARE = 6;
 
 const HandleSquareDraw = (ctx, shape, width) => {
-    const reverseScale = 1 / shape.getStage().scaleX();
-    const offset = -width * 0.5 * reverseScale;
-    const squareSize = width * reverseScale;
+    const inverseScale = 1 / shape.getStage().scaleX();
+    const offset = -width * 0.5 * inverseScale;
+    const squareSize = width * inverseScale;
     ctx.beginPath();
     ctx.rect(offset, offset, squareSize, squareSize);
     ctx.fillStrokeShape(shape);
@@ -88,9 +88,9 @@ export const Anchor = (props: AnchorProps) => {
     };
 
     const handleCircleDraw = (ctx, shape) => {
-        const reverseScale = 1 / shape.getStage().scaleX();
-        const radius = CIRCLE_ANCHOR_RADIUS * reverseScale;
-        const offsetY = props.isLineRegion ? 0 : -ROTATOR_ANCHOR_HEIGHT * reverseScale;
+        const inverseScale = 1 / shape.getStage().scaleX();
+        const radius = CIRCLE_ANCHOR_RADIUS * inverseScale;
+        const offsetY = props.isLineRegion ? 0 : -ROTATOR_ANCHOR_HEIGHT * inverseScale;
         ctx.beginPath();
         ctx.arc(0, offsetY, radius, 0, 2 * Math.PI, false);
         ctx.fillStrokeShape(shape);
@@ -145,10 +145,10 @@ export const CursorMarker = (props: CursorMarkerProps) => {
     };
 
     const handleCrossDraw = (ctx, shape) => {
-        const reverseScale = 1 / shape.getStage().scaleX();
-        const offset = -CURSOR_CROSS_CENTER_SQUARE * 0.5 * reverseScale;
-        const crossWidth = CURSOR_CROSS_LENGTH * reverseScale;
-        const crossHeight = CURSOR_CROSS_THICKNESS_WIDE * reverseScale;
+        const inverseScale = 1 / shape.getStage().scaleX();
+        const offset = -CURSOR_CROSS_CENTER_SQUARE * 0.5 * inverseScale;
+        const crossWidth = CURSOR_CROSS_LENGTH * inverseScale;
+        const crossHeight = CURSOR_CROSS_THICKNESS_WIDE * inverseScale;
         ctx.beginPath();
         ctx.rect(-offset, offset / 2, crossWidth, crossHeight);
         ctx.rect(offset - crossWidth, offset / 2, crossWidth, crossHeight);

--- a/src/components/ImageView/RegionView/InvariantShapes.tsx
+++ b/src/components/ImageView/RegionView/InvariantShapes.tsx
@@ -90,7 +90,7 @@ export const Anchor = (props: AnchorProps) => {
     const handleCircleDraw = (ctx, shape) => {
         const reverseScale = 1 / shape.getStage().scaleX();
         const radius = CIRCLE_ANCHOR_RADIUS * reverseScale;
-        const offsetY = props.isLineRegion ? 0 : -ROTATOR_ANCHOR_HEIGHT / shape.getStage().scaleX();
+        const offsetY = props.isLineRegion ? 0 : -ROTATOR_ANCHOR_HEIGHT * reverseScale;
         ctx.beginPath();
         ctx.arc(0, offsetY, radius, 0, 2 * Math.PI, false);
         ctx.fillStrokeShape(shape);

--- a/src/components/ImageView/RegionView/InvariantShapes.tsx
+++ b/src/components/ImageView/RegionView/InvariantShapes.tsx
@@ -5,7 +5,7 @@ const POINT_DRAG_WIDTH = 13;
 
 const SQUARE_ANCHOR_WIDTH = 7;
 const CIRCLE_ANCHOR_RADIUS = SQUARE_ANCHOR_WIDTH / Math.sqrt(2);
-const ROTATOR_ANCHOR_HEIGHT = 15;
+export const ROTATOR_ANCHOR_HEIGHT = 15;
 
 const CURSOR_CROSS_LENGTH = 10;
 const CURSOR_CROSS_THICKNESS_WIDE = 3;
@@ -79,6 +79,7 @@ interface AnchorProps {
     onDragEnd: (ev) => void;
     onDragMove: (ev) => void;
     onDblClick?: (ev) => void;
+    isLineRegion?: boolean;
 }
 
 export const Anchor = (props: AnchorProps) => {
@@ -89,7 +90,7 @@ export const Anchor = (props: AnchorProps) => {
     const handleCircleDraw = (ctx, shape) => {
         const reverseScale = 1 / shape.getStage().scaleX();
         const radius = CIRCLE_ANCHOR_RADIUS * reverseScale;
-        const offsetY = -ROTATOR_ANCHOR_HEIGHT / shape.getStage().scaleX();
+        const offsetY = props.isLineRegion ? 0 : -ROTATOR_ANCHOR_HEIGHT / shape.getStage().scaleX();
         ctx.beginPath();
         ctx.arc(0, offsetY, radius, 0, 2 * Math.PI, false);
         ctx.fillStrokeShape(shape);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -266,7 +266,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         // trigger re-render when exporting images
         const imageRatio = AppStore.Instance.imageRatio;
         // trigger rotation anchor re-render when zooming
-        const zoomLevel = frame.spatialReference?.zoomLevel ?? frame.zoomLevel; 
+        const zoomLevel = frame.spatialReference?.zoomLevel ?? frame.zoomLevel;
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -302,8 +302,6 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 const pCanvasPos = transformedImageToCanvasPos(pSecondaryImage, frame, this.props.layerWidth, this.props.layerHeight, this.props.stageRef.current);
                 newAnchor = <NonEditableAnchor x={pCanvasPos.x} y={pCanvasPos.y} rotation={rotation} />;
             }
-
-            rotation = (-frame.spatialTransform.rotation * 180.0) / Math.PI;
         } else {
             controlPoints = controlPoints.map(p => {
                 return transformedImageToCanvasPos(p, frame, this.props.layerWidth, this.props.layerHeight, this.props.stageRef.current);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -10,7 +10,7 @@ import {FrameStore, RegionStore} from "stores/Frame";
 import {Point2D} from "models";
 import {add2D, average2D, closestPointOnLine, transformPoint, rotate2D, subtract2D, angle2D} from "utilities";
 import {adjustPosToUnityStage, canvasToTransformedImagePos, transformedImageToCanvasPos} from "./shared";
-import {Anchor, NonEditableAnchor} from "./InvariantShapes";
+import {Anchor, NonEditableAnchor, ROTATOR_ANCHOR_HEIGHT} from "./InvariantShapes";
 
 interface LineSegmentRegionComponentProps {
     region: RegionStore;
@@ -246,6 +246,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 onDragEnd={this.handleAnchorDragEnd}
                 onDragMove={this.handleAnchorDrag}
                 onDblClick={this.props.region.regionType === CARTA.RegionType.LINE ? null : this.handleAnchorDoubleClick}
+                isLineRegion={this.props.region.regionType === CARTA.RegionType.LINE}
             />
         );
     }
@@ -261,9 +262,11 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         let newAnchor = null;
         let pointArray: Array<number>;
 
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         // trigger re-render when exporting images
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const imageRatio = AppStore.Instance.imageRatio;
+        // trigger rotation anchor re-render when zooming
+        const zoomLevel = frame.spatialReference?.zoomLevel ?? frame.zoomLevel; 
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);
@@ -287,7 +290,8 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 });
 
                 if (region.regionType === CARTA.RegionType.LINE && frame.hasSquarePixels) {
-                    const rotatorOffset = 1;
+                    const reverseScale = 1 / this.props.stageRef.current.scaleX();
+                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;
                     anchors.push(this.anchorNode(centerPointCanvasSpace.x + rotatorOffset * Math.sin(rotatorAngle), centerPointCanvasSpace.y - rotatorOffset * Math.cos(rotatorAngle), rotation, 2, true));
                 }
@@ -313,7 +317,8 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 }
 
                 if (region.regionType === CARTA.RegionType.LINE && frame.hasSquarePixels) {
-                    const rotatorOffset = 1;
+                    const reverseScale = 1 / this.props.stageRef.current.scaleX();
+                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;
                     anchors.push(this.anchorNode(centerPointCanvasSpace.x + rotatorOffset * Math.sin(rotatorAngle), centerPointCanvasSpace.y - rotatorOffset * Math.cos(rotatorAngle), rotation, 2, true));
                 }

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -291,8 +291,8 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                     // trigger rotation anchor re-render when zooming
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const zoomLevel = frame.spatialReference?.zoomLevel;
-                    const reverseScale = 1 / this.props.stageRef.current.scaleX();
-                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
+                    const inverseScale = 1 / this.props.stageRef.current.scaleX();
+                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * inverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;
                     anchors.push(this.anchorNode(centerPointCanvasSpace.x + rotatorOffset * Math.sin(rotatorAngle), centerPointCanvasSpace.y - rotatorOffset * Math.cos(rotatorAngle), rotation, 2, true));
                 }
@@ -319,8 +319,8 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                     // trigger rotation anchor re-render when zooming
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const zoomLevel = frame.zoomLevel;
-                    const reverseScale = 1 / this.props.stageRef.current.scaleX();
-                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
+                    const inverseScale = 1 / this.props.stageRef.current.scaleX();
+                    const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * inverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;
                     anchors.push(this.anchorNode(centerPointCanvasSpace.x + rotatorOffset * Math.sin(rotatorAngle), centerPointCanvasSpace.y - rotatorOffset * Math.cos(rotatorAngle), rotation, 2, true));
                 }

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -262,11 +262,9 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         let newAnchor = null;
         let pointArray: Array<number>;
 
-        /* eslint-disable @typescript-eslint/no-unused-vars */
         // trigger re-render when exporting images
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const imageRatio = AppStore.Instance.imageRatio;
-        // trigger rotation anchor re-render when zooming
-        const zoomLevel = frame.spatialReference?.zoomLevel ?? frame.zoomLevel;
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);
@@ -290,6 +288,9 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 });
 
                 if (region.regionType === CARTA.RegionType.LINE && frame.hasSquarePixels) {
+                    // trigger rotation anchor re-render when zooming
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const zoomLevel = frame.spatialReference?.zoomLevel;
                     const reverseScale = 1 / this.props.stageRef.current.scaleX();
                     const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;
@@ -315,6 +316,9 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 }
 
                 if (region.regionType === CARTA.RegionType.LINE && frame.hasSquarePixels) {
+                    // trigger rotation anchor re-render when zooming
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const zoomLevel = frame.zoomLevel;
                     const reverseScale = 1 / this.props.stageRef.current.scaleX();
                     const rotatorOffset = ROTATOR_ANCHOR_HEIGHT * reverseScale;
                     const rotatorAngle = (rotation * Math.PI) / 180.0;

--- a/src/icons/CustomIcons.tsx
+++ b/src/icons/CustomIcons.tsx
@@ -274,7 +274,7 @@ const imageFittingSvg = (
             clipRule="evenodd"
             fillRule="evenodd"
         />
-        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" font-size="9.44322px" id="svg_3" y="5.3225346" x="5.1441765" strokeWidth="0" stroke="#000">
+        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" fontSize="9.44322px" id="svg_3" y="5.3225346" x="5.1441765" strokeWidth="0" stroke="#000">
             xy
         </text>
     </>
@@ -289,7 +289,7 @@ const lineFittingSvg = (
             clipRule="evenodd"
             fillRule="evenodd"
         />
-        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" font-size="10px" id="svg_3" y="5.7571483" x="7.3132892" strokeWidth="0" stroke="#000">
+        <text xmlSpace="preserve" textAnchor="start" fontFamily="sans-serif" fontSize="10px" id="svg_3" y="5.7571483" x="7.3132892" strokeWidth="0" stroke="#000">
             {" "}
             z
         </text>


### PR DESCRIPTION
This PR closes #1739 rotation anchor offset of line regions.

changes:
* The offset of the rotation anchor was `1 * imageRatio` + `ROTATOR_ANCHOR_HEIGHT / reverseScale`. Removed `1 * imageRatio` in order to be consistent with other regions. Handle the `ROTATOR_ANCHOR_HEIGHT / reverseScale` offset in `LineSegmentRegionComponent` instead of `Anchor` so that `handleAnchorDrag` works smoothly.
* Removed unused calculation `rotation = (-frame.spatialTransform.rotation * 180.0) / Math.PI;` in `LineSegmentRegionComponent`
* Removed warnings in `CustomIcons`
  <img width="638" alt="image" src="https://user-images.githubusercontent.com/43841102/169776700-a3c551d4-833e-4643-a23a-9db4d5cd89ae.png">

tested:
* consistent rotation anchor offset (on unmatched / spatially matched images)
* rotation anchor re-renders properly when zooming