### PR TITLE
thchang/ issue 1786 QU profile 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the displayed values in the cursor info of the histogram widget by adopting binary-searched data x and y values ([#1917](https://github.com/CARTAvis/carta-frontend/issues/1917)) 
 * Fixed missing regions when the image is matched or unmatched to the reference ([#1780](https://github.com/CARTAvis/carta-frontend/issues/1780)).
 * Fixed inconsistent vector line width on spatially matched images ([#1854](https://github.com/CARTAvis/carta-frontend/issues/1854)).
+* Fixed QU profile rendering black at the first channel in the stokes widget ([#1786](https://github.com/CARTAvis/carta-frontend/issues/1786)).
 
 
 ## [3.0.0-beta.3]

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -609,10 +609,6 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
 
     private fillLineColor(data: Array<Point2D>, lineColor: string): Array<string> {
         let lineColors = [];
-        // n points have n-1 gaps between all points for line plot
-        if (this.widgetStore.plotType !== PlotType.POINTS) {
-            lineColors.push("");
-        }
         if (data && data.length && lineColor) {
             for (let index = 0; index < data.length; index++) {
                 const point = data[index];


### PR DESCRIPTION
**Description**
closes #1786: Q,U rendering black at first channel in the stokes widget.

Fixed this issue by removing the workaround, adding empty color string in `fillLineColor`, which is no longer needed for the  [bug](https://github.com/chartjs/Chart.js/pull/9644) has been fixed after Chart.js [v3.6.0](https://github.com/chartjs/Chart.js/releases/v3.6.0).

**Checklist**
- [ ] changelog updated / no changelog update needed
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed