### PR TITLE
ksw/show tooltip when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issues of crowded Frame idices in the animator and misalignment of channel slider indices ([#940](https://github.com/CARTAvis/carta-frontend/issues/940)), ([#1892]https://github.com/CARTAvis/carta-frontend/issues/1892).
 * Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
 * Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
+* Fixed tooltip blocking issue of the toolbar in the image viewer ([#1897](https://github.com/CARTAvis/carta-frontend/issues/1897))
+* Fixed persisent tooltip after exporting a png image ([#1742](https://github.com/CARTAvis/carta-frontend/issues/1742))
 
 ## [3.0.0-beta.3]
 

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -229,22 +229,22 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                             <AnchorButton icon={"locate"} active={catalogOverlayEnabled} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.Catalog)} disabled={catalogSelectionDisabled} />
                         </Tooltip2>
                         {frame.regionSet.mode === RegionMode.CREATING && (
-                            <Tooltip2
-                                position={tooltipPosition}
-                                content={
-                                    <span>
-                                        Create region
-                                        <br />
-                                        <i>
-                                            <small>Click to select region type</small>
-                                        </i>
-                                    </span>
-                                }
-                            >
-                                <Popover2 popoverClassName="region-menu" content={regionMenu} position={Position.TOP} minimal={true}>
+                            <Popover2 popoverClassName="region-menu" content={regionMenu} position={Position.TOP} minimal={true}>
+                                <Tooltip2
+                                    position={tooltipPosition}
+                                    content={
+                                        <span>
+                                            Create region
+                                            <br />
+                                            <i>
+                                                <small>Click to select region type</small>
+                                            </i>
+                                        </span>
+                                    }
+                                >
                                     <AnchorButton icon={regionIcon} active={appStore.activeLayer === ImageViewLayer.RegionCreating} onClick={() => this.handleActiveLayerClicked(ImageViewLayer.RegionCreating)} />
-                                </Popover2>
-                            </Tooltip2>
+                                </Tooltip2>
+                            </Popover2>
                         )}
                         {frame.regionSet.mode === RegionMode.MOVING && (
                             <Tooltip2
@@ -287,57 +287,57 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                         <Tooltip2 position={tooltipPosition} content={<span>Zoom to fit{currentZoomSpan}</span>}>
                             <AnchorButton icon="zoom-to-fit" onClick={this.props.onZoomToFit} />
                         </Tooltip2>
-                        <Tooltip2
-                            position={tooltipPosition}
-                            content={
-                                <span>
-                                    WCS Matching <br />
-                                    <small>
-                                        <i>Current: {wcsButtonTooltip}</i>
-                                    </small>
-                                </span>
-                            }
-                        >
-                            <Popover2 content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
+                        <Popover2 content={wcsMatchingMenu} position={Position.TOP} minimal={true}>
+                            <Tooltip2
+                                position={tooltipPosition}
+                                content={
+                                    <span>
+                                        WCS Matching <br />
+                                        <small>
+                                            <i>Current: {wcsButtonTooltip}</i>
+                                        </small>
+                                    </span>
+                                }
+                            >
                                 <AnchorButton icon="link" className="link-button">
                                     {wcsButtonSuperscript}
                                 </AnchorButton>
-                            </Popover2>
-                        </Tooltip2>
-                        <Tooltip2
-                            position={tooltipPosition}
-                            content={
-                                <span>
-                                    Overlay Coordinate <br />
-                                    <small>
-                                        <i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i>
-                                    </small>
-                                </span>
-                            }
-                        >
-                            <Popover2 content={coordinateSystemMenu} position={Position.TOP} minimal={true}>
+                            </Tooltip2>
+                        </Popover2>
+                        <Popover2 content={coordinateSystemMenu} position={Position.TOP} minimal={true}>
+                            <Tooltip2
+                                position={tooltipPosition}
+                                content={
+                                    <span>
+                                        Overlay Coordinate <br />
+                                        <small>
+                                            <i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i>
+                                        </small>
+                                    </span>
+                                }
+                            >
                                 <AnchorButton disabled={!frame.validWcs} text={ToolbarComponent.CoordinateSystemName.get(coordinateSystem)} />
-                            </Popover2>
-                        </Tooltip2>
+                            </Tooltip2>
+                        </Popover2>
                         <Tooltip2 position={tooltipPosition} content="Toggle grid">
                             <AnchorButton icon="grid" active={grid.visible} onClick={() => grid.setVisible(!grid.visible)} />
                         </Tooltip2>
                         <Tooltip2 position={tooltipPosition} content="Toggle labels">
                             <AnchorButton icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels} />
                         </Tooltip2>
-                        <Tooltip2
-                            position={tooltipPosition}
-                            content={
-                                <span>
-                                    Export image
-                                    {this.exportImageTooltip()}
-                                </span>
-                            }
-                        >
-                            <Popover2 content={exportImageMenu} position={Position.TOP} minimal={true}>
+                        <Popover2 content={exportImageMenu} position={Position.TOP} minimal={true}>
+                            <Tooltip2
+                                position={tooltipPosition}
+                                content={
+                                    <span>
+                                        Export image
+                                        {this.exportImageTooltip()}
+                                    </span>
+                                }
+                            >
                                 <AnchorButton disabled={appStore.isExportingImage} icon="floppy-disk" />
-                            </Popover2>
-                        </Tooltip2>
+                            </Tooltip2>
+                        </Popover2>
                     </React.Fragment>
                 )}
                 <Tooltip2 position={tooltipPosition} content={appStore.toolbarExpanded ? "Hide toolbar" : "Show toolbar"}>


### PR DESCRIPTION
**Description**
This is to address https://github.com/CARTAvis/carta-frontend/issues/1897 and also fixes https://github.com/CARTAvis/carta-frontend/issues/1742.

Thanks for the suggestion from @YuHsuan-Hwang based on the example code from Blueprintjs. The root cause (sort of) is the nested structure of popover2 and tooltip2. If we place them in the correct order, the tooltip issue is gone. 

The following buttons+tooltips in the image viewer are revised
- region
- match wcs
- grid wcs type
- export image

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / ~added corresponding fix~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed