### PR TITLE
Yuhsuan/1740 1887 projected regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issue with exporting decimated data instead of full resolution data in spatial profiler ([#1546](https://github.com/CARTAvis/carta-frontend/issues/1546))
 * Fixed larger position errors of projected contours, catalog overlays, and vector overlays near the border ([#1843](https://github.com/CARTAvis/carta-frontend/issues/1843)).
 * Fixed no updating of spatial profile after region deleting ([#1831](https://github.com/CARTAvis/carta-frontend/issues/1831), [#1855](https://github.com/CARTAvis/carta-frontend/issues/1855)).
+* Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
+* Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
 
 ## [3.0.0-beta.3]
 

--- a/src/stores/Frame/RegionStore.ts
+++ b/src/stores/Frame/RegionStore.ts
@@ -491,6 +491,12 @@ export class RegionStore {
     @action endCreating = async () => {
         this.creating = false;
         this.editing = false;
+
+        // re-calculate projected points when the status changes from unclosed to closed
+        if (this.regionType === CARTA.RegionType.POLYGON) {
+            this.regionApproximationMap.clear();
+        }
+
         if (this.regionType !== CARTA.RegionType.POINT) {
             try {
                 const ack = await this.backendService.setRegion(this.fileId, -1, this);

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -196,6 +196,9 @@ export function getApproximatePolygonPoints(astTransform: AST.FrameSet, controlP
             const p = add2D(p0, scale2D(dir, j * segmentSubdivisionLength));
             approxPointsOriginalSpace.push(p);
         }
+        if (i === M - 1 && !closed) {
+            approxPointsOriginalSpace.push(p1);
+        }
     }
 
     const N = approxPointsOriginalSpace.length;


### PR DESCRIPTION
**Description**

1. Closes #1887:

When we add a new control point during creation, we clear the projected point map and re-calculate with an unclosed polygon. The root cause of this issue is that after the last point is created (first mouse up event of the double click), we keep using the stored projected points (an unclosed polygon).

Fixed it by clearing the map when the entire creation is finished (after the double click) so that the projected points are re-calculated with a closed polygon.

2. Closes #1740:

Included the end point to avoid the gaps in unclosed regions including polygons during creation, lines, and polylines.

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / ~added corresponding fix~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed