### PR TITLE
carli/2028_region_position_offset_problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed mean and RMS not updating when smoothing in the spatial and spectral profilers ([#1838](https://github.com/CARTAvis/carta-frontend/issues/1838)).
 * Fixed limitations of the point size for catalog overlay rendering ([#1662](https://github.com/CARTAvis/carta-frontend/issues/1662) and [#1802](https://github.com/CARTAvis/carta-frontend/issues/1802)).
 * Fixed the issue of updating image view mode when catalog selection button is disabled ([#1967](https://github.com/CARTAvis/carta-frontend/issues/1967)).
+* Fixed the region position offset mismatch problem after zooming to fit for spatially matched images. ([#2028](https://github.com/CARTAvis/carta-frontend/issues/2028)).
 * Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040))
 * Fixed offset between cusorInfo and upper wcs axis in the spatial profilers ([#1319](https://github.com/CARTAvis/carta-frontend/issues/1319)).
 ### Changed

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -77,9 +77,6 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
     private onRegionViewZoom = (zoom: number, isZoomToFit: boolean = false) => {
         const frame = this.props.frame;
         if (frame) {
-            if (isZoomToFit) {
-                this.regionViewRef?.centerStage();
-            }
             this.regionViewRef?.stageZoomToPoint(frame.renderWidth / 2, frame.renderHeight / 2, zoom);
         }
     };

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -65,7 +65,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         if (frame) {
             const zoom = frame.fitZoom();
             if (zoom) {
-                this.onRegionViewZoom(zoom, true);
+                this.onRegionViewZoom(zoom);
             }
         }
     };
@@ -74,7 +74,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
         this.regionViewRef = ref;
     };
 
-    private onRegionViewZoom = (zoom: number, isZoomToFit: boolean = false) => {
+    private onRegionViewZoom = (zoom: number) => {
         const frame = this.props.frame;
         if (frame) {
             this.regionViewRef?.stageZoomToPoint(frame.renderWidth / 2, frame.renderHeight / 2, zoom);

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -465,7 +465,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             const newOrigin = add2D(origin, centerMovementCanvas);
             // Correct the origin if region view is ever resized
             const correctedOrigin = subtract2D(newOrigin, scale2D(this.stageResizeOffset, refFrameZoom));
-            stage.position(correctedOrigin);
+            stage.position(this.props.frame.spatialReference ? origin : correctedOrigin);
         }
     };
 

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -465,17 +465,6 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
             const newOrigin = add2D(origin, centerMovementCanvas);
             // Correct the origin if region view is ever resized
             const correctedOrigin = subtract2D(newOrigin, scale2D(this.stageResizeOffset, refFrameZoom));
-            stage.position(this.props.frame.spatialReference ? origin : correctedOrigin);
-        }
-    };
-
-    public centerStage = () => {
-        const stage = this.stageRef.current;
-        if (stage) {
-            const zoom = stage.scaleX();
-            const newOrigin = scale2D({x: this.props.width / 2, y: this.props.height / 2}, 1 - zoom);
-            // Correct the origin if region view is ever resized
-            const correctedOrigin = subtract2D(newOrigin, scale2D(this.stageResizeOffset, zoom));
             stage.position(correctedOrigin);
         }
     };

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -19,7 +19,7 @@ export class ToolbarComponentProps {
     frame: FrameStore;
     activeLayer: ImageViewLayer;
     onActiveLayerChange: (layer: ImageViewLayer) => void;
-    onRegionViewZoom: (zoom: number, isZoomToFit?: boolean) => void;
+    onRegionViewZoom: (zoom: number) => void;
     onZoomToFit: () => void;
 }
 


### PR DESCRIPTION
**Description**
This PR fixes #2028. The `centerStage` function in the `RegionViewComponent` sets the `stage.position()` to `correctedOrigin`, when the user clicks `Zoom to Fit` button in the tool bar. However, before calling `centerStage`, the program calls `syncStage` function in the `RegionViewComponent`, which does the same thing as `centerStage` function. The solution to this bug is simply removing the `centerStage` function.

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~