### PR TITLE
Keep update value prop of NumericInput with observable and action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added settings in the image view settings widget for panning and zooming the images ([#1176](https://github.com/CARTAvis/carta-frontend/issues/1176)).
 * Added layout renaming dialog ([#458](https://github.com/CARTAvis/carta-frontend/issues/458)).
 ### Fixed
-* Fixed the issue of annoying text input fields in the vector rendering dialog ([#1906](https://github.com/CARTAvis/carta-frontend/issues/1906)).
+* Fixed the issue of annoying text input fields ([#1906](https://github.com/CARTAvis/carta-frontend/issues/1906)).
 * Fixed the issues of copying the Session URL in the macOS Electron and Linux AppImage versions ([#2102](https://github.com/CARTAvis/carta-frontend/issues/2102), [#2108](https://github.com/CARTAvis/carta-frontend/issues/2108)).
 * Fixed the issue of contour levels not deleted as intended ([#2091](https://github.com/CARTAvis/carta-frontend/issues/2091)).
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added a toggle button to let users decide whether or not to keep the previously generated moment images ([#2054](https://github.com/CARTAvis/carta-frontend/issues/2054)).
 * Added settings in the image view settings widget for panning and zooming the images ([#1176](https://github.com/CARTAvis/carta-frontend/issues/1176)).
 ### Fixed
+* Fixed the issue of annoying text input fields in the vector rendering dialog ([#1906](https://github.com/CARTAvis/carta-frontend/issues/1906)).
 * Fixed the issue of contour levels not deleted as intended ([#2091](https://github.com/CARTAvis/carta-frontend/issues/2091)).
 * Fixed issue of only enabling catalog selection button when there is a layer of catalog overlay ([#1826](https://github.com/CARTAvis/carta-frontend/issues/1826)).
 * Fixed the issue of the corrupted spatial profile when cursor is moving ([#1602](https://github.com/CARTAvis/carta-frontend/issues/1602)).

--- a/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
+++ b/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
@@ -20,7 +20,9 @@ export class SafeNumericInput extends React.Component<SafeNumericInputProps> {
     }
 
     @action setValueString = (valueString: string) => {
-        this.valueString = valueString;
+        if (!this.props.onBlur || !this.props.onKeyDown) {
+            this.valueString = valueString;
+        }
     };
 
     safeHandleValueChanged = (valueAsNumber: number, valueAsString: string, inputElement: HTMLInputElement) => {

--- a/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
+++ b/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
@@ -23,7 +23,7 @@ export class SafeNumericInput extends React.Component<SafeNumericInputProps> {
             () => this.props.value,
             value => {
                 if (!this.isFocused) {
-                    this.setValueString(value.toString()) 
+                    this.setValueString(value.toString());
                 }
             }
         );

--- a/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
+++ b/src/components/Shared/SafeNumericInput/SafeNumericInput.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import {INumericInputProps, NumericInput} from "@blueprintjs/core";
+import {action, makeObservable, observable} from "mobx";
+import {observer} from "mobx-react";
 
 export interface SafeNumericInputProps extends INumericInputProps {
     intOnly?: boolean;
@@ -7,8 +9,19 @@ export interface SafeNumericInputProps extends INumericInputProps {
     onKeyDown?(ev: React.KeyboardEvent<HTMLInputElement>): void;
 }
 
+@observer
 export class SafeNumericInput extends React.Component<SafeNumericInputProps> {
     private static minorStepSize = 0.001;
+    @observable valueString: string = this.props.value?.toString();
+
+    constructor(props) {
+        super(props);
+        makeObservable(this);
+    }
+
+    @action setValueString = (valueString: string) => {
+        this.valueString = valueString;
+    };
 
     safeHandleValueChanged = (valueAsNumber: number, valueAsString: string, inputElement: HTMLInputElement) => {
         if (this.props.intOnly) {
@@ -21,12 +34,21 @@ export class SafeNumericInput extends React.Component<SafeNumericInputProps> {
         }
         if (this.props.onValueChange && isFinite(valueAsNumber) && (!isFinite(this.props.min) || this.props.min <= valueAsNumber) && (!isFinite(this.props.max) || this.props.max >= valueAsNumber)) {
             this.props.onValueChange(valueAsNumber, valueAsString, inputElement);
+            this.setValueString(valueAsString);
         }
     };
 
     render() {
         const {intOnly, ...otherProps} = this.props;
 
-        return <NumericInput {...otherProps} asyncControl={true} minorStepSize={this.props.minorStepSize ? this.props.minorStepSize : intOnly ? 1 : SafeNumericInput.minorStepSize} onValueChange={this.safeHandleValueChanged} />;
+        return (
+            <NumericInput
+                {...otherProps}
+                asyncControl={true}
+                minorStepSize={this.props.minorStepSize ? this.props.minorStepSize : intOnly ? 1 : SafeNumericInput.minorStepSize}
+                onValueChange={this.safeHandleValueChanged}
+                value={this.valueString}
+            />
+        );
     }
 }


### PR DESCRIPTION
**Description**

The PR is to fix #1906 again with a different idea.

Since the fix in #2104 does not work for all the cases using `SafeNumericInput` thus I create another branch for another method of solving the problem.
In this fix, Decorators `@observable` and `@action` are applied to keep updating the `value` prop of the `NumericInput` used in `SafeNumericInput`.
Please test if there's any problem for those Input columns using the `SafeNumericInput`.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [X] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / no changelog update needed
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~