### PR TITLE
Yuhsuan/1802 catalog overlay refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed NaN pixel value in the cursor info bar of the image viewer when the image is 1x1 pixel ([#1879](https://github.com/CARTAvis/carta-frontend/issues/1879)).
 * Fixed issue to show cursor info of smoothed profiles in the spatial and spectral profilers ([#1880](https://github.com/CARTAvis/carta-frontend/issues/1880), [#1938](https://github.com/CARTAvis/carta-frontend/pull/1938)).
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
+* Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 ### Changed
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).
 

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -228,7 +228,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.SizeMajorMapEnabled, 1);
                     this.gl.activeTexture(GL2.TEXTURE3);
                     this.gl.bindTexture(GL2.TEXTURE_2D, sizeTexture);
-                    this.gl.uniform1i(shaderUniforms.SizeTexture, 2);
+                    this.gl.uniform1i(shaderUniforms.SizeTexture, 3);
                 }
 
                 // color
@@ -239,7 +239,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.CmapIndex, RenderConfigStore.COLOR_MAPS_ALL.indexOf(catalogWidgetStore.colorMap));
                     this.gl.activeTexture(GL2.TEXTURE4);
                     this.gl.bindTexture(GL2.TEXTURE_2D, colorTexture);
-                    this.gl.uniform1i(shaderUniforms.ColorTexture, 3);
+                    this.gl.uniform1i(shaderUniforms.ColorTexture, 4);
                 }
 
                 this.gl.uniform1f(shaderUniforms.FeatherWidth, featherWidth);
@@ -251,7 +251,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.OmapEnabled, 1);
                     this.gl.activeTexture(GL2.TEXTURE5);
                     this.gl.bindTexture(GL2.TEXTURE_2D, orientationTexture);
-                    this.gl.uniform1i(shaderUniforms.OrientationTexture, 4);
+                    this.gl.uniform1i(shaderUniforms.OrientationTexture, 5);
                 }
 
                 // selected source
@@ -259,7 +259,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 if (selectedSource) {
                     this.gl.activeTexture(GL2.TEXTURE6);
                     this.gl.bindTexture(GL2.TEXTURE_2D, selectedSource);
-                    this.gl.uniform1i(shaderUniforms.SelectedSourceTexture, 5);
+                    this.gl.uniform1i(shaderUniforms.SelectedSourceTexture, 6);
                 }
 
                 // size minor
@@ -270,7 +270,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.SizeMinorMapEnabled, 1);
                     this.gl.activeTexture(GL2.TEXTURE7);
                     this.gl.bindTexture(GL2.TEXTURE_2D, sizeMinorTexture);
-                    this.gl.uniform1i(shaderUniforms.SizeMinorTexture, 6);
+                    this.gl.uniform1i(shaderUniforms.SizeMinorTexture, 7);
                 }
 
                 // position
@@ -294,6 +294,15 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 }
 
                 const hasBuffer = this.catalogWebGLService.bindBuffer(fileId);
+
+                // position
+                const positionTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Position);
+                if (positionTexture) {
+                    this.gl.activeTexture(GL2.TEXTURE2);
+                    this.gl.bindTexture(GL2.TEXTURE_2D, positionTexture);
+                    this.gl.uniform1i(shaderUniforms.PositionTexture, 2);
+                }
+
                 if (hasBuffer) {
                     this.gl.uniform3f(shaderUniforms.PointColor, color.r / 255.0, color.g / 255.0, color.b / 255.0);
                     this.gl.uniform3f(shaderUniforms.SelectedSourceColor, selectedSourceColor.r / 255.0, selectedSourceColor.g / 255.0, selectedSourceColor.b / 255.0);

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -219,6 +219,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 this.gl.uniform2f(shaderUniforms.RangeScale, rangeScale.x, rangeScale.y);
                 this.gl.uniform1f(shaderUniforms.ScaleAdjustment, scaleAdjustment);
                 this.gl.uniform1f(shaderUniforms.RotationAngle, rotationAngle);
+                this.gl.uniform1f(shaderUniforms.ZoomLevel, sourceFrame?.spatialReference?.zoomLevel ?? sourceFrame?.zoomLevel); 
 
                 // size
                 this.gl.uniform1i(shaderUniforms.SizeMajorMapEnabled, 0);
@@ -307,7 +308,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.ShapeType, catalogWidgetStore.catalogShape);
                     this.gl.uniform1f(shaderUniforms.PointSize, pointSize * devicePixelRatio * AppStore.Instance.imageRatio);
 
-                    this.gl.drawArrays(GL2.POINTS, 0, count);
+                    this.gl.drawArrays(GL2.TRIANGLES, 0, count * 6);
                     this.gl.finish();
                 }
             }

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -293,9 +293,6 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.ControlMapTexture, 1);
                 }
 
-                const hasBuffer = this.catalogWebGLService.bindBuffer(fileId);
-
-                // position
                 const positionTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Position);
                 if (positionTexture) {
                     this.gl.activeTexture(GL2.TEXTURE2);
@@ -303,13 +300,12 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.PositionTexture, 2);
                 }
 
-                if (hasBuffer) {
+                const hasSources = this.catalogWebGLService.updatePositionTexture(fileId);
+                if (hasSources) {
                     this.gl.uniform3f(shaderUniforms.PointColor, color.r / 255.0, color.g / 255.0, color.b / 255.0);
                     this.gl.uniform3f(shaderUniforms.SelectedSourceColor, selectedSourceColor.r / 255.0, selectedSourceColor.g / 255.0, selectedSourceColor.b / 255.0);
                     this.gl.uniform1i(shaderUniforms.ShapeType, catalogWidgetStore.catalogShape);
                     this.gl.uniform1f(shaderUniforms.PointSize, pointSize * devicePixelRatio * AppStore.Instance.imageRatio);
-
-                    this.gl.vertexAttribPointer(this.catalogWebGLService.vertexPositionAttribute, 2, GL2.FLOAT, false, 0, 0);
 
                     this.gl.drawArrays(GL2.POINTS, 0, count);
                     this.gl.finish();

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -219,7 +219,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 this.gl.uniform2f(shaderUniforms.RangeScale, rangeScale.x, rangeScale.y);
                 this.gl.uniform1f(shaderUniforms.ScaleAdjustment, scaleAdjustment);
                 this.gl.uniform1f(shaderUniforms.RotationAngle, rotationAngle);
-                this.gl.uniform1f(shaderUniforms.ZoomLevel, sourceFrame?.spatialReference?.zoomLevel ?? sourceFrame?.zoomLevel); 
+                this.gl.uniform1f(shaderUniforms.ZoomLevel, sourceFrame?.spatialReference?.zoomLevel ?? sourceFrame?.zoomLevel);
 
                 // size
                 this.gl.uniform1i(shaderUniforms.SizeMajorMapEnabled, 0);

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -226,7 +226,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 const sizeTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Size);
                 if (!catalogWidgetStore.disableSizeMap && sizeTexture) {
                     this.gl.uniform1i(shaderUniforms.SizeMajorMapEnabled, 1);
-                    this.gl.activeTexture(GL2.TEXTURE2);
+                    this.gl.activeTexture(GL2.TEXTURE3);
                     this.gl.bindTexture(GL2.TEXTURE_2D, sizeTexture);
                     this.gl.uniform1i(shaderUniforms.SizeTexture, 2);
                 }
@@ -237,7 +237,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 if (!catalogWidgetStore.disableColorMap && colorTexture) {
                     this.gl.uniform1i(shaderUniforms.CmapEnabled, 1);
                     this.gl.uniform1i(shaderUniforms.CmapIndex, RenderConfigStore.COLOR_MAPS_ALL.indexOf(catalogWidgetStore.colorMap));
-                    this.gl.activeTexture(GL2.TEXTURE3);
+                    this.gl.activeTexture(GL2.TEXTURE4);
                     this.gl.bindTexture(GL2.TEXTURE_2D, colorTexture);
                     this.gl.uniform1i(shaderUniforms.ColorTexture, 3);
                 }
@@ -249,7 +249,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 const orientationTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Orientation);
                 if (!catalogWidgetStore.disableOrientationMap && orientationTexture) {
                     this.gl.uniform1i(shaderUniforms.OmapEnabled, 1);
-                    this.gl.activeTexture(GL2.TEXTURE4);
+                    this.gl.activeTexture(GL2.TEXTURE5);
                     this.gl.bindTexture(GL2.TEXTURE_2D, orientationTexture);
                     this.gl.uniform1i(shaderUniforms.OrientationTexture, 4);
                 }
@@ -257,7 +257,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 // selected source
                 const selectedSource = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.SelectedSource);
                 if (selectedSource) {
-                    this.gl.activeTexture(GL2.TEXTURE5);
+                    this.gl.activeTexture(GL2.TEXTURE6);
                     this.gl.bindTexture(GL2.TEXTURE_2D, selectedSource);
                     this.gl.uniform1i(shaderUniforms.SelectedSourceTexture, 5);
                 }
@@ -268,7 +268,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 const sizeMinorTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.SizeMinor);
                 if (!catalogWidgetStore.disableSizeMinorMap && sizeMinorTexture && catalogWidgetStore.catalogShape === CatalogOverlayShape.ELLIPSE_LINED) {
                     this.gl.uniform1i(shaderUniforms.SizeMinorMapEnabled, 1);
-                    this.gl.activeTexture(GL2.TEXTURE6);
+                    this.gl.activeTexture(GL2.TEXTURE7);
                     this.gl.bindTexture(GL2.TEXTURE_2D, sizeMinorTexture);
                     this.gl.uniform1i(shaderUniforms.SizeMinorTexture, 6);
                 }

--- a/src/services/CatalogWebGLService.ts
+++ b/src/services/CatalogWebGLService.ts
@@ -23,6 +23,7 @@ interface ShaderUniforms {
     RangeOffset: WebGLUniformLocation;
     RangeScale: WebGLUniformLocation;
     ScaleAdjustment: WebGLUniformLocation;
+    ZoomLevel: WebGLUniformLocation;
     // spatial matching
     ControlMapEnabled: WebGLUniformLocation;
     ControlMapSize: WebGLUniformLocation;
@@ -185,6 +186,7 @@ export class CatalogWebGLService {
             RangeOffset: this.gl.getUniformLocation(shaderProgram, "uRangeOffset"),
             RangeScale: this.gl.getUniformLocation(shaderProgram, "uRangeScale"),
             ScaleAdjustment: this.gl.getUniformLocation(shaderProgram, "uScaleAdjustment"),
+            ZoomLevel: this.gl.getUniformLocation(shaderProgram, "uZoomLevel"),
             // spatial matching
             ControlMapEnabled: this.gl.getUniformLocation(shaderProgram, "uControlMapEnabled"),
             ControlMapSize: this.gl.getUniformLocation(shaderProgram, "uControlMapSize"),

--- a/src/services/CatalogWebGLService.ts
+++ b/src/services/CatalogWebGLService.ts
@@ -3,6 +3,7 @@ import {catalogShaders} from "./GLSL";
 import allMaps from "../static/allmaps.png";
 
 export enum CatalogTextureType {
+    Position,
     Size,
     Color,
     Orientation,
@@ -29,9 +30,10 @@ interface ShaderUniforms {
     ControlMapMin: WebGLUniformLocation;
     ControlMapMax: WebGLUniformLocation;
     // texture
-    OrientationTexture: WebGLUniformLocation;
-    ColorTexture: WebGLUniformLocation;
+    PositionTexture: WebGLUniformLocation;
     SizeTexture: WebGLUniformLocation;
+    ColorTexture: WebGLUniformLocation;
+    OrientationTexture: WebGLUniformLocation;
     SelectedSourceTexture: WebGLUniformLocation;
     SizeMinorTexture: WebGLUniformLocation;
     // size
@@ -52,6 +54,7 @@ export class CatalogWebGLService {
     private static staticInstance: CatalogWebGLService;
     private cmapTexture: WebGLTexture;
     private vertexBuffers: Map<number, WebGLBuffer>;
+    private positionTextures: Map<number, WebGLTexture>;
     private sizeTextures: Map<number, WebGLTexture>;
     private colorTextures: Map<number, WebGLTexture>;
     private orientationTextures: Map<number, WebGLTexture>;
@@ -105,20 +108,23 @@ export class CatalogWebGLService {
         }
         // colorMap is texture0, controlMap is texture1
         switch (textureType) {
+            case CatalogTextureType.Position:
+                this.positionTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE2, 1));
+                break;
             case CatalogTextureType.Size:
-                this.sizeTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE2, 1));
+                this.sizeTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE3, 1));
                 break;
             case CatalogTextureType.Color:
-                this.colorTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE3, 1));
+                this.colorTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE4, 1));
                 break;
             case CatalogTextureType.Orientation:
-                this.orientationTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE4, 1));
+                this.orientationTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE5, 1));
                 break;
             case CatalogTextureType.SelectedSource:
-                this.selectedSourceTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE5, 1));
+                this.selectedSourceTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE6, 1));
                 break;
             case CatalogTextureType.SizeMinor:
-                this.sizeMinorTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE6, 1));
+                this.sizeMinorTextures.set(fileId, createTextureFromArray(this.gl, dataPoints, GL2.TEXTURE7, 1));
                 break;
             default:
                 break;
@@ -127,6 +133,8 @@ export class CatalogWebGLService {
 
     public getDataTexture = (fileId: number, textureType: CatalogTextureType): WebGLTexture => {
         switch (textureType) {
+            case CatalogTextureType.Position:
+                return this.positionTextures.get(fileId);
             case CatalogTextureType.Size:
                 return this.sizeTextures.get(fileId);
             case CatalogTextureType.Color:
@@ -143,10 +151,11 @@ export class CatalogWebGLService {
     };
 
     public clearTexture = (fileId: number) => {
-        this.selectedSourceTextures.delete(fileId);
+        this.positionTextures.delete(fileId);
         this.sizeTextures.delete(fileId);
         this.colorTextures.delete(fileId);
         this.orientationTextures.delete(fileId);
+        this.selectedSourceTextures.delete(fileId);
         this.sizeMinorTextures.delete(fileId);
         this.vertexBuffers.delete(fileId);
     };
@@ -186,23 +195,26 @@ export class CatalogWebGLService {
             ControlMapSize: this.gl.getUniformLocation(shaderProgram, "uControlMapSize"),
             ControlMapMin: this.gl.getUniformLocation(shaderProgram, "uControlMapMin"),
             ControlMapMax: this.gl.getUniformLocation(shaderProgram, "uControlMapMax"),
+            // texture 1
             ControlMapTexture: this.gl.getUniformLocation(shaderProgram, "uControlMapTexture"),
-            // texture 0 1 2 3 4 5 6 7
+            // texture 0 2 3 4 5 6 7
             CmapTexture: this.gl.getUniformLocation(shaderProgram, "uCmapTexture"),
-            OrientationTexture: this.gl.getUniformLocation(shaderProgram, "uOrientationTexture"),
+            PositionTexture: this.gl.getUniformLocation(shaderProgram, "uPositionTexture"),
             SizeTexture: this.gl.getUniformLocation(shaderProgram, "uSizeTexture"),
             ColorTexture: this.gl.getUniformLocation(shaderProgram, "uColorTexture"),
+            OrientationTexture: this.gl.getUniformLocation(shaderProgram, "uOrientationTexture"),
             SelectedSourceTexture: this.gl.getUniformLocation(shaderProgram, "uSelectedSourceTexture"),
-            SizeMinorTexture: this.gl.getUniformLocation(shaderProgram, "uSizeMinorTexture")
+            SizeMinorTexture: this.gl.getUniformLocation(shaderProgram, "uSizeMinorTexture"),
         };
 
         this.vertexBuffers = new Map<number, WebGLBuffer>();
         this.gl.uniform1i(this.shaderUniforms.NumCmaps, 79);
         this.gl.uniform1i(this.shaderUniforms.CmapTexture, 0);
-        this.selectedSourceTextures = new Map<number, WebGLTexture>();
-        this.orientationTextures = new Map<number, WebGLTexture>();
+        this.positionTextures = new Map<number, WebGLTexture>();
         this.sizeTextures = new Map<number, WebGLTexture>();
         this.colorTextures = new Map<number, WebGLTexture>();
+        this.orientationTextures = new Map<number, WebGLTexture>();
+        this.selectedSourceTextures = new Map<number, WebGLTexture>();
         this.sizeMinorTextures = new Map<number, WebGLTexture>();
     }
 

--- a/src/services/CatalogWebGLService.ts
+++ b/src/services/CatalogWebGLService.ts
@@ -201,7 +201,7 @@ export class CatalogWebGLService {
             ColorTexture: this.gl.getUniformLocation(shaderProgram, "uColorTexture"),
             OrientationTexture: this.gl.getUniformLocation(shaderProgram, "uOrientationTexture"),
             SelectedSourceTexture: this.gl.getUniformLocation(shaderProgram, "uSelectedSourceTexture"),
-            SizeMinorTexture: this.gl.getUniformLocation(shaderProgram, "uSizeMinorTexture"),
+            SizeMinorTexture: this.gl.getUniformLocation(shaderProgram, "uSizeMinorTexture")
         };
 
         this.positionArrays = new Map<number, Float32Array>();

--- a/src/services/CatalogWebGLService.ts
+++ b/src/services/CatalogWebGLService.ts
@@ -83,8 +83,7 @@ export class CatalogWebGLService {
     public updatePositionArray = (fileId: number, dataPoints: Float32Array, offset: number) => {
         const positionArray = this.positionArrays.get(fileId);
         if (positionArray) {
-            const newArray = new Float32Array(offset + dataPoints.length);
-            newArray.set(positionArray.slice(0, offset));
+            const newArray = new Float32Array(positionArray.buffer, 0, offset + dataPoints.length);
             newArray.set(dataPoints, offset);
             this.positionArrays.set(fileId, newArray);
         } else {

--- a/src/services/GLSL/pixel_shader_catalog.glsl
+++ b/src/services/GLSL/pixel_shader_catalog.glsl
@@ -14,6 +14,7 @@ uniform int uShapeType;
 uniform vec3 uSelectedSourceColor;
 uniform bool uOmapEnabled;
 
+in vec2 v_pointCoord;
 in vec3 v_colour;
 in float v_pointSize;
 in float v_orientation;
@@ -403,7 +404,7 @@ void main() {
     if (v_minorSize > v_pointSize) {
         side = v_minorSize;
     }
-    vec2 posPixelSpace = (0.5 - gl_PointCoord) * (side + v_featherWidth);
+    vec2 posPixelSpace = (0.5 - v_pointCoord) * (side + v_featherWidth);
     float rMax = v_pointSize * 0.5;
     float rMin = rMax - uLineThickness;
     float outline = 0.0;

--- a/src/services/GLSL/utilities.glsl
+++ b/src/services/GLSL/utilities.glsl
@@ -91,3 +91,25 @@ uvec4 getValueByIndexFromTextureU(usampler2D texture, int index) {
     int col = index - row * size.x;
     return texelFetch(texture, ivec2(col, row), 0);
 }
+
+// Get vertex offset in units of length, based on the vertex ID
+vec2 getOffsetFromId(int id) {
+    int index = id % 6;
+    switch(index) {
+        // First triangle is TRC, TLC, BRC
+        case 0:
+        return vec2(0.5, 0.5);
+        case 1:
+        return vec2(-0.5, 0.5);
+        case 2:
+        return vec2(0.5, -0.5);
+        // Second triangle is BRC, TLC, BLC
+        case 3:
+        return vec2(0.5, -0.5);
+        case 4:
+        return vec2(-0.5, 0.5);
+        case 5:
+        default:
+        return vec2(-0.5, -0.5);
+    }
+}

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -39,7 +39,6 @@ uniform vec2 uControlMapSize;
 uniform float uLineThickness;
 uniform float uPixelRatio;
 
-in vec4 a_position;
 out vec3 v_colour;
 out float v_pointSize;
 out float v_orientation;

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -74,13 +74,14 @@ bool isNaN(float val) {
 
 void main() {
     uvec4 selectedSource = getValueByIndexFromTextureU(uSelectedSourceTexture, gl_VertexID);
-    // Scale and rotate
-    vec2 posImageSpace = vec2(a_position.x,a_position.y);
+    vec4 position = getValueByIndexFromTexture(uPositionTexture, gl_VertexID);
+    vec2 posImageSpace = position.xy;
 
     if (uControlMapEnabled > 0) {
         posImageSpace = controlMapLookup(uControlMapTexture, posImageSpace, uControlMapSize, uControlMapMin, uControlMapMax);
     }
 
+    // Scale and rotate
     vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;
 
     gl_Position = vec4(imageToGL(pos), 0.5, 1.0);

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -30,6 +30,7 @@ uniform float uRotationAngle;
 uniform vec2 uRangeOffset;
 uniform vec2 uRangeScale;
 uniform float uScaleAdjustment;
+uniform float uZoomLevel;
 
 // Control-map based transformation
 uniform int uControlMapEnabled;
@@ -39,6 +40,7 @@ uniform vec2 uControlMapSize;
 uniform float uLineThickness;
 uniform float uPixelRatio;
 
+out vec2 v_pointCoord;
 out vec3 v_colour;
 out float v_pointSize;
 out float v_orientation;
@@ -72,18 +74,16 @@ bool isNaN(float val) {
 }
 
 void main() {
-    uvec4 selectedSource = getValueByIndexFromTextureU(uSelectedSourceTexture, gl_VertexID);
-    vec4 position = getValueByIndexFromTexture(uPositionTexture, gl_VertexID);
+    int dataPointIndex = gl_VertexID / 6;  
+    uvec4 selectedSource = getValueByIndexFromTextureU(uSelectedSourceTexture, dataPointIndex);
+    vec4 position = getValueByIndexFromTexture(uPositionTexture, dataPointIndex);
     vec2 posImageSpace = position.xy;
 
     if (uControlMapEnabled > 0) {
         posImageSpace = controlMapLookup(uControlMapTexture, posImageSpace, uControlMapSize, uControlMapMin, uControlMapMax);
     }
 
-    // Scale and rotate
-    vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;
-
-    gl_Position = vec4(imageToGL(pos), 0.5, 1.0);
+    float point_size = 0.0;
 
     v_colour = uPointColor;
     v_orientation = 0.0;
@@ -93,7 +93,7 @@ void main() {
     v_featherWidth = uFeatherWidth;
 
     if (uCmapEnabled) {
-        vec4 color = getValueByIndexFromTexture(uColorTexture, gl_VertexID);
+        vec4 color = getValueByIndexFromTexture(uColorTexture, dataPointIndex);
         float x = clamp(color.x, 0.0, 1.0);
         float cmapYVal = (float(uCmapIndex) + 0.5) / float(uNumCmaps);
         vec2 cmapCoords = vec2(x, cmapYVal);
@@ -101,14 +101,14 @@ void main() {
     }
 
     if (uOmapEnabled) {
-        vec4 orientation = getValueByIndexFromTexture(uOrientationTexture, gl_VertexID);
+        vec4 orientation = getValueByIndexFromTexture(uOrientationTexture, dataPointIndex);
         if (!isNaN(orientation.x)) {
             v_orientation = orientation.x;
         }
     }
 
     if (uSizeMajorMapEnabled) {
-        vec4 sizeMajor = getValueByIndexFromTexture(uSizeTexture, gl_VertexID);
+        vec4 sizeMajor = getValueByIndexFromTexture(uSizeTexture, dataPointIndex);
         float size = sizeMajor.x;
         if(!isNaN(size)) {
             v_pointSize = size;
@@ -121,26 +121,35 @@ void main() {
 
     if (uShowSelectedSource) {
         if (v_selected == 1.0) {
-            gl_PointSize = v_pointSize + v_featherWidth;
+            point_size = v_pointSize + v_featherWidth;
         } else {
-            gl_PointSize = 0.0;
+            point_size = 0.0;
         }
     } else {
-        gl_PointSize = v_pointSize + v_featherWidth;
+        point_size = v_pointSize + v_featherWidth;
     }
 
     if (uSizeMinorMapEnabled) {
-        vec4 sizeMinor = getValueByIndexFromTexture(uSizeMinorTexture, gl_VertexID);
+        vec4 sizeMinor = getValueByIndexFromTexture(uSizeMinorTexture, dataPointIndex);
         v_minorSize = sizeMinor.x;
         if (uAreaModeMinor) {
             v_minorSize = getSquareSideByArea(v_pointSize, v_minorSize);
         }
         if (v_pointSize < v_minorSize) {
-            gl_PointSize = v_minorSize + v_featherWidth;
+            point_size = v_minorSize + v_featherWidth;
         }
     }
 
     if (uShapeType == ELLIPSE_LINED) {
         v_featherWidth = v_pointSize / 50.0 * 15.0 + 0.7;
     }
+
+    vec2 offset = getOffsetFromId(gl_VertexID);
+    v_pointCoord = offset + 0.5;
+    posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment);
+
+    // Scale and rotate
+    vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;
+
+    gl_Position = vec4(imageToGL(pos), 0.5, 1.0);
 }

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -145,7 +145,7 @@ void main() {
     }
 
     vec2 offset = getOffsetFromId(gl_VertexID);
-    v_pointCoord = offset + 0.5;
+    v_pointCoord = vec2(offset.x, -offset.y) + 0.5;
     posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment);
 
     // Scale and rotate

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -146,7 +146,7 @@ void main() {
 
     vec2 offset = getOffsetFromId(gl_VertexID);
     v_pointCoord = vec2(offset.x, -offset.y) + 0.5;
-    posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment);
+    posImageSpace += offset * ceil(point_size) / (uZoomLevel * uScaleAdjustment);
 
     // Scale and rotate
     vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -146,7 +146,7 @@ void main() {
 
     vec2 offset = getOffsetFromId(gl_VertexID);
     v_pointCoord = vec2(offset.x, -offset.y) + 0.5;
-    posImageSpace += offset * ceil(point_size) / (uZoomLevel * uScaleAdjustment);
+    posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment);
 
     // Scale and rotate
     vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -3,6 +3,7 @@ precision highp int;
 
 uniform sampler2D uCmapTexture;
 uniform highp sampler2D uControlMapTexture;
+uniform sampler2D uPositionTexture;
 uniform sampler2D uSizeTexture;
 uniform sampler2D uColorTexture;
 uniform sampler2D uOrientationTexture;

--- a/src/services/GLSL/vertex_shader_overlay.glsl
+++ b/src/services/GLSL/vertex_shader_overlay.glsl
@@ -49,28 +49,6 @@ float calculateLength(float intensity) {
     return mix(uLengthMin, uLengthMax, clamp(calculateScaledIntensity(intensity), 0.0, 1.0));
 }
 
-// Get vertex offset in units of length, based on the vertex ID
-vec2 getOffsetFromId(int id) {
-    int index = id % 6;
-    switch(index) {
-        // First triangle is TRC, TLC, BRC
-        case 0:
-        return vec2(0.5, 0.5);
-        case 1:
-        return vec2(-0.5, 0.5);
-        case 2:
-        return vec2(0.5, -0.5);
-        // Second triangle is BRC, TLC, BLC
-        case 3:
-        return vec2(0.5, -0.5);
-        case 4:
-        return vec2(-0.5, 0.5);
-        case 5:
-        default:
-        return vec2(-0.5, -0.5);
-    }
-}
-
 void main() {
     int dataPointIndex = gl_VertexID / 6;
     vec4 data = getValueByIndexFromTexture(uDataTexture, dataPointIndex);

--- a/src/stores/CatalogStore.ts
+++ b/src/stores/CatalogStore.ts
@@ -95,7 +95,7 @@ export class CatalogStore {
                     break;
             }
             this.catalogCounts.set(fileId, this.catalogCounts.get(fileId) + xData.length);
-            CatalogWebGLService.Instance.updateBuffer(fileId, position, startIndex * 2);
+            CatalogWebGLService.Instance.updatePositionArray(fileId, position, startIndex * 2);
         }
     }
 
@@ -106,7 +106,7 @@ export class CatalogStore {
             catalog.y = new Float32Array(catalog.y.length);
             const position = new Float32Array(catalog.x.length * 2);
             this.catalogCounts.set(fileId, 0);
-            CatalogWebGLService.Instance.updateBuffer(fileId, position, 0);
+            CatalogWebGLService.Instance.updatePositionArray(fileId, position, 0);
         }
     }
 

--- a/src/utilities/webgl.ts
+++ b/src/utilities/webgl.ts
@@ -167,10 +167,3 @@ function getBufferElementType(buffer: ArrayBufferView): string {
         return "Float32";
     }
 }
-
-export function makeBuffer(gl: WebGL2RenderingContext, data: Float32Array, usage: number) {
-    const buffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, data, usage);
-    return buffer;
-}


### PR DESCRIPTION
**Description**

Closes #1802 and closes #1662: migrated from `GL2.POINTS` to `GL2.TRIANGLES` for catalog overlay rendering

changes:
* change `drawArrays` function
* use texture instead of attribute for source position data in vertex shader
* add uniform `uZoomLevel` for calculating point size in px unit in vertex shader
* use varying `v_pointCoord` for `gl_PointCoord` in pixel shader
* move `getOffsetFromId` from vector overlay vertex shader to utilities

**Checklist**
- [ ] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed