### PR TITLE
Set default histogram in contour widget is per-channel if stokes changed

### DIFF
--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1795,6 +1795,7 @@ export class FrameStore {
         // Automatically switch to per-channel histograms when Stokes parameter changes
         if (this.requiredStokes !== stokes) {
             this.renderConfig.setUseCubeHistogram(false);
+            this.renderConfig.setUseCubeHistogramContours(false);
             this.renderConfig.updateCubeHistogram(null, 0);
         }
 


### PR DESCRIPTION
This is related to the [backend issue 1013](https://github.com/CARTAvis/carta-backend/issues/1013). The default histogram option in the contour widget should be `per-channel` when stokes is changed. Just like the histogram option in the render configuration widget.