### PR TITLE
Icchen/2091 contour levels not deleted as intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 * Added settings in the image view settings widget for panning and zooming the images ([#1176](https://github.com/CARTAvis/carta-frontend/issues/1176)).
 ### Fixed
+* Fixed the issue of contour levels not deleted as intended ([#2091](https://github.com/CARTAvis/carta-frontend/issues/2091)).
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).
 * Fixed NaN pixel value in the cursor info bar of the image viewer when the image is 1x1 pixel ([#1879](https://github.com/CARTAvis/carta-frontend/issues/1879)).

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -251,6 +251,7 @@ export class ContourDialogComponent extends React.Component {
                 const val = parseFloat(valueString);
                 if (isFinite(val)) {
                     this.levels.push(val);
+                    this.levels.sort()
                 }
             }
         } catch (e) {

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -223,6 +223,7 @@ export class ContourDialogComponent extends React.Component {
 
     private handleGraphClicked = (x: number) => {
         this.levels.push(x);
+        this.levels = this.levels.sort();
     };
 
     private handleGraphRightClicked = (x: number) => {

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -251,7 +251,7 @@ export class ContourDialogComponent extends React.Component {
                 const val = parseFloat(valueString);
                 if (isFinite(val)) {
                     this.levels.push(val);
-                    this.levels.sort()
+                    this.levels.sort();
                 }
             }
         } catch (e) {

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -223,7 +223,7 @@ export class ContourDialogComponent extends React.Component {
 
     private handleGraphClicked = (x: number) => {
         this.levels.push(x);
-        this.levels = this.levels.sort();
+        this.levels.sort();
     };
 
     private handleGraphRightClicked = (x: number) => {


### PR DESCRIPTION
**Description**
This PR is to resolve #2091.

The bug is due to that the original `handleGraphClicked` only push the new added level and it is hence always located at the last element of the array. On the other hand, the `handleLevelRemoved` delete level according to the index of the level, thus it hence delete the wrong level. To resolve the issue, I sort the levels array after pushing the new added one.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [X] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [X] changelog updated / ~no changelog update needed~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~