### PR TITLE
Icchen/2058 region list not rendered properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 * Added settings in the image view settings widget for panning and zooming the images ([#1176](https://github.com/CARTAvis/carta-frontend/issues/1176)).
 ### Fixed
+* Fixed the issue of region list is not rendered properly with missing entries ([#2058](https://github.com/CARTAvis/carta-frontend/issues/2058))
 * Fixed the issue of contour levels not deleted as intended ([#2091](https://github.com/CARTAvis/carta-frontend/issues/2091)).
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 * Added settings in the image view settings widget for panning and zooming the images ([#1176](https://github.com/CARTAvis/carta-frontend/issues/1176)).
 ### Fixed
-* Fixed the issue of region list is not rendered properly with missing entries ([#2058](https://github.com/CARTAvis/carta-frontend/issues/2058))
 * Fixed the issue of contour levels not deleted as intended ([#2091](https://github.com/CARTAvis/carta-frontend/issues/2091)).
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -28,7 +28,6 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private static readonly ROTATION_COLUMN_DEFAULT_WIDTH = 80;
     private static readonly ROW_HEIGHT = 35;
     private static readonly HEADER_ROW_HEIGHT = 25;
-    private matchedIterLocation: {line: number; num: number} = {line: -1, num: -1};
     private listRef = React.createRef<any>();
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -28,6 +28,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private static readonly ROTATION_COLUMN_DEFAULT_WIDTH = 80;
     private static readonly ROW_HEIGHT = 35;
     private static readonly HEADER_ROW_HEIGHT = 25;
+    private matchedIterLocation: {line: number; num: number} = {line: -1, num: -1};
     private listRef = React.createRef<any>();
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
@@ -61,7 +62,8 @@ export class RegionListComponent extends React.Component<WidgetProps> {
 
     private scrollToSelected = (selected: any) => {
         const listRefCurrent = this.listRef.current;
-        if (!listRefCurrent) {
+        const height = listRefCurrent.props.height;
+        if (!listRefCurrent || height < 0) {
             return;
         } else {
             this.listRef.current.scrollToItem(selected, "smart");


### PR DESCRIPTION
**Description**

This PR is to fix #2058.
This issue only occurs when selecting region on image viewer with "Region List" panel not focused (selected). To fix it, adding a condition "height < 0" to `scrollToSelected` method will prevent scrolling of the "Region List" when "Region List" is not focused  (selected). In other word, the scrolling is activated only when "Region List" panel is selected.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [X] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [X] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / no changelog update needed
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~