### PR TITLE
ksw/increase region batch import size to 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 * Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
+* Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040))
 ### Changed
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).
 

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -60,7 +60,7 @@ interface ChannelUpdate {
     stokes: number;
 }
 
-const IMPORT_REGION_BATCH_SIZE = 100;
+const IMPORT_REGION_BATCH_SIZE = 1000;
 const EXPORT_IMAGE_DELAY = 500;
 
 export class AppStore {


### PR DESCRIPTION
**Description**
This is an easy solution to address the performance issue https://github.com/CARTAvis/carta-frontend/issues/2040 

Based on the following test results (loading a region file with 20000 regions), it appears that with a batch size of 100 regions slows down the region import performance quite significantly. 

```
batch_size	batch_import_time + rendering_time
100		19.6349
500		8.816
1000		6.944
2000		6.869
10000		5.449
20000		5.238
```

The choice of 1000 is not very scientific though. We still need this batch import process as a visual indicator of region import process. However, it appears to me that with a batch size of 20000 to load 20000-region region file also performs quite nicely.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~~corresponding fix added~~
- [x] changelog updated / ~~no changelog update needed~~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~