### PR TITLE
make animator frame indices less crowded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issue with exporting decimated data instead of full resolution data in spatial profiler ([#1546](https://github.com/CARTAvis/carta-frontend/issues/1546))
 * Fixed larger position errors of projected contours, catalog overlays, and vector overlays near the border ([#1843](https://github.com/CARTAvis/carta-frontend/issues/1843)).
 * Fixed no updating of spatial profile after region deleting ([#1831](https://github.com/CARTAvis/carta-frontend/issues/1831), [#1855](https://github.com/CARTAvis/carta-frontend/issues/1855)).
+* Fixed issues of crowded Frame idices in the animator and misalignment of channel slider indices ([#940](https://github.com/CARTAvis/carta-frontend/issues/940)), ([#1892]https://github.com/CARTAvis/carta-frontend/issues/1892)
 
 ## [3.0.0-beta.3]
 

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -216,7 +216,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (appStore.frames.length > 1) {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
-            const frameStep = numFrames > 10 ? Math.floor( (numFrames - 1) / (numIndices - 1) ) : 1;
+            const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
             frameSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.FRAME} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.FRAME} onChange={this.onAnimationModeChanged} label="Image" />

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -203,6 +203,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
 
     public render() {
         const appStore = AppStore.Instance;
+        const numFrames = appStore.frames.length;
         const activeFrame = appStore.activeFrame;
         const numChannels = activeFrame ? activeFrame.frameInfo.fileInfoExtended.depth : 0;
         const numStokes = activeFrame ? activeFrame.frameInfo.fileInfoExtended.stokes : 0;
@@ -214,13 +215,15 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         // Frame Control
         if (appStore.frames.length > 1) {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
+            const numIndices = 5;
+            const frameStep = numFrames > 10 ? Math.floor( (numFrames - 1) / (numIndices - 1) ) : 1;
             frameSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.FRAME} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.FRAME} onChange={this.onAnimationModeChanged} label="Image" />
-                    {hideSliders && <SafeNumericInput value={frameIndex} min={-1} max={appStore.frames.length} stepSize={1} onValueChange={this.onFrameChanged} fill={true} disabled={appStore.animatorStore.animationActive} />}
+                    {hideSliders && <SafeNumericInput value={frameIndex} min={-1} max={numFrames} stepSize={1} onValueChange={this.onFrameChanged} fill={true} disabled={appStore.animatorStore.animationActive} />}
                     {!hideSliders && (
                         <React.Fragment>
-                            <Slider value={frameIndex} min={0} max={appStore.frames.length - 1} showTrackFill={false} stepSize={1} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
+                            <Slider value={frameIndex} min={0} max={numFrames - 1} showTrackFill={false} labelStepSize={frameStep} labelPrecision={0} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
                             <div className="slider-info">{activeFrame.filename}</div>
                         </React.Fragment>
                     )}

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -234,7 +234,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         // Channel Control
         if (numChannels > 1) {
             const numLabels = 5;
-            const channelStep = numChannels > 10 ? (numChannels - 1) / (numLabels - 1) : 1;
+            const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
             channelSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.CHANNEL} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL} onChange={this.onAnimationModeChanged} label="Channel" />


### PR DESCRIPTION
**Description**
This PR is for issue #940 "**crowded indices of the Frame axis in the animator**". The original indices of Frame slider are like:
<img width="557" alt="animator_image_is_crowded" src="https://user-images.githubusercontent.com/106953609/175046206-5ae827f4-56a7-4f9f-b9b9-46234362001e.png">

The issue is fixed with the similar concept of Channel slider. The result is shown below:
<img width="324" alt="animator_image_not_crowded" src="https://user-images.githubusercontent.com/106953609/175045506-e91598b6-edfc-43d9-93b6-a958be010b8c.png">

**Checklist**
Since I'm not quite aware of our standard procedure of making PR, thus I'm not quite sure that should I do the e2e test by myself before making pull request? As for changelog, should I do that after the PR review?
- [x] changelog updated / no changelog update needed
- [x] e2e test passing / ~added corresponding fix~
- [x] protobuf updated to the latest dev commit / ~~no protobuf update needed~~