### PR TITLE
ajm/jenkinsfile update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
                     steps {
                         unstash "protobuf"
                         unstash "wasm_libs"
+                        sh "uname -a"
+                        sh "lsb_release -a"
                         sh 'rm -rf node_modules build'
                         sh 'n 12'
                         sh 'n exec 12 node -v'
@@ -41,6 +43,8 @@ pipeline {
                     steps {
                         unstash "protobuf"
                         unstash "wasm_libs"
+                        sh "uname -a"
+                        sh "lsb_release -a"
                         sh 'rm -rf node_modules build'
                         sh 'n 14' 
                         sh 'n exec 14 node -v'
@@ -55,6 +59,8 @@ pipeline {
                     steps {
                         unstash "protobuf"
                         unstash "wasm_libs"
+                        sh "uname -a"
+                        sh "sw_vers"
                         sh 'rm -rf node_modules build'
                         sh 'n 16'
                         sh 'n exec 16 node -v'
@@ -67,10 +73,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "carta-frontend - Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "carta-frontend - Success - ${env.BRANCH_NAME} <${env.RUN_DISPLAY_URL}|${COMMIT_ID}>";
         }
         failure {
-            slackSend color: 'danger', message: "carta-frontend - Fail - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'danger', message: "carta-frontend - Fail - ${env.BRANCH_NAME} <${env.RUN_DISPLAY_URL}|${COMMIT_ID}>";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,13 @@
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-frontend"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
 pipeline {
     agent none
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,3 @@
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-frontend"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
-}
-
 pipeline {
     agent none
     environment {
@@ -27,14 +17,6 @@ pipeline {
                 stash includes: "protobuf/**/*", name: "protobuf" 
                 stash includes: "wasm_libs/built/**/*,wasm_libs/zstd/build/standalone_zstd.bc", name: "wasm_libs"
             }
-            post {
-                success {
-                    setBuildStatus("WebAssembly compilation succeeded", "SUCCESS");
-                }
-                failure {
-                    setBuildStatus("WebAssembly compilation failed", "FAILURE");
-                }
-            }
         }
         stage('Build') {
             parallel {
@@ -51,14 +33,6 @@ pipeline {
                         sh 'n exec 12 npm install'
                         sh 'n exec 12 npm run build-docker'
                     }
-                    post {
-                        success {
-                            setBuildStatus("Build with node v12 succeeded", "SUCCESS");
-                        }
-                        failure {
-                            setBuildStatus("Build with node v12 failed", "FAILURE");
-                        }
-                    }
                 }
                 stage('Build with node v14') {
                     agent {
@@ -73,14 +47,6 @@ pipeline {
                         sh 'n exec 14 npm install'
                         sh 'n exec 14 npm run build-docker'
                     }
-                    post {
-                        success {
-                            setBuildStatus("Build with node v14 succeeded", "SUCCESS");
-                        }
-                        failure {
-                            setBuildStatus("Build with node v14 failed", "FAILURE");
-                        }
-                    }
                 }
                 stage('Build with node v16') {
                     agent {
@@ -94,14 +60,6 @@ pipeline {
                         sh 'n exec 16 node -v'
                         sh 'n exec 16 npm install --legacy-peer-deps'
                         sh 'n exec 16 npm run build-docker'
-                    }
-                    post {
-                        success {
-                            setBuildStatus("Build with node v16 succeeded", "SUCCESS");
-                        }
-                        failure {
-                            setBuildStatus("Build with node v16 failed", "FAILURE");
-                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                         unstash "protobuf"
                         unstash "wasm_libs"
                         sh "uname -a"
-                        sh "sw_vers"
+                        sh "lsb_release -a"
                         sh 'rm -rf node_modules build'
                         sh 'n 16'
                         sh 'n exec 16 node -v'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
                 }
                 stage('Build with node v16') {
                     agent {
-                       label "macos11-agent"
+                       label "almalinux86-agent"
                     }
                     steps {
                         unstash "protobuf"


### PR DESCRIPTION
**Description**
This makes two changes to the Jenkinsfile:
1. It uses the slackSend Jenkins plugin to send a final success or failure status to the #jenkins-build-status Slack channel.
2. Previously we only had one server doing the web assembly compilation and then the three build stages for node v12, v14, and v16 occurred parallel. An ongoing issue has been that occasionally two of the three parallel stages fail to contact Github for some unknown reason. This PR attempts to circumvent that issue by performing the three parallel build stages on three different servers instead of only one. Let's try it for a while. If the problem remains, then we can remove the parallel stage.

**Checklist**
- [v] no changelog update needed
- [v] e2e test passing - This should have no effect on the e2e tests
- [v] no protobuf update needed