### PR TITLE
Increasing the upper limit of averaging width for line/polyline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).
+### Changed
+* Changed the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).
 
 ## [3.0.1]
 

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -197,7 +197,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                 >
                     <HTMLSelect value={selectedValue} options={this.widgetStore.regionOptions} onChange={this.handleRegionChanged} />
                 </FormGroup>
-                <FormGroup inline={true} label="Average Width (px)">
+                <FormGroup inline={true} label="Average Width">
                     <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.width} onValueChange={value => this.widgetStore.setWidth(value)} />
                 </FormGroup>
                 <div className="generate-button">

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -197,8 +197,8 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                 >
                     <HTMLSelect value={selectedValue} options={this.widgetStore.regionOptions} onChange={this.handleRegionChanged} />
                 </FormGroup>
-                <FormGroup inline={true} label="Average Width">
-                    <SafeNumericInput min={1} max={10} stepSize={1} value={this.widgetStore.width} onValueChange={value => this.widgetStore.setWidth(value)} />
+                <FormGroup inline={true} label="Average Width (px)">
+                    <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.width} onValueChange={value => this.widgetStore.setWidth(value)} />
                 </FormGroup>
                 <div className="generate-button">
                     <Tooltip2 disabled={isAbleToGenerate} content={hint} position={Position.BOTTOM}>

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -199,7 +199,7 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
                         title="Computation"
                         panel={
                             <FormGroup label={"Width"} inline={true}>
-                                <SafeNumericInput min={1} max={10} stepSize={1} value={this.widgetStore.lineRegionSampleWidth} onValueChange={value => this.widgetStore.setLineRegionSampleWidth(value)} />
+                                <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.lineRegionSampleWidth} onValueChange={value => this.widgetStore.setLineRegionSampleWidth(value)} />
                             </FormGroup>
                         }
                     />


### PR DESCRIPTION
**Description**
linked issues #1949. Increasing the upper limit of averaging width for line/polyline spatial profiles or PV image calculations.

**Checklist**
- [x] changelog updated / no changelog update needed
- [x] e2e test passing / ~~added corresponding fix~~
- [x] no protobuf update needed