### PR TITLE
unify text style in GUI

### DIFF
--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -12,7 +12,7 @@ import {AnimationMode, AnimatorStore, AppStore, DefaultWidgetConfig, HelpType, P
 import "./AnimatorComponent.scss";
 
 enum NumericInputType {
-    FrameRate = "Frame Rate",
+    FrameRate = "Frame rate",
     Step = "Step"
 }
 
@@ -331,8 +331,8 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 className={playbackModeClass}
                 content={
                     <Menu>
-                        <MenuItem icon="arrow-right" text="Play Forward" active={appStore.animatorStore.playMode === PlayMode.FORWARD} onClick={() => (appStore.animatorStore.playMode = PlayMode.FORWARD)} />
-                        <MenuItem icon="arrow-left" text="Play Backwards" active={appStore.animatorStore.playMode === PlayMode.BACKWARD} onClick={() => (appStore.animatorStore.playMode = PlayMode.BACKWARD)} />
+                        <MenuItem icon="arrow-right" text="Play forward" active={appStore.animatorStore.playMode === PlayMode.FORWARD} onClick={() => (appStore.animatorStore.playMode = PlayMode.FORWARD)} />
+                        <MenuItem icon="arrow-left" text="Play backwards" active={appStore.animatorStore.playMode === PlayMode.BACKWARD} onClick={() => (appStore.animatorStore.playMode = PlayMode.BACKWARD)} />
                         <MenuItem icon="swap-horizontal" text="Bouncing" active={appStore.animatorStore.playMode === PlayMode.BOUNCING} onClick={() => (appStore.animatorStore.playMode = PlayMode.BOUNCING)} />
                         <MenuItem icon="exchange" text="Blink" active={appStore.animatorStore.playMode === PlayMode.BLINK} onClick={() => (appStore.animatorStore.playMode = PlayMode.BLINK)} />
                     </Menu>

--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -339,7 +339,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
                 }
                 position={Position.TOP}
             >
-                <Tooltip2 content="Playback Mode" position={Position.TOP}>
+                <Tooltip2 content="Playback mode" position={Position.TOP}>
                     <AnchorButton icon={this.getPlayModeIcon()} disabled={appStore.animatorStore.animationActive}>
                         {!iconOnly && "Mode"}
                     </AnchorButton>

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -821,7 +821,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
                             <ClearableNumericInputComponent
                                 className={"catalog-max-rows"}
-                                label="Max Rows"
+                                label="Max rows"
                                 value={profileStore.maxRows}
                                 onValueChanged={val => profileStore.setMaxRows(val)}
                                 onValueCleared={() => profileStore.setMaxRows(profileStore.catalogInfo.dataSize)}

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -173,7 +173,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 <FormGroup label={"Scaling"} inline={true} disabled={disableSizeMap}>
                     <ScalingSelectComponent selectedItem={widgetStore.sizeScalingType} onItemSelect={type => widgetStore.setSizeScalingType(type)} disabled={disableSizeMap} />
                 </FormGroup>
-                <FormGroup inline={true} label={"Size Mode"} disabled={disableSizeMap}>
+                <FormGroup inline={true} label={"Size mode"} disabled={disableSizeMap}>
                     <ButtonGroup>
                         <AnchorButton disabled={disableSizeMap} text={"Diameter"} active={!widgetStore.sizeArea} onClick={() => widgetStore.setSizeArea(false)} />
                         <AnchorButton disabled={disableSizeMap} text={"Area"} active={widgetStore.sizeArea} onClick={() => widgetStore.setSizeArea(true)} />
@@ -181,7 +181,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 </FormGroup>
                 <div className="numeric-input-lock">
                     <ClearableNumericInputComponent
-                        label="Clip Min"
+                        label="Clip min"
                         max={widgetStore.sizeColumnMax.clipd}
                         integerOnly={false}
                         value={widgetStore.sizeColumnMin.clipd}
@@ -201,7 +201,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 </div>
                 <div className="numeric-input-lock">
                     <ClearableNumericInputComponent
-                        label="Clip Max"
+                        label="Clip max"
                         min={widgetStore.sizeColumnMin.clipd}
                         integerOnly={false}
                         value={widgetStore.sizeColumnMax.clipd}
@@ -243,7 +243,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 <FormGroup label={"Scaling"} inline={true} disabled={disableSizeMinorMap}>
                     <ScalingSelectComponent selectedItem={widgetStore.sizeMinorScalingType} onItemSelect={type => widgetStore.setSizeMinorScalingType(type)} disabled={disableSizeMinorMap} />
                 </FormGroup>
-                <FormGroup inline={true} label={"Size Mode"} disabled={disableSizeMinorMap}>
+                <FormGroup inline={true} label={"Size mode"} disabled={disableSizeMinorMap}>
                     <ButtonGroup>
                         <AnchorButton disabled={disableSizeMinorMap} text={"Diameter"} active={!widgetStore.sizeMinorArea} onClick={() => widgetStore.setSizeMinorArea(false)} />
                         <AnchorButton disabled={disableSizeMinorMap} text={"Area"} active={widgetStore.sizeMinorArea} onClick={() => widgetStore.setSizeMinorArea(true)} />
@@ -251,7 +251,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 </FormGroup>
                 <div className="numeric-input-lock">
                     <ClearableNumericInputComponent
-                        label="Clip Min"
+                        label="Clip min"
                         max={widgetStore.sizeMinorColumnMax.clipd}
                         integerOnly={false}
                         value={widgetStore.sizeMinorColumnMin.clipd}
@@ -271,7 +271,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 </div>
                 <div className="numeric-input-lock">
                     <ClearableNumericInputComponent
-                        label="Clip Max"
+                        label="Clip max"
                         min={widgetStore.sizeMinorColumnMin.clipd}
                         integerOnly={false}
                         value={widgetStore.sizeMinorColumnMax.clipd}
@@ -368,7 +368,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                         disabled={disabledOverlayPanel || !widgetStore.disableColorMap}
                     />
                 </FormGroup>
-                <FormGroup label={"Overlay Highlight"} inline={true} disabled={disabledOverlayPanel}>
+                <FormGroup label={"Overlay highlight"} inline={true} disabled={disabledOverlayPanel}>
                     <AutoColorPickerComponent
                         color={widgetStore.highlightColor}
                         presetColors={[...SWATCH_COLORS, "transparent"]}
@@ -398,14 +398,14 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 <FormGroup label={"Scaling"} inline={true} disabled={disableColorMap}>
                     <ScalingSelectComponent selectedItem={widgetStore.colorScalingType} onItemSelect={type => widgetStore.setColorScalingType(type)} disabled={disableColorMap} />
                 </FormGroup>
-                <FormGroup inline={true} label="Color Map" disabled={disableColorMap}>
+                <FormGroup inline={true} label="Colormap" disabled={disableColorMap}>
                     <ColormapComponent inverted={false} selectedItem={widgetStore.colorMap} onItemSelect={selected => widgetStore.setColorMap(selected)} disabled={disableColorMap} />
                 </FormGroup>
-                <FormGroup label={"Invert Color Map"} inline={true} disabled={disableColorMap}>
+                <FormGroup label={"Invert Colormap"} inline={true} disabled={disableColorMap}>
                     <Switch checked={widgetStore.invertedColorMap} onChange={ev => widgetStore.setColorMapDirection(ev.currentTarget.checked)} disabled={disableColorMap} />
                 </FormGroup>
                 <ClearableNumericInputComponent
-                    label="Clip Min"
+                    label="Clip min"
                     max={widgetStore.colorColumnMax.clipd}
                     integerOnly={false}
                     value={widgetStore.colorColumnMin.clipd}
@@ -415,7 +415,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                     disabled={disableColorMap}
                 />
                 <ClearableNumericInputComponent
-                    label="Clip Max"
+                    label="Clip max"
                     min={widgetStore.colorColumnMin.clipd}
                     integerOnly={false}
                     value={widgetStore.colorColumnMax.clipd}
@@ -448,7 +448,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 <FormGroup label={"Scaling"} inline={true} disabled={disableOrientationMap}>
                     <ScalingSelectComponent selectedItem={widgetStore.orientationScalingType} onItemSelect={type => widgetStore.setOrientationScalingType(type)} disabled={disableOrientationMap} />
                 </FormGroup>
-                <FormGroup inline={true} label="Orientation Min" labelInfo="(degree)" disabled={disableOrientationMap}>
+                <FormGroup inline={true} label="Orientation min" labelInfo="(degree)" disabled={disableOrientationMap}>
                     <SafeNumericInput
                         allowNumericCharactersOnly={true}
                         asyncControl={true}
@@ -460,7 +460,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                         onKeyDown={ev => this.handleChange(ev, "angle-min")}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Orientation Max" labelInfo="(degree)" disabled={disableOrientationMap}>
+                <FormGroup inline={true} label="Orientation max" labelInfo="(degree)" disabled={disableOrientationMap}>
                     <SafeNumericInput
                         allowNumericCharactersOnly={true}
                         asyncControl={true}
@@ -473,7 +473,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                     />
                 </FormGroup>
                 <ClearableNumericInputComponent
-                    label="Clip Min"
+                    label="Clip min"
                     max={widgetStore.orientationMax.clipd}
                     integerOnly={false}
                     value={widgetStore.orientationMin.clipd}
@@ -483,7 +483,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                     disabled={disableOrientationMap}
                 />
                 <ClearableNumericInputComponent
-                    label="Clip Max"
+                    label="Clip max"
                     min={widgetStore.orientationMin.clipd}
                     integerOnly={false}
                     value={widgetStore.orientationMax.clipd}

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -326,7 +326,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                     <Tab id={CatalogSettingsTabs.SIZE_MAJOR} title="Major" panel={sizeMajor} />
                     <Tab id={CatalogSettingsTabs.SIZE_MINOR} title="Minor" panel={sizeMinor} disabled={!widgetStore.enableSizeMinorTab} />
                 </Tabs>
-                <FormGroup inline={true} label="Size Min" labelInfo="(px)" disabled={disableSizeMap}>
+                <FormGroup inline={true} label="Size min" labelInfo="(px)" disabled={disableSizeMap}>
                     <SafeNumericInput
                         allowNumericCharactersOnly={true}
                         asyncControl={true}
@@ -338,7 +338,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                         onKeyDown={ev => this.handleChange(ev, "size-min")}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Size Max" labelInfo="(px)" disabled={disableSizeMap}>
+                <FormGroup inline={true} label="Size max" labelInfo="(px)" disabled={disableSizeMap}>
                     <Tooltip2 content={`Maximum size ${widgetStore.maxPointSizebyType}`}>
                         <SafeNumericInput
                             allowNumericCharactersOnly={true}
@@ -401,7 +401,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 <FormGroup inline={true} label="Colormap" disabled={disableColorMap}>
                     <ColormapComponent inverted={false} selectedItem={widgetStore.colorMap} onItemSelect={selected => widgetStore.setColorMap(selected)} disabled={disableColorMap} />
                 </FormGroup>
-                <FormGroup label={"Invert Colormap"} inline={true} disabled={disableColorMap}>
+                <FormGroup label={"Invert colormap"} inline={true} disabled={disableColorMap}>
                     <Switch checked={widgetStore.invertedColorMap} onChange={ev => widgetStore.setColorMapDirection(ev.currentTarget.checked)} disabled={disableColorMap} />
                 </FormGroup>
                 <ClearableNumericInputComponent

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -695,7 +695,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
         );
 
         const renderHistogramLog = (
-            <FormGroup label={"Log Scale"} inline={true} disabled={disabled}>
+            <FormGroup label={"Log scale"} inline={true} disabled={disabled}>
                 <Switch checked={widgetStore.logScaleY} onChange={this.handleLogScaleYChanged} disabled={disabled} />
             </FormGroup>
         );
@@ -720,7 +720,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
         );
 
         const renderStatisticSelect = (
-            <FormGroup inline={true} label="Statistic Source">
+            <FormGroup inline={true} label="Statistic source">
                 <Select
                     className="bp3-fill"
                     items={xyOptions}

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -938,7 +938,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             />
         );
 
-        const renderLinearRegressionButton = <AnchorButton intent={Intent.PRIMARY} text="Linear Fit" onClick={() => this.handleFittingClick(selectedPointIndices)} disabled={disabled || selectedPointIndices?.length === 1} />;
+        const renderLinearRegressionButton = <AnchorButton intent={Intent.PRIMARY} text="Linear fit" onClick={() => this.handleFittingClick(selectedPointIndices)} disabled={disabled || selectedPointIndices?.length === 1} />;
         const infoStrings = [this.genProfilerInfo];
         if (widgetStore.showStatisticResult && widgetStore.enableStatistic) {
             infoStrings.push(widgetStore.statisticString);

--- a/src/components/Dialogs/CatalogQueryDialog/CatalogOnlineQueryDialogComponent.tsx
+++ b/src/components/Dialogs/CatalogQueryDialog/CatalogOnlineQueryDialogComponent.tsx
@@ -131,7 +131,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                     </Select>
                 </FormGroup>
                 {isVizier ? (
-                    <FormGroup inline={false} label="Key Words (Catalog Title)" disabled={disable} className={isVizier ? "vizier-key-words" : ""}>
+                    <FormGroup inline={false} label="Keywords (catalog title)" disabled={disable} className={isVizier ? "vizier-key-words" : ""}>
                         <InputGroup asyncControl={false} disabled={disable} onChange={event => configStore.setVizierKeyWords(event.target.value)} value={configStore.vizierKeyWords} />
                     </FormGroup>
                 ) : null}
@@ -141,7 +141,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                         <Button disabled={disable || configStore.disableObjectSearch} text={"Resolve"} intent={Intent.NONE} onClick={this.handleObjectUpdate} />
                     </Tooltip2>
                 </FormGroup>
-                <FormGroup inline={false} label="Search Radius" disabled={disable}>
+                <FormGroup inline={false} label="Search radius" disabled={disable}>
                     <Tooltip2 content={`0 - ${configStore.maxRadius} ${configStore.radiusUnits}`} disabled={disable} position={Position.BOTTOM} hoverOpenDelay={300}>
                         <SafeNumericInput
                             asyncControl={true}
@@ -165,13 +165,13 @@ export class CatalogQueryDialogComponent extends React.Component {
                     >
                         <Button text={configStore.radiusUnits} disabled={disable} rightIcon="double-caret-vertical" />
                     </Select>
-                    <Tooltip2 content="Reset Center Coordinates and Search Radius according current image viewer" disabled={disable} position={Position.BOTTOM} hoverOpenDelay={300}>
+                    <Tooltip2 content="Reset center coordinates and search radius according current image viewer" disabled={disable} position={Position.BOTTOM} hoverOpenDelay={300}>
                         <Button disabled={disable} onClick={() => configStore.resetSearchRadius()}>
                             Set to viewer
                         </Button>
                     </Tooltip2>
                 </FormGroup>
-                <FormGroup inline={false} label="Center Coordinates" disabled={disable}>
+                <FormGroup inline={false} label="Center coordinates" disabled={disable}>
                     <Select
                         items={Object.keys(SystemType).map(key => SystemType[key])}
                         activeItem={null}
@@ -188,7 +188,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                         <SafeNumericInput
                             allowNumericCharactersOnly={false}
                             buttonPosition="none"
-                            placeholder="X WCS Coordinate"
+                            placeholder="X WCS coordinate"
                             disabled={!wcsInfo || !centerWcsPoint || disable}
                             value={centerWcsPoint ? centerWcsPoint.x : ""}
                             onBlur={this.handleCenterWcsXChange}
@@ -199,7 +199,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                         <SafeNumericInput
                             allowNumericCharactersOnly={false}
                             buttonPosition="none"
-                            placeholder="Y WCS Coordinate"
+                            placeholder="Y WCS coordinate"
                             disabled={!wcsInfo || !centerWcsPoint || disable}
                             value={centerWcsPoint ? centerWcsPoint.y : ""}
                             onBlur={this.handleCenterWcsYChange}
@@ -211,7 +211,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                     </Tooltip2>
                 </FormGroup>
                 <ClearableNumericInputComponent
-                    label={isVizier ? "Max Number of Objects Per Catalog" : "Max Number of Objects"}
+                    label={isVizier ? "Max number of objects per catalog" : "Max number of objects"}
                     min={CatalogOnlineQueryConfigStore.MIN_OBJECTS}
                     max={CatalogOnlineQueryConfigStore.MAX_OBJECTS}
                     integerOnly={true}
@@ -223,7 +223,7 @@ export class CatalogQueryDialogComponent extends React.Component {
                     inline={false}
                 />
                 {configStore.showVizierResult ? (
-                    <FormGroup inline={false} label="VizieR Catalog" disabled={disable}>
+                    <FormGroup inline={false} label="VizieR catalog" disabled={disable}>
                         <MultiSelect
                             placeholder={"Please select catalog tables"}
                             fill={true}

--- a/src/components/Dialogs/CodeSnippetDialog/CodeSnippetDialogComponent.tsx
+++ b/src/components/Dialogs/CodeSnippetDialog/CodeSnippetDialogComponent.tsx
@@ -119,7 +119,7 @@ export class CodeSnippetDialogComponent extends React.Component {
             isOpen: appStore.dialogStore.codeSnippetDialogVisible,
             onClose: appStore.dialogStore.hideCodeSnippetDialog,
             isCloseButtonShown: true,
-            title: "Edit code snippet"
+            title: "Edit Code Snippet"
         };
 
         const editor = (

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -437,7 +437,7 @@ export class ContourDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Smoothing mode">
                     <HTMLSelect value={this.smoothingMode} onChange={ev => (this.smoothingMode = Number(ev.currentTarget.value))}>
                         <option key={CARTA.SmoothingMode.NoSmoothing} value={CARTA.SmoothingMode.NoSmoothing}>
-                            No Smoothing
+                            No smoothing
                         </option>
                         <option key={CARTA.SmoothingMode.BlockAverage} value={CARTA.SmoothingMode.BlockAverage}>
                             Block

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -158,7 +158,7 @@ export class ContourDialogComponent extends React.Component {
     };
 
     private renderHistogramSelectItem = (isCube: boolean, {handleClick, modifiers, query}) => {
-        return <MenuItem text={isCube ? "Per-Cube" : "Per-Channel"} onClick={handleClick} key={isCube ? "cube" : "channel"} />;
+        return <MenuItem text={isCube ? "Per-cube" : "Per-channel"} onClick={handleClick} key={isCube ? "cube" : "channel"} />;
     };
 
     private handleHistogramChange = (value: boolean) => {
@@ -407,7 +407,7 @@ export class ContourDialogComponent extends React.Component {
                             onItemSelect={this.handleHistogramChange}
                             itemRenderer={this.renderHistogramSelectItem}
                         >
-                            <Button text={dataSource.renderConfig.useCubeHistogramContours ? "Per-Cube" : "Per-Channel"} rightIcon="double-caret-vertical" alignText={"right"} />
+                            <Button text={dataSource.renderConfig.useCubeHistogramContours ? "Per-cube" : "Per-channel"} rightIcon="double-caret-vertical" alignText={"right"} />
                         </HistogramSelect>
                     </FormGroup>
                 )}
@@ -434,7 +434,7 @@ export class ContourDialogComponent extends React.Component {
 
         const configPanel = (
             <div className="contour-config-panel">
-                <FormGroup inline={true} label="Smoothing Mode">
+                <FormGroup inline={true} label="Smoothing mode">
                     <HTMLSelect value={this.smoothingMode} onChange={ev => (this.smoothingMode = Number(ev.currentTarget.value))}>
                         <option key={CARTA.SmoothingMode.NoSmoothing} value={CARTA.SmoothingMode.NoSmoothing}>
                             No Smoothing
@@ -447,9 +447,9 @@ export class ContourDialogComponent extends React.Component {
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Smoothing Factor">
+                <FormGroup inline={true} label="Smoothing factor">
                     <SafeNumericInput
-                        placeholder="Smoothing Factor"
+                        placeholder="Smoothing factor"
                         min={1}
                         max={33}
                         value={this.smoothingFactor}
@@ -468,7 +468,7 @@ export class ContourDialogComponent extends React.Component {
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.CONTOUR} defaultWidth={ContourDialogComponent.DefaultWidth} defaultHeight={ContourDialogComponent.DefaultHeight} enableResizing={true}>
                 <div className={Classes.DIALOG_BODY}>
-                    <FormGroup inline={true} label="Data Source">
+                    <FormGroup inline={true} label="Data source">
                         <DataSourceSelect
                             activeItem={dataSource}
                             onItemSelect={appStore.setContourDataSource}

--- a/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
@@ -265,7 +265,7 @@ export class ContourGeneratorPanelComponent extends React.Component<{
                     <ClearableNumericInputComponent label="Sigma" value={this.sigmaValue} onValueChanged={val => (this.enteredSigmaValue = val)} onValueCleared={() => (this.enteredSigmaValue = undefined)} displayExponential={true} />
                 </div>
                 <div className="parameter-line">
-                    <FormGroup label={"Sigma List"} inline={true}>
+                    <FormGroup label={"Sigma list"} inline={true}>
                         <TagInput
                             addOnBlur={true}
                             fill={true}

--- a/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
@@ -15,7 +15,7 @@ const DashModeSelect = Select.ofType<ContourDashMode>();
 @observer
 export class ContourStylePanelComponent extends React.Component<{frame: FrameStore; darkTheme: boolean}> {
     private renderDashModeSelectItem = (mode: ContourDashMode, {handleClick, modifiers, query}) => {
-        return <MenuItem text={ContourDashMode[mode]} onClick={handleClick} key={mode} />;
+        return <MenuItem text={mode} onClick={handleClick} key={mode} />;
     };
 
     render() {
@@ -34,7 +34,7 @@ export class ContourStylePanelComponent extends React.Component<{frame: FrameSto
                         items={[ContourDashMode.None, ContourDashMode.Dashed, ContourDashMode.NegativeOnly]}
                         itemRenderer={this.renderDashModeSelectItem}
                     >
-                        <Button text={ContourDashMode[frame.contourConfig.dashMode]} rightIcon="double-caret-vertical" alignText={"right"} />
+                        <Button text={frame.contourConfig.dashMode} rightIcon="double-caret-vertical" alignText={"right"} />
                     </DashModeSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Color mode">

--- a/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
@@ -37,17 +37,17 @@ export class ContourStylePanelComponent extends React.Component<{frame: FrameSto
                         <Button text={ContourDashMode[frame.contourConfig.dashMode]} rightIcon="double-caret-vertical" alignText={"right"} />
                     </DashModeSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Color Mode">
+                <FormGroup inline={true} label="Color mode">
                     <HTMLSelect value={frame.contourConfig.colormapEnabled ? 1 : 0} onChange={ev => frame.contourConfig.setColormapEnabled(parseInt(ev.currentTarget.value) > 0)}>
                         <option key={0} value={0}>
-                            Constant Color
+                            Constant color
                         </option>
                         <option key={1} value={1}>
                             Color-mapped
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Color Map" disabled={!frame.contourConfig.colormapEnabled}>
+                <FormGroup inline={true} label="Colormap" disabled={!frame.contourConfig.colormapEnabled}>
                     <ColormapComponent inverted={false} disabled={!frame.contourConfig.colormapEnabled} selectedItem={frame.contourConfig.colormap} onItemSelect={frame.contourConfig.setColormap} />
                 </FormGroup>
                 <FormGroup inline={true} label="Bias" disabled={!frame.contourConfig.colormapEnabled}>

--- a/src/components/Dialogs/DistanceMeasuringDialog/DistanceMeasuringDialog.tsx
+++ b/src/components/Dialogs/DistanceMeasuringDialog/DistanceMeasuringDialog.tsx
@@ -210,13 +210,13 @@ export class DistanceMeasuringDialog extends React.Component {
                                             </FormGroup>
                                         </td>
                                         <td colSpan={2} className="distance-measuring-settings-table-line-style-numeric-input">
-                                            <FormGroup inline={true} label="Line Width" labelInfo="(px)">
-                                                <SafeNumericInput placeholder="Line Width" min={0.5} max={20} value={distanceMeasuringStore?.lineWidth} stepSize={0.5} onValueChange={value => distanceMeasuringStore?.setLineWidth(value)} />
+                                            <FormGroup inline={true} label="Line width" labelInfo="(px)">
+                                                <SafeNumericInput placeholder="Line width" min={0.5} max={20} value={distanceMeasuringStore?.lineWidth} stepSize={0.5} onValueChange={value => distanceMeasuringStore?.setLineWidth(value)} />
                                             </FormGroup>
                                         </td>
                                         <td width="300px" className="distance-measuring-settings-table-line-style-numeric-input">
-                                            <FormGroup inline={true} label="Font Size" labelInfo="(px)">
-                                                <SafeNumericInput placeholder="Font Size" min={0.5} max={50} value={distanceMeasuringStore?.fontSize} stepSize={1} onValueChange={value => distanceMeasuringStore?.setFontSize(value)} />
+                                            <FormGroup inline={true} label="Font size" labelInfo="(px)">
+                                                <SafeNumericInput placeholder="Font size" min={0.5} max={50} value={distanceMeasuringStore?.fontSize} stepSize={1} onValueChange={value => distanceMeasuringStore?.setFontSize(value)} />
                                             </FormGroup>
                                         </td>
                                     </tr>

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -443,7 +443,7 @@ export class FileBrowserDialogComponent extends React.Component {
                 content={
                     <Menu>
                         <MenuItem text="CRTF region file" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.CRTF)} />
-                        <MenuItem text="ds9 region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
+                        <MenuItem text="DS9 region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
                     </Menu>
                 }
                 position={Position.BOTTOM_RIGHT}

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -385,7 +385,7 @@ export class FileBrowserDialogComponent extends React.Component {
                             intent={Intent.PRIMARY}
                             disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo}
                             onClick={this.loadSelectedFiles}
-                            text="Load Region"
+                            text="Load region"
                         />
                     </Tooltip2>
                 );
@@ -396,7 +396,7 @@ export class FileBrowserDialogComponent extends React.Component {
                             intent={Intent.PRIMARY}
                             disabled={appStore.fileLoading || !fileBrowserStore.selectedFile || !fileBrowserStore.fileInfoResp || fileBrowserStore.loadingInfo || !appStore.activeFrame}
                             onClick={this.loadSelectedFiles}
-                            text="Load Catalog"
+                            text="Load catalog"
                         />
                     </Tooltip2>
                 );
@@ -408,7 +408,7 @@ export class FileBrowserDialogComponent extends React.Component {
                             intent={Intent.PRIMARY}
                             disabled={!FileBrowserDialogComponent.ValidateFilename(fileBrowserStore.exportFilename) || !frame || frame.regionSet.regions.length <= 1 || fileBrowserStore.exportRegionNum < 1}
                             onClick={this.handleExportRegionsClicked}
-                            text="Export Regions"
+                            text="Export regions"
                         />
                     </Tooltip2>
                 );

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -425,8 +425,8 @@ export class FileBrowserDialogComponent extends React.Component {
                 minimal={true}
                 content={
                     <Menu>
-                        <MenuItem text="World Coordinates" onClick={() => fileBrowserStore.setExportCoordinateType(CARTA.CoordinateType.WORLD)} />
-                        <MenuItem text="Pixel Coordinates" onClick={() => fileBrowserStore.setExportCoordinateType(CARTA.CoordinateType.PIXEL)} />
+                        <MenuItem text="World coordinates" onClick={() => fileBrowserStore.setExportCoordinateType(CARTA.CoordinateType.WORLD)} />
+                        <MenuItem text="Pixel coordinates" onClick={() => fileBrowserStore.setExportCoordinateType(CARTA.CoordinateType.PIXEL)} />
                     </Menu>
                 }
                 position={Position.BOTTOM_RIGHT}
@@ -442,8 +442,8 @@ export class FileBrowserDialogComponent extends React.Component {
                 minimal={true}
                 content={
                     <Menu>
-                        <MenuItem text="CRTF Region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.CRTF)} />
-                        <MenuItem text="DS9 Region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
+                        <MenuItem text="CRTF region file" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.CRTF)} />
+                        <MenuItem text="ds9 region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
                     </Menu>
                 }
                 position={Position.BOTTOM_RIGHT}

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -443,7 +443,7 @@ export class FileBrowserDialogComponent extends React.Component {
                 content={
                     <Menu>
                         <MenuItem text="CRTF region file" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.CRTF)} />
-                        <MenuItem text="DS9 region File" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
+                        <MenuItem text="DS9 region file" onClick={() => fileBrowserStore.setExportFileType(CARTA.FileType.DS9_REG)} />
                     </Menu>
                 }
                 position={Position.BOTTOM_RIGHT}

--- a/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
@@ -231,7 +231,7 @@ export class ImageSaveComponent extends React.Component {
                                 <ClearableNumericInputComponent
                                     label="Rest frequency"
                                     value={fileBrowser.saveRestFreq.value}
-                                    placeholder="rest frequency"
+                                    placeholder="Rest frequency"
                                     selectAllOnFocus={true}
                                     onValueChanged={fileBrowser.setSaveRestFreqVal}
                                     onValueCleared={fileBrowser.resetSaveRestFreq}

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -115,11 +115,11 @@ export class FittingDialogComponent extends React.Component {
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.IMAGE_FITTING} minWidth={350} minHeight={200} defaultWidth={600} defaultHeight={660} enableResizing={true}>
                 <div className={Classes.DIALOG_BODY}>
-                    <FormGroup label="Data Source" inline={true}>
+                    <FormGroup label="Data source" inline={true}>
                         <HTMLSelect value={fittingStore.selectedFileId} options={fittingStore.frameOptions} onChange={ev => fittingStore.setSelectedFileId(parseInt(ev.target.value))} />
                     </FormGroup>
                     <FormGroup label="Region" inline={true}>
-                        <HTMLSelect value={0} options={[{value: 0, label: "Field of View"}]} disabled={true} />
+                        <HTMLSelect value={0} options={[{value: 0, label: "Field of view"}]} disabled={true} />
                     </FormGroup>
                     <FormGroup label="Components" inline={true}>
                         <SafeNumericInput className="components-input" value={fittingStore.components.length} min={1} max={20} stepSize={1} onValueChange={val => fittingStore.setComponents(Math.round(val))} />
@@ -134,7 +134,7 @@ export class FittingDialogComponent extends React.Component {
                                     onChange={val => fittingStore.setSelectedComponentIndex(val - 1)}
                                     disabled={fittingStore.components.length <= 1}
                                 />
-                                <Tooltip2 content="Delete current component.">
+                                <Tooltip2 content="Delete current component">
                                     <AnchorButton icon={"trash"} onClick={fittingStore.deleteSelectedComponent} />
                                 </Tooltip2>
                             </>
@@ -159,10 +159,10 @@ export class FittingDialogComponent extends React.Component {
                     <div className={Classes.DIALOG_FOOTER_ACTIONS}>
                         <Switch checked={fittingStore.createModelImage} onChange={fittingStore.toggleCreateModelImage} label="Model" />
                         <Switch checked={fittingStore.createResidualImage} onChange={fittingStore.toggleCreateResidualImage} label="Residual" />
-                        <Tooltip2 content="Clear fitting parameters." position={Position.BOTTOM}>
+                        <Tooltip2 content="Clear fitting parameters" position={Position.BOTTOM}>
                             <AnchorButton intent={Intent.WARNING} onClick={fittingStore.clearComponents} text="Clear" />
                         </Tooltip2>
-                        <Tooltip2 content="Clear existing fitting results and fit the current channel of the image." position={Position.BOTTOM} disabled={fittingStore.fitDisabled}>
+                        <Tooltip2 content="Clear existing fitting results and fit the current channel of the image" position={Position.BOTTOM} disabled={fittingStore.fitDisabled}>
                             <AnchorButton intent={Intent.PRIMARY} onClick={fittingStore.fitImage} text="Fit" disabled={fittingStore.fitDisabled} />
                         </Tooltip2>
                     </div>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -715,7 +715,7 @@ export class PreferenceDialogComponent extends React.Component {
             <div className="panel-container">
                 <FormGroup inline={true} label="Displayed columns">
                     <SafeNumericInput
-                        placeholder="Default Displayed Columns"
+                        placeholder="Default displayed columns"
                         min={1}
                         value={preference.catalogDisplayedColumnSize}
                         stepSize={1}

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -193,7 +193,7 @@ export class PreferenceDialogComponent extends React.Component {
                         <option value={WCSMatchingType.NONE}>None</option>
                         <option value={WCSMatchingType.SPATIAL}>Spatial only</option>
                         <option value={WCSMatchingType.SPECTRAL}>Spectral only</option>
-                        <option value={WCSMatchingType.SPATIAL | WCSMatchingType.SPECTRAL}>Spatial and Spectral</option>
+                        <option value={WCSMatchingType.SPATIAL | WCSMatchingType.SPECTRAL}>Spatial and spectral</option>
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Spectral matching">

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -145,20 +145,20 @@ export class PreferenceDialogComponent extends React.Component {
                         <option value={Theme.DARK}>Dark</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Enable Code Snippets">
+                <FormGroup inline={true} label="Enable code snippets">
                     <Switch checked={preference.codeSnippetsEnabled} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_CODE_SNIPPETS_ENABLED, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Auto-launch File Browser">
+                <FormGroup inline={true} label="Auto-launch file browser">
                     <Switch checked={preference.autoLaunch} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_AUTOLAUNCH, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="File List">
+                <FormGroup inline={true} label="File list">
                     <HTMLSelect value={preference.fileFilterMode} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_FILE_FILTER_MODE, ev.currentTarget.value)}>
                         <option value={FileFilterMode.Content}>Filter by file content</option>
                         <option value={FileFilterMode.Extension}>Filter by extension</option>
                         <option value={FileFilterMode.All}>All files</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Initial Layout">
+                <FormGroup inline={true} label="Initial layout">
                     <HTMLSelect value={preference.layout} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_LAYOUT, ev.currentTarget.value)}>
                         {layoutStore.orderedLayoutNames.map(layout => (
                             <option key={layout} value={layout}>
@@ -167,13 +167,13 @@ export class PreferenceDialogComponent extends React.Component {
                         ))}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Initial Cursor Position">
+                <FormGroup inline={true} label="Initial cursor position">
                     <RadioGroup selectedValue={preference.cursorPosition} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_CURSOR_POSITION, ev.currentTarget.value)} inline={true}>
                         <Radio label="Fixed" value={CursorPosition.FIXED} />
                         <Radio label="Tracking" value={CursorPosition.TRACKING} />
                     </RadioGroup>
                 </FormGroup>
-                <FormGroup inline={true} label="Initial Zoom Level">
+                <FormGroup inline={true} label="Initial zoom level">
                     <RadioGroup selectedValue={preference.zoomMode} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_ZOOM_MODE, ev.currentTarget.value)} inline={true}>
                         <Radio label="Zoom to fit" value={Zoom.FIT} />
                         <Radio label="Zoom to 1.0x" value={Zoom.FULL} />
@@ -182,7 +182,7 @@ export class PreferenceDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Zoom to">
                     <RadioGroup selectedValue={preference.zoomPoint} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_ZOOM_POINT, ev.currentTarget.value)} inline={true}>
                         <Radio label="Cursor" value={ZoomPoint.CURSOR} />
-                        <Radio label="Current Center" value={ZoomPoint.CENTER} />
+                        <Radio label="Current center" value={ZoomPoint.CENTER} />
                     </RadioGroup>
                 </FormGroup>
                 <FormGroup inline={true} label="Enable drag-to-pan">
@@ -191,12 +191,12 @@ export class PreferenceDialogComponent extends React.Component {
                 <FormGroup inline={true} label="WCS matching on append">
                     <HTMLSelect value={preference.autoWCSMatching} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING, Number(ev.currentTarget.value))}>
                         <option value={WCSMatchingType.NONE}>None</option>
-                        <option value={WCSMatchingType.SPATIAL}>Spatial Only</option>
-                        <option value={WCSMatchingType.SPECTRAL}>Spectral Only</option>
+                        <option value={WCSMatchingType.SPATIAL}>Spatial only</option>
+                        <option value={WCSMatchingType.SPECTRAL}>Spectral only</option>
                         <option value={WCSMatchingType.SPATIAL | WCSMatchingType.SPECTRAL}>Spatial and Spectral</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Spectral Matching">
+                <FormGroup inline={true} label="Spectral matching">
                     <HTMLSelect value={preference.spectralMatchingType} onChange={ev => appStore.setSpectralMatchingType(ev.currentTarget.value as SpectralType)}>
                         {SPECTRAL_MATCHING_TYPES.map(type => (
                             <option key={type} value={type}>
@@ -205,7 +205,7 @@ export class PreferenceDialogComponent extends React.Component {
                         ))}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Transparent Image Background">
+                <FormGroup inline={true} label="Transparent image background">
                     <Switch checked={preference.transparentImageBackground} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Save last used directory">
@@ -216,13 +216,13 @@ export class PreferenceDialogComponent extends React.Component {
 
         const renderConfigPanel = (
             <React.Fragment>
-                <FormGroup inline={true} label="Default Scaling">
+                <FormGroup inline={true} label="Default scaling">
                     <ScalingSelectComponent selectedItem={preference.scaling} onItemSelect={selected => preference.setPreference(PreferenceKeys.RENDER_CONFIG_SCALING, selected)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color Map">
+                <FormGroup inline={true} label="Default colormap">
                     <ColormapComponent inverted={false} selectedItem={preference.colormap} onItemSelect={selected => preference.setPreference(PreferenceKeys.RENDER_CONFIG_COLORMAP, selected)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Percentile Ranks">
+                <FormGroup inline={true} label="Default percentile ranks">
                     <PercentileSelect
                         activeItem={preference.percentile.toString(10)}
                         onItemSelect={selected => preference.setPreference(PreferenceKeys.RENDER_CONFIG_PERCENTILE, Number(selected))}
@@ -252,7 +252,7 @@ export class PreferenceDialogComponent extends React.Component {
                         />
                     </FormGroup>
                 )}
-                <FormGroup inline={true} label="NaN Color">
+                <FormGroup inline={true} label="NaN color">
                     <ColorPickerComponent
                         color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
                         presetColors={[...SWATCH_COLORS, "transparent"]}
@@ -264,7 +264,7 @@ export class PreferenceDialogComponent extends React.Component {
                         darkTheme={appStore.darkTheme}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Smoothed Bias/Contrast">
+                <FormGroup inline={true} label="Smoothed bias/contrast">
                     <Switch checked={preference.useSmoothedBiasContrast} onChange={ev => preference.setPreference(PreferenceKeys.RENDER_CONFIG_USE_SMOOTHED_BIAS_CONTRAST, ev.currentTarget.checked)} />
                 </FormGroup>
             </React.Fragment>
@@ -272,17 +272,17 @@ export class PreferenceDialogComponent extends React.Component {
 
         const contourConfigPanel = (
             <React.Fragment>
-                <FormGroup inline={true} label="Generator Type">
+                <FormGroup inline={true} label="Generator type">
                     <HTMLSelect
                         value={preference.contourGeneratorType}
                         options={Object.keys(ContourGeneratorType).map(key => ({label: ContourGeneratorType[key], value: ContourGeneratorType[key]}))}
                         onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_GENERATOR_TYPE, ev.currentTarget.value as ContourGeneratorType)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Smoothing Mode">
+                <FormGroup inline={true} label="Smoothing mode">
                     <HTMLSelect value={preference.contourSmoothingMode} onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_SMOOTHING_MODE, Number(ev.currentTarget.value))}>
                         <option key={CARTA.SmoothingMode.NoSmoothing} value={CARTA.SmoothingMode.NoSmoothing}>
-                            No Smoothing
+                            No smoothing
                         </option>
                         <option key={CARTA.SmoothingMode.BlockAverage} value={CARTA.SmoothingMode.BlockAverage}>
                             Block
@@ -292,9 +292,9 @@ export class PreferenceDialogComponent extends React.Component {
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Default Smoothing Factor">
+                <FormGroup inline={true} label="Default smoothing factor">
                     <SafeNumericInput
-                        placeholder="Default Smoothing Factor"
+                        placeholder="Default smoothing factor"
                         min={1}
                         max={33}
                         value={preference.contourSmoothingFactor}
@@ -303,9 +303,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_SMOOTHING_FACTOR, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Contour Levels">
+                <FormGroup inline={true} label="Default contour levels">
                     <SafeNumericInput
-                        placeholder="Default Contour Levels"
+                        placeholder="Default contour levels"
                         min={1}
                         max={15}
                         value={preference.contourNumLevels}
@@ -325,20 +325,20 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_THICKNESS, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color Mode">
+                <FormGroup inline={true} label="Default color mode">
                     <HTMLSelect value={preference.contourColormapEnabled ? 1 : 0} onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_ENABLED, parseInt(ev.currentTarget.value) > 0)}>
                         <option key={0} value={0}>
-                            Constant Color
+                            Constant color
                         </option>
                         <option key={1} value={1}>
                             Color-mapped
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color Map">
+                <FormGroup inline={true} label="Default colormap">
                     <ColormapComponent inverted={false} selectedItem={preference.contourColormap} onItemSelect={selected => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP, selected)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color">
+                <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent
                         color={preference.contourColor}
                         presetColors={SWATCH_COLORS}
@@ -352,9 +352,9 @@ export class PreferenceDialogComponent extends React.Component {
 
         const vectorOverlayConfigPanel = (
             <React.Fragment>
-                <FormGroup inline={true} label="Default Pixel Averaging">
+                <FormGroup inline={true} label="Default pixel averaging">
                     <SafeNumericInput
-                        placeholder="Default Pixel Averaging"
+                        placeholder="Default pixel averaging"
                         min={0}
                         max={64}
                         value={preference.vectorOverlayPixelAveraging}
@@ -363,7 +363,7 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Use Fractional Intensity">
+                <FormGroup inline={true} label="Use fractional intensity">
                     <Switch checked={preference.vectorOverlayFractionalIntensity} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_FRACTIONAL_INTENSITY, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Thickness">
@@ -377,20 +377,20 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_THICKNESS, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color Mode">
+                <FormGroup inline={true} label="Default color mode">
                     <HTMLSelect value={preference.vectorOverlayColormapEnabled ? 1 : 0} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_ENABLED, parseInt(ev.currentTarget.value) > 0)}>
                         <option key={0} value={0}>
-                            Constant Color
+                            Constant color
                         </option>
                         <option key={1} value={1}>
                             Color-mapped
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color Map">
+                <FormGroup inline={true} label="Default colormap">
                     <ColormapComponent inverted={false} selectedItem={preference.vectorOverlayColormap} onItemSelect={selected => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP, selected)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Default Color">
+                <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent
                         color={preference.vectorOverlayColor}
                         presetColors={SWATCH_COLORS}
@@ -407,13 +407,13 @@ export class PreferenceDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Color">
                     <AutoColorPickerComponent color={preference.astColor} presetColors={SWATCH_COLORS} setColor={(color: string) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_COLOR, color)} disableAlpha={true} />
                 </FormGroup>
-                <FormGroup inline={true} label="WCS Grid Visible">
+                <FormGroup inline={true} label="WCS grid visible">
                     <Switch checked={preference.astGridVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_GRID_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Labels Visible">
+                <FormGroup inline={true} label="Labels visible">
                     <Switch checked={preference.astLabelsVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Cursor Info Visible">
+                <FormGroup inline={true} label="Cursor info visible">
                     <HTMLSelect value={preference.cursorInfoVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_CURSOR_INFO, ev.currentTarget.value)}>
                         <option value={CursorInfoVisibility.Always}>Always</option>
                         <option value={CursorInfoVisibility.ActiveImage}>Active image only</option>
@@ -421,29 +421,29 @@ export class PreferenceDialogComponent extends React.Component {
                         <option value={CursorInfoVisibility.Never}>Never</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="WCS Format">
+                <FormGroup inline={true} label="WCS format">
                     <HTMLSelect
                         options={[WCSType.AUTOMATIC, WCSType.DEGREES, WCSType.SEXAGESIMAL]}
                         value={preference.wcsType}
                         onChange={(event: React.FormEvent<HTMLSelectElement>) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_WCS_TYPE, event.currentTarget.value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Visible">
+                <FormGroup inline={true} label="Colorbar visible">
                     <Switch checked={preference.colorbarVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Interactive">
+                <FormGroup inline={true} label="Colorbar interactive">
                     <Switch checked={preference.colorbarInteractive} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_INTERACTIVE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Position">
+                <FormGroup inline={true} label="Colorbar position">
                     <HTMLSelect value={preference.colorbarPosition} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_POSITION, ev.currentTarget.value)}>
-                        <option value={"right"}>right</option>
-                        <option value={"top"}>top</option>
-                        <option value={"bottom"}>bottom</option>
+                        <option value={"right"}>Right</option>
+                        <option value={"top"}>Top</option>
+                        <option value={"bottom"}>Bottom</option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Width" labelInfo="(px)">
+                <FormGroup inline={true} label="Colorbar width" labelInfo="(px)">
                     <SafeNumericInput
-                        placeholder="Colorbar Width"
+                        placeholder="Colorbar width"
                         min={1}
                         max={100}
                         value={preference.colorbarWidth}
@@ -454,9 +454,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={(value: number) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_WIDTH, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Ticks Density" labelInfo="(per 100px)">
+                <FormGroup inline={true} label="Colorbar ticks density" labelInfo="(per 100px)">
                     <SafeNumericInput
-                        placeholder="Colorbar Ticks Density"
+                        placeholder="Colorbar ticks density"
                         min={0.2}
                         max={20}
                         value={preference.colorbarTicksDensity}
@@ -466,16 +466,16 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={(value: number) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_TICKS_DENSITY, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Colorbar Label Visible">
+                <FormGroup inline={true} label="Colorbar label visible">
                     <Switch checked={preference.colorbarLabelVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_LABEL_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Beam Visible">
+                <FormGroup inline={true} label="Beam visible">
                     <Switch checked={preference.beamVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Beam Color">
+                <FormGroup inline={true} label="Beam color">
                     <AutoColorPickerComponent color={preference.beamColor} presetColors={SWATCH_COLORS} setColor={(color: string) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_BEAM_COLOR, color)} disableAlpha={true} />
                 </FormGroup>
-                <FormGroup inline={true} label="Beam Type">
+                <FormGroup inline={true} label="Beam type">
                     <HTMLSelect value={preference.beamType} onChange={(event: React.FormEvent<HTMLSelectElement>) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_BEAM_TYPE, event.currentTarget.value as BeamType)}>
                         <option key={0} value={BeamType.Open}>
                             Open
@@ -485,9 +485,9 @@ export class PreferenceDialogComponent extends React.Component {
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Beam Width" labelInfo="(px)">
+                <FormGroup inline={true} label="Beam width" labelInfo="(px)">
                     <SafeNumericInput
-                        placeholder="Beam Width"
+                        placeholder="Beam width"
                         min={0.5}
                         max={10}
                         value={preference.beamWidth}
@@ -520,9 +520,9 @@ export class PreferenceDialogComponent extends React.Component {
                         darkTheme={appStore.darkTheme}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Line Width" labelInfo="(px)">
+                <FormGroup inline={true} label="Line width" labelInfo="(px)">
                     <SafeNumericInput
-                        placeholder="Line Width"
+                        placeholder="Line width"
                         min={RegionStore.MIN_LINE_WIDTH}
                         max={RegionStore.MAX_LINE_WIDTH}
                         value={preference.regionLineWidth}
@@ -530,9 +530,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_LINE_WIDTH, Math.max(RegionStore.MIN_LINE_WIDTH, Math.min(RegionStore.MAX_LINE_WIDTH, value)))}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Dash Length" labelInfo="(px)">
+                <FormGroup inline={true} label="Dash length" labelInfo="(px)">
                     <SafeNumericInput
-                        placeholder="Dash Length"
+                        placeholder="Dash length"
                         min={0}
                         max={RegionStore.MAX_DASH_LENGTH}
                         value={preference.regionDashLength}
@@ -540,7 +540,7 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_DASH_LENGTH, Math.max(0, Math.min(RegionStore.MAX_DASH_LENGTH, value)))}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Region Type">
+                <FormGroup inline={true} label="Region type">
                     <HTMLSelect value={preference.regionType} onChange={ev => preference.setPreference(PreferenceKeys.REGION_TYPE, Number(ev.currentTarget.value))}>
                         {regionTypes}
                     </HTMLSelect>
@@ -548,7 +548,7 @@ export class PreferenceDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Region size" labelInfo="(px)">
                     <SafeNumericInput placeholder="Region size" min={1} value={preference.regionSize} stepSize={1} onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_SIZE, Math.max(1, value))} />
                 </FormGroup>
-                <FormGroup inline={true} label="Creation Mode">
+                <FormGroup inline={true} label="Creation mode">
                     <RadioGroup selectedValue={preference.regionCreationMode} onChange={ev => preference.setPreference(PreferenceKeys.REGION_CREATION_MODE, ev.currentTarget.value)}>
                         <Radio label="Center to corner" value={RegionCreationMode.CENTER} />
                         <Radio label="Corner to corner" value={RegionCreationMode.CORNER} />
@@ -565,9 +565,9 @@ export class PreferenceDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Limit overlay redraw">
                     <Switch checked={preference.limitOverlayRedraw} onChange={ev => preference.setPreference(PreferenceKeys.PERFORMANCE_LIMIT_OVERLAY_REDRAW, ev.currentTarget.checked)} />
                 </FormGroup>
-                <FormGroup inline={true} label="Compression Quality" labelInfo={"(Images)"}>
+                <FormGroup inline={true} label="Compression quality" labelInfo={"(Images)"}>
                     <SafeNumericInput
-                        placeholder="Compression Quality"
+                        placeholder="Compression quality"
                         min={CompressionQuality.IMAGE_MIN}
                         max={CompressionQuality.IMAGE_MAX}
                         value={preference.imageCompressionQuality}
@@ -575,9 +575,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={this.handleImageCompressionQualityChange}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Compression Quality" labelInfo={"(Animation)"}>
+                <FormGroup inline={true} label="Compression quality" labelInfo={"(Animation)"}>
                     <SafeNumericInput
-                        placeholder="Compression Quality"
+                        placeholder="Compression quality"
                         min={CompressionQuality.ANIMATION_MIN}
                         max={CompressionQuality.ANIMATION_MAX}
                         value={preference.animationCompressionQuality}
@@ -585,9 +585,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={this.handleAnimationCompressionQualityChange}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="GPU Tile Cache Size">
+                <FormGroup inline={true} label="GPU tile cache size">
                     <SafeNumericInput
-                        placeholder="GPU Tile Cache Size"
+                        placeholder="GPU tile cache size"
                         min={TileCache.GPU_MIN}
                         max={TileCache.GPU_MAX}
                         value={preference.gpuTileCache}
@@ -596,9 +596,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={this.handleGPUTileCacheChange}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="System Tile Cache Size">
+                <FormGroup inline={true} label="System tile cache size">
                     <SafeNumericInput
-                        placeholder="System Tile Cache Size"
+                        placeholder="System tile cache size"
                         min={TileCache.SYSTEM_MIN}
                         max={TileCache.SYSTEM_MAX}
                         value={preference.systemTileCache}
@@ -607,9 +607,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={this.handleSystemTileCacheChange}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Contour Rounding Factor">
+                <FormGroup inline={true} label="Contour rounding factor">
                     <SafeNumericInput
-                        placeholder="Contour Rounding Factor"
+                        placeholder="Contour rounding factor"
                         min={1}
                         max={32}
                         value={preference.contourDecimation}
@@ -618,9 +618,9 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.PERFORMANCE_CONTOUR_DECIMATION, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Contour Compression Level">
+                <FormGroup inline={true} label="Contour compression level">
                     <SafeNumericInput
-                        placeholder="Contour Compression Level"
+                        placeholder="Contour compression level"
                         min={0}
                         max={19}
                         value={preference.contourCompressionLevel}
@@ -629,7 +629,7 @@ export class PreferenceDialogComponent extends React.Component {
                         onValueChange={value => preference.setPreference(PreferenceKeys.PERFORMANCE_CONTOUR_COMPRESSION_LEVEL, value)}
                     />
                 </FormGroup>
-                <FormGroup inline={true} label="Contour Chunk Size">
+                <FormGroup inline={true} label="Contour chunk size">
                     <HTMLSelect value={preference.contourChunkSize} onChange={ev => preference.setPreference(PreferenceKeys.PERFORMANCE_CONTOUR_CHUNK_SIZE, parseInt(ev.currentTarget.value))}>
                         <option key={0} value={25000}>
                             25K
@@ -651,7 +651,7 @@ export class PreferenceDialogComponent extends React.Component {
                         </option>
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Control Map Resolution">
+                <FormGroup inline={true} label="Control map resolution">
                     <HTMLSelect value={preference.contourControlMapWidth} onChange={ev => preference.setPreference(PreferenceKeys.PERFORMANCE_CONTOUR_CONTROL_MAP_WIDTH, parseInt(ev.currentTarget.value))}>
                         <option key={0} value={128}>
                             128&times;128 (128 KB)

--- a/src/components/Dialogs/RegionDialog/AppearanceForm/AppearanceForm.tsx
+++ b/src/components/Dialogs/RegionDialog/AppearanceForm/AppearanceForm.tsx
@@ -41,13 +41,13 @@ export class AppearanceForm extends React.Component<{region: RegionStore; darkTh
                         <ColorPickerComponent color={region.color} presetColors={SWATCH_COLORS} setColor={(color: ColorResult) => region.setColor(color.hex)} disableAlpha={true} darkTheme={this.props.darkTheme} />
                     </FormGroup>
                     {region.regionType !== CARTA.RegionType.POINT && (
-                        <FormGroup inline={true} label="Line Width" labelInfo="(px)">
-                            <SafeNumericInput placeholder="Line Width" min={RegionStore.MIN_LINE_WIDTH} max={RegionStore.MAX_LINE_WIDTH} value={region.lineWidth} stepSize={0.5} onValueChange={this.handleLineWidthChange} />
+                        <FormGroup inline={true} label="Line width" labelInfo="(px)">
+                            <SafeNumericInput placeholder="Line width" min={RegionStore.MIN_LINE_WIDTH} max={RegionStore.MAX_LINE_WIDTH} value={region.lineWidth} stepSize={0.5} onValueChange={this.handleLineWidthChange} />
                         </FormGroup>
                     )}
                     {region.regionType !== CARTA.RegionType.POINT && (
-                        <FormGroup inline={true} label="Dash Length" labelInfo="(px)">
-                            <SafeNumericInput placeholder="Dash Length" min={0} max={RegionStore.MAX_DASH_LENGTH} value={region.dashLength} stepSize={1} onValueChange={this.handleDashLengthChange} />
+                        <FormGroup inline={true} label="Dash length" labelInfo="(px)">
+                            <SafeNumericInput placeholder="Dash length" min={0} max={RegionStore.MAX_DASH_LENGTH} value={region.dashLength} stepSize={1} onValueChange={this.handleDashLengthChange} />
                         </FormGroup>
                     )}
                 </div>

--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -206,7 +206,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
                     <table>
                         <tbody>
                             <tr>
-                                <td>Region Name</td>
+                                <td>Region name</td>
                                 <td colSpan={2}>
                                     <InputGroup placeholder="Enter a region name" value={region.name} onChange={this.handleNameChange} />
                                 </td>

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -402,8 +402,8 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         const startWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, this.startPoint);
         let startInputX, startInputY;
         if (region.coordinate === CoordinateMode.Image) {
-            startInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={this.startPoint.x} onBlur={this.handleStartXChange} onKeyDown={this.handleStartXChange} />;
-            startInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={this.startPoint.y} onBlur={this.handleStartYChange} onKeyDown={this.handleStartYChange} />;
+            startInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={this.startPoint.x} onBlur={this.handleStartXChange} onKeyDown={this.handleStartXChange} />;
+            startInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={this.startPoint.y} onBlur={this.handleStartYChange} onKeyDown={this.handleStartYChange} />;
         } else {
             startInputX = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>
@@ -438,8 +438,8 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         const endWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, this.endPoint);
         let endInputX, endInputY;
         if (region.coordinate === CoordinateMode.Image) {
-            endInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={this.endPoint.x} onBlur={this.handleEndXChange} onKeyDown={this.handleEndXChange} />;
-            endInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={this.endPoint.y} onBlur={this.handleEndYChange} onKeyDown={this.handleEndYChange} />;
+            endInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={this.endPoint.x} onBlur={this.handleEndXChange} onKeyDown={this.handleEndXChange} />;
+            endInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={this.endPoint.y} onBlur={this.handleEndYChange} onKeyDown={this.handleEndYChange} />;
         } else {
             endInputX = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>
@@ -475,8 +475,8 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         const centerWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, centerPoint);
         let centerInputX, centerInputY;
         if (region.coordinate === CoordinateMode.Image) {
-            centerInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
-            centerInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
+            centerInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
+            centerInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
         } else {
             centerInputX = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -446,7 +446,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !endWCSPoint}
                         value={endWCSPoint ? endWCSPoint.x : ""}
                         onBlur={this.handleEndXWCSChange}
@@ -459,7 +459,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !endWCSPoint}
                         value={endWCSPoint ? endWCSPoint.y : ""}
                         onBlur={this.handleEndYWCSChange}
@@ -537,7 +537,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <table>
                         <tbody>
                             <tr>
-                                <td>Region Name</td>
+                                <td>Region name</td>
                                 <td colSpan={2}>
                                     <InputGroup placeholder="Enter a region name" value={region.name} onChange={this.handleNameChange} />
                                 </td>

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -410,7 +410,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !startWCSPoint}
                         value={startWCSPoint ? startWCSPoint.x : ""}
                         onBlur={this.handleStartXWCSChange}
@@ -423,7 +423,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !startWCSPoint}
                         value={startWCSPoint ? startWCSPoint.y : ""}
                         onBlur={this.handleStartYWCSChange}
@@ -483,7 +483,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.x : ""}
                         onBlur={this.handleCenterWCSXChange}
@@ -496,7 +496,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.y : ""}
                         onBlur={this.handleCenterWCSYChange}

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -118,8 +118,8 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
         const centerWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, centerPoint);
         let xInput, yInput;
         if (region.coordinate === CoordinateMode.Image) {
-            xInput = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
-            yInput = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
+            xInput = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
+            yInput = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
         } else {
             xInput = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -126,7 +126,7 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.x : ""}
                         onBlur={this.handleCenterWCSXChange}
@@ -139,7 +139,7 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.y : ""}
                         onBlur={this.handleCenterWCSYChange}
@@ -157,7 +157,7 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
                     <table>
                         <tbody>
                             <tr>
-                                <td>Region Name</td>
+                                <td>Region name</td>
                                 <td colSpan={2}>
                                     <InputGroup placeholder="Enter a region name" value={region.name} onChange={this.handleNameChange} />
                                 </td>

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -105,7 +105,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                     <SafeNumericInput
                         selectAllOnFocus={true}
                         buttonPosition="none"
-                        placeholder="X Coordinate"
+                        placeholder="X coordinate"
                         value={point.x}
                         onBlur={evt => this.handlePointChange(index, true, evt)}
                         onKeyDown={evt => this.handlePointChange(index, true, evt)}
@@ -115,7 +115,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                     <SafeNumericInput
                         selectAllOnFocus={true}
                         buttonPosition="none"
-                        placeholder="Y Coordinate"
+                        placeholder="Y coordinate"
                         value={point.y}
                         onBlur={evt => this.handlePointChange(index, false, evt)}
                         onKeyDown={evt => this.handlePointChange(index, false, evt)}

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -127,7 +127,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                         <SafeNumericInput
                             allowNumericCharactersOnly={false}
                             buttonPosition="none"
-                            placeholder="X WCS Coordinate"
+                            placeholder="X WCS coordinate"
                             disabled={!this.props.wcsInfo || !pointWCS}
                             value={pointWCS ? pointWCS.x : ""}
                             onBlur={evt => this.handleWCSPointChange(index, true, evt)}
@@ -140,7 +140,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                         <SafeNumericInput
                             allowNumericCharactersOnly={false}
                             buttonPosition="none"
-                            placeholder="Y WCS Coordinate"
+                            placeholder="Y WCS coordinate"
                             disabled={!this.props.wcsInfo || !pointWCS}
                             value={pointWCS ? pointWCS.y : ""}
                             onBlur={evt => this.handleWCSPointChange(index, false, evt)}
@@ -170,7 +170,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                     <table>
                         <tbody>
                             <tr>
-                                <td>Region Name</td>
+                                <td>Region name</td>
                                 <td colSpan={2}>
                                     <InputGroup placeholder="Enter a region name" value={region.name} onChange={this.handleNameChange} />
                                 </td>

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -603,7 +603,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <table>
                         <tbody>
                             <tr>
-                                <td>Region Name</td>
+                                <td>Region name</td>
                                 <td colSpan={2}>
                                     <InputGroup placeholder="Enter a region name" value={region.name} onChange={this.handleNameChange} />
                                 </td>

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -458,7 +458,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.x : ""}
                         onBlur={this.handleCenterWCSXChange}
@@ -471,7 +471,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !centerWCSPoint}
                         value={centerWCSPoint ? centerWCSPoint.y : ""}
                         onBlur={this.handleCenterWCSYChange}
@@ -499,7 +499,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !bottomLeftWCSPoint || isRotated}
                         value={bottomLeftWCSPoint ? bottomLeftWCSPoint.x : ""}
                         onBlur={this.handleLeftWCSChange}
@@ -512,7 +512,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !bottomLeftWCSPoint || isRotated}
                         value={bottomLeftWCSPoint ? bottomLeftWCSPoint.y : ""}
                         onBlur={this.handleBottomWCSChange}
@@ -535,7 +535,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="X WCS Coordinate"
+                        placeholder="X WCS coordinate"
                         disabled={!this.props.wcsInfo || !topRightWCSPoint || isRotated}
                         value={topRightWCSPoint ? topRightWCSPoint.x : ""}
                         onBlur={this.handleRightWCSChange}
@@ -548,7 +548,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                     <SafeNumericInput
                         allowNumericCharactersOnly={false}
                         buttonPosition="none"
-                        placeholder="Y WCS Coordinate"
+                        placeholder="Y WCS coordinate"
                         disabled={!this.props.wcsInfo || !topRightWCSPoint || isRotated}
                         value={topRightWCSPoint ? topRightWCSPoint.y : ""}
                         onBlur={this.handleTopWCSChange}
@@ -631,7 +631,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                                 </td>
                             </tr>
                             <tr>
-                                <td>Bottom Left {pxUnitSpan}</td>
+                                <td>Bottom-left {pxUnitSpan}</td>
                                 <td>{bottomLeftInputX}</td>
                                 <td>{bottomLeftInputY}</td>
                                 <td>
@@ -639,7 +639,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                                 </td>
                             </tr>
                             <tr>
-                                <td>Top Right {pxUnitSpan}</td>
+                                <td>Top-right {pxUnitSpan}</td>
                                 <td>{topRightInputX}</td>
                                 <td>{topRightInputY}</td>
                                 <td>

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -450,8 +450,8 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
         const centerWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, centerPoint);
         let centerInputX, centerInputY;
         if (region.coordinate === CoordinateMode.Image) {
-            centerInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
-            centerInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
+            centerInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={centerPoint.x} onBlur={this.handleCenterXChange} onKeyDown={this.handleCenterXChange} />;
+            centerInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={centerPoint.y} onBlur={this.handleCenterYChange} onKeyDown={this.handleCenterYChange} />;
         } else {
             centerInputX = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>
@@ -488,10 +488,10 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
         let bottomLeftInputX, bottomLeftInputY;
         if (region.coordinate === CoordinateMode.Image) {
             bottomLeftInputX = (
-                <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={this.bottomLeftPoint.x} onBlur={this.handleLeftChange} onKeyDown={this.handleLeftChange} disabled={isRotated} />
+                <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={this.bottomLeftPoint.x} onBlur={this.handleLeftChange} onKeyDown={this.handleLeftChange} disabled={isRotated} />
             );
             bottomLeftInputY = (
-                <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={this.bottomLeftPoint.y} onBlur={this.handleBottomChange} onKeyDown={this.handleBottomChange} disabled={isRotated} />
+                <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={this.bottomLeftPoint.y} onBlur={this.handleBottomChange} onKeyDown={this.handleBottomChange} disabled={isRotated} />
             );
         } else {
             bottomLeftInputX = (
@@ -527,8 +527,8 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
         const topRightWCSPoint = getFormattedWCSPoint(this.props.wcsInfo, this.topRightPoint);
         let topRightInputX, topRightInputY;
         if (region.coordinate === CoordinateMode.Image) {
-            topRightInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X Coordinate" value={this.topRightPoint.x} onBlur={this.handleRightChange} onKeyDown={this.handleRightChange} disabled={isRotated} />;
-            topRightInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y Coordinate" value={this.topRightPoint.y} onBlur={this.handleTopChange} onKeyDown={this.handleTopChange} disabled={isRotated} />;
+            topRightInputX = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="X coordinate" value={this.topRightPoint.x} onBlur={this.handleRightChange} onKeyDown={this.handleRightChange} disabled={isRotated} />;
+            topRightInputY = <SafeNumericInput selectAllOnFocus={true} buttonPosition="none" placeholder="Y coordinate" value={this.topRightPoint.y} onBlur={this.handleTopChange} onKeyDown={this.handleTopChange} disabled={isRotated} />;
         } else {
             topRightInputX = (
                 <Tooltip2 content={`Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`} position={Position.BOTTOM} hoverOpenDelay={300}>

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -343,7 +343,7 @@ export class VectorOverlayDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Color mode">
                     <HTMLSelect value={dataSource.vectorOverlayConfig.colormapEnabled ? 1 : 0} onChange={ev => dataSource.vectorOverlayConfig.setColormapEnabled(parseInt(ev.currentTarget.value) > 0)}>
                         <option key={0} value={0}>
-                            Constant Color
+                            Constant color
                         </option>
                         <option key={1} value={1}>
                             Color-mapped

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -223,7 +223,7 @@ export class VectorOverlayDialogComponent extends React.Component {
         const intensityOnly = frame.vectorOverlayConfig.angularSource === VectorOverlaySource.None;
 
         return (
-            <FormGroup label={intensityOnly ? "Block Width" : "Line Length"} labelInfo="(px)" inline={true}>
+            <FormGroup label={intensityOnly ? "Block width" : "Line length"} labelInfo="(px)" inline={true}>
                 <div className="parameter-container">
                     <div className="parameter-line parameter-length">
                         <FormGroup inline={true} label="Min">
@@ -273,33 +273,33 @@ export class VectorOverlayDialogComponent extends React.Component {
 
         const configPanel = (
             <div className="vector-overlay-config-panel">
-                <FormGroup inline={true} label="Angular Source">
+                <FormGroup inline={true} label="Angular source">
                     <HTMLSelect value={this.angularSource} onChange={this.handleAngularSourceChanged}>
                         <option value={VectorOverlaySource.None}>None</option>
                         <option value={VectorOverlaySource.Current}>Current image</option>
                         {dataSource.hasLinearStokes && <option value={VectorOverlaySource.Computed}>Computed PA</option>}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Intensity Source">
+                <FormGroup inline={true} label="Intensity source">
                     <HTMLSelect value={this.intensitySource} onChange={this.handleIntensitySourceChanged}>
                         <option value={VectorOverlaySource.None}>None</option>
                         <option value={VectorOverlaySource.Current}>Current image</option>
                         {dataSource.hasLinearStokes && <option value={VectorOverlaySource.Computed}>Computed PI</option>}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Pixel Averaging">
+                <FormGroup inline={true} label="Pixel averaging">
                     <Switch checked={this.pixelAveragingEnabled} onChange={this.handlePixelAveragingEnabledChanged} />
                 </FormGroup>
-                <FormGroup inline={true} label="Averaging Width" labelInfo="(px)" disabled={!this.pixelAveragingEnabled}>
+                <FormGroup inline={true} label="Averaging width" labelInfo="(px)" disabled={!this.pixelAveragingEnabled}>
                     <SafeNumericInput placeholder="Width (px)" min={2} max={64} value={this.pixelAveraging} majorStepSize={2} stepSize={2} onValueChange={this.handlePixelAveragingChanged} disabled={!this.pixelAveragingEnabled} />
                 </FormGroup>
-                <FormGroup inline={true} label="Polarization Intensity" disabled={this.intensitySource === VectorOverlaySource.None}>
+                <FormGroup inline={true} label="Polarization intensity" disabled={this.intensitySource === VectorOverlaySource.None}>
                     <RadioGroup inline={true} onChange={this.handleFractionalIntensityChanged} selectedValue={this.fractionalIntensity ? 1 : 0} disabled={this.intensitySource === VectorOverlaySource.None}>
                         <Radio label={"Absolute"} value={0} />
                         <Radio label={"Fractional"} value={1} />
                     </RadioGroup>
                 </FormGroup>
-                <FormGroup inline={true} label="Threshold Enabled">
+                <FormGroup inline={true} label="Threshold enabled">
                     <Switch checked={this.thresholdEnabled} onChange={this.handleThresholdEnabledChanged} />
                 </FormGroup>
                 <FormGroup disabled={!this.thresholdEnabled} inline={true} label="Threshold" labelInfo={dataSource.headerUnit ? `(${dataSource.headerUnit})` : ""}>
@@ -308,10 +308,10 @@ export class VectorOverlayDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Debiasing">
                     <Switch checked={this.debiasing} onChange={this.handleDebiasingChanged} />
                 </FormGroup>
-                <FormGroup disabled={!this.debiasing} inline={true} label="Stokes Q Error">
+                <FormGroup disabled={!this.debiasing} inline={true} label="Stokes Q error">
                     <SafeNumericInput disabled={!this.debiasing} buttonPosition="none" placeholder="Value" value={this.qError} onValueChange={this.handleQErrorChanged} />
                 </FormGroup>
-                <FormGroup disabled={!this.debiasing} inline={true} label="Stokes U Error">
+                <FormGroup disabled={!this.debiasing} inline={true} label="Stokes U error">
                     <SafeNumericInput disabled={!this.debiasing} buttonPosition="none" placeholder="Value" value={this.uError} onValueChange={this.handleUErrorChanged} />
                 </FormGroup>
             </div>
@@ -319,7 +319,7 @@ export class VectorOverlayDialogComponent extends React.Component {
 
         const stylingPanel = (
             <div className="vector-overlay-style-panel">
-                <FormGroup disabled={intensityOnly} inline={true} label="Line Thickness" labelInfo="(px)">
+                <FormGroup disabled={intensityOnly} inline={true} label="Line thickness" labelInfo="(px)">
                     <SafeNumericInput
                         disabled={intensityOnly}
                         placeholder="Thickness"
@@ -340,7 +340,7 @@ export class VectorOverlayDialogComponent extends React.Component {
                     onValueChanged={dataSource.vectorOverlayConfig.setRotationOffset}
                     onValueCleared={() => dataSource.vectorOverlayConfig.setRotationOffset(0)}
                 />
-                <FormGroup inline={true} label="Color Mode">
+                <FormGroup inline={true} label="Color mode">
                     <HTMLSelect value={dataSource.vectorOverlayConfig.colormapEnabled ? 1 : 0} onChange={ev => dataSource.vectorOverlayConfig.setColormapEnabled(parseInt(ev.currentTarget.value) > 0)}>
                         <option key={0} value={0}>
                             Constant Color
@@ -352,7 +352,7 @@ export class VectorOverlayDialogComponent extends React.Component {
                 </FormGroup>
                 {dataSource.vectorOverlayConfig.colormapEnabled ? (
                     <React.Fragment>
-                        <FormGroup inline={true} label="Color Map">
+                        <FormGroup inline={true} label="Colormap">
                             <ColormapComponent inverted={false} selectedItem={dataSource.vectorOverlayConfig.colormap} onItemSelect={dataSource.vectorOverlayConfig.setColormap} />
                         </FormGroup>
                         <FormGroup inline={true} label="Bias">
@@ -387,7 +387,7 @@ export class VectorOverlayDialogComponent extends React.Component {
         return (
             <DraggableDialogComponent dialogProps={dialogProps} helpType={HelpType.VECTOR_OVERLAY} defaultWidth={VectorOverlayDialogComponent.DefaultWidth} defaultHeight={VectorOverlayDialogComponent.DefaultHeight} enableResizing={true}>
                 <div className={Classes.DIALOG_BODY}>
-                    <FormGroup inline={true} label="Data Source">
+                    <FormGroup inline={true} label="Data source">
                         <DataSourceSelect
                             activeItem={dataSource}
                             onItemSelect={appStore.setActiveFrame}

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -499,9 +499,9 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                 </FormGroup>
                 <FormGroup inline={true} label="Position" disabled={!colorbar.visible}>
                     <HTMLSelect value={colorbar.position} disabled={!colorbar.visible} onChange={ev => colorbar.setPosition(ev.currentTarget.value)}>
-                        <option value={"right"}>right</option>
-                        <option value={"top"}>top</option>
-                        <option value={"bottom"}>bottom</option>
+                        <option value={"right"}>Right</option>
+                        <option value={"top"}>Top</option>
+                        <option value={"bottom"}>Bottom</option>
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Width" labelInfo="(px)" disabled={!colorbar.visible}>

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -471,10 +471,10 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                     <Switch checked={labels.customText} disabled={!labels.visible} onChange={ev => labels.setCustomText(ev.currentTarget.checked)} />
                 </FormGroup>
                 <Collapse isOpen={labels.customText}>
-                    <FormGroup inline={true} label="Label Text (X)" disabled={!labels.visible}>
+                    <FormGroup inline={true} label="Label text (X)" disabled={!labels.visible}>
                         <InputGroup disabled={!labels.visible} value={labels.customLabelX} placeholder="Enter label text" onChange={ev => labels.setCustomLabelX(ev.currentTarget.value)} />
                     </FormGroup>
-                    <FormGroup inline={true} label="Label Text (Y)" disabled={!labels.visible}>
+                    <FormGroup inline={true} label="Label text (Y)" disabled={!labels.visible}>
                         <InputGroup disabled={!labels.visible} value={labels.customLabelY} placeholder="Enter label text" onChange={ev => labels.setCustomLabelY(ev.currentTarget.value)} />
                     </FormGroup>
                 </Collapse>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -229,7 +229,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                             position={tooltipPosition}
                             content={
                                 <span>
-                                    Distance Measurement
+                                    Distance measurement
                                     <br />
                                     <i>
                                         <small>Click to create geodesic curves.</small>
@@ -338,7 +338,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                                 position={tooltipPosition}
                                 content={
                                     <span>
-                                        WCS Matching <br />
+                                        WCS matching <br />
                                         <small>
                                             <i>Current: {wcsButtonTooltip}</i>
                                         </small>
@@ -355,7 +355,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                                 position={tooltipPosition}
                                 content={
                                     <span>
-                                        Overlay Coordinate <br />
+                                        Overlay coordinate <br />
                                         <small>
                                             <i>Current: {ToolbarComponent.CoordinateSystemTooltip.get(coordinateSystem)}</i>
                                         </small>

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -188,7 +188,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const wcsMatchingMenu = (
             <Menu>
                 <MenuItem
-                    text={`Spectral (${preferenceStore.spectralMatchingType}) and Spatial`}
+                    text={`Spectral (${preferenceStore.spectralMatchingType}) and spatial`}
                     disabled={!canEnableSpatialMatching || !canEnableSpectralMatching}
                     active={spectralMatchingEnabled && spatialMatchingEnabled}
                     onClick={() => appStore.setMatchingEnabled(true, true)}

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -319,10 +319,10 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                                 active={frame.regionSet.mode === RegionMode.MOVING && appStore.activeLayer === ImageViewLayer.RegionMoving}
                             />
                         </Tooltip2>
-                        <Tooltip2 position={tooltipPosition} content={<span>Zoom in (Scroll wheel up){currentZoomSpan}</span>}>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom in (scroll wheel up){currentZoomSpan}</span>}>
                             <AnchorButton icon={"zoom-in"} onClick={this.handleZoomInClicked} />
                         </Tooltip2>
-                        <Tooltip2 position={tooltipPosition} content={<span>Zoom out (Scroll wheel down){currentZoomSpan}</span>}>
+                        <Tooltip2 position={tooltipPosition} content={<span>Zoom out (scroll wheel down){currentZoomSpan}</span>}>
                             <AnchorButton icon={"zoom-out"} onClick={this.handleZoomOutClicked} />
                         </Tooltip2>
                         <Tooltip2 position={tooltipPosition} content={<span>Zoom to 1.0x{currentZoomSpan}</span>}>

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -121,7 +121,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         position={"bottom"}
                         content={
                             <span>
-                                Raster layer
+                                Raster Layer
                                 <br />
                                 <i>
                                     <small>Click to {frame.renderConfig.visible ? "hide" : "show"}</small>
@@ -138,7 +138,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                             position={"bottom"}
                             content={
                                 <span>
-                                    Contour layer
+                                    Contour Layer
                                     <br />
                                     <i>
                                         <small>Click to {frame.contourConfig.visible ? "hide" : "show"}</small>
@@ -156,7 +156,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                             position={"bottom"}
                             content={
                                 <span>
-                                    Vector overlay layer
+                                    Vector Overlay Layer
                                     <br />
                                     <i>
                                         <small>Click to {frame.vectorOverlayConfig.visible ? "hide" : "show"}</small>
@@ -195,7 +195,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Spatial matching
+                            Spatial Matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>
@@ -230,7 +230,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Spectral matching
+                            Spectral Matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>
@@ -265,7 +265,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Raster scaling matching
+                            Raster Scaling Matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>

--- a/src/components/LayerList/LayerListComponent.tsx
+++ b/src/components/LayerList/LayerListComponent.tsx
@@ -121,7 +121,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                         position={"bottom"}
                         content={
                             <span>
-                                Raster Layer
+                                Raster layer
                                 <br />
                                 <i>
                                     <small>Click to {frame.renderConfig.visible ? "hide" : "show"}</small>
@@ -138,7 +138,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                             position={"bottom"}
                             content={
                                 <span>
-                                    Contour Layer
+                                    Contour layer
                                     <br />
                                     <i>
                                         <small>Click to {frame.contourConfig.visible ? "hide" : "show"}</small>
@@ -156,7 +156,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                             position={"bottom"}
                             content={
                                 <span>
-                                    Vector Overlay Layer
+                                    Vector overlay layer
                                     <br />
                                     <i>
                                         <small>Click to {frame.vectorOverlayConfig.visible ? "hide" : "show"}</small>
@@ -195,7 +195,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Spatial Matching
+                            Spatial matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>
@@ -230,7 +230,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Spectral Matching
+                            Spectral matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>
@@ -265,7 +265,7 @@ export class LayerListComponent extends React.Component<WidgetProps> {
                     position={"bottom"}
                     content={
                         <span>
-                            Raster Scaling Matching
+                            Raster scaling matching
                             <br />
                             <i>
                                 <small>{tooltipSubtitle}</small>

--- a/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
+++ b/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
@@ -62,7 +62,7 @@ export class LayerListSettingsPanelComponent extends React.Component<WidgetProps
                     label="Rest frequency"
                     value={restFreqStore.customRestFreq.value}
                     disabled={frameOption.disable}
-                    placeholder="rest frequency"
+                    placeholder="Rest frequency"
                     selectAllOnFocus={true}
                     onValueChanged={val => {
                         restFreqStore.setCustomVal(val);

--- a/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
+++ b/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
@@ -86,7 +86,7 @@ export class LayerListSettingsPanelComponent extends React.Component<WidgetProps
 
         const matchingPanel = (
             <div className="panel-container">
-                <FormGroup inline={true} label="Spectral Matching Type">
+                <FormGroup inline={true} label="Spectral matching type">
                     <HTMLSelect value={appStore.preferenceStore.spectralMatchingType} onChange={ev => appStore.setSpectralMatchingType(ev.currentTarget.value as SpectralType)}>
                         {SPECTRAL_MATCHING_TYPES.map(type => (
                             <option key={type} value={type}>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -316,7 +316,7 @@ export class RootMenuComponent extends React.Component {
                 <Menu.Item text="Vector Overlay" icon={<CustomIcon icon="vectorOverlay" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showVectorOverlayDialog} />
                 <Menu.Item text="Image Fitting" icon={<CustomIcon icon="imageFitting" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showFittingDialog} />
                 <Menu.Item text="Online Catalog Query" icon="geosearch" disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showCatalogQueryDialog} />
-                {appStore.preferenceStore.codeSnippetsEnabled && <Menu.Item text="Code snippets" icon={"console"} onClick={appStore.dialogStore.showCodeSnippetDialog} />}
+                {appStore.preferenceStore.codeSnippetsEnabled && <Menu.Item text="Code Snippets" icon={"console"} onClick={appStore.dialogStore.showCodeSnippetDialog} />}
             </Menu>
         );
 

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -439,7 +439,7 @@ export class RootMenuComponent extends React.Component {
                 </div>
                 <div className={Classes.ALERT_FOOTER}>
                     <Button intent={Intent.PRIMARY} text="OK" onClick={this.newReleaseButtonOnClick} />
-                    <Switch checked={this.disableCheckRelease} onChange={this.toggleDisableCheckRelease} label="Don't show new releases again." />
+                    <Switch checked={this.disableCheckRelease} onChange={this.toggleDisableCheckRelease} label="Don't show new releases again" />
                 </div>
             </div>
         );

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -220,34 +220,34 @@ export class RootMenuComponent extends React.Component {
 
         const fileMenu = (
             <Menu>
-                <Menu.Item text="Open image" label={`${modString}O`} disabled={appStore.openFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, false)} />
-                <Menu.Item text="Append image" label={`${modString}L`} disabled={appStore.appendFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />
+                <Menu.Item text="Open Image" label={`${modString}O`} disabled={appStore.openFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, false)} />
+                <Menu.Item text="Append Image" label={`${modString}L`} disabled={appStore.appendFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />
                 <Tooltip2 content={"not allowed in read-only mode"} disabled={appStore.appendFileDisabled || appStore.backendService?.serverFeatureFlags !== CARTA.ServerFeatureFlags.READ_ONLY} position={Position.LEFT}>
                     <Menu.Item
-                        text="Save image"
+                        text="Save Image"
                         label={`${modString}S`}
                         disabled={appStore.appendFileDisabled || appStore.backendService?.serverFeatureFlags === CARTA.ServerFeatureFlags.READ_ONLY}
                         onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)}
                     />
                 </Tooltip2>
-                <Menu.Item text="Close image" label={`${modString}W`} disabled={appStore.appendFileDisabled} onClick={() => appStore.closeCurrentFile(true)} />
+                <Menu.Item text="Close Image" label={`${modString}W`} disabled={appStore.appendFileDisabled} onClick={() => appStore.closeCurrentFile(true)} />
                 <Menu.Divider />
-                <Menu.Item text="Import regions" disabled={!appStore.activeFrame} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)} />
+                <Menu.Item text="Import Regions" disabled={!appStore.activeFrame} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)} />
                 <Tooltip2
                     content={"not allowed in read-only mode"}
                     disabled={!appStore.activeFrame || !appStore.activeFrame.regionSet.regions || appStore.activeFrame.regionSet.regions.length <= 1 || appStore.backendService?.serverFeatureFlags !== CARTA.ServerFeatureFlags.READ_ONLY}
                     position={Position.LEFT}
                 >
                     <Menu.Item
-                        text="Export regions"
+                        text="Export Regions"
                         disabled={!appStore.activeFrame || !appStore.activeFrame.regionSet.regions || appStore.activeFrame.regionSet.regions.length <= 1 || appStore.backendService.serverFeatureFlags === CARTA.ServerFeatureFlags.READ_ONLY}
                         onClick={() => appStore.fileBrowserStore.showExportRegions()}
                     />
                 </Tooltip2>
                 <Menu.Divider />
-                <Menu.Item text="Import catalog" label={`${modString}G`} disabled={appStore.appendFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)} />
+                <Menu.Item text="Import Catalog" label={`${modString}G`} disabled={appStore.appendFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)} />
                 <Menu.Divider />
-                <Menu.Item text="Export image" disabled={!appStore.activeFrame || appStore.isExportingImage}>
+                <Menu.Item text="Export Image" disabled={!appStore.activeFrame || appStore.isExportingImage}>
                     <ExportImageMenuComponent />
                 </Menu.Item>
                 <Menu.Item text="Preferences" onClick={appStore.dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE} />
@@ -307,14 +307,14 @@ export class RootMenuComponent extends React.Component {
                     <Menu.Item text="Images" icon={"multi-select"}>
                         {layerItems}
                         <Menu.Divider />
-                        <Menu.Item text="Previous image" icon={"step-backward"} disabled={layerItems.length < 2} onClick={appStore.prevFrame} />
-                        <Menu.Item text="Next image" icon={"step-forward"} disabled={layerItems.length < 2} onClick={appStore.nextFrame} />
+                        <Menu.Item text="Previous Image" icon={"step-backward"} disabled={layerItems.length < 2} onClick={appStore.prevFrame} />
+                        <Menu.Item text="Next Image" icon={"step-forward"} disabled={layerItems.length < 2} onClick={appStore.nextFrame} />
                     </Menu.Item>
                 )}
-                <Menu.Item text="File header" icon={"app-header"} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showFileInfoDialog} />
+                <Menu.Item text="File Header" icon={"app-header"} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showFileInfoDialog} />
                 <Menu.Item text="Contours" icon={<CustomIcon icon="contour" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showContourDialog} />
-                <Menu.Item text="Vector overlay" icon={<CustomIcon icon="vectorOverlay" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showVectorOverlayDialog} />
-                <Menu.Item text="Image fitting" icon={<CustomIcon icon="imageFitting" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showFittingDialog} />
+                <Menu.Item text="Vector Overlay" icon={<CustomIcon icon="vectorOverlay" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showVectorOverlayDialog} />
+                <Menu.Item text="Image Fitting" icon={<CustomIcon icon="imageFitting" />} disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showFittingDialog} />
                 <Menu.Item text="Online Catalog Query" icon="geosearch" disabled={!appStore.activeFrame} onClick={appStore.dialogStore.showCatalogQueryDialog} />
                 {appStore.preferenceStore.codeSnippetsEnabled && <Menu.Item text="Code snippets" icon={"console"} onClick={appStore.dialogStore.showCodeSnippetDialog} />}
             </Menu>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -222,7 +222,7 @@ export class RootMenuComponent extends React.Component {
             <Menu>
                 <Menu.Item text="Open Image" label={`${modString}O`} disabled={appStore.openFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, false)} />
                 <Menu.Item text="Append Image" label={`${modString}L`} disabled={appStore.appendFileDisabled} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />
-                <Tooltip2 content={"not allowed in read-only mode"} disabled={appStore.appendFileDisabled || appStore.backendService?.serverFeatureFlags !== CARTA.ServerFeatureFlags.READ_ONLY} position={Position.LEFT}>
+                <Tooltip2 content={"Not allowed in read-only mode"} disabled={appStore.appendFileDisabled || appStore.backendService?.serverFeatureFlags !== CARTA.ServerFeatureFlags.READ_ONLY} position={Position.LEFT}>
                     <Menu.Item
                         text="Save Image"
                         label={`${modString}S`}
@@ -234,7 +234,7 @@ export class RootMenuComponent extends React.Component {
                 <Menu.Divider />
                 <Menu.Item text="Import Regions" disabled={!appStore.activeFrame} onClick={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.RegionImport, false)} />
                 <Tooltip2
-                    content={"not allowed in read-only mode"}
+                    content={"Not allowed in read-only mode"}
                     disabled={!appStore.activeFrame || !appStore.activeFrame.regionSet.regions || appStore.activeFrame.regionSet.regions.length <= 1 || appStore.backendService?.serverFeatureFlags !== CARTA.ServerFeatureFlags.READ_ONLY}
                     position={Position.LEFT}
                 >
@@ -501,7 +501,7 @@ export class RootMenuComponent extends React.Component {
                     </Tooltip2>
                 )}
                 {appStore.snippetStore.isExecuting && (
-                    <Tooltip2 content="CARTA is currently executing a code snippet.">
+                    <Tooltip2 content="CARTA is currently executing a code snippet">
                         <Icon icon={"console"} intent={"warning"} />
                     </Tooltip2>
                 )}

--- a/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
+++ b/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
@@ -142,7 +142,7 @@ export class ToolbarMenuComponent extends React.Component {
                     })}
                 </ButtonGroup>
                 <ButtonGroup className={dialogClassName}>
-                    <Tooltip2 content={<span>File Header</span>} position={Position.BOTTOM}>
+                    <Tooltip2 content={<span>File header</span>} position={Position.BOTTOM}>
                         <AnchorButton icon={"app-header"} onClick={dialogStore.showFileInfoDialog} active={dialogStore.fileInfoDialogVisible} />
                     </Tooltip2>
                     <Tooltip2 content={<span>Preferences</span>} position={Position.BOTTOM}>
@@ -151,23 +151,23 @@ export class ToolbarMenuComponent extends React.Component {
                     <Tooltip2 content={<span>Contours</span>} position={Position.BOTTOM}>
                         <AnchorButton icon={<CustomIcon icon={"contour"} />} onClick={dialogStore.showContourDialog} active={dialogStore.contourDialogVisible} />
                     </Tooltip2>
-                    <Tooltip2 content={<span>Vector Overlay</span>} position={Position.BOTTOM}>
+                    <Tooltip2 content={<span>Vector overlay</span>} position={Position.BOTTOM}>
                         <AnchorButton icon={<CustomIcon icon={"vectorOverlay"} />} onClick={dialogStore.showVectorOverlayDialog} active={dialogStore.vectorOverlayDialogVisible} />
                     </Tooltip2>
-                    <Tooltip2 content={<span>Image Fitting</span>} position={Position.BOTTOM}>
+                    <Tooltip2 content={<span>Image fitting</span>} position={Position.BOTTOM}>
                         <AnchorButton icon={<CustomIcon icon="imageFitting" />} onClick={dialogStore.showFittingDialog} active={dialogStore.fittingDialogVisible} />
                     </Tooltip2>
-                    <Tooltip2 content={<span>Online Catalog Query</span>} position={Position.BOTTOM}>
+                    <Tooltip2 content={<span>Online catalog query</span>} position={Position.BOTTOM}>
                         <AnchorButton icon="geosearch" onClick={dialogStore.showCatalogQueryDialog} active={dialogStore.catalogQueryDialogVisible} />
                     </Tooltip2>
-                    <Tooltip2 content={<span>Distance Measurement</span>} position={Position.BOTTOM}>
+                    <Tooltip2 content={<span>Distance measurement</span>} position={Position.BOTTOM}>
                         <AnchorButton icon={<CustomIcon icon="distanceMeasuring" />} active={dialogStore.distanceMeasuringDialogVisible} onClick={this.handleDistanceMeasuringClicked} />
                     </Tooltip2>
                     {appStore.preferenceStore.codeSnippetsEnabled && (
                         <Tooltip2
                             content={
                                 <span>
-                                    Code Snippets
+                                    Code snippets
                                     <span>
                                         <br />
                                         <i>

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -253,7 +253,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                 >
                     <HTMLSelect value={selectedValue} options={this.widgetStore.regionOptions} onChange={this.handleRegionChanged} />
                 </FormGroup>
-                <FormGroup inline={true} label="Average Width">
+                <FormGroup inline={true} label="Average width">
                     <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.width} onValueChange={value => this.widgetStore.setWidth(value)} />
                 </FormGroup>
                 <SpectralSettingsComponent
@@ -280,10 +280,10 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                         </div>
                     </FormGroup>
                 )}
-                <FormGroup className="label-info-group" inline={true} label="Axes Order">
+                <FormGroup className="label-info-group" inline={true} label="Axes order">
                     <HTMLSelect options={Object.values(this.axesOrder)} onChange={this.handleAxesOrderChanged} />
                 </FormGroup>
-                <FormGroup inline={true} label={"Keep previous PV Image"}>
+                <FormGroup inline={true} label={"Keep previous PV image(s)"}>
                     <Switch
                         onChange={event => {
                             const e = event.target as HTMLInputElement;

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -303,7 +303,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
             <div className="pv-generator-widget">
                 <div className="pv-generator-panel">
                     <Tabs id="pvGeneratorTabs" selectedTabId={this.selectedTabId} onChange={this.setSelectedTab} animate={false}>
-                        <Tab id={PvGeneratorComponentTabs.PV_IMAGE} title="Generate PV image" panel={pvImagePanel} />
+                        <Tab id={PvGeneratorComponentTabs.PV_IMAGE} title="Generate PV Image" panel={pvImagePanel} />
                     </Tabs>
                 </div>
                 <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}></ReactResizeDetector>

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -256,7 +256,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                     <div className={className} style={props.style}>
                         <div className="cell" style={{width: RegionListComponent.ACTION_COLUMN_DEFAULT_WIDTH * 3}}>
                             <Icon icon={"blank"} style={{width: 16}} />
-                            <Tooltip2 disabled={regionsVisibility === RegionsOpacity.Invisible} content="Lock All Regions" position={Position.BOTTOM}>
+                            <Tooltip2 disabled={regionsVisibility === RegionsOpacity.Invisible} content="Lock all regions" position={Position.BOTTOM}>
                                 <Icon
                                     icon={regionsLock ? "lock" : regionsVisibility === RegionsOpacity.Invisible ? "lock" : "unlock"}
                                     onClick={regionsVisibility === RegionsOpacity.Invisible ? () => {} : ev => this.handleAllRegionsLockClicked(ev)}
@@ -264,7 +264,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                                 />
                             </Tooltip2>
                             <Icon icon={"blank"} style={{width: 5}} />
-                            <Tooltip2 content={regionsVisibility === RegionsOpacity.Invisible ? "Show Regions" : "Hide Regions"} position={Position.BOTTOM}>
+                            <Tooltip2 content={regionsVisibility === RegionsOpacity.Invisible ? "Show regions" : "Hide regions"} position={Position.BOTTOM}>
                                 <Icon
                                     icon={regionsVisibility === RegionsOpacity.Invisible ? "eye-off" : "eye-open"}
                                     onClick={this.handleToggleHideClicked()}

--- a/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
+++ b/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
@@ -45,10 +45,10 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                 <FormGroup label={"Scaling"} inline={true}>
                     <ScalingSelectComponent selectedItem={renderConfig.scaling} onItemSelect={renderConfig.setScaling} />
                 </FormGroup>
-                <FormGroup label={"Color map"} inline={true}>
+                <FormGroup label={"Colormap"} inline={true}>
                     <ColormapComponent inverted={renderConfig.inverted} selectedItem={renderConfig.colorMap} onItemSelect={renderConfig.setColorMap} />
                 </FormGroup>
-                <FormGroup label={"Invert color map"} inline={true}>
+                <FormGroup label={"Invert colormap"} inline={true}>
                     <Switch checked={renderConfig.inverted} onChange={this.handleInvertedChanged} />
                 </FormGroup>
                 {(renderConfig.scaling === FrameScaling.LOG || renderConfig.scaling === FrameScaling.POWER) && (
@@ -91,7 +91,7 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                         contrastMax={RenderConfigStore.CONTRAST_MAX}
                     />
                 </Collapse>
-                <FormGroup inline={true} label="NaN Color" className="nan-color-button">
+                <FormGroup inline={true} label="NaN color" className="nan-color-button">
                     <ColorPickerComponent
                         color={tinycolor(preference.nanColorHex).setAlpha(preference.nanAlpha).toRgb()}
                         presetColors={[...SWATCH_COLORS, "transparent"]}

--- a/src/components/RenderConfig/HistogramConfigComponent/HistogramConfigComponent.tsx
+++ b/src/components/RenderConfig/HistogramConfigComponent/HistogramConfigComponent.tsx
@@ -30,7 +30,7 @@ export class HistogramConfigComponent extends React.Component<HistogramConfigPro
     }
 
     renderHistogramSelectItem = (isCube: boolean, {handleClick, modifiers, query}) => {
-        return <MenuItem text={isCube ? "Per-Cube" : "Per-Channel"} onClick={handleClick} key={isCube ? "cube" : "channel"} />;
+        return <MenuItem text={isCube ? "Per-cube" : "Per-channel"} onClick={handleClick} key={isCube ? "cube" : "channel"} />;
     };
 
     handleHistogramChange = (value: boolean) => {
@@ -64,7 +64,7 @@ export class HistogramConfigComponent extends React.Component<HistogramConfigPro
                             itemRenderer={this.renderHistogramSelectItem}
                             disabled={this.props.disableHistogramSelect}
                         >
-                            <Button text={renderConfig.useCubeHistogram ? "Per-Cube" : "Per-Channel"} rightIcon="double-caret-vertical" alignText={"right"} disabled={this.props.disableHistogramSelect} />
+                            <Button text={renderConfig.useCubeHistogram ? "Per-cube" : "Per-channel"} rightIcon="double-caret-vertical" alignText={"right"} disabled={this.props.disableHistogramSelect} />
                         </HistogramSelect>
                     </FormGroup>
                 )}

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -450,10 +450,10 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
                         disableHistogramSelect={appStore.animatorStore.animationActive}
                         warnOnCubeHistogram={(frame.frameInfo.fileFeatureFlags & CARTA.FileFeatureFlags.CUBE_HISTOGRAMS) === 0}
                     />
-                    <FormGroup label={"Clip Min"} inline={true}>
+                    <FormGroup label={"Clip min"} inline={true}>
                         <SafeNumericInput value={frame.renderConfig.scaleMinVal} selectAllOnFocus={true} buttonPosition={"none"} onBlur={this.handleScaleMinChange} onKeyDown={this.handleScaleMinChange} />
                     </FormGroup>
-                    <FormGroup label={"Clip Max"} inline={true}>
+                    <FormGroup label={"Clip max"} inline={true}>
                         <SafeNumericInput value={frame.renderConfig.scaleMaxVal} selectAllOnFocus={true} buttonPosition={"none"} onBlur={this.handleScaleMaxChange} onKeyDown={this.handleScaleMaxChange} />
                     </FormGroup>
                     <ColormapConfigComponent renderConfig={frame.renderConfig} />

--- a/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
+++ b/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
@@ -61,10 +61,10 @@ const WcsCoordNumericInput = ({inputType, valueWcs, onChangeWcs, disabled = fals
     let placeholder = "";
     switch (inputType) {
         case InputType.XCoord:
-            placeholder = "X WCS Coordinate";
+            placeholder = "X WCS coordinate";
             break;
         case InputType.YCoord:
-            placeholder = "Y WCS Coordinate";
+            placeholder = "Y WCS coordinate";
             break;
         default:
             break;

--- a/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotSettings/LinePlotSettingsPanelComponent.tsx
@@ -70,7 +70,7 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                             <FormGroup
                                 key={index}
                                 inline={true}
-                                label="Line Color"
+                                label="Line color"
                                 labelInfo={
                                     lineLabel ? (
                                         <React.Fragment>
@@ -113,9 +113,9 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         </FormGroup>
                     )}
                     {this.getLineColorSelectors()}
-                    <FormGroup inline={true} label="Line Width" labelInfo="(px)">
+                    <FormGroup inline={true} label="Line width" labelInfo="(px)">
                         <SafeNumericInput
-                            placeholder="Line Width"
+                            placeholder="Line width"
                             min={LineSettings.MIN_WIDTH}
                             max={LineSettings.MAX_WIDTH}
                             value={props.lineWidth}
@@ -124,9 +124,9 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                             onValueChange={(value: number) => props.setLineWidth(value)}
                         />
                     </FormGroup>
-                    <FormGroup inline={true} label="Point Size" labelInfo="(px)">
+                    <FormGroup inline={true} label="Point size" labelInfo="(px)">
                         <SafeNumericInput
-                            placeholder="Point Size"
+                            placeholder="Point size"
                             min={LineSettings.MIN_POINT_SIZE}
                             max={LineSettings.MAX_POINT_SIZE}
                             value={props.linePlotPointSize}
@@ -136,35 +136,35 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         />
                     </FormGroup>
                     {typeof props.logScaleY !== "undefined" && props.handleLogScaleChanged && (
-                        <FormGroup inline={true} label={"Log Scale"}>
+                        <FormGroup inline={true} label={"Log scale"}>
                             <Switch checked={props.logScaleY} onChange={props.handleLogScaleChanged} />
                         </FormGroup>
                     )}
                     {typeof props.markerTextVisible !== "undefined" && props.handleMarkerTextChanged && (
-                        <FormGroup inline={true} label={"Show Labels"}>
+                        <FormGroup inline={true} label={"Show labels"}>
                             <Switch checked={props.markerTextVisible} onChange={props.handleMarkerTextChanged} />
                         </FormGroup>
                     )}
                     {typeof props.useWcsValues !== "undefined" && props.handleWcsValuesChanged && (
-                        <FormGroup inline={true} label={"Use WCS Values"}>
+                        <FormGroup inline={true} label={"Use WCS values"}>
                             <Switch checked={props.useWcsValues} onChange={props.handleWcsValuesChanged} />
                         </FormGroup>
                     )}
                     {typeof props.showWCSAxis !== "undefined" && props.handleWcsAxisChanged && (
-                        <FormGroup disabled={props.disableShowWCSAxis} inline={true} label={"Show WCS Axis"}>
+                        <FormGroup disabled={props.disableShowWCSAxis} inline={true} label={"Show WCS axis"}>
                             <Switch disabled={props.disableShowWCSAxis} checked={props.showWCSAxis} onChange={props.handleWcsAxisChanged} />
                         </FormGroup>
                     )}
                     {typeof props.meanRmsVisible !== "undefined" && props.handleMeanRmsChanged && (
-                        <FormGroup inline={true} label={"Show Mean/RMS"} helperText={"Only visible in single profile"}>
+                        <FormGroup inline={true} label={"Show mean/RMS"} helperText={"Only visible in single profile"}>
                             <Switch checked={props.meanRmsVisible} onChange={props.handleMeanRmsChanged} />
                         </FormGroup>
                     )}
-                    <FormGroup inline={true} label={"Line Style"}>
+                    <FormGroup inline={true} label={"Line style"}>
                         <PlotTypeSelectorComponent value={props.plotType} onValueChanged={props.setPlotType} />
                     </FormGroup>
                     {typeof props.xMinVal !== "undefined" && props.handleXMinChange && (
-                        <FormGroup label={"X Min"} inline={true}>
+                        <FormGroup label={"X min"} inline={true}>
                             <SafeNumericInput
                                 className="line-boundary"
                                 value={props.xMinVal}
@@ -177,7 +177,7 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         </FormGroup>
                     )}
                     {typeof props.xMaxVal !== "undefined" && props.handleXMaxChange && (
-                        <FormGroup label={"X Max"} inline={true}>
+                        <FormGroup label={"X max"} inline={true}>
                             <SafeNumericInput
                                 className="line-boundary"
                                 value={props.xMaxVal}
@@ -190,7 +190,7 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         </FormGroup>
                     )}
                     {typeof props.yMinVal !== "undefined" && props.handleYMinChange && (
-                        <FormGroup label={"Y Min"} inline={true}>
+                        <FormGroup label={"Y min"} inline={true}>
                             <SafeNumericInput
                                 className="line-boundary"
                                 asyncControl={true}
@@ -204,7 +204,7 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         </FormGroup>
                     )}
                     {typeof props.yMaxVal !== "undefined" && props.handleYMaxChange && (
-                        <FormGroup label={"Y Max"} inline={true}>
+                        <FormGroup label={"Y max"} inline={true}>
                             <SafeNumericInput
                                 className="line-boundary"
                                 asyncControl={true}
@@ -218,9 +218,9 @@ export class LinePlotSettingsPanelComponent extends React.Component<LinePlotSett
                         </FormGroup>
                     )}
                     {typeof props.isAutoScaledX !== "undefined" && typeof props.isAutoScaledY !== "undefined" && props.clearXYBounds && (
-                        <FormGroup label={"Reset Range"} inline={true} className="reset-range-content">
+                        <FormGroup label={"Reset range"} inline={true} className="reset-range-content">
                             <Button className="reset-range-button" icon={"zoom-to-fit"} small={true} disabled={props.isAutoScaledX && props.isAutoScaledY} onClick={props.clearXYBounds}>
-                                Reset Range
+                                Reset range
                             </Button>
                         </FormGroup>
                     )}

--- a/src/components/Shared/ScatterPlot/PlotSettings/ScatterPlotSettingsPanelComponent.tsx
+++ b/src/components/Shared/ScatterPlot/PlotSettings/ScatterPlotSettingsPanelComponent.tsx
@@ -35,7 +35,7 @@ export class ScatterPlotSettingsPanelComponent extends React.Component<ScatterPl
         return (
             <div className="scatter-settings-panel">
                 <React.Fragment>
-                    <FormGroup inline={true} label="Color Map">
+                    <FormGroup inline={true} label="Colormap">
                         <ColormapComponent
                             inverted={props.invertedColorMap}
                             selectedItem={props.colorMap}
@@ -44,12 +44,12 @@ export class ScatterPlotSettingsPanelComponent extends React.Component<ScatterPl
                             }}
                         />
                     </FormGroup>
-                    <FormGroup label={"Invert Color Map"} inline={true}>
+                    <FormGroup label={"Invert colormap"} inline={true}>
                         <Switch checked={props.invertedColorMap} onChange={props.handleInvertedColorMapChanged} />
                     </FormGroup>
-                    <FormGroup inline={true} label="Symbol Size" labelInfo="(px)">
+                    <FormGroup inline={true} label="Symbol size" labelInfo="(px)">
                         <SafeNumericInput
-                            placeholder="Symbol Size"
+                            placeholder="Symbol size"
                             min={ScatterSettings.MIN_POINT_SIZE}
                             max={ScatterSettings.MAX_POINT_SIZE}
                             value={props.scatterPlotPointSize}
@@ -59,7 +59,7 @@ export class ScatterPlotSettingsPanelComponent extends React.Component<ScatterPl
                     </FormGroup>
                     <FormGroup inline={true} label="Transparency">
                         <SafeNumericInput
-                            placeholder="transparency"
+                            placeholder="Transparency"
                             min={ScatterSettings.MIN_TRANSPARENCY}
                             max={ScatterSettings.MAX_TRANSPARENCY}
                             value={props.pointTransparency}
@@ -67,7 +67,7 @@ export class ScatterPlotSettingsPanelComponent extends React.Component<ScatterPl
                             onValueChange={(value: number) => props.setPointTransparency(value)}
                         />
                     </FormGroup>
-                    <FormGroup inline={true} label={"Equal Axes"}>
+                    <FormGroup inline={true} label={"Equal axes"}>
                         <Switch checked={props.equalAxes} onChange={props.handleEqualAxesValuesChanged} />
                     </FormGroup>
                 </React.Fragment>

--- a/src/components/Shared/SmoothingSettings/SmoothingSettingsComponent.tsx
+++ b/src/components/Shared/SmoothingSettings/SmoothingSettingsComponent.tsx
@@ -79,13 +79,13 @@ export class SmoothingSettingsComponent extends React.Component<{
                                 />
                             </FormGroup>
                         )}
-                        <FormGroup inline={true} label={"Line Style"}>
+                        <FormGroup inline={true} label={"Line style"}>
                             <PlotTypeSelectorComponent value={smoothingStore.lineType} onValueChanged={smoothingStore.setLineType} />
                         </FormGroup>
                         {!this.props.disableColorAndLineWidth && (
-                            <FormGroup inline={true} label="Line Width" labelInfo="(px)">
+                            <FormGroup inline={true} label="Line width" labelInfo="(px)">
                                 <SafeNumericInput
-                                    placeholder="Line Width"
+                                    placeholder="Line width"
                                     min={LineSettings.MIN_WIDTH}
                                     max={LineSettings.MAX_WIDTH}
                                     value={smoothingStore.lineWidth}
@@ -95,9 +95,9 @@ export class SmoothingSettingsComponent extends React.Component<{
                                 />
                             </FormGroup>
                         )}
-                        <FormGroup inline={true} label="Point Size" labelInfo="(px)">
+                        <FormGroup inline={true} label="Point size" labelInfo="(px)">
                             <SafeNumericInput
-                                placeholder="Point Size"
+                                placeholder="Point size"
                                 min={LineSettings.MIN_POINT_SIZE}
                                 max={LineSettings.MAX_POINT_SIZE}
                                 value={smoothingStore.pointRadius}
@@ -129,12 +129,12 @@ export class SmoothingSettingsComponent extends React.Component<{
                     </FormGroup>
                 )}
                 {smoothingStore.type === SmoothingType.DECIMATION && (
-                    <FormGroup label={"Decimation Width"} inline={true}>
+                    <FormGroup label={"Decimation width"} inline={true}>
                         <SafeNumericInput value={smoothingStore.decimationWidth} min={2} stepSize={1} className="narrow" onValueChange={val => smoothingStore.setDecimationWidth(Math.round(val))} />
                     </FormGroup>
                 )}
                 {smoothingStore.type === SmoothingType.BINNING && (
-                    <FormGroup label={"Binning Width"} inline={true}>
+                    <FormGroup label={"Binning width"} inline={true}>
                         <SafeNumericInput value={smoothingStore.binWidth} min={2} stepSize={1} className="narrow" onValueChange={val => smoothingStore.setBinWidth(Math.round(val))} />
                     </FormGroup>
                 )}
@@ -143,7 +143,7 @@ export class SmoothingSettingsComponent extends React.Component<{
                         <FormGroup label={"Kernel"} inline={true}>
                             <SafeNumericInput value={smoothingStore.savitzkyGolaySize} min={5} stepSize={2} className="narrow" onValueChange={val => smoothingStore.setSavitzkyGolaySize(Math.round(val))} />
                         </FormGroup>
-                        <FormGroup label="Degree of Fitting" inline={true}>
+                        <FormGroup label="Order of fitting" inline={true}>
                             <SafeNumericInput value={smoothingStore.savitzkyGolayOrder} min={0} max={4} stepSize={2} className="narrow" onValueChange={val => smoothingStore.setSavitzkyGolayOrder(Math.round(val))} />
                         </FormGroup>
                     </React.Fragment>

--- a/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
+++ b/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
@@ -43,7 +43,7 @@ export class SpectralSettingsComponent extends React.Component<{
                     />
                 </FormGroup>
                 {this.props.secondaryAxisCursorInfoVisible && (
-                    <FormGroup label={"Secondary Coordinate"} inline={true} disabled={disableCoordinateSetting}>
+                    <FormGroup label={"Secondary coordinate"} inline={true} disabled={disableCoordinateSetting}>
                         <HTMLSelect
                             disabled={disableCoordinateSetting}
                             value={frame && frame.spectralCoordinateSecondary ? frame.spectralCoordinateSecondary : ""}

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -284,7 +284,7 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
                             <Switch checked={widgetStore.intensityLimitEnabled} onChange={() => widgetStore.toggleIntensityLimit()} />
                         </FormGroup>
                         {widgetStore.intensityLimitEnabled && (
-                            <Tooltip2 content="CDMS/JPL Intensity (Log)" position={Position.BOTTOM}>
+                            <Tooltip2 content="CDMS/JPL intensity (log)" position={Position.BOTTOM}>
                                 <SafeNumericInput value={widgetStore.intensityLimitValue} buttonPosition="none" onValueChange={val => widgetStore.setIntensityLimitValue(val)} />
                             </Tooltip2>
                         )}

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -280,11 +280,11 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
                         <HTMLSelect options={Object.values(SpectralLineQueryUnit)} value={widgetStore.queryUnit} onChange={ev => widgetStore.setQueryUnit(ev.currentTarget.value as SpectralLineQueryUnit)} />
                     </FormGroup>
                     <ControlGroup className="intensity-limit">
-                        <FormGroup label={"Intensity Limit"} inline={true}>
+                        <FormGroup label={"Intensity limit"} inline={true}>
                             <Switch checked={widgetStore.intensityLimitEnabled} onChange={() => widgetStore.toggleIntensityLimit()} />
                         </FormGroup>
                         {widgetStore.intensityLimitEnabled && (
-                            <Tooltip2 content="CDMS/JPL intensity (log)" position={Position.BOTTOM}>
+                            <Tooltip2 content="CDMS/JPL Intensity (Log)" position={Position.BOTTOM}>
                                 <SafeNumericInput value={widgetStore.intensityLimitValue} buttonPosition="none" onValueChange={val => widgetStore.setIntensityLimitValue(val)} />
                             </Tooltip2>
                         )}
@@ -392,7 +392,7 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
                                 <pre>{widgetStore.resultTableInfo}</pre>
                             </div>
                             <div className="bp3-dialog-footer-actions">
-                                <FormGroup inline={true} label={this.width < MINIMUM_WIDTH ? "" : "Spectral Profiler"}>
+                                <FormGroup inline={true} label={this.width < MINIMUM_WIDTH ? "" : "Spectral profiler"}>
                                     {widgetMenu}
                                 </FormGroup>
                                 <Tooltip2 content="Apply filter" position={Position.BOTTOM}>

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -242,7 +242,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                     />
                 </FormGroup>
                 <Divider />
-                <FormGroup inline={true} label={"Keep previous Moment Image"}>
+                <FormGroup inline={true} label={"Keep previous moment image(s)"}>
                     <Switch
                         onChange={event => {
                             const e = event.target as HTMLInputElement;

--- a/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
+++ b/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
@@ -220,7 +220,7 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
 
         return (
             <div className="profile-fitting-panel">
-                <Tooltip2 disabled={!disabled} content={"Profile fitting is not available when there are multiple profiles in the plot."}>
+                <Tooltip2 disabled={!disabled} content={"Profile fitting is not available when there are multiple profiles in the plot"}>
                     <FormGroup disabled={disabled}>
                         <div className="profile-fitting-form">
                             <FormGroup label="Data source" inline={true}>
@@ -275,7 +275,7 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
                                             <Tooltip2
                                                 content={
                                                     <span>
-                                                        <i>Delete Current Component</i>
+                                                        <i>Delete current component</i>
                                                     </span>
                                                 }
                                             >

--- a/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
+++ b/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
@@ -250,7 +250,7 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
                                         <AnchorButton onClick={this.autoDetect} icon="series-search" disabled={disabled} />
                                     </Tooltip2>
                                     <Switch label="w/ cont." checked={fittingStore.isAutoDetectWithCont} onChange={ev => fittingStore.setIsAutoDetectWithCont(!fittingStore.isAutoDetectWithCont)} disabled={disabled} />
-                                    <Switch label="auto fit" checked={fittingStore.isAutoDetectWithFitting} onChange={ev => fittingStore.setIsAutoDetectWithFitting(!fittingStore.isAutoDetectWithFitting)} disabled={disabled} />
+                                    <Switch label="Auto fit" checked={fittingStore.isAutoDetectWithFitting} onChange={ev => fittingStore.setIsAutoDetectWithFitting(!fittingStore.isAutoDetectWithFitting)} disabled={disabled} />
                                 </div>
                             </FormGroup>
                             {fittingStore.hasAutoDetectResult && (
@@ -422,7 +422,7 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
                                 <AnchorButton text="View log" onClick={this.showLog} intent={Intent.PRIMARY} disabled={!fittingStore.hasResult || disabled} />
                             </Popover2>
                             <div className="switch-wrapper">
-                                <Switch label="residual" checked={fittingStore.enableResidual} onChange={ev => fittingStore.setEnableResidual(ev.currentTarget.checked)} disabled={disabled} />
+                                <Switch label="Residual" checked={fittingStore.enableResidual} onChange={ev => fittingStore.setEnableResidual(ev.currentTarget.checked)} disabled={disabled} />
                             </div>
                         </div>
                     </FormGroup>

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -195,7 +195,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
                                 <FormGroup label={"Intensity unit"} inline={true}>
                                     <HTMLSelect disabled={!widgetStore.isIntensityConvertible} value={widgetStore.intensityUnit} options={widgetStore.intensityOptions} onChange={ev => widgetStore.setIntensityUnit(ev.currentTarget.value)} />
                                 </FormGroup>
-                                <FormGroup inline={true} label={"Secondary Info"}>
+                                <FormGroup inline={true} label={"Secondary info"}>
                                     <Switch checked={widgetStore.secondaryAxisCursorInfoVisible} onChange={event => widgetStore.setSecondaryAxisCursorInfoVisible(event.currentTarget.checked as boolean)} />
                                 </FormGroup>
                             </React.Fragment>

--- a/src/models/Wcs/WCSType.ts
+++ b/src/models/Wcs/WCSType.ts
@@ -1,7 +1,7 @@
 export class WCSType {
-    public static readonly AUTOMATIC = "automatic";
-    public static readonly DEGREES = "degrees";
-    public static readonly SEXAGESIMAL = "sexagesimal";
+    public static readonly AUTOMATIC = "Automatic";
+    public static readonly DEGREES = "Degrees";
+    public static readonly SEXAGESIMAL = "Sexagesimal";
 
     public static isValid = (wcsType: string): boolean => {
         return wcsType && (wcsType === WCSType.AUTOMATIC || wcsType === WCSType.DEGREES || wcsType === WCSType.SEXAGESIMAL);

--- a/src/stores/Frame/ContourStore/ContourConfigStore.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.ts
@@ -13,9 +13,9 @@ export enum ContourGeneratorType {
 }
 
 export enum ContourDashMode {
-    None,
-    Dashed,
-    NegativeOnly
+    None = "None",
+    Dashed = "Dashed",
+    NegativeOnly = "Negative only"
 }
 
 export class ContourConfigStore {

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -9,9 +9,9 @@ import {FrameScaling} from "stores/Frame";
 import {clamp, minMaxArray} from "utilities";
 
 export enum CatalogPlotType {
-    ImageOverlay = "Image Overlay",
+    ImageOverlay = "Image overlay",
     Histogram = "Histogram",
-    D2Scatter = "2D Scatter"
+    D2Scatter = "2D scatter"
 }
 
 export enum CatalogOverlayShape {

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -52,20 +52,20 @@ import {
 } from "stores/Widgets";
 
 export enum WidgetType {
-    Region = "Region List Widget",
-    Log = "Log Widget",
-    SpatialProfiler = "Spatial Profiler",
-    SpectralProfiler = "Spectral Profiler",
-    Statistics = "Statistics Widget",
-    Histogram = "Histogram Widget",
-    Animator = "Animator Widget",
-    RenderConfig = "Render Config Widget",
-    StokesAnalysis = "Stokes Analysis Widget",
-    ImageList = "Image List Widget",
-    Catalog = "Catalog Widget",
-    SpectralLineQuery = "Spectral Line Query Widget",
-    CursorInfo = "Cursor Info Widget",
-    PvGenerator = "PV Generator"
+    Region = "Region list widget",
+    Log = "Log widget",
+    SpatialProfiler = "Spatial profiler",
+    SpectralProfiler = "Spectral profiler",
+    Statistics = "Statistics widget",
+    Histogram = "Histogram widget",
+    Animator = "Animator widget",
+    RenderConfig = "Render configuration widget",
+    StokesAnalysis = "Stokes analysis widget",
+    ImageList = "Image list widget",
+    Catalog = "Catalog widget",
+    SpectralLineQuery = "Spectral line query widget",
+    CursorInfo = "Cursor info widget",
+    PvGenerator = "PV generator"
 }
 
 export interface DefaultWidgetConfig {


### PR DESCRIPTION
**Description**
This is an attempt of unifying text style elsewhere in the GUI for issue #1931.

Basically we keep the text style in the root menu (eg File), tab title, widget/dialog title as "title-case". Others such as button name, tooltip, placeholder, and switch name are "sentence-case". Hopefully the coverage is complete but if you spot missing parts, please let me know.  



**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing~ / corresponding fix added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~