### PR TITLE
carli/1989_cannot_pan_when_change_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 * Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
+* Fixed the issue of stuck image viewer after changing single/multi panel mode after catalog selection ([#1989](https://github.com/CARTAvis/carta-frontend/issues/1989)).
 * Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040))
 * Fixed offset between cusorInfo and upper wcs axis in the spatial profilers ([#1319](https://github.com/CARTAvis/carta-frontend/issues/1319)).
 ### Changed

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,7 +29,6 @@ interface ImagePanelComponentProps {
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;
-    readonly activeLayer: ImageViewLayer;
 
     private regionViewRef: RegionViewComponent;
 
@@ -42,8 +41,6 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
     constructor(props: ImagePanelComponentProps) {
         super(props);
         makeObservable(this);
-
-        this.activeLayer = AppStore.Instance.activeLayer;
     }
 
     componentDidMount() {
@@ -129,6 +126,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
     render() {
         const appStore = AppStore.Instance;
         const overlayStore = appStore.overlayStore;
+        const activeLayer = appStore.activeLayer;
 
         const frame = this.props.frame;
         if (frame?.isRenderable && appStore.astReady) {
@@ -191,13 +189,13 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                         onClickToCenter={this.onClickToCenter}
                         overlaySettings={overlayStore}
                         dragPanningEnabled={appStore.preferenceStore.dragPanning}
-                        docked={this.props.docked && this.activeLayer !== ImageViewLayer.Catalog}
+                        docked={this.props.docked && activeLayer !== ImageViewLayer.Catalog}
                     />
                     <ToolbarComponent
                         docked={this.props.docked}
                         visible={this.imageToolbarVisible}
                         frame={frame}
-                        activeLayer={this.activeLayer}
+                        activeLayer={activeLayer}
                         onActiveLayerChange={appStore.updateActiveLayer}
                         onRegionViewZoom={this.onRegionViewZoom}
                         onZoomToFit={this.fitZoomFrameAndRegion}

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -1,4 +1,3 @@
-import "./ImageViewComponent.scss";
 import * as React from "react";
 import $ from "jquery";
 import {action, autorun, computed, makeObservable, observable} from "mobx";


### PR DESCRIPTION
**Description**

The issue is caused by the `docked` props of the `RegionViewComponent` in the `ImagePanelComponent`. If the `docked` props is true, the image viewer works as expected. If the `docked` props is false, the image viewer cannot zoom or pan, or even create region or distance measurement curve. The `docked` props is dependent on` AppStore.Instance.activeLayer`, which is saved as a `readonly` attribute in `ImagePanelComponent`. The `activeLayer` attribute is initialised when the `ImagePanelComponent` is instantiated. When the user sets the image panel mode to single panel, and switches back to multi panel view, the `ImagePanelComponent` object of the hidden frame is instantiated, and the `activeLayer` attribute is set to `AppStore.Instance.activeLayer` at that instance in time. For instance, when the user set to single panel mode, and switches the `activeLayer` to catalog selection, and returns to the multi panel mode. The `activeLayer` attribute of the `ImagePanelComponent` of the hidden frame is initialised to catalog selection. The problem is that since the `AppStore.Instance.activeLayer` is set to a `readonly` attribute, further changes in `AppStore.Instance.activeLayer` would not affect the `activeLayer` attribute of the `ImagePanelComponent`. Consequently, the frame stays at catalog selection mode and the `docked` props of the `RegionViewComponent` stays false. The simple fix is to use `AppStore.Intance.activeLayer` directly in the `ImagePanelComponent`. The PR fixed #1989.

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~