### PR TITLE
adjust texCoordsPixel

### DIFF
--- a/src/services/GLSL/pixel_shader_raster.glsl
+++ b/src/services/GLSL/pixel_shader_raster.glsl
@@ -53,7 +53,7 @@ void main(void) {
     // Mimics texel fetch in WebGL1
     vec2 tileCoordsPixel = vUV * uTileTextureSize;
     // Prevent edge artefacts
-    vec2 texCoordsPixel = clamp(tileCoordsPixel, 0.5, uTileTextureSize - 0.5) + uTileTextureOffset;
+    vec2 texCoordsPixel = clamp(floor(tileCoordsPixel), 0.5, uTileTextureSize - 0.5) + uTileTextureOffset;
     vec2 f = fract(tileCoordsPixel);
 
     // Pixel grid: 1.1px feather on line width. 1.1 instead of 1.0 to reduce Moire effects


### PR DESCRIPTION
**Description**
Closes #949. The root cause is that `texCoordsPixel` loses precision when adding with non zero `uTileTextureOffset`.

code snippet to reproduce the issue:
```javascript
await app.openFile(PATH, "HD163296_CO_2_1.fits"); // load another file to make uTileTextureOffset !== 0
await app.delay(1000); // delay to avoid missing tiles

const file = await app.openFile(PATH, "image_4_4.fits"); // an image with size 4 x 4
file.regionSet.addRectangularRegion({x: 1, y: 1}, 1, 1);
file.regionSet.selectRegionByIndex(1);
file.setZoom(4000000);
```

before fix
![image](https://user-images.githubusercontent.com/43841102/187120151-d1855d4b-0d17-402e-9a53-fd091bc505bc.png)
after fix
![image](https://user-images.githubusercontent.com/43841102/187120228-36a04148-f67b-4164-aa14-207d3d73fd7e.png)

**Checklist**
- [ ] changelog updated / no changelog update needed
- [x] e2e test passing / ~~added corresponding fix~~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed