### PR TITLE
ksw/add user data collection policy URL to About dialog

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -24,7 +24,7 @@ export class AboutDialogComponent extends React.Component {
         };
 
         return (
-            <DraggableDialogComponent dialogProps={dialogProps} defaultWidth={620} defaultHeight={700} enableResizing={false}>
+            <DraggableDialogComponent dialogProps={dialogProps} defaultWidth={620} defaultHeight={705} enableResizing={false}>
                 <div className={Classes.DIALOG_BODY}>
                     <div className={"image-div"}>
                         <img src="carta_logo.png" width={80} />
@@ -80,6 +80,12 @@ export class AboutDialogComponent extends React.Component {
                             Documentation is available{" "}
                             <a href="https://carta.readthedocs.io/en/3.0" rel="noopener noreferrer" target="_blank">
                                 online
+                            </a>
+                        </li>
+                        <li>
+                            User data collection policy is available{" "}
+                            <a href="https://cartavis.org/telemetry" rel="noopener noreferrer" target="_blank">
+                                here
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
**Description**
Added the user data collection policy entry in the About dialog along with a URL. Now we have two places to access the policy info.

![Screen Shot 2022-06-15 at 15 18 05](https://user-images.githubusercontent.com/20819712/173766675-d0d6cd39-1ff8-487e-98c4-2fee9ceb6405.png)



**Checklist**
- [x] ~changelog updated~ / no changelog update needed
- [x] e2e test passing / added corresponding fix
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed