### PR TITLE
Angus/1854 vector line width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issue when the active frame changes while the region is being imported.
 * Fixed the displayed values in the cursor info of the histogram widget by adopting binary-searched data x and y values ([#1917](https://github.com/CARTAvis/carta-frontend/issues/1917)) 
 * Fixed missing regions when the image is matched or unmatched to the reference ([#1780](https://github.com/CARTAvis/carta-frontend/issues/1780)).
+* Fixed inconsistent vector line width on spatially matched images ([#1854](https://github.com/CARTAvis/carta-frontend/issues/1854)).
 
 
 ## [3.0.0-beta.3]

--- a/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
+++ b/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
@@ -160,9 +160,7 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         this.gl.uniform1i(shaderUniforms.DataTexture, 0);
         this.gl.uniform1f(shaderUniforms.CanvasSpaceLineWidth, pixelRatio * frame.vectorOverlayConfig.thickness);
         const baseScale = baseFrame.spatialTransform?.scale ?? 1.0;
-        const frameScale = frame.spatialTransform?.scale ?? 1.0;
-        const scaleRatio = frameScale / baseScale;
-        this.gl.uniform1f(shaderUniforms.FeatherWidth, pixelRatio * scaleRatio);
+        this.gl.uniform1f(shaderUniforms.FeatherWidth, pixelRatio / baseScale);
         if (isFinite(frame.vectorOverlayConfig.rotationOffset)) {
             this.gl.uniform1f(shaderUniforms.RotationOffset, (frame.vectorOverlayConfig.rotationOffset * Math.PI) / 180.0);
         } else {

--- a/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
+++ b/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
@@ -159,7 +159,10 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
 
         this.gl.uniform1i(shaderUniforms.DataTexture, 0);
         this.gl.uniform1f(shaderUniforms.CanvasSpaceLineWidth, pixelRatio * frame.vectorOverlayConfig.thickness);
-        this.gl.uniform1f(shaderUniforms.FeatherWidth, pixelRatio);
+        const baseScale = baseFrame.spatialTransform?.scale ?? 1.0;
+        const frameScale = frame.spatialTransform?.scale ?? 1.0;
+        const scaleRatio = frameScale / baseScale;
+        this.gl.uniform1f(shaderUniforms.FeatherWidth, pixelRatio * scaleRatio);
         if (isFinite(frame.vectorOverlayConfig.rotationOffset)) {
             this.gl.uniform1f(shaderUniforms.RotationOffset, (frame.vectorOverlayConfig.rotationOffset * Math.PI) / 180.0);
         } else {

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1960,8 +1960,6 @@ export class AppStore {
         }
         this.activeFrame = frame;
         this.widgetsStore.updateImageWidgetTitle(this.layoutStore.dockedLayout);
-        const fileUrl = `${frame.frameInfo.directory}/${frame.frameInfo.fileInfo.name}`.replace(/^\.\//, "");
-        window.history.replaceState({}, this.activeFrame.frameInfo.fileInfo.name, window.location.href.replace(window.location.search, "") + `?file=${encodeURI(fileUrl)}`);
         this.catalogStore.resetActiveCatalogFile(frame.frameInfo.fileId);
         if (this.syncContourToFrame) {
             this.contourDataSource = frame;


### PR DESCRIPTION
**Description**
Closes #1854. It was actually the feather width, rather than the line thickness :facepalm: That's why it only showed up in extreme cases (where `featherWidth * relativeScale ~ lineThickness`)

(also reverts erroneous [commit](https://github.com/CARTAvis/carta-frontend/commit/a244aa7ccf3ab649c8c8e28fbed078adae3f0350)) 

**Checklist**
- [ ] changelog updated / no changelog update needed
- [ ] e2e test passing / ~~added corresponding fix~~
- [ ] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed