### PR TITLE
add disableConcurrentBuilds option to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent none
+    options {
+        disableConcurrentBuilds()
+    }
     environment {
         COMMIT_ID=''
     }


### PR DESCRIPTION
**Description**
This small modification should fix the issue where if a new commit is made to a branch while the previous commit is still in the process of building, then the CI fails on the new commit.
The issue should be eliminated by activating the "disable concurrent builds" options. The only way to do so for a multi-branch pipeline job with a Jenkinsfile is to add the option to the Jenkinsfile.

**Checklist**
- [x] changelog updated / no changelog update needed
- [x] e2e test passing / added corresponding fix - should have no effect on the e2e tests
- [x] no protobuf update needed