### PR TITLE
disable splash screen when showing an alert

### DIFF
--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -13,7 +13,7 @@ export class SplashScreenComponent extends React.Component {
         const className = classNames("splash-screen", {"bp3-dark": appStore.darkTheme});
 
         return (
-            <Overlay className={Classes.OVERLAY_SCROLL_CONTAINER} autoFocus={false} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.splashScreenVisible} usePortal={true}>
+            <Overlay className={Classes.OVERLAY_SCROLL_CONTAINER} autoFocus={false} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.splashScreenVisible && !appStore.alertStore.alertVisible} usePortal={true}>
                 <div className={className}>
                     <div className={"image-div"}>
                         <img src="carta_logo.png" width={150} />


### PR DESCRIPTION
Closes #1808 (Hopefully). Can we see if this solves the issue? I simply hide the splash screen when an alert is visible. This hides the spinner, which seems to improve CPU usage