### PR TITLE
To read session URL correctly from the Electron version

### DIFF
--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -200,7 +200,7 @@ export class RootMenuComponent extends React.Component {
                 onClick={async () => {
                     try {
                         const url = new URL(window.location.href);
-                        if (!url.searchParams.has("socketUrl")) {
+                        if (url.protocol.startsWith("file")) {
                             await navigator.clipboard?.writeText(window.location.href);
                         } else {
                             const socketUrl = url.searchParams.get("socketUrl");

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -200,7 +200,7 @@ export class RootMenuComponent extends React.Component {
                 onClick={async () => {
                     try {
                         const url = new URL(window.location.href);
-                        if (url.protocol.startsWith("file")) {
+                        if (!url.protocol.startsWith("file")) {
                             await navigator.clipboard?.writeText(window.location.href);
                         } else {
                             const socketUrl = url.searchParams.get("socketUrl");

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -200,7 +200,7 @@ export class RootMenuComponent extends React.Component {
                 onClick={async () => {
                     try {
                         const url = new URL(window.location.href);
-                        if (!url.protocol.startsWith("file://")) {
+                        if (!url.protocol.startsWith("file")) {
                             await navigator.clipboard?.writeText(window.location.href);
                         } else {
                             const socketUrl = url.searchParams.get("socketUrl");

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -200,7 +200,7 @@ export class RootMenuComponent extends React.Component {
                 onClick={async () => {
                     try {
                         const url = new URL(window.location.href);
-                        if (!url.protocol.startsWith("file")) {
+                        if (!url.protocol.startsWith("file://")) {
                             await navigator.clipboard?.writeText(window.location.href);
                         } else {
                             const socketUrl = url.searchParams.get("socketUrl");

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -199,7 +199,16 @@ export class RootMenuComponent extends React.Component {
                 text="Copy session URL to clipboard"
                 onClick={async () => {
                     try {
-                        await navigator.clipboard?.writeText(window.location.href);
+                        const url = new URL(window.location.href);
+                        if (!url.searchParams.has("socketUrl")) {
+                            await navigator.clipboard?.writeText(window.location.href);
+                        } else {
+                            const socketUrl = url.searchParams.get("socketUrl");
+                            const token = url.searchParams.get("token");
+                            const httpUrl = socketUrl.replace("ws", "http");
+                            const finalUrl = `${httpUrl}?token=${token}`;
+                            await navigator.clipboard?.writeText(finalUrl);
+                        }
                         AppToaster.show(SuccessToast("clipboard", "Session URL copied!"));
                     } catch (err) {
                         console.log(err);


### PR DESCRIPTION
**Description**

This addresses issue #2102. 

The problem is if using the Electron version of CARTA, the URL is not as expected e.g.: 
```
file:///Applications/CARTA.app/Contents/Resources/app/index.html?socketUrl=ws://localhost:55051&token=c533b90f-5bf1-4814-b81c-a889a35e79d8/
```
We only want http://localhost, the port number, and the token information.

This fix assumes that if the word "socketUrl" is present in the string, then you must be using the Electron version.
If "socketUrl" is not present, it simply produces the URL as before using "window.location.href"
If "socketUrl" is present, it works on assembling the correct shorter URL. It also switches "ws" with "http" and uses "?" instead of "&".

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [ ] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / ~corresponding fix added~
- [ ] changelog updated / no changelog update needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] `BackendService` unchanged / `BackendService` changed and corresponding ICD test fix added