### PR TITLE
use binary searched data value for cursor info display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed high CPU/GPU usage when CARTA is idle or attempting to reconnect to server ([#153](https://github.com/CARTAvis/carta/issues/153) and [#1808](https://github.com/CARTAvis/carta-frontend/issues/1808)).
 * Fixed incorrect region positions when importing regions on a spatially matched image ([#1899](https://github.com/CARTAvis/carta-frontend/issues/1899)).
 * Fixed issue when the active frame changes while the region is being imported.
+* Fixed the displayed values in the cursor info of the histogram widget by adopting binary-searched data x and y values ([#1917](https://github.com/CARTAvis/carta-frontend/issues/1917)) 
 
 ## [3.0.0-beta.3]
 

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -196,7 +196,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             if (this.widgetStore.isMouseMoveIntoLinePlots) {
                 const nearest = binarySearchByX(this.plotData.values, this.widgetStore.cursorX);
                 if (nearest?.point) {
-                    let xValueLabel = (Math.abs(nearest.point.x) < 1e-5 ? `${toExponential(nearest.point.x, 5)}` : `${toFixed(nearest.point.x, 5)}`);
+                    let xValueLabel = Math.abs(nearest.point.x) < 1e-5 ? `${toExponential(nearest.point.x, 5)}` : `${toFixed(nearest.point.x, 5)}`;
                     let yValueLabel = `${nearest.point.y !== 0.5 ? nearest.point.y : 0}`;
                     if (unit) {
                         xValueLabel += ` ${unit}`;

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -196,7 +196,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             if (this.widgetStore.isMouseMoveIntoLinePlots) {
                 const nearest = binarySearchByX(this.plotData.values, this.widgetStore.cursorX);
                 if (nearest?.point) {
-                    let xValueLabel = Math.abs(nearest.point.x) < 1e-5 ? `${toExponential(nearest.point.x, 5)}` : `${toFixed(nearest.point.x, 5)}`;
+                    let xValueLabel = Math.abs(nearest.point.x) < 1e-5 ? `toExponential(nearest.point.x, 5)` : `toFixed(nearest.point.x, 5)`;
                     let yValueLabel = `${nearest.point.y !== 0.5 ? nearest.point.y : 0}`;
                     if (unit) {
                         xValueLabel += ` ${unit}`;

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -196,7 +196,7 @@ export class HistogramComponent extends React.Component<WidgetProps> {
             if (this.widgetStore.isMouseMoveIntoLinePlots) {
                 const nearest = binarySearchByX(this.plotData.values, this.widgetStore.cursorX);
                 if (nearest?.point) {
-                    let xValueLabel = Math.abs(nearest.point.x) < 1e-5 ? `toExponential(nearest.point.x, 5)` : `toFixed(nearest.point.x, 5)`;
+                    let xValueLabel = Math.abs(nearest.point.x) < 1e-5 ? toExponential(nearest.point.x, 5) : toFixed(nearest.point.x, 5);
                     let yValueLabel = `${nearest.point.y !== 0.5 ? nearest.point.y : 0}`;
                     if (unit) {
                         xValueLabel += ` ${unit}`;

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -194,30 +194,23 @@ export class HistogramComponent extends React.Component<WidgetProps> {
         let profilerInfo: string[] = [];
         if (this.plotData) {
             if (this.widgetStore.isMouseMoveIntoLinePlots) {
-                let numberString;
-                // Switch between standard and scientific notation
-                if (this.widgetStore.cursorX < 1e-5) {
-                    numberString = toExponential(this.widgetStore.cursorX, 5);
-                } else {
-                    numberString = toFixed(this.widgetStore.cursorX, 5);
-                }
                 const nearest = binarySearchByX(this.plotData.values, this.widgetStore.cursorX);
                 if (nearest?.point) {
-                    let valueLabel = `${nearest.point.y !== 0.5 ? nearest.point.y : 0}`;
-
+                    let xValueLabel = (Math.abs(nearest.point.x) < 1e-5 ? `${toExponential(nearest.point.x, 5)}` : `${toFixed(nearest.point.x, 5)}`);
+                    let yValueLabel = `${nearest.point.y !== 0.5 ? nearest.point.y : 0}`;
                     if (unit) {
-                        numberString += ` ${unit}`;
+                        xValueLabel += ` ${unit}`;
                     }
                     if (nearest.point.y <= 1) {
-                        valueLabel += ` Count`;
+                        yValueLabel += ` Count`;
                     } else {
-                        valueLabel += ` Counts`;
+                        yValueLabel += ` Counts`;
                     }
-
                     if (this.widgetStore.cursorX > this.plotData.xMax || this.widgetStore.cursorX < this.plotData.xMin) {
-                        valueLabel = `NaN`;
+                        xValueLabel = `NaN`;
+                        yValueLabel = `NaN`;
                     }
-                    profilerInfo.push(`Cursor: ${numberString}, ${valueLabel}`);
+                    profilerInfo.push(`Cursor: ${xValueLabel}, ${yValueLabel}`);
                 }
             }
         }


### PR DESCRIPTION
**Description**
This tries to fix #1917 by adopting the binary searched data value (x and y) for cursor info display. The original displayed x value is derived from the coordinate system of the plot. 

**Checklist**
- [x] changelog updated / ~~no changelog update needed~~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed