### PR TITLE
adjust console icon padding

### DIFF
--- a/src/components/Menu/RootMenuComponent.scss
+++ b/src/components/Menu/RootMenuComponent.scss
@@ -30,7 +30,7 @@
         color: $green3;
     }
 
-    .bp3-icon-console {
+    .bp3-icon-console.bp3-intent-warning {
         padding-right: 8px;
     }
 


### PR DESCRIPTION
**Description**
Closes #1968: one-line fix of the console icon padding.

Before / After
<img width="195" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/43841102/183556738-12539db0-daa6-4f91-ac87-3a0804a4f5d5.png">
<img width="196" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/43841102/183556753-37735bde-f9de-4992-9b86-b5f23bdc9898.png">

**Checklist**
- [X] ~changelog updated~ / no changelog update needed
- [X] e2e test passing / ~~added corresponding fix~~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed