### PR TITLE
Yuhsuan/2106 fk4 plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed offset between cusorInfo and upper wcs axis in the spatial profilers ([#1319](https://github.com/CARTAvis/carta-frontend/issues/1319)).
 * Fixed mismatch between cursor and image during PV image panning ([#1790](https://github.com/CARTAvis/carta-frontend/issues/1790)).
 * Fixed the hanging problem for computed stokes animation ([#1238](https://github.com/CARTAvis/carta-backend/issues/1238)).
+* Fixed the AST grid rendering issues in different reference systems due to missing explicit equinox in the setup ([#2106](https://github.com/CARTAvis/carta-frontend/issues/2106))
 ### Changed
 * Re-arranged the order of File menu ([#2092](https://github.com/CARTAvis/carta-frontend/issues/2092))
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -5,7 +5,7 @@ import * as _ from "lodash";
 import {observer} from "mobx-react";
 
 import {CursorInfo, SPECTRAL_TYPE_STRING} from "models";
-import {AppStore, OverlayStore, PreferenceStore, SystemType} from "stores";
+import {AppStore, OverlayStore, PreferenceStore} from "stores";
 import {FrameStore} from "stores/Frame";
 
 import "./OverlayComponent.scss";
@@ -111,10 +111,6 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
             if (settings.title.customText && frame.titleCustomText?.length) {
                 currentStyleString += `, Title=${frame.titleCustomText}`;
-            }
-
-            if (settings.global.system === SystemType.FK4) {
-                currentStyleString += `, Equinox=1950`;
             }
 
             plot(currentStyleString);

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -5,7 +5,7 @@ import * as _ from "lodash";
 import {observer} from "mobx-react";
 
 import {CursorInfo, SPECTRAL_TYPE_STRING} from "models";
-import {AppStore, OverlayStore, PreferenceStore} from "stores";
+import {AppStore, OverlayStore, PreferenceStore, SystemType} from "stores";
 import {FrameStore} from "stores/Frame";
 
 import "./OverlayComponent.scss";
@@ -111,6 +111,10 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
 
             if (settings.title.customText && frame.titleCustomText?.length) {
                 currentStyleString += `, Title=${frame.titleCustomText}`;
+            }
+
+            if (settings.global.system === SystemType.FK4) {
+                currentStyleString += `, Equinox=1950`;
             }
 
             plot(currentStyleString);

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -42,7 +42,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         [SystemType.FK5, "FK5 coordinates, J2000.0 equinox"],
         [SystemType.FK4, "FK4 coordinates, B1950.0 equinox"],
         [SystemType.Galactic, "Galactic coordinates"],
-        [SystemType.Ecliptic, "Ecliptic coordinates"],
+        [SystemType.Ecliptic, "Ecliptic coordinates, J2000.0 equinox"],
         [SystemType.ICRS, "International Celestial Reference System"]
     ]);
 

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -100,11 +100,11 @@ export class OverlayGlobalSettings {
         astString.add("Color", AstColorsIndex.GLOBAL);
         astString.add("Tol", toFixed(this.tolerance / 100, 2), this.tolerance >= 0.001); // convert to fraction
         astString.add("System", this.explicitSystem);
-        if (this.explicitSystem === SystemType.FK4) {
-            astString.add("Equinox", "1950");
-        }
         if (this.explicitSystem === SystemType.FK5) {
             astString.add("Equinox", "2000");
+        }
+        else if (this.explicitSystem === SystemType.FK4) {
+            astString.add("Equinox", "1950");
         }
         return astString.toString();
     }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -100,6 +100,9 @@ export class OverlayGlobalSettings {
         astString.add("Color", AstColorsIndex.GLOBAL);
         astString.add("Tol", toFixed(this.tolerance / 100, 2), this.tolerance >= 0.001); // convert to fraction
         astString.add("System", this.explicitSystem);
+        if (this.explicitSystem === SystemType.FK4) {
+            astString.add("Equinox", "1950");
+        }
         return astString.toString();
     }
 

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -103,6 +103,9 @@ export class OverlayGlobalSettings {
         if (this.explicitSystem === SystemType.FK4) {
             astString.add("Equinox", "1950");
         }
+        if (this.explicitSystem === SystemType.FK5) {
+            astString.add("Equinox", "2000");
+        }
         return astString.toString();
     }
 

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -102,8 +102,7 @@ export class OverlayGlobalSettings {
         astString.add("System", this.explicitSystem);
         if (this.explicitSystem === SystemType.FK5) {
             astString.add("Equinox", "2000");
-        }
-        else if (this.explicitSystem === SystemType.FK4) {
+        } else if (this.explicitSystem === SystemType.FK4) {
             astString.add("Equinox", "1950");
         }
         return astString.toString();

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -100,11 +100,13 @@ export class OverlayGlobalSettings {
         astString.add("Color", AstColorsIndex.GLOBAL);
         astString.add("Tol", toFixed(this.tolerance / 100, 2), this.tolerance >= 0.001); // convert to fraction
         astString.add("System", this.explicitSystem);
-        if (this.explicitSystem === SystemType.FK5) {
-            astString.add("Equinox", "2000");
-        } else if (this.explicitSystem === SystemType.FK4) {
+
+        if (this.system === SystemType.FK4) {
             astString.add("Equinox", "1950");
+        } else {
+            astString.add("Equinox", "2000");
         }
+
         return astString.toString();
     }
 


### PR DESCRIPTION
**Description**

Fixes #2106. Added an Equinox argument to the AST plot ~when the system is FK4~. Set equinox to 1950 for FK4, and 2000 for the others. When the system is "Auto", equinox should follow the header.

Also adjust the tooltip to show ecliptic coordinates is in equinox 2000.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~