### PR TITLE
carli/2021_empty_tsv_file_for_xy_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 * Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
+* Fixed empty tsv file export for xy profiler ([#2021](https://github.com/CARTAvis/carta-frontend/issues/2021)).
 * Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040))
 ### Changed
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -661,7 +661,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             // data part
             rows.push("# x\ty");
             const useScientificForm = plotName === "histogram" || this.props.tickTypeX === TickType.Scientific;
-            const data = this.props.fullResolutionData?.length > 0 ? this.props.fullResolutionData : this.props.data;
+            const data = this.props.fullResolutionData?.some(data => data !== undefined) ? this.props.fullResolutionData : this.props.data;
             rows = rows.concat(data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
 
             exportTsvFile(imageName, plotName, `${comment}\n${rows.join("\n")}\n`);

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -661,7 +661,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             // data part
             rows.push("# x\ty");
             const useScientificForm = plotName === "histogram" || this.props.tickTypeX === TickType.Scientific;
-            const data = this.props.fullResolutionData?.some(data => data !== undefined) ? this.props.fullResolutionData : this.props.data;
+            const data = this.props.fullResolutionData?.some(data => data === undefined) ? this.props.data : this.props.fullResolutionData;
             rows = rows.concat(data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
 
             exportTsvFile(imageName, plotName, `${comment}\n${rows.join("\n")}\n`);

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -661,7 +661,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             // data part
             rows.push("# x\ty");
             const useScientificForm = plotName === "histogram" || this.props.tickTypeX === TickType.Scientific;
-            const data = this.props.fullResolutionData?.some(data => data === undefined) ? this.props.data : this.props.fullResolutionData;
+            const data = this.props.fullResolutionData?.some(data => data !== undefined) ? this.props.fullResolutionData : this.props.data;
             rows = rows.concat(data.map(o => (useScientificForm ? `${toExponential(o.x, 10)}\t${toExponential(o.y, 10)}` : `${o.x}\t${toExponential(o.y, 10)}`)));
 
             exportTsvFile(imageName, plotName, `${comment}\n${rows.join("\n")}\n`);


### PR DESCRIPTION
**Description**

This bug is related to PR#1865. On line 664 of `LinePlotComponent`, the `fullResolutionData` is checked empty by using the `length` attribute, but since it is initialized with `new Array(N)` constructor function, the length attribute do not equal to 0. As a result, an empty array of a fixed length is exported to the tsv file. The solution is to use `Array.some()` function to checked is there are undefined values in the `fullResolutionData` array. This PR fixes #2021.

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~