### PR TITLE
Add NaN pixel color selection in render config overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added a button for NaN pixel color selection in render config overlay ([#1946](https://github.com/cartavis/carta-frontend/issues/1946))
 * Added a setting dialog for the angular distance measurement ([#1201](https://github.com/cartavis/carta-frontend/issues/1201)).
 * Added the functionality to show/hide and lock all regions ([#1796](https://github.com/cartavis/carta-frontend/issues/1796)).
 * Added a method to auto-scrolling the selected region into the region list view ([#1797](https://github.com/CARTAvis/carta-frontend/issues/1797)).

--- a/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
+++ b/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
@@ -47,18 +47,6 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                 <FormGroup label={"Color map"} inline={true}>
                     <ColormapComponent inverted={renderConfig.inverted} selectedItem={renderConfig.colorMap} onItemSelect={renderConfig.setColorMap} />
                 </FormGroup>
-                <FormGroup inline={true} label="NaN Color">
-                    <ColorPickerComponent
-                        color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
-                        presetColors={[...SWATCH_COLORS, "transparent"]}
-                        setColor={(color: ColorResult) => {
-                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, color.hex === "transparent" ? "#000000" : color.hex);
-                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_ALPHA, color.rgb.a);
-                        }}
-                        disableAlpha={false}
-                        darkTheme={appStore.darkTheme}
-                    />
-                </FormGroup>
                 <FormGroup label={"Invert color map"} inline={true}>
                     <Switch checked={renderConfig.inverted} onChange={this.handleInvertedChanged} />
                 </FormGroup>
@@ -102,6 +90,18 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                         contrastMax={RenderConfigStore.CONTRAST_MAX}
                     />
                 </Collapse>
+                <FormGroup inline={true} label="NaN Color">
+                    <ColorPickerComponent
+                        color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
+                        presetColors={[...SWATCH_COLORS, "transparent"]}
+                        setColor={(color: ColorResult) => {
+                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, color.hex === "transparent" ? "#000000" : color.hex);
+                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_ALPHA, color.rgb.a);
+                        }}
+                        disableAlpha={false}
+                        darkTheme={appStore.darkTheme}
+                    />
+                </FormGroup>
             </React.Fragment>
         );
     }

--- a/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
+++ b/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
@@ -1,9 +1,13 @@
 import * as React from "react";
+import tinycolor from "tinycolor2";
 import {observer} from "mobx-react";
 import {action, makeObservable, observable} from "mobx";
 import {Button, Collapse, FormGroup, Switch} from "@blueprintjs/core";
+import {ColorResult} from "react-color";
+import {AppStore, PreferenceKeys} from "stores";
 import {FrameScaling, RenderConfigStore} from "stores/Frame";
-import {BiasContrastSelectComponent, ColormapComponent, ScalingSelectComponent, SafeNumericInput} from "components/Shared";
+import {BiasContrastSelectComponent, ColormapComponent, ColorPickerComponent, ScalingSelectComponent, SafeNumericInput} from "components/Shared";
+import {SWATCH_COLORS} from "utilities";
 
 interface ColormapConfigProps {
     renderConfig: RenderConfigStore;
@@ -31,6 +35,9 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
             return null;
         }
 
+        const appStore = AppStore.Instance;
+        const preference = appStore.preferenceStore;
+
         const renderConfig = this.props.renderConfig;
         return (
             <React.Fragment>
@@ -39,6 +46,18 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                 </FormGroup>
                 <FormGroup label={"Color map"} inline={true}>
                     <ColormapComponent inverted={renderConfig.inverted} selectedItem={renderConfig.colorMap} onItemSelect={renderConfig.setColorMap} />
+                </FormGroup>
+                <FormGroup inline={true} label="NaN Color">
+                    <ColorPickerComponent
+                        color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
+                        presetColors={[...SWATCH_COLORS, "transparent"]}
+                        setColor={(color: ColorResult) => {
+                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX, color.hex === "transparent" ? "#000000" : color.hex);
+                            preference.setPreference(PreferenceKeys.RENDER_CONFIG_NAN_ALPHA, color.rgb.a);
+                        }}
+                        disableAlpha={false}
+                        darkTheme={appStore.darkTheme}
+                    />
                 </FormGroup>
                 <FormGroup label={"Invert color map"} inline={true}>
                     <Switch checked={renderConfig.inverted} onChange={this.handleInvertedChanged} />

--- a/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
+++ b/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
@@ -90,7 +90,7 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                         contrastMax={RenderConfigStore.CONTRAST_MAX}
                     />
                 </Collapse>
-                <FormGroup inline={true} label="NaN Color">
+                <FormGroup inline={true} label="NaN Color" className="nan-color-button">
                     <ColorPickerComponent
                         color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
                         presetColors={[...SWATCH_COLORS, "transparent"]}

--- a/src/components/RenderConfig/RenderConfigComponent.scss
+++ b/src/components/RenderConfig/RenderConfigComponent.scss
@@ -90,6 +90,12 @@
                 width: 30px;
             }
         }
+
+        .nan-color-button {
+            .bp3-button {
+                width: 50px;
+            }
+        }
     }
 
     .histogram-container {


### PR DESCRIPTION
**Description**

This draft PR is to resolve #1946.

A `FormGroup` is added to `ColormapConfigComponent` to add a NaN pixel color selection to the `Render Configuration` overlay. The result is shown below:
[Screencast from 12-14-2022 10:14:37 AM.webm](https://user-images.githubusercontent.com/106953609/207488938-d2dcca49-d358-4819-afb7-6919476e995f.webm)

Would like to make sure with @kswang1029:
1. If this is the effect you would like to have for this issue?
2. If the position of the "NaN pixel color selection" is OK for you?

If it's all OK for Kuo-Song, then I will turn this draft into a formal one.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [X] changelog updated / ~no changelog update needed~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / `BackendService` changed and corresponding ICD test fix added