### PR TITLE
Angus/remove css animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed larger position errors of projected contours, catalog overlays, and vector overlays near the border ([#1843](https://github.com/CARTAvis/carta-frontend/issues/1843)).
 * Fixed no updating of spatial profile after region deleting ([#1831](https://github.com/CARTAvis/carta-frontend/issues/1831), [#1855](https://github.com/CARTAvis/carta-frontend/issues/1855)).
 * Fixed unable to switch channel by clicking scatter plot in stokes analysis widgets ([#1313](https://github.com/CARTAvis/carta-frontend/issues/1313)).
-* Fixed issues of crowded Frame idices in the animator and misalignment of channel slider indices ([#940](https://github.com/CARTAvis/carta-frontend/issues/940)), ([#1892]https://github.com/CARTAvis/carta-frontend/issues/1892).
+* Fixed issues of crowded Frame idices in the animator and misalignment of channel slider indices ([#940](https://github.com/CARTAvis/carta-frontend/issues/940), [#1892](https://github.com/CARTAvis/carta-frontend/issues/1892)).
 * Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
 * Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
 * Fixed incorrect channels of matched images requested for animation ([#569](https://github.com/CARTAvis/carta-frontend/issues/569)).
 * Fixed tooltip blocking issue of the toolbar in the image viewer ([#1897](https://github.com/CARTAvis/carta-frontend/issues/1897)).
 * Fixed persisent tooltip after exporting a png image ([#1742](https://github.com/CARTAvis/carta-frontend/issues/1742)).
-
+* Fixed high CPU/GPU usage when CARTA is idle or attempting to reconnect to server ([#153](https://github.com/CARTAvis/carta/issues/153) and [#1808](https://github.com/CARTAvis/carta-frontend/issues/1808)).
 ## [3.0.0-beta.3]
 
 ### Added

--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -27,24 +27,10 @@
 
     .contour-loading-icon {
         padding-right: 8px;
-        animation: pulse-green 2s infinite;
         opacity: 0;
-        transition: opacity 0.5s;
 
         &.icon-visible {
             opacity: 1;
-        }
-
-        @keyframes pulse-green {
-            0% {
-                color: $green2;
-            }
-            50% {
-                color: $green4;
-            }
-            100% {
-                color: $green2;
-            }
         }
     }
 

--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -28,6 +28,7 @@
     .contour-loading-icon {
         padding-right: 8px;
         opacity: 0;
+        color: $green3;
 
         &.icon-visible {
             opacity: 1;

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -13,7 +13,7 @@ export class SplashScreenComponent extends React.Component {
         const className = classNames("splash-screen", {"bp3-dark": appStore.darkTheme});
 
         return (
-            <Overlay className={Classes.OVERLAY_SCROLL_CONTAINER} autoFocus={false} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.splashScreenVisible} usePortal={true}>
+            <Overlay className={Classes.OVERLAY_SCROLL_CONTAINER} autoFocus={false} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={appStore.splashScreenVisible && !appStore.alertStore.alertVisible} usePortal={true}>
                 <div className={className}>
                     <div className={"image-div"}>
                         <img src="carta_logo.png" width={150} />


### PR DESCRIPTION
**Description**
Closes #1808 and https://github.com/CARTAvis/carta/issues/153 by:
- removing the CSS animation on the loading indicator
- hiding the splash screen (with animated spinner) when an alert is displayed

**Checklist**
- [x] changelog updated / ~~no changelog update needed~~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed