### PR TITLE
add variable for gradient visibility

### DIFF
--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -163,7 +163,7 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
                 height={rectHeight}
                 fillLinearGradientStartPoint={rectGradientStart}
                 fillLinearGradientEndPoint={rectGradientEnd}
-                fillLinearGradientColorStops={frame.renderConfig.colorscaleArray}
+                fillLinearGradientColorStops={colorbarSettings.gradientVisible ? frame.renderConfig.colorscaleArray : null}
                 stroke={colorbarSettings.borderVisible ? getColor(colorbarSettings.borderCustomColor, colorbarSettings.borderColor) : null}
                 strokeWidth={colorbarSettings.borderWidth / devicePixelRatio}
             />

--- a/src/stores/OverlayStore.ts
+++ b/src/stores/OverlayStore.ts
@@ -714,6 +714,7 @@ export class OverlayColorbarSettings {
     @observable labelCustomText: boolean;
     @observable labelCustomColor: boolean;
     @observable labelColor: string;
+    @observable gradientVisible: boolean;
     private textRatio = [0.56, 0.51, 0.56, 0.51, 0.6];
 
     constructor() {
@@ -751,6 +752,7 @@ export class OverlayColorbarSettings {
         this.labelCustomText = false;
         this.labelCustomColor = false;
         this.labelColor = AST_DEFAULT_COLOR;
+        this.gradientVisible = true;
     }
 
     @action setVisible = (visible: boolean) => {
@@ -879,6 +881,10 @@ export class OverlayColorbarSettings {
 
     @action setLabelColor = (color: string) => {
         this.labelColor = color;
+    };
+
+    @action setGradientVisible = (visible: boolean) => {
+        this.gradientVisible = visible;
     };
 
     @computed get yOffset(): number {


### PR DESCRIPTION
**Description**
Closes #1908: the colorbar gradient can be hidden by `app.overlayStore.colorbar.setGradientVisible(false)`.

**Checklist**
- [X] ~changelog updated~ / no changelog update needed
- [X] e2e test passing / ~~added corresponding fix~~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed