### PR TITLE
OIDC serverside

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28934,8 +28934,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
             "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -29341,8 +29340,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
             "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@mapbox/point-geometry": {
             "version": "0.1.0",
@@ -30758,8 +30756,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -30836,15 +30833,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "almost-equal": {
             "version": "1.1.0",
@@ -31393,8 +31388,7 @@
             "version": "0.3.7",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
             "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.2.2",
@@ -35052,8 +35046,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-testing-library": {
             "version": "3.10.2",
@@ -38738,8 +38731,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -40033,8 +40025,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz",
             "integrity": "sha512-q5+UHIqYCOpBoFm/PElDuOhbcatvTllgRp3M1s+Hp5j0Z6XNgDbgqxawJ0ZAUEyKM8X1zs70PCuhAIzX1f4Q/g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "moment": {
             "version": "2.29.4",
@@ -43605,8 +43596,7 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz",
             "integrity": "sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-split-pane": {
             "version": "0.1.92",
@@ -43644,8 +43634,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.5.tgz",
             "integrity": "sha512-kivjYVWX15TX2IUrm8F1jaCEX8EXrpy3DD+u41WGqJ1ZqbljWpiwscV+VxOM1l7sSIM1jwi2LADjhhAJkJ9dxA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-window": {
             "version": "1.8.6",
@@ -49234,8 +49223,7 @@
             "version": "7.5.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
             "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -189,7 +189,7 @@ export class ApiService {
             try {
                 await this.axiosInstance.post(ApiService.RuntimeConfig.logoutAddress);
             } catch (err) {
-                if (err.response.status == 404) {
+                if (err.response.status === 404) {
                     // OIDC logout requires GET for logout vs POST for other mechanisms
                     window.open(ApiService.RuntimeConfig.logoutAddress, "_self");
                     return; // avoid later potential dashboard redirect

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -184,10 +184,18 @@ export class ApiService {
         if (ApiService.RuntimeConfig.googleClientId) {
             this.authInstance?.signOut();
         } else if (ApiService.RuntimeConfig.logoutAddress) {
+            // The controller will assume an existing login session exists if this exists
+            localStorage.removeItem("authenticationType");
             try {
                 await this.axiosInstance.post(ApiService.RuntimeConfig.logoutAddress);
             } catch (err) {
-                console.log(err);
+                if (err.response.status == 404) {
+                    // OIDC logout requires GET for logout vs POST for other mechanisms
+                    window.open(ApiService.RuntimeConfig.logoutAddress, "_self");
+                    return; // avoid later potential dashboard redirect
+                } else {
+                    console.log(err);
+                }
             }
         }
         // Redirect to dashboard URL if it exists


### PR DESCRIPTION
**Description**

Supersedes / replaces #1861, with the OIDC login moved to the serverside to eliminate a dependence on public clients which aren't accepted by all identity providers.  Note that the scope of changes required in the frontend has been significantly reduced due to the resulting similarity with the local authentication providers supported by the server such that the changes herein are expected to be minimal.  (The bulk of the changes to support OIDC login can be found in [this pull request in the carta-controller repo](https://github.com/CARTAvis/carta-controller/pull/129))

**Checklist**
- [?] changelog updated / no changelog update needed

Given the short nature of the change here I'm not sure that a changelog update is needed beyond what might be needed for the carta-controller.  (That said, I don't see a corresponding changelog in the carta-controller repo).

- [?] e2e test passing / added corresponding fix

Not sure how to run these tests but I suspect that the changes here are small enough in scope that it's unlikely to trigger new test failures.

- [X] protobuf updated to the latest dev commit / no protobuf update needed