### PR TITLE
Fix the problem of computed stokes animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the region position offset mismatch problem after zooming to fit for spatially matched images. ([#2028](https://github.com/CARTAvis/carta-frontend/issues/2028)).
 * Improved the performance of loading regions in batches ([#2040](https://github.com/CARTAvis/carta-frontend/issues/2040)).
 * Fixed offset between cusorInfo and upper wcs axis in the spatial profilers ([#1319](https://github.com/CARTAvis/carta-frontend/issues/1319)).
+* Fixed the hanging problem for computed stokes animation ([#1238](https://github.com/CARTAvis/carta-backend/issues/1238)).
 ### Changed
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).
 * Set white color or black color, based on the theme, as the background for the image view PNG export ([#2029](https://github.com/CARTAvis/carta-frontend/issues/2029)). 

--- a/src/stores/AnimatorStore/AnimatorStore.ts
+++ b/src/stores/AnimatorStore/AnimatorStore.ts
@@ -224,11 +224,11 @@ export class AnimatorStore {
         if (this.animationMode === AnimationMode.CHANNEL) {
             firstFrame = {
                 channel: frame.animationChannelRange[0],
-                stokes: frame.stokes
+                stokes: frame.requiredPolarizationIndex
             };
             lastFrame = {
                 channel: frame.animationChannelRange[1],
-                stokes: frame.stokes
+                stokes: frame.requiredPolarizationIndex
             };
             deltaFrame = {
                 channel: this.step,


### PR DESCRIPTION
**Description**

linked issues and companion PRs (if there are), what is implemented or fixed, how to test it, …

This is to fix the [issue 1238](https://github.com/CARTAvis/carta-backend/issues/1238) from the backend. Since I think a more correct way is by fixing the stokes index setting in the `StartAnimation` message that is sent from the frontend. @kswang1029 could you please verify does it fix the problem of computed stokes animation? Thank you!

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated ~/ no changelog update needed~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] `BackendService` unchanged ~/ `BackendService` changed and corresponding ICD test fix added~