### PR TITLE
show dashboard link when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added support for image fitting with field of view ([#1397](https://github.com/CARTAvis/carta-frontend/issues/1397)).
 * Size conversion in the image fitting results ([#1397](https://github.com/CARTAvis/carta-frontend/issues/1397)).
+* Added links to the CARTA Dashboard to the splashscreen and alert dialog where appropriate ([#1874](https://github.com/CARTAvis/carta-frontend/issues/1874)).
 ### Changed
 * Splatalogue queries are now made directly with the server, rather than proxied through the backend ([#1755](https://github.com/CARTAvis/carta-frontend/issues/1755)).
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {FloatingWidgetManagerComponent, UIControllerComponent} from "./component
 import {TaskProgressDialogComponent} from "./components/Dialogs";
 import {AlertStore, AlertType, AppStore} from "./stores";
 import {HotkeyTargetContainer} from "./HotkeyWrapper";
+import {ApiService} from "./services";
 import "./App.scss";
 import "./layout-base.scss";
 import "./layout-theme.scss";
@@ -44,12 +45,21 @@ export class App extends React.Component {
                     </Alert>
                 );
             case AlertType.Retry:
+                const cancelProps =
+                    alertStore.showDashboardLink && ApiService.RuntimeConfig?.dashboardAddress
+                        ? {
+                              cancelButtonText: "Open CARTA Dashboard",
+                              onCancel: () => window.open(ApiService.RuntimeConfig.dashboardAddress, "_blank")
+                          }
+                        : {};
+
                 return (
                     <Alert
                         icon={alertStore.alertIcon}
                         className={darkTheme ? "bp3-dark" : ""}
                         isOpen={alertStore.alertVisible}
                         confirmButtonText="Retry"
+                        {...cancelProps}
                         intent={Intent.DANGER}
                         onClose={alertStore.handleInteractiveAlertClosed}
                         canEscapeKeyCancel={false}

--- a/src/components/SplashScreen/SplashScreenComponent.scss
+++ b/src/components/SplashScreen/SplashScreenComponent.scss
@@ -43,7 +43,8 @@
     }
 
     .dashboard-info-div {
+        font-size: small;
         margin-left: auto;
-        margin-right: 25px;
+        margin-right: 22px;
     }
 }

--- a/src/components/SplashScreen/SplashScreenComponent.scss
+++ b/src/components/SplashScreen/SplashScreenComponent.scss
@@ -26,19 +26,24 @@
         height: 175px;
     }
 
-    .appInfo-div {
+    .app-info-div {
         margin: 10px 0 10px 0;
         h1 {
             margin: 0 0 0 0;
         }
     }
 
-    .loadingInfo-div {
+    .loading-info-div {
         height: 40px;
         display: flex;
         align-items: center;
         p {
             margin: 0 0 0 0;
         }
+    }
+
+    .dashboard-info-div {
+        margin-left: auto;
+        margin-right: 25px;
     }
 }

--- a/src/components/SplashScreen/SplashScreenComponent.scss
+++ b/src/components/SplashScreen/SplashScreenComponent.scss
@@ -45,6 +45,6 @@
     .dashboard-info-div {
         font-size: small;
         margin-left: auto;
-        margin-right: 22px;
+        margin-right: auto;
     }
 }

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -29,7 +29,7 @@ export class SplashScreenComponent extends React.Component {
                     <div className={"loading-info-div"}>
                         <p>{appStore.logStore.newestMsg}</p>
                     </div>
-                    {ApiService.RuntimeConfig.apiAddress ? (
+                    {ApiService.RuntimeConfig?.dashboardAddress ? (
                         <div className="dashboard-info-div">
                             <a href={ApiService.RuntimeConfig.apiAddress}>CARTA dashboard</a>
                         </div>

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -4,6 +4,7 @@ import {observer} from "mobx-react";
 import {Classes, Intent, Overlay, Spinner} from "@blueprintjs/core";
 import {AppStore} from "stores";
 import {CARTA_INFO} from "models";
+import {ApiService} from "services";
 import "./SplashScreenComponent.scss";
 
 @observer
@@ -18,16 +19,21 @@ export class SplashScreenComponent extends React.Component {
                     <div className={"image-div"}>
                         <img src="carta_logo.png" width={150} />
                     </div>
-                    <div className={"appInfo-div"}>
+                    <div className={"app-info-div"}>
                         <h1>
                             {CARTA_INFO.acronym} {CARTA_INFO.version} ({CARTA_INFO.date})
                         </h1>
                         <p>{CARTA_INFO.fullName}</p>
                     </div>
-                    <Spinner intent={Intent.PRIMARY} size={30} value={null} />
-                    <div className={"loadingInfo-div"}>
+                    <Spinner intent={Intent.PRIMARY} size={30} />
+                    <div className={"loading-info-div"}>
                         <p>{appStore.logStore.newestMsg}</p>
                     </div>
+                    {ApiService.RuntimeConfig.apiAddress ? (
+                        <div className="dashboard-info-div">
+                            <a href={ApiService.RuntimeConfig.apiAddress}>CARTA dashboard</a>
+                        </div>
+                    ) : null}
                 </div>
             </Overlay>
         );

--- a/src/components/SplashScreen/SplashScreenComponent.tsx
+++ b/src/components/SplashScreen/SplashScreenComponent.tsx
@@ -31,7 +31,7 @@ export class SplashScreenComponent extends React.Component {
                     </div>
                     {ApiService.RuntimeConfig?.dashboardAddress ? (
                         <div className="dashboard-info-div">
-                            <a href={ApiService.RuntimeConfig.apiAddress}>CARTA dashboard</a>
+                            <a href={ApiService.RuntimeConfig.apiAddress}>Connection problems? Open the CARTA dashboard</a>
                         </div>
                     ) : null}
                 </div>

--- a/src/stores/AlertStore.ts
+++ b/src/stores/AlertStore.ts
@@ -1,5 +1,7 @@
 import {action, observable, makeObservable} from "mobx";
 import React from "react";
+import {IconName} from "@blueprintjs/icons";
+import {MaybeElement} from "@blueprintjs/core";
 import {Deferred} from "services";
 
 export enum AlertType {
@@ -20,15 +22,17 @@ export class AlertStore {
 
     @observable alertVisible: boolean;
     @observable alertText: string | React.ReactNode;
-    @observable alertIcon: any;
+    @observable alertIcon: IconName | MaybeElement;
     @observable alertType: AlertType;
     @observable interactiveAlertText: string | React.ReactNode;
+    @observable showDashboardLink: boolean;
     private interactionPromise: Deferred<boolean>;
 
-    @action showAlert = (text: string | React.ReactNode, icon?: any) => {
+    @action showAlert = (text: string | React.ReactNode, icon?: IconName | MaybeElement, showDashboard = false) => {
         this.alertText = text;
         this.alertIcon = icon;
         this.alertType = AlertType.Info;
+        this.showDashboardLink = showDashboard;
         this.alertVisible = true;
     };
 
@@ -36,20 +40,22 @@ export class AlertStore {
         this.alertVisible = false;
     };
 
-    @action showInteractiveAlert = (text: string | React.ReactNode, icon?: any) => {
+    @action showInteractiveAlert = (text: string | React.ReactNode, icon?: IconName | MaybeElement, showDashboard = false) => {
         this.interactiveAlertText = text;
         this.alertIcon = icon;
         this.alertType = AlertType.Interactive;
         this.alertVisible = true;
+        this.showDashboardLink = showDashboard;
         this.interactionPromise = new Deferred<boolean>();
         return this.interactionPromise.promise;
     };
 
-    @action showRetryAlert = (text: string | React.ReactNode, icon?: any) => {
+    @action showRetryAlert = (text: string | React.ReactNode, icon?: IconName | MaybeElement, showDashboard = false) => {
         this.interactiveAlertText = text;
         this.alertIcon = icon;
         this.alertType = AlertType.Retry;
         this.alertVisible = true;
+        this.showDashboardLink = showDashboard;
         this.interactionPromise = new Deferred<boolean>();
         return this.interactionPromise.promise;
     };
@@ -65,5 +71,6 @@ export class AlertStore {
     private constructor() {
         makeObservable(this);
         this.alertVisible = false;
+        this.showDashboardLink = false;
     }
 }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1412,7 +1412,11 @@ export class AppStore {
                     if (this.previousConnectionStatus === ConnectionStatus.ACTIVE || this.previousConnectionStatus === ConnectionStatus.PENDING) {
                         AppToaster.show(ErrorToast("Disconnected from server"));
                         this.alertStore
-                            .showRetryAlert("You have been disconnected from the server. Do you want to reconnect? Please note that temporary images such as moment images or PV images generated via the GUI will be unloaded.")
+                            .showRetryAlert(
+                                "You have been disconnected from the server. Do you want to reconnect? Please note that temporary images such as moment images or PV images generated via the GUI will be unloaded.",
+                                "offline",
+                                true
+                            )
                             .then(this.onReconnectAlertClosed);
                     }
                     break;


### PR DESCRIPTION
**Description**
Closes #1874. Shows dashboard links if the runtime config defines a dashboard address.

![image](https://user-images.githubusercontent.com/592504/179721493-be762507-cbb6-4e2c-adda-94874412f059.png)
![image](https://user-images.githubusercontent.com/592504/179721615-0fb40490-c161-4b7f-9df0-6624bc5c4400.png)



**Checklist**
- [x] changelog updated / ~~no changelog update needed~~
- [ ] e2e test passing / added corresponding fix
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed