### PR TITLE
Carli/2054 support keeping moment image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added tooltip to the Image column for Image List and Cursor Info overlay ([#1948](https://github.com/CARTAvis/carta-frontend/issues/1948)).
 * Added additional cursor info option to spectral profile widget ([#1837](https://github.com/CARTAvis/carta-frontend/issues/1837)).
 * Added a selection option in the PV generator widget to swap x and y axis, an input for spectral axis limit, and a toggle button to let users decide whether or not to keep the previously generated PV images ([#1950](https://github.com/cartavis/carta-frontend/issues/1950), [#1951](https://github.com/cartavis/carta-frontend/issues/1951), [#1952](https://github.com/cartavis/carta-frontend/issues/1952)).
+* Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 ### Fixed
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -242,10 +242,10 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                 <Divider />
                 <FormGroup inline={true} label={"Keep previous Moment Image"}>
                     <Switch
-                    onChange={event => {
-                        const e = event.target as HTMLInputElement;
-                        this.props.widgetStore.setKeep(e.checked);
-                    }}
+                        onChange={event => {
+                            const e = event.target as HTMLInputElement;
+                            this.props.widgetStore.setKeep(e.checked);
+                        }}
                     />
                 </FormGroup>
                 <div className="moment-generate">

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -244,7 +244,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                     <Switch
                         onChange={event => {
                             const e = event.target as HTMLInputElement;
-                            this.props.widgetStore.setKeep(e.checked);
+                            widgetStore.setKeep(e.checked);
                         }}
                     />
                 </FormGroup>

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {observer} from "mobx-react";
 import {CARTA} from "carta-protobuf";
-import {AnchorButton, Button, Divider, FormGroup, HTMLSelect, MenuItem, Position} from "@blueprintjs/core";
+import {AnchorButton, Button, Divider, FormGroup, HTMLSelect, MenuItem, Position, Switch} from "@blueprintjs/core";
 import {Tooltip2} from "@blueprintjs/popover2";
 import {ItemPredicate, ItemRenderer, MultiSelect} from "@blueprintjs/select";
 import {TaskProgressDialogComponent} from "components/Dialogs";
@@ -237,6 +237,15 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                             },
                             rightElement: <Button icon="cross" minimal={true} onClick={this.handleMomentsClear} />
                         }}
+                    />
+                </FormGroup>
+                <Divider />
+                <FormGroup inline={true} label={"Keep previous Moment Image"}>
+                    <Switch
+                    onChange={event => {
+                        const e = event.target as HTMLInputElement;
+                        this.props.widgetStore.setKeep(e.checked);
+                    }}
                     />
                 </FormGroup>
                 <div className="moment-generate">

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -29,7 +29,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
             minWidth: 280,
             minHeight: 225,
             defaultWidth: 550,
-            defaultHeight: 600,
+            defaultHeight: 650,
             title: "spectral-profiler-settings",
             isCloseable: true,
             parentId: "spectal-profiler",

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1025,7 +1025,7 @@ export class AppStore {
 
         this.startFileLoading();
         // clear previously generated moment images under this frame if keep is false
-        if(!message.keep){
+        if (!message.keep) {
             if (frame.momentImages && frame.momentImages.length > 0) {
                 frame.momentImages.forEach(momentFrame => this.closeFile(momentFrame));
             }

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1024,11 +1024,14 @@ export class AppStore {
         }
 
         this.startFileLoading();
-        // clear previously generated moment images under this frame
-        if (frame.momentImages && frame.momentImages.length > 0) {
-            frame.momentImages.forEach(momentFrame => this.closeFile(momentFrame));
+        // clear previously generated moment images under this frame if keep is false
+        if(!message.keep){
+            if (frame.momentImages && frame.momentImages.length > 0) {
+                frame.momentImages.forEach(momentFrame => this.closeFile(momentFrame));
+            }
+
+            frame.removeMomentImage();
         }
-        frame.removeMomentImage();
 
         this.restartTaskProgress();
 

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -65,6 +65,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
 
     @observable secondaryAxisCursorInfoVisible: boolean;
 
+    @observable keep: boolean;
+
     // line key will be "Primary" in single line mode
     public static readonly PRIMARY_LINE_KEY = "Primary";
 
@@ -198,7 +200,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                     regionId: regionId,
                     spectralRange: channelIndexRange,
                     mask: this.momentMask,
-                    pixelRange: new CARTA.FloatBounds({min: this.maskRange[0], max: this.maskRange[1]})
+                    pixelRange: new CARTA.FloatBounds({min: this.maskRange[0], max: this.maskRange[1]}),
+                    keep: this.keep,
                 };
                 frame.resetMomentRequestState();
                 frame.setIsRequestingMoments(true);
@@ -298,6 +301,10 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.secondaryAxisCursorInfoVisible = val;
     };
 
+    @action setKeep = (bool: boolean) => {
+        this.keep = bool;
+    };
+
     constructor(coordinate: string = "z") {
         super(RegionsType.CLOSED_AND_POINT);
         makeObservable<SpectralProfileWidgetStore, "spectralLinesMHz" | "updateRanges">(this);
@@ -326,6 +333,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.maskRange = [0, 1];
         this.selectedMoments = [CARTA.Moment.INTEGRATED_OF_THE_SPECTRUM];
         this.settingsTabId = SpectralProfilerSettingsTabs.CONVERSION;
+        this.keep = false;
 
         this.intensityConversion = undefined;
         this.setIntensityUnit(this.effectiveFrame?.headerUnit);

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -201,7 +201,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                     spectralRange: channelIndexRange,
                     mask: this.momentMask,
                     pixelRange: new CARTA.FloatBounds({min: this.maskRange[0], max: this.maskRange[1]}),
-                    keep: this.keep,
+                    keep: this.keep
                 };
                 frame.resetMomentRequestState();
                 frame.setIsRequestingMoments(true);

--- a/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -357,7 +357,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         );
 
         reaction(
-            () => this.effectiveFrame.channelValueBounds,
+            () => this.effectiveFrame?.channelValueBounds,
             channelValueBounds => {
                 if (channelValueBounds) {
                     this.updateRanges();


### PR DESCRIPTION
**Description**

Resolves #2054. Added option to keep previously generated moment images.
Resolves #2061.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing~ / corresponding fix added
- [x] changelog updated / ~no changelog update needed~
- [x] protobuf updated to the latest dev commit / ~~no protobuf update needed~~
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~