### PR TITLE
Icchen/1397 export result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Add a method to auto-scrolling the selected region into the region list view ([#1797](https://github.com/CARTAvis/carta-frontend/issues/1797)).
 * Added the functionality to mirror cursor position on spatially matched frame via hotkey "G" ([#1947](https://github.com/cartavis/carta-frontend/issues/1947)).
+* Added buttons to image (2D) fitting for exporting fitting result and full log ([#1397](https://github.com/cartavis/carta-frontend/issues/1397)).
 ### Fixed
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
@@ -48,6 +48,32 @@
         margin-bottom: 0;
     }
 
+    .output-result-button {
+        position: absolute;
+        bottom: 40px;
+        right: 15px;
+        margin: 0 10px 10px 0;
+        transition: opacity 400ms;
+
+        .bp3-button {
+            transition: opacity 400ms;
+            user-select: none;
+        }
+    }
+
+    .output-log-button {
+        position: absolute;
+        bottom: 40px;
+        right: 30px;
+        margin: 0 10px 10px 0;
+        transition: opacity 400ms;
+
+        .bp3-button {
+            transition: opacity 400ms;
+            user-select: none;
+        }
+    }
+
     .fitting-result {
         height: 70%;
         margin-bottom: 0;

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
@@ -50,8 +50,8 @@
 
     .output-result-button {
         position: absolute;
-        bottom: 20px;
-        right: 20px;
+        bottom: 25px;
+        right: 25px;
         margin: 0 0 0 0;
         transition: opacity 400ms;
 
@@ -63,8 +63,8 @@
 
     .output-log-button {
         position: absolute;
-        bottom: 20px;
-        right: 20px;
+        bottom: 25px;
+        right: 25px;
         margin: 0 0 0 0;
         transition: opacity 400ms;
 

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
@@ -50,8 +50,8 @@
 
     .output-result-button {
         position: absolute;
-        bottom: 15px;
-        right: 15px;
+        bottom: 20px;
+        right: 20px;
         margin: 0 0 0 0;
         transition: opacity 400ms;
 
@@ -63,8 +63,8 @@
 
     .output-log-button {
         position: absolute;
-        bottom: 15px;
-        right: 15px;
+        bottom: 20px;
+        right: 20px;
         margin: 0 0 0 0;
         transition: opacity 400ms;
 

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
@@ -48,20 +48,7 @@
         margin-bottom: 0;
     }
 
-    .output-result-button {
-        position: absolute;
-        bottom: 25px;
-        right: 25px;
-        margin: 0 0 0 0;
-        transition: opacity 400ms;
-
-        .bp3-button {
-            transition: opacity 400ms;
-            user-select: none;
-        }
-    }
-
-    .output-log-button {
+    .output-button {
         position: absolute;
         bottom: 25px;
         right: 25px;

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.scss
@@ -50,9 +50,9 @@
 
     .output-result-button {
         position: absolute;
-        bottom: 40px;
+        bottom: 15px;
         right: 15px;
-        margin: 0 10px 10px 0;
+        margin: 0 0 0 0;
         transition: opacity 400ms;
 
         .bp3-button {
@@ -63,9 +63,9 @@
 
     .output-log-button {
         position: absolute;
-        bottom: 40px;
-        right: 30px;
-        margin: 0 10px 10px 0;
+        bottom: 15px;
+        right: 15px;
+        margin: 0 0 0 0;
         transition: opacity 400ms;
 
         .bp3-button {

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -9,7 +9,7 @@ import {DraggableDialogComponent} from "components/Dialogs";
 import {SafeNumericInput} from "components/Shared";
 import {CustomIcon} from "icons/CustomIcons";
 import "./FittingDialogComponent.scss";
-import {exportTxtFile} from "utilities";
+import {exportTxtFile, getTimestamp} from "utilities";
 
 enum FittingResultTabs {
     RESULT,
@@ -36,7 +36,13 @@ export class FittingDialogComponent extends React.Component {
 
     private exportResult = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingResult;
-        const fileName = "fittingReult";
+        const fileName = `${getTimestamp()}-2D_Fitting_Result`;
+        exportTxtFile(fileName, content);
+    };
+
+    private exportFullLog = () => {
+        const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingLog;
+        const fileName = `${getTimestamp()}-2D_Fitting_Full_Log`;
         exportTxtFile(fileName, content);
     };
 
@@ -67,12 +73,18 @@ export class FittingDialogComponent extends React.Component {
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
+                <Tooltip2 content={"Output result as .txt"} position={Position.LEFT} className="output-result-button">
+                    <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
+                </Tooltip2>
             </Pre>
         );
 
         const fullLogPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
+                <Tooltip2 content={"Output log as .txt"} position={Position.LEFT} className="output-log-button">
+                    <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
+                </Tooltip2>
             </Pre>
         );
 

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -8,8 +8,8 @@ import {AppStore, HelpType} from "stores";
 import {DraggableDialogComponent} from "components/Dialogs";
 import {SafeNumericInput} from "components/Shared";
 import {CustomIcon} from "icons/CustomIcons";
-import "./FittingDialogComponent.scss";
 import {exportTxtFile, getTimestamp} from "utilities";
+import "./FittingDialogComponent.scss";
 
 enum FittingResultTabs {
     RESULT,
@@ -45,7 +45,7 @@ export class FittingDialogComponent extends React.Component {
 
     private exportResult = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingResult;
-        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename}-${getTimestamp()}_2D-Fitting-Result`;
+        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename}-${getTimestamp()}-2D_Fitting_Result`;
         exportTxtFile(fileName, content);
     };
 
@@ -82,8 +82,8 @@ export class FittingDialogComponent extends React.Component {
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
-                <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} className="output-result-button">
+                <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
+                    <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
                         <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>
@@ -93,8 +93,8 @@ export class FittingDialogComponent extends React.Component {
         const fullLogPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
-                <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Exportput as txt"} position={Position.LEFT} className="output-log-button">
+                <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
+                    <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
                         <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -45,13 +45,13 @@ export class FittingDialogComponent extends React.Component {
 
     private exportResult = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingResult;
-        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename.split(".")[0]}-${getTimestamp()}_2D-Fitting-Result`;
+        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename}-${getTimestamp()}_2D-Fitting-Result`;
         exportTxtFile(fileName, content);
     };
 
     private exportFullLog = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingLog;
-        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename.split(".")[0]}-${getTimestamp()}-2D_Fitting_Full_Log`;
+        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename}-${getTimestamp()}-2D_Fitting_Full_Log`;
         exportTxtFile(fileName, content);
     };
 

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {action, makeObservable, observable} from "mobx";
-import {AnchorButton, Classes, Dialog, FormGroup, HTMLSelect, Icon, IDialogProps, Intent, NonIdealState, Position, Pre, Slider, Tab, Tabs, Text} from "@blueprintjs/core";
+import {AnchorButton, ButtonGroup, Classes, Dialog, FormGroup, HTMLSelect, Icon, IDialogProps, Intent, NonIdealState, Position, Pre, Slider, Tab, Tabs, Text} from "@blueprintjs/core";
 import {Tooltip2} from "@blueprintjs/popover2";
 import classNames from "classnames";
 import {AppStore, HelpType} from "stores";
@@ -19,9 +19,18 @@ enum FittingResultTabs {
 @observer
 export class FittingDialogComponent extends React.Component {
     @observable private fittingResultTabId: FittingResultTabs;
+    @observable isMouseEntered: boolean = false;
 
     @action private setFittingResultTabId = (tabId: FittingResultTabs) => {
         this.fittingResultTabId = tabId;
+    };
+
+    @action onMouseEnter = () => {
+        this.isMouseEntered = true;
+    };
+
+    @action onMouseLeave = () => {
+        this.isMouseEntered = false;
     };
 
     constructor(props: any) {
@@ -73,21 +82,25 @@ export class FittingDialogComponent extends React.Component {
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
-                <Tooltip2 content={"Output result as .txt"} position={Position.LEFT} className="output-result-button">
-                    <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
-                </Tooltip2>
+                <ButtonGroup style={{opacity: this.isMouseEntered ? 1 : 0}}>
+                    <Tooltip2 content={"Export result as .txt"} position={Position.LEFT} className="output-result-button">
+                        <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
+                    </Tooltip2>
+                </ButtonGroup>
             </Pre>
         );
 
         const fullLogPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
-                <Tooltip2 content={"Output log as .txt"} position={Position.LEFT} className="output-log-button">
-                    <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
-                </Tooltip2>
+                <ButtonGroup style={{opacity: this.isMouseEntered ? 1 : 0}}>
+                    <Tooltip2 content={"Exportput log as .txt"} position={Position.LEFT} className="output-log-button">
+                        <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
+                    </Tooltip2>
+                </ButtonGroup>
             </Pre>
         );
-        console.log("fileName: "+fittingStore.effectiveFrame?.filename.split(".")[0])
+        console.log("fileName: " + fittingStore.effectiveFrame?.filename.split(".")[0]);
 
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.IMAGE_FITTING} minWidth={200} minHeight={140} defaultWidth={600} defaultHeight={660} enableResizing={true}>
@@ -142,7 +155,7 @@ export class FittingDialogComponent extends React.Component {
                         </Tooltip2>
                     </div>
                 </div>
-                <div className={classNames(Classes.DIALOG_BODY, "fitting-result")}>
+                <div className={classNames(Classes.DIALOG_BODY, "fitting-result")} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
                     <Tabs id="fittingResultTabs" vertical={true} selectedTabId={this.fittingResultTabId} onChange={this.setFittingResultTabId}>
                         <Tab id={FittingResultTabs.RESULT} title="Fitting Result" panel={fittingResultPanel} />
                         <Tab id={FittingResultTabs.LOG} title="Full Log" panel={fullLogPanel} />

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -36,13 +36,13 @@ export class FittingDialogComponent extends React.Component {
 
     private exportResult = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingResult;
-        const fileName = `${getTimestamp()}-2D_Fitting_Result`;
+        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename.split(".")[0]}-${getTimestamp()}_2D-Fitting-Result`;
         exportTxtFile(fileName, content);
     };
 
     private exportFullLog = () => {
         const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingLog;
-        const fileName = `${getTimestamp()}-2D_Fitting_Full_Log`;
+        const fileName = `${AppStore.Instance.imageFittingStore.effectiveFrame?.filename.split(".")[0]}-${getTimestamp()}-2D_Fitting_Full_Log`;
         exportTxtFile(fileName, content);
     };
 
@@ -87,6 +87,7 @@ export class FittingDialogComponent extends React.Component {
                 </Tooltip2>
             </Pre>
         );
+        console.log("fileName: "+fittingStore.effectiveFrame?.filename.split(".")[0])
 
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.IMAGE_FITTING} minWidth={200} minHeight={140} defaultWidth={600} defaultHeight={660} enableResizing={true}>

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -83,7 +83,7 @@ export class FittingDialogComponent extends React.Component {
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
                 <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export result as .txt"} position={Position.LEFT} className="output-result-button">
+                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} className="output-result-button">
                         <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>
@@ -94,7 +94,7 @@ export class FittingDialogComponent extends React.Component {
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
                 <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Exportput log as .txt"} position={Position.LEFT} className="output-log-button">
+                    <Tooltip2 content={"Exportput as txt"} position={Position.LEFT} className="output-log-button">
                         <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -9,6 +9,7 @@ import {DraggableDialogComponent} from "components/Dialogs";
 import {SafeNumericInput} from "components/Shared";
 import {CustomIcon} from "icons/CustomIcons";
 import "./FittingDialogComponent.scss";
+import {exportTxtFile} from "utilities";
 
 enum FittingResultTabs {
     RESULT,
@@ -31,6 +32,12 @@ export class FittingDialogComponent extends React.Component {
 
     private renderParamInput = (value: number, placeholder: string, onValueChange) => {
         return <SafeNumericInput value={isFinite(value) ? value : ""} placeholder={placeholder} onValueChange={onValueChange} buttonPosition="none" />;
+    };
+
+    private exportResult = () => {
+        const content = AppStore.Instance.imageFittingStore.effectiveFrame?.fittingResult;
+        const fileName = "fittingReult";
+        exportTxtFile(fileName, content);
     };
 
     render() {

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -82,7 +82,7 @@ export class FittingDialogComponent extends React.Component {
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
-                <ButtonGroup style={{opacity: this.isMouseEntered ? 1 : 0}}>
+                <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
                     <Tooltip2 content={"Export result as .txt"} position={Position.LEFT} className="output-result-button">
                         <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
                     </Tooltip2>
@@ -93,14 +93,13 @@ export class FittingDialogComponent extends React.Component {
         const fullLogPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
-                <ButtonGroup style={{opacity: this.isMouseEntered ? 1 : 0}}>
+                <ButtonGroup style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
                     <Tooltip2 content={"Exportput log as .txt"} position={Position.LEFT} className="output-log-button">
                         <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>
             </Pre>
         );
-        console.log("fileName: " + fittingStore.effectiveFrame?.filename.split(".")[0]);
 
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.IMAGE_FITTING} minWidth={200} minHeight={140} defaultWidth={600} defaultHeight={660} enableResizing={true}>


### PR DESCRIPTION
**Description**
This PR links to the sub-task of issue #1397: "Export results as txt files".
Two buttons are added to the "Fitting Result" panel and the "Full Log" panel respectively.

When there is no information on the info panel, the button doesn't show up:
![image](https://user-images.githubusercontent.com/106953609/192470605-cfdbfa35-3c6c-45e9-9afd-d2b9e2ce78b8.png)

When there's information on the panel and when the mouse cursor moves into the area, the button and a tooltip show up:
![image](https://user-images.githubusercontent.com/106953609/192471542-ef9c7ca8-9fae-4159-a0de-1ebcb752db14.png)

The button is able to export the content of the info panel:
![image](https://user-images.githubusercontent.com/106953609/192472325-31dcd512-e18d-4129-afe9-c128a30558e5.png)
and the default format of the output file name is like:
**ImageName-DateTime-2D_Fitting_Result**

Similar button can also be found on "Full Log" panel and the default format of the output file name is:
**ImageName-DateTime-2D_Fitting_Full_Log**

**Checklist**
- [X] changelog updated / ~no changelog update needed~
- [X] e2e test passing / ~~added corresponding fix~~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed