### PR TITLE
Icchen/1893 show last index of animator slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
 * Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
 * Fixed incorrect channels of matched images requested for animation ([#569](https://github.com/CARTAvis/carta-frontend/issues/569)).
-* Fixed issue of show last index of animator sliders ([#1893] https://github.com/CARTAvis/carta-frontend/issues/1893)
+* Fixed issue of showing last index of animator sliders ([#1893] (https://github.com/CARTAvis/carta-frontend/issues/1893))
 
 ## [3.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed gaps in projected unclosed regions ([#1740](https://github.com/CARTAvis/carta-frontend/issues/1740)).
 * Fixed projection of polygon regions created on spatially matched images ([#1887](https://github.com/CARTAvis/carta-frontend/issues/1887)).
 * Fixed incorrect channels of matched images requested for animation ([#569](https://github.com/CARTAvis/carta-frontend/issues/569)).
+* Fixed issue of show last index of animator sliders ([#1893] https://github.com/CARTAvis/carta-frontend/issues/1893)
 
 ## [3.0.0-beta.3]
 

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -217,8 +217,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
             const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
-            // The purpose of the "frameStep - 1" term in the next line is to add a tolerance to make the shown indices more reasonable.
-            const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep - 1 ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
+            const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep / 2 ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
             const frameTick = numFrames > 10 ? frameTickPre : Array.from(Array(numFrames).keys());
             frameSlider = (
                 <div className="animator-slider">
@@ -238,9 +237,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (numChannels > 1) {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
-            // The purpose of the "channelStep - 1" term in the next line is to add a tolerance to make the shown indices more reasonable.
             const channelTickPre =
-                numChannels - 1 - 4 * channelStep < channelStep - 1 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
+                numChannels - 1 - 4 * channelStep < channelStep / 2 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
             const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -217,13 +217,15 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
             const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
+            const tickFrame = numFrames > 10 ? [0, frameStep, 2*frameStep, 3*frameStep, 4*frameStep, numFrames - 1] : Array.from(Array(numFrames).keys())
+            console.log(frameStep)
             frameSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.FRAME} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.FRAME} onChange={this.onAnimationModeChanged} label="Image" />
                     {hideSliders && <SafeNumericInput value={frameIndex} min={-1} max={numFrames} stepSize={1} onValueChange={this.onFrameChanged} fill={true} disabled={appStore.animatorStore.animationActive} />}
                     {!hideSliders && (
                         <React.Fragment>
-                            <Slider value={frameIndex} min={0} max={numFrames - 1} showTrackFill={false} labelStepSize={frameStep} labelPrecision={0} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
+                            <Slider value={frameIndex} min={0} max={numFrames - 1} showTrackFill={false} labelValues={tickFrame} labelPrecision={0} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
                             <div className="slider-info">{activeFrame.filename}</div>
                         </React.Fragment>
                     )}
@@ -235,6 +237,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (numChannels > 1) {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
+            const tickChannels = numChannels > 10 ? [0, channelStep, 2*channelStep, 3*channelStep, 4*channelStep, numChannels - 1] : Array.from(Array(numChannels).keys())
             channelSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.CHANNEL} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL} onChange={this.onAnimationModeChanged} label="Channel" />
@@ -246,7 +249,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                                 value={activeFrame.requiredChannel}
                                 min={0}
                                 max={numChannels - 1}
-                                labelStepSize={channelStep}
+                                labelValues={tickChannels}
                                 labelPrecision={0}
                                 showTrackFill={false}
                                 onChange={this.onChannelChanged}

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -216,8 +216,9 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (appStore.frames.length > 1) {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
-            const frameStep = numFrames > 10 ? Math.ceil((numFrames - 1) / (numIndices - 1)) : 1;
-            const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
+            const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
+            // The purpose of the "frameStep - 1" term in the next line is to add a tolerance to make the shown indices more reasonable.
+            const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep - 1 ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
             const frameTick = numFrames > 10 ? frameTickPre : Array.from(Array(numFrames).keys());
             frameSlider = (
                 <div className="animator-slider">
@@ -236,8 +237,9 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         // Channel Control
         if (numChannels > 1) {
             const numLabels = 5;
-            const channelStep = numChannels > 10 ? Math.ceil((numChannels - 1) / (numLabels - 1)) : 1;
-            const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
+            const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
+            // The purpose of the "channelStep - 1" term in the next line is to add a tolerance to make the shown indices more reasonable.
+            const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep - 1 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
             const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -217,7 +217,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
             const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
-            const frameTickPre = numFrames - 1 - 4 * frameStep > 5 ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
+            const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
             const frameTick = numFrames > 10 ? frameTickPre : Array.from(Array(numFrames).keys());
             frameSlider = (
                 <div className="animator-slider">
@@ -237,7 +237,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (numChannels > 1) {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
-            const channelTickPre = numChannels - 1 - 4 * channelStep > 0 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
+            const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
             const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -217,8 +217,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
             const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
-            const tickFrame = numFrames > 10 ? [0, frameStep, 2*frameStep, 3*frameStep, 4*frameStep, numFrames - 1] : Array.from(Array(numFrames).keys())
-            console.log(frameStep)
+            const tickFrame = numFrames > 10 ? [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1] : Array.from(Array(numFrames).keys());
+            console.log(frameStep);
             frameSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.FRAME} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.FRAME} onChange={this.onAnimationModeChanged} label="Image" />
@@ -237,7 +237,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (numChannels > 1) {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
-            const tickChannels = numChannels > 10 ? [0, channelStep, 2*channelStep, 3*channelStep, 4*channelStep, numChannels - 1] : Array.from(Array(numChannels).keys())
+            const tickChannels = numChannels > 10 ? [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1] : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.CHANNEL} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL} onChange={this.onAnimationModeChanged} label="Channel" />

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -217,15 +217,15 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
             const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
-            const tickFrame = numFrames > 10 ? [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1] : Array.from(Array(numFrames).keys());
-            console.log(frameStep);
+            const frameTickPre = numFrames - 1 - 4 * frameStep > 5 ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
+            const frameTick = numFrames > 10 ? frameTickPre : Array.from(Array(numFrames).keys());
             frameSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.FRAME} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.FRAME} onChange={this.onAnimationModeChanged} label="Image" />
                     {hideSliders && <SafeNumericInput value={frameIndex} min={-1} max={numFrames} stepSize={1} onValueChange={this.onFrameChanged} fill={true} disabled={appStore.animatorStore.animationActive} />}
                     {!hideSliders && (
                         <React.Fragment>
-                            <Slider value={frameIndex} min={0} max={numFrames - 1} showTrackFill={false} labelValues={tickFrame} labelPrecision={0} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
+                            <Slider value={frameIndex} min={0} max={numFrames - 1} showTrackFill={false} labelValues={frameTick} labelPrecision={0} onChange={this.onFrameChanged} disabled={appStore.animatorStore.animationActive} />
                             <div className="slider-info">{activeFrame.filename}</div>
                         </React.Fragment>
                     )}
@@ -237,7 +237,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (numChannels > 1) {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
-            const tickChannels = numChannels > 10 ? [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1] : Array.from(Array(numChannels).keys());
+            const channelTickPre = numChannels - 1 - 4 * channelStep > 0 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
+            const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">
                     <Radio value={AnimationMode.CHANNEL} disabled={appStore.animatorStore.animationActive} checked={appStore.animatorStore.animationMode === AnimationMode.CHANNEL} onChange={this.onAnimationModeChanged} label="Channel" />
@@ -249,7 +250,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                                 value={activeFrame.requiredChannel}
                                 min={0}
                                 max={numChannels - 1}
-                                labelValues={tickChannels}
+                                labelValues={channelTick}
                                 labelPrecision={0}
                                 showTrackFill={false}
                                 onChange={this.onChannelChanged}

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -239,7 +239,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             const numLabels = 5;
             const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
             // The purpose of the "channelStep - 1" term in the next line is to add a tolerance to make the shown indices more reasonable.
-            const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep - 1 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
+            const channelTickPre =
+                numChannels - 1 - 4 * channelStep < channelStep - 1 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
             const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (
                 <div className="animator-slider">

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -216,7 +216,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         if (appStore.frames.length > 1) {
             const frameIndex = appStore.frames.findIndex(f => f.frameInfo.fileId === activeFrame.frameInfo.fileId);
             const numIndices = 5;
-            const frameStep = numFrames > 10 ? Math.floor((numFrames - 1) / (numIndices - 1)) : 1;
+            const frameStep = numFrames > 10 ? Math.ceil((numFrames - 1) / (numIndices - 1)) : 1;
             const frameTickPre = numFrames - 1 - 4 * frameStep < frameStep ? [0, frameStep, 2 * frameStep, 3 * frameStep, numFrames - 1] : [0, frameStep, 2 * frameStep, 3 * frameStep, 4 * frameStep, numFrames - 1];
             const frameTick = numFrames > 10 ? frameTickPre : Array.from(Array(numFrames).keys());
             frameSlider = (
@@ -236,7 +236,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
         // Channel Control
         if (numChannels > 1) {
             const numLabels = 5;
-            const channelStep = numChannels > 10 ? Math.floor((numChannels - 1) / (numLabels - 1)) : 1;
+            const channelStep = numChannels > 10 ? Math.ceil((numChannels - 1) / (numLabels - 1)) : 1;
             const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
             const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
             channelSlider = (


### PR DESCRIPTION
**Description**
This PR is linked to [#1893 Show last index of animator sliders](https://github.com/CARTAvis/carta-frontend/issues/1893)
`labelValues` is adopted instead of `labelStepSize`, to force the appearance of the last index of the animator slider. The result is shown below:

<img width="344" alt="image" src="https://user-images.githubusercontent.com/106953609/177364763-c0d621ab-4f2b-43ec-925b-5f3565c225ad.png">

**Checklist**
- [x] changelog updated / ~~no changelog update needed~~
- [ ] e2e test passing / added corresponding fix
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed