### PR TITLE
carli/1947_mirror_cursor_when_spatially_matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Add a method to auto-scrolling the selected region into the region list view ([#1797](https://github.com/CARTAvis/carta-frontend/issues/1797)).
+* Added the functionality to mirror cursor position on spatially matched frame via hotkey "G" ([#1947](https://github.com/cartavis/carta-frontend/issues/1947)).
 ### Fixed
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -149,7 +149,8 @@ export class HotkeyContainer extends React.Component {
 
         const otherHotKeys = [
             <Hotkey key={0} group={otherGroupTitle} global={true} combo="shift + D" label="Toggle light/dark theme" onKeyDown={HotkeyContainer.ToggleDarkTheme} />,
-            <Hotkey key={1} group={otherGroupTitle} global={true} combo="F" label="Freeze/unfreeze cursor position" onKeyDown={appStore.toggleCursorFrozen} />
+            <Hotkey key={1} group={otherGroupTitle} global={true} combo="F" label="Freeze/unfreeze cursor position" onKeyDown={appStore.toggleCursorFrozen} />,
+            <Hotkey key={2} group={otherGroupTitle} global={true} combo="G" label="Mirror cursor on multipanel view" onKeyDown={appStore.toggleCursorMirror} />
         ];
 
         return (

--- a/src/components/CursorInfo/CursorInfoComponent.tsx
+++ b/src/components/CursorInfo/CursorInfoComponent.tsx
@@ -120,6 +120,10 @@ export class CursorInfoComponent extends React.Component<WidgetProps> {
         }
     };
 
+    private toggleCursorMirror = () => {
+        AppStore.Instance.cursorMirror = !AppStore.Instance.cursorMirror;
+    };
+
     render() {
         const appStore = AppStore.Instance;
         const frameNum = appStore.frames.length;
@@ -170,6 +174,7 @@ export class CursorInfoComponent extends React.Component<WidgetProps> {
 
         return (
             <div className="cursor-info-widget">
+                <button onClick={this.toggleCursorMirror}>Click here</button>
                 {this.width > 0 && ( // prevent row index header not rendering
                     <SimpleTableComponent
                         dataset={columnsData}

--- a/src/components/CursorInfo/CursorInfoComponent.tsx
+++ b/src/components/CursorInfo/CursorInfoComponent.tsx
@@ -120,10 +120,6 @@ export class CursorInfoComponent extends React.Component<WidgetProps> {
         }
     };
 
-    private toggleCursorMirror = () => {
-        AppStore.Instance.cursorMirror = !AppStore.Instance.cursorMirror;
-    };
-
     render() {
         const appStore = AppStore.Instance;
         const frameNum = appStore.frames.length;
@@ -174,7 +170,6 @@ export class CursorInfoComponent extends React.Component<WidgetProps> {
 
         return (
             <div className="cursor-info-widget">
-                <button onClick={this.toggleCursorMirror}>Click here</button>
                 {this.width > 0 && ( // prevent row index header not rendering
                     <SimpleTableComponent
                         dataset={columnsData}

--- a/src/components/ImageView/RegionView/CursorRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/CursorRegionComponent.tsx
@@ -18,8 +18,8 @@ export class CursorRegionComponent extends React.Component<CursorRegionComponent
         const appStore = AppStore.Instance;
         const frame = this.props.frame;
         const posImageSpace = frame?.cursorInfo?.posImageSpace;
-        //check the current frame is the spatialReg
-        const isSpatialMatchingOn = appStore.frames.some(thisFrame => thisFrame.spatialReference === frame);
+        //check the current frame is the spatialRef
+        const isSpatialMatchingOn: boolean = frame.secondarySpatialImages?.length ? true : false;
 
         if ((appStore.cursorFrozen || (appStore.cursorMirror && (frame?.spatialReference || isSpatialMatchingOn || frame === appStore.activeFrame))) && posImageSpace) {
             const rotation = frame.spatialReference ? (frame.spatialTransform.rotation * 180.0) / Math.PI : 0.0;

--- a/src/components/ImageView/RegionView/CursorRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/CursorRegionComponent.tsx
@@ -15,13 +15,14 @@ interface CursorRegionComponentProps {
 @observer
 export class CursorRegionComponent extends React.Component<CursorRegionComponentProps> {
     render() {
+        const appStore = AppStore.Instance;
         const frame = this.props.frame;
         const posImageSpace = frame?.cursorInfo?.posImageSpace;
 
-        if (AppStore.Instance.cursorFrozen && posImageSpace) {
+        if ((appStore.cursorFrozen || (appStore.cursorMirror && (frame?.spatialReference || frame === appStore.spatialReference))) && posImageSpace) {
             const rotation = frame.spatialReference ? (frame.spatialTransform.rotation * 180.0) / Math.PI : 0.0;
             const cursorCanvasSpace = transformedImageToCanvasPos(posImageSpace, frame, this.props.width, this.props.height, this.props.stageRef.current);
-            return <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} />;
+            return isFinite(cursorCanvasSpace.x) && isFinite(cursorCanvasSpace.y) && <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} />;
         }
 
         return null;

--- a/src/components/ImageView/RegionView/CursorRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/CursorRegionComponent.tsx
@@ -22,7 +22,7 @@ export class CursorRegionComponent extends React.Component<CursorRegionComponent
         if ((appStore.cursorFrozen || (appStore.cursorMirror && (frame?.spatialReference || frame === appStore.spatialReference))) && posImageSpace) {
             const rotation = frame.spatialReference ? (frame.spatialTransform.rotation * 180.0) / Math.PI : 0.0;
             const cursorCanvasSpace = transformedImageToCanvasPos(posImageSpace, frame, this.props.width, this.props.height, this.props.stageRef.current);
-            return isFinite(cursorCanvasSpace.x) && isFinite(cursorCanvasSpace.y) && <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} />;
+            return isFinite(cursorCanvasSpace.x) && isFinite(cursorCanvasSpace.y) && <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} color={appStore.cursorFrozen ? "white" : "yellow"} />;
         }
 
         return null;

--- a/src/components/ImageView/RegionView/CursorRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/CursorRegionComponent.tsx
@@ -18,8 +18,10 @@ export class CursorRegionComponent extends React.Component<CursorRegionComponent
         const appStore = AppStore.Instance;
         const frame = this.props.frame;
         const posImageSpace = frame?.cursorInfo?.posImageSpace;
+        //check the current frame is the spatialReg
+        const isSpatialMatchingOn = appStore.frames.some(thisFrame => thisFrame.spatialReference === frame);
 
-        if ((appStore.cursorFrozen || (appStore.cursorMirror && (frame?.spatialReference || frame === appStore.spatialReference))) && posImageSpace) {
+        if ((appStore.cursorFrozen || (appStore.cursorMirror && (frame?.spatialReference || isSpatialMatchingOn || frame === appStore.activeFrame))) && posImageSpace) {
             const rotation = frame.spatialReference ? (frame.spatialTransform.rotation * 180.0) / Math.PI : 0.0;
             const cursorCanvasSpace = transformedImageToCanvasPos(posImageSpace, frame, this.props.width, this.props.height, this.props.stageRef.current);
             return isFinite(cursorCanvasSpace.x) && isFinite(cursorCanvasSpace.y) && <CursorMarker x={cursorCanvasSpace.x} y={cursorCanvasSpace.y} rotation={-rotation} color={appStore.cursorFrozen ? "white" : "yellow"} />;

--- a/src/components/ImageView/RegionView/InvariantShapes.tsx
+++ b/src/components/ImageView/RegionView/InvariantShapes.tsx
@@ -137,6 +137,7 @@ interface CursorMarkerProps {
     x: number;
     y: number;
     rotation: number;
+    color: string;
 }
 
 export const CursorMarker = (props: CursorMarkerProps) => {
@@ -160,7 +161,7 @@ export const CursorMarker = (props: CursorMarkerProps) => {
     return (
         <Group x={props.x} y={props.y} rotation={-props.rotation}>
             <Shape listening={false} strokeScaleEnabled={false} strokeWidth={1} stroke={"black"} sceneFunc={handleSquareDraw} />
-            <Shape listening={false} strokeScaleEnabled={false} fill={"white"} strokeWidth={1} stroke={"black"} sceneFunc={handleCrossDraw} />
+            <Shape listening={false} strokeScaleEnabled={false} fill={props.color} strokeWidth={1} stroke={"black"} sceneFunc={handleCrossDraw} />
         </Group>
     );
 };

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -116,6 +116,7 @@ export class AppStore {
     // ImageViewer
     @observable activeLayer: ImageViewLayer;
     @observable cursorFrozen: boolean;
+    @observable cursorMirror: boolean = false;
     @observable toolbarExpanded: boolean;
     @observable imageRatio: number;
     @observable isExportingImage: boolean;

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1182,6 +1182,10 @@ export class AppStore {
         this.cursorFrozen = val;
     };
 
+    @action toggleCursorMirror = () => {
+        this.cursorMirror = !this.cursorMirror;
+    };
+
     @action toggleToolbarExpanded = () => {
         this.toolbarExpanded = !this.toolbarExpanded;
     };


### PR DESCRIPTION
**Description**
This is an enhancement functionality. The cursor is mirrored on all other spatially matched images to allow users to see the current corresponding cursor position on other images. An boolean observable is added to the AppStore called cursorMirror to keep track of the functionality status, and a button is added to the cursorInfo widget to toggle on/off. Once the functionality is turned on, a cross cursor appears on the reference image and it follows the user's cursor. When the user turn on the spatial matching to the reference image, a cross cursor appears on the corresponding image. Users can hover on any of the images that are spatially matched to each other to see the corresponding cursor location on all other spatially matched frames.

**Checklist**
- [x] changelog updated / ~~no changelog update needed~~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] protobuf updated to the latest dev commit / ~no protobuf update needed~