### PR TITLE
Add disabled props to disable the button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a selection option in the PV generator widget to swap x and y axis, an input for spectral axis limit, and a toggle button to let users decide whether or not to keep the previously generated PV images ([#1950](https://github.com/cartavis/carta-frontend/issues/1950), [#1951](https://github.com/cartavis/carta-frontend/issues/1951), [#1952](https://github.com/cartavis/carta-frontend/issues/1952)).
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 ### Fixed
-* Fixed the issue of invisible export txt file button in the image fitting dialog ([#2057](https://github.com/CARTAvis/carta-frontend/issues/2057))
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).
 * Fixed NaN pixel value in the cursor info bar of the image viewer when the image is 1x1 pixel ([#1879](https://github.com/CARTAvis/carta-frontend/issues/1879)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a selection option in the PV generator widget to swap x and y axis, an input for spectral axis limit, and a toggle button to let users decide whether or not to keep the previously generated PV images ([#1950](https://github.com/cartavis/carta-frontend/issues/1950), [#1951](https://github.com/cartavis/carta-frontend/issues/1951), [#1952](https://github.com/cartavis/carta-frontend/issues/1952)).
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 ### Fixed
+* Fixed the issue of invisible export txt file button in the image fitting dialog ([#2057](https://github.com/CARTAvis/carta-frontend/issues/2057))
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).
 * Fixed NaN pixel value in the cursor info bar of the image viewer when the image is 1x1 pixel ([#1879](https://github.com/CARTAvis/carta-frontend/issues/1879)).

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -88,8 +88,8 @@ export class FittingDialogComponent extends React.Component {
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
                 <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
-                        <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
+                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} disabled={fittingStore.effectiveFrame.fittingResult === ""}>
+                        <AnchorButton icon="th" onClick={this.exportResult} disabled={fittingStore.effectiveFrame.fittingResult === ""}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>
             </Pre>
@@ -99,8 +99,8 @@ export class FittingDialogComponent extends React.Component {
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
                 <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
-                        <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
+                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} disabled={fittingStore.effectiveFrame.fittingLog === ""}>
+                        <AnchorButton icon="th" onClick={this.exportFullLog} disabled={fittingStore.effectiveFrame.fittingLog === ""}></AnchorButton>
                     </Tooltip2>
                 </ButtonGroup>
             </Pre>

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -87,22 +87,26 @@ export class FittingDialogComponent extends React.Component {
         const fittingResultPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="fitting-result-text">{fittingStore.effectiveFrame?.fittingResult ?? ""}</Text>
-                <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} disabled={fittingStore.effectiveFrame.fittingResult === ""}>
-                        <AnchorButton icon="th" onClick={this.exportResult} disabled={fittingStore.effectiveFrame.fittingResult === ""}></AnchorButton>
-                    </Tooltip2>
-                </ButtonGroup>
+                {fittingStore.effectiveFrame?.fittingResult !== "" && (
+                    <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingResult !== "" ? 1 : 0}}>
+                        <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
+                            <AnchorButton icon="th" onClick={this.exportResult}></AnchorButton>
+                        </Tooltip2>
+                    </ButtonGroup>
+                )}
             </Pre>
         );
 
         const fullLogPanel = (
             <Pre className="fitting-result-pre">
                 <Text className="log-text">{fittingStore.effectiveFrame?.fittingLog ?? ""}</Text>
-                <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
-                    <Tooltip2 content={"Export as txt"} position={Position.LEFT} disabled={fittingStore.effectiveFrame.fittingLog === ""}>
-                        <AnchorButton icon="th" onClick={this.exportFullLog} disabled={fittingStore.effectiveFrame.fittingLog === ""}></AnchorButton>
-                    </Tooltip2>
-                </ButtonGroup>
+                {fittingStore.effectiveFrame?.fittingLog !== "" && (
+                    <ButtonGroup className="output-button" style={{opacity: this.isMouseEntered && fittingStore.effectiveFrame.fittingLog !== "" ? 1 : 0}}>
+                        <Tooltip2 content={"Export as txt"} position={Position.LEFT}>
+                            <AnchorButton icon="th" onClick={this.exportFullLog}></AnchorButton>
+                        </Tooltip2>
+                    </ButtonGroup>
+                )}
             </Pre>
         );
 


### PR DESCRIPTION
**Description**

This draft PR is to fix #2057.

Since the buttons are rendered as a whole with the panel, `disabled` props are added to `AnchorButton` and `Tooltip2` to disable the buttons & tooltips. The modification does disappear the tooltip and prevent user from outputting the result, nevertheless, a "forbidden" icon is shown when the cursor hover to the position of the button (see the image shown below...)
![Dialog2](https://user-images.githubusercontent.com/106953609/205873448-4a78c2b3-4d0e-4f24-9c96-66eaeacf169a.jpg)
(Sorry for taking the photo using my cellphone since the "print screen" function of Linux cannot record the cursor status.)
which is a bit weird.

It is perhaps not the best solution thus I would like to take suggestions from you.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [X] e2e test passing / ~corresponding fix added~
- [X] changelog updated / ~no changelog update needed~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~