### PR TITLE
Carli/2052 _pv_generator_crash

### DIFF
--- a/src/stores/widgets/PvGeneratorWidgetStore.ts
+++ b/src/stores/widgets/PvGeneratorWidgetStore.ts
@@ -14,7 +14,7 @@ export class PvGeneratorWidgetStore extends RegionWidgetStore {
     @observable width: number;
     @observable reverse: boolean;
     @observable keep: boolean;
-    @observable range: CARTA.IIntBounds = {min: this.effectiveFrame.channelValueBounds?.min, max: this.effectiveFrame.channelValueBounds?.max};
+    @observable range: CARTA.IIntBounds = {min: this.effectiveFrame?.channelValueBounds?.min, max: this.effectiveFrame?.channelValueBounds?.max};
 
     @computed get regionOptions(): IOptionProps[] {
         const appStore = AppStore.Instance;
@@ -111,7 +111,7 @@ export class PvGeneratorWidgetStore extends RegionWidgetStore {
         this.reverse = false;
         this.keep = false;
         reaction(
-            () => this.effectiveFrame.channelValueBounds,
+            () => this.effectiveFrame?.channelValueBounds,
             channelValueBounds => {
                 if (channelValueBounds) {
                     this.setSpectralRange(channelValueBounds);


### PR DESCRIPTION
**Description**

the effectiveFrame is null when no image is loaded, so when the program tries to read the channelValueBound, it throws an error. Counting for the case where effectiveFrame is null would solve the problem. Close #2052.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~