### PR TITLE
carli/2063_catalog_not_rendering_initially

### DIFF
--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -293,7 +293,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.bindTexture(GL2.TEXTURE_2D, controlMap.getTextureX(this.gl));
                     this.gl.uniform1i(shaderUniforms.ControlMapTexture, 1);
                 }
-                
+
                 const hasSources = this.catalogWebGLService.updatePositionTexture(fileId);
                 const positionTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Position);
                 if (positionTexture) {

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -293,7 +293,8 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.bindTexture(GL2.TEXTURE_2D, controlMap.getTextureX(this.gl));
                     this.gl.uniform1i(shaderUniforms.ControlMapTexture, 1);
                 }
-
+                
+                const hasSources = this.catalogWebGLService.updatePositionTexture(fileId);
                 const positionTexture = this.catalogWebGLService.getDataTexture(fileId, CatalogTextureType.Position);
                 if (positionTexture) {
                     this.gl.activeTexture(GL2.TEXTURE2);
@@ -301,7 +302,6 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform1i(shaderUniforms.PositionTexture, 2);
                 }
 
-                const hasSources = this.catalogWebGLService.updatePositionTexture(fileId);
                 if (hasSources) {
                     this.gl.uniform3f(shaderUniforms.PointColor, color.r / 255.0, color.g / 255.0, color.b / 255.0);
                     this.gl.uniform3f(shaderUniforms.SelectedSourceColor, selectedSourceColor.r / 255.0, selectedSourceColor.g / 255.0, selectedSourceColor.b / 255.0);


### PR DESCRIPTION
**Description**

This PR fixes #2063. The `positionTexture` in `CatalogViewGLComponent` on line 298 was originally undefined at first when catalog is loaded. The fix is to move `updatePositionTexture` function before `getDataTexture`.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / corresponding fix added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~