### PR TITLE
Yuhsuan/1899 import region fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed tooltip blocking issue of the toolbar in the image viewer ([#1897](https://github.com/CARTAvis/carta-frontend/issues/1897)).
 * Fixed persisent tooltip after exporting a png image ([#1742](https://github.com/CARTAvis/carta-frontend/issues/1742)).
 * Fixed high CPU/GPU usage when CARTA is idle or attempting to reconnect to server ([#153](https://github.com/CARTAvis/carta/issues/153) and [#1808](https://github.com/CARTAvis/carta-frontend/issues/1808)).
+* Fixed incorrect region positions when importing regions on a spatially matched image ([#1899](https://github.com/CARTAvis/carta-frontend/issues/1899)).
+* Fixed issue when the active frame changes while the region is being imported.
+
 ## [3.0.0-beta.3]
 
 ### Added


### PR DESCRIPTION
**Description**
Fixed two issues related to importing regions:
* Closes #1899:
the region positions are incorrect when importing regions on a spatially matched image. Fixed by applying the spatial reference frame instead of the active frame.
* Fixed issue when the active frame changes while the region is being imported. When adding regions, apply the active frame when requesting regions instead of the current active frame.

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / added corresponding new test
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed