### PR TITLE
Icchen/1967 update image view mode when catalog selection button disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issue to show cursor info of smoothed profiles in the spatial and spectral profilers ([#1880](https://github.com/CARTAvis/carta-frontend/issues/1880), [#1938](https://github.com/CARTAvis/carta-frontend/pull/1938)).
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
+* Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
 ### Changed
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).
 

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -16,6 +16,8 @@ import {CatalogWidgetStore, CatalogPlotWidgetStoreProps, CatalogPlotType, Catalo
 import {toFixed, ProcessedColumnData} from "utilities";
 import {AbstractCatalogProfileStore, CatalogOverlay, CatalogSystemType} from "models";
 import "./CatalogOverlayComponent.scss";
+import {ImageViewLayer} from "components/ImageView/ImageViewComponent";
+import {RegionMode} from "stores/Frame";
 
 enum HeaderTableColumnName {
     Name = "Name",
@@ -453,6 +455,12 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         const profileStore = this.profileStore;
         const catalogWidgetStore = this.widgetStore;
         const appStore = AppStore.Instance;
+        const catalogStore = CatalogStore.Instance;
+        const frame = appStore.getFrame(catalogStore.getFrameIdByCatalogId(this.catalogFileId));
+
+        appStore.updateActiveLayer(ImageViewLayer.RegionMoving);
+        frame.regionSet.setMode(RegionMode.MOVING);
+
         if (profileStore && catalogWidgetStore) {
             profileStore.resetCatalogFilterRequest();
             this.resetSelectedPointIndices();

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -15,9 +15,9 @@ import {AppStore, CatalogStore, CatalogProfileStore, CatalogOnlineQueryProfileSt
 import {CatalogWidgetStore, CatalogPlotWidgetStoreProps, CatalogPlotType, CatalogSettingsTabs} from "stores/widgets";
 import {toFixed, ProcessedColumnData} from "utilities";
 import {AbstractCatalogProfileStore, CatalogOverlay, CatalogSystemType} from "models";
-import "./CatalogOverlayComponent.scss";
 import {ImageViewLayer} from "components/ImageView/ImageViewComponent";
 import {RegionMode} from "stores/Frame";
+import "./CatalogOverlayComponent.scss";
 
 enum HeaderTableColumnName {
     Name = "Name",


### PR DESCRIPTION
**Description**
This PR is to resolve #1967.

Two lines are added in `handleResetClick` to set:
1. `ImageViewerLayer` to `RegionMoving` mode
2. `RegionMode` to `MOVING` mode

which updates the image view mode to "pan mode" when catalog selection button is disabled. The result is shown below:

https://user-images.githubusercontent.com/106953609/199252243-751cf0d2-09dc-4028-b599-1ed77d155487.mov


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [X] changelog updated / ~no changelog update needed~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~