### PR TITLE
Yuhsuan/569 animate matched contour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issues of crowded Frame idices in the animator and misalignment of channel slider indices ([#940](https://github.com/CARTAvis/carta-frontend/issues/940)), ([#1892]https://github.com/CARTAvis/carta-frontend/issues/1892).
 * Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
 * Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
+* Fixed incorrect channels of matched images requested for animation ([#569](https://github.com/CARTAvis/carta-frontend/issues/569)).
 
 ## [3.0.0-beta.3]
 

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -96,6 +96,8 @@ export function getTransformedChannel(srcTransform: AST.FrameSet, destTransform:
     // Set common spectral
     AST.set(srcTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
     AST.set(destTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
+
+    // Get spectral value from forward transform
     const sourceSpectralValue = AST.transform3DPoint(srcTransform, 0, 0, srcChannel, true);
     if (!sourceSpectralValue || !isFinite(sourceSpectralValue.z)) {
         return NaN;
@@ -126,18 +128,19 @@ export function getTransformedChannelList(srcTransform: AST.FrameSet, destTransf
     AST.set(srcTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
     AST.set(destTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
 
+    // Get a sensible pixel coordinate for the reverse transform by forward transforming first pixel in image
+    const dummySpectralValue = AST.transform3DPoint(destTransform, 1, 1, 1, true);
+
     const N = lastChannel - firstChannel + 1;
     const destChannels = new Array<number>(N);
     for (let i = 0; i < N; i++) {
-        // Get spectral value from forward transform.
+        // Get spectral value from forward transform
         const sourceSpectralValue = AST.transform3DPoint(srcTransform, 1, 1, firstChannel + i, true);
         if (!sourceSpectralValue || !isFinite(sourceSpectralValue.z) || isAstBad(sourceSpectralValue.z)) {
             destChannels[i] = NaN;
             continue;
         }
 
-        // Get a sensible pixel coordinate for the reverse transform by forward transforming first pixel in image
-        const dummySpectralValue = AST.transform3DPoint(destTransform, 1, 1, 1, true);
         // Get pixel value from destination transform (reverse)
         const destPixelValue = AST.transform3DPoint(destTransform, dummySpectralValue.x, dummySpectralValue.y, sourceSpectralValue.z, false);
         if (!destPixelValue || !isFinite(destPixelValue.z) || isAstBad(sourceSpectralValue.z)) {

--- a/src/utilities/wcs.ts
+++ b/src/utilities/wcs.ts
@@ -129,8 +129,8 @@ export function getTransformedChannelList(srcTransform: AST.FrameSet, destTransf
     const N = lastChannel - firstChannel + 1;
     const destChannels = new Array<number>(N);
     for (let i = 0; i < N; i++) {
-        // Get spectral value from forward transform. Adjust for 1-based index
-        const sourceSpectralValue = AST.transform3DPoint(srcTransform, 1, 1, firstChannel + i + 1, true);
+        // Get spectral value from forward transform.
+        const sourceSpectralValue = AST.transform3DPoint(srcTransform, 1, 1, firstChannel + i, true);
         if (!sourceSpectralValue || !isFinite(sourceSpectralValue.z) || isAstBad(sourceSpectralValue.z)) {
             destChannels[i] = NaN;
             continue;
@@ -145,8 +145,7 @@ export function getTransformedChannelList(srcTransform: AST.FrameSet, destTransf
             continue;
         }
 
-        // Revert back to 0-based index
-        destChannels[i] = destPixelValue.z - 1;
+        destChannels[i] = destPixelValue.z;
     }
     return destChannels;
 }


### PR DESCRIPTION
**Description**
This PR is related to #569. Fixed incorrect channels of matched images requested for animation by removing the 1-index shifts in `getTransformedChannelList`.

before / after fix

<img src="https://user-images.githubusercontent.com/43841102/176091028-40e74bee-82f8-4b15-b99b-65b9f232711c.gif" width="300" /> <img src="https://user-images.githubusercontent.com/43841102/176091033-03c10c96-5387-488b-9c61-0b7b1463cd42.gif" width="300" />

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / ~added corresponding fix~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed