### PR TITLE
carli/2034_single_source_catalog_file_not_rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 * Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
+* Fixed missing catalog overlay for single source catalog files ([#2034](https://github.com/CARTAvis/carta-frontend/issues/2034)).
 * Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040))
 * Fixed offset between cusorInfo and upper wcs axis in the spatial profilers ([#1319](https://github.com/CARTAvis/carta-frontend/issues/1319)).
 ### Changed

--- a/src/services/GLSL/utilities.glsl
+++ b/src/services/GLSL/utilities.glsl
@@ -75,6 +75,9 @@ vec2 controlMapLookup(sampler2D controlMapTexture, vec2 pos, vec2 controlMapSize
     vec2 range = controlMapMax - controlMapMin;
     vec2 shiftedPoint = pos - controlMapMin;
     vec2 index = shiftedPoint / range * controlMapSize;
+    if (controlMapMax == controlMapMin) {
+        return bicubicFilter(controlMapTexture, vec2(0, 0), controlMapSize).rg;
+    }
     return bicubicFilter(controlMapTexture, index, controlMapSize).rg;
 }
 

--- a/src/services/GLSL/utilities.glsl
+++ b/src/services/GLSL/utilities.glsl
@@ -75,7 +75,7 @@ vec2 controlMapLookup(sampler2D controlMapTexture, vec2 pos, vec2 controlMapSize
     vec2 range = controlMapMax - controlMapMin;
     vec2 shiftedPoint = pos - controlMapMin;
     vec2 index = shiftedPoint / range * controlMapSize;
-    if(range.x == 0.0 && range.y == 0.0) {
+    if (range.x == 0.0 && range.y == 0.0) {
         index = vec2(0, 0);
     }
     return bicubicFilter(controlMapTexture, index, controlMapSize).rg;

--- a/src/services/GLSL/utilities.glsl
+++ b/src/services/GLSL/utilities.glsl
@@ -75,8 +75,8 @@ vec2 controlMapLookup(sampler2D controlMapTexture, vec2 pos, vec2 controlMapSize
     vec2 range = controlMapMax - controlMapMin;
     vec2 shiftedPoint = pos - controlMapMin;
     vec2 index = shiftedPoint / range * controlMapSize;
-    if (controlMapMax == controlMapMin) {
-        return bicubicFilter(controlMapTexture, vec2(0, 0), controlMapSize).rg;
+    if(range.x == 0.0 && range.y == 0.0) {
+        index = vec2(0, 0);
     }
     return bicubicFilter(controlMapTexture, index, controlMapSize).rg;
 }


### PR DESCRIPTION
**Description**

The problem is from `controlMapLookUp` in `utilities.glsl`. The `index` is calculated with `range`, but when there is only one source, `range` is 0, which results in the wrong `index`. The resolution is to add an if-statement to account for when `range` is 0. This PR fixes #2034.

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~