### PR TITLE
Icchen/1797 scroll selected region into region list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add a method to auto-scrolling the selected region into the region list view ([#1797](https://github.com/CARTAvis/carta-frontend/issues/1797)).
 ### Fixed
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -72,12 +72,9 @@ export class RegionListComponent extends React.Component<WidgetProps> {
             () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
             id => {
                 if (id > 0) {
-                    const validRegionId = [];
-                    for (let i = 0; i < this.validRegions.length; i++) {
-                        validRegionId.push(this.validRegions[i].regionId);
-                    }
+                    const validRegionId = this.validRegions.map(el => el.regionId);
                     this.scrollToSelected(validRegionId.findIndex(element => element === id));
-                } else return;
+                }
             }
         );
     }

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -72,7 +72,11 @@ export class RegionListComponent extends React.Component<WidgetProps> {
             () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
             id => {
                 if (id > 0) {
-                    this.scrollToSelected(id);
+                    const validRegionId = [];
+                    for (let i = 0; i < this.validRegions.length; i++) {
+                        validRegionId.push(this.validRegions[i].regionId);
+                    }
+                    this.scrollToSelected(validRegionId.findIndex(element => element === id));
                 } else return;
             }
         );

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {action, computed, makeObservable, observable} from "mobx";
+import {action, computed, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 import {Icon, NonIdealState, Position, Spinner} from "@blueprintjs/core";
 import {Tooltip2} from "@blueprintjs/popover2";
@@ -26,6 +26,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private static readonly ROTATION_COLUMN_DEFAULT_WIDTH = 80;
     private static readonly ROW_HEIGHT = 35;
     private static readonly HEADER_ROW_HEIGHT = 25;
+    private listRef = React.createRef<any>();
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -54,9 +55,27 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     @observable firstVisibleRow: number = 0;
     @observable lastVisibleRow: number = 0;
 
+    private scrollToSelected = (selected: any) => {
+        const listRefCurrent = this.listRef.current;
+        if (!listRefCurrent) {
+            return;
+        } else {
+            this.listRef.current.scrollToItem(selected, "smart");
+        }
+    };
+
     constructor(props: any) {
         super(props);
         makeObservable(this);
+
+        reaction(
+            () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
+            id => {
+                if (id > 0) {
+                    this.scrollToSelected(id);
+                } else return;
+            }
+        );
     }
 
     @action private onResize = (width: number, height: number) => {
@@ -346,7 +365,14 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                     <FixedSizeList itemSize={RegionListComponent.HEADER_ROW_HEIGHT} height={RegionListComponent.HEADER_ROW_HEIGHT} itemCount={1} width="100%" className="list-header">
                         {headerRenderer}
                     </FixedSizeList>
-                    <FixedSizeList onItemsRendered={this.onListRendered} height={tableHeight - RegionListComponent.HEADER_ROW_HEIGHT - padding * 2} itemCount={this.validRegions.length} itemSize={RegionListComponent.ROW_HEIGHT} width="100%">
+                    <FixedSizeList
+                        onItemsRendered={this.onListRendered}
+                        height={tableHeight - RegionListComponent.HEADER_ROW_HEIGHT - padding * 2}
+                        itemCount={this.validRegions.length}
+                        itemSize={RegionListComponent.ROW_HEIGHT}
+                        width="100%"
+                        ref={this.listRef}
+                    >
                         {rowRenderer}
                     </FixedSizeList>
                 </div>


### PR DESCRIPTION
**Description**
This PR is to fix #1797.
A method called "scrollToSelected" is added to the RegionListComponent.tsx to let the selected region auto-scroll into the view of the region list. The result is shown below:

[Screencast from 09-08-2022 04:59:35 PM.webm](https://user-images.githubusercontent.com/106953609/189081318-b96cd777-e418-4a01-9524-2ec95898e011.webm)


**Checklist**
- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed