### PR TITLE
Yuhsuan/1780 migrate region fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed high CPU/GPU usage when CARTA is idle or attempting to reconnect to server ([#153](https://github.com/CARTAvis/carta/issues/153) and [#1808](https://github.com/CARTAvis/carta-frontend/issues/1808)).
 * Fixed incorrect region positions when importing regions on a spatially matched image ([#1899](https://github.com/CARTAvis/carta-frontend/issues/1899)).
 * Fixed issue when the active frame changes while the region is being imported.
+* Fixed missing regions when the image is matched or unmatched to the reference ([#1780](https://github.com/CARTAvis/carta-frontend/issues/1780)).
 
 ## [3.0.0-beta.3]
 

--- a/src/stores/Frame/RegionSetStore.ts
+++ b/src/stores/Frame/RegionSetStore.ts
@@ -172,10 +172,11 @@ export class RegionSetStore {
             return;
         }
 
+        const dstRegionTimestamps = this.regions.map(r => r.modifiedTimestamp);
         let newId = -1;
         for (const region of sourceRegionSet.regions) {
             // skip duplicates
-            const duplicateRegion = this.regions.find(r => r.modifiedTimestamp === region.modifiedTimestamp);
+            const duplicateRegion = dstRegionTimestamps.find(t => t === region.modifiedTimestamp);
             if (duplicateRegion) {
                 continue;
             }


### PR DESCRIPTION
**Description**
Closes #1780 missing regions when the image is matched or unmatched to the reference.

When migrating regions, we check existing time stamps and skip duplicate ones. The root cause is that regions imported from a file may have same time stamps. Some regions are skipped when compared with regions that are just migrated. Fixed by copying existing time stamps before migrating regions to avoid comparison between the group of regions.

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / ~~added corresponding fix~~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed