### PR TITLE
include pixel ratio in vertex shader

### DIFF
--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -222,6 +222,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 this.gl.uniform1f(shaderUniforms.ScaleAdjustment, scaleAdjustment);
                 this.gl.uniform1f(shaderUniforms.RotationAngle, rotationAngle);
                 this.gl.uniform1f(shaderUniforms.ZoomLevel, sourceFrame?.spatialReference?.zoomLevel ?? sourceFrame?.zoomLevel);
+                this.gl.uniform1f(shaderUniforms.PixelRatio, sourceFrame?.spatialReference?.aspectRatio ?? sourceFrame?.aspectRatio);
 
                 // size
                 this.gl.uniform1i(shaderUniforms.SizeMajorMapEnabled, 0);

--- a/src/services/CatalogWebGLService.ts
+++ b/src/services/CatalogWebGLService.ts
@@ -26,6 +26,7 @@ interface ShaderUniforms {
     RangeScale: WebGLUniformLocation;
     ScaleAdjustment: WebGLUniformLocation;
     ZoomLevel: WebGLUniformLocation;
+    PixelRatio: WebGLUniformLocation;
     // spatial matching
     ControlMapEnabled: WebGLUniformLocation;
     ControlMapSize: WebGLUniformLocation;
@@ -188,6 +189,7 @@ export class CatalogWebGLService {
             RangeScale: this.gl.getUniformLocation(shaderProgram, "uRangeScale"),
             ScaleAdjustment: this.gl.getUniformLocation(shaderProgram, "uScaleAdjustment"),
             ZoomLevel: this.gl.getUniformLocation(shaderProgram, "uZoomLevel"),
+            PixelRatio: this.gl.getUniformLocation(shaderProgram, "uPixelRatio"),
             // spatial matching
             ControlMapEnabled: this.gl.getUniformLocation(shaderProgram, "uControlMapEnabled"),
             ControlMapSize: this.gl.getUniformLocation(shaderProgram, "uControlMapSize"),

--- a/src/services/GLSL/vertex_shader_catalog.glsl
+++ b/src/services/GLSL/vertex_shader_catalog.glsl
@@ -31,6 +31,7 @@ uniform vec2 uRangeOffset;
 uniform vec2 uRangeScale;
 uniform float uScaleAdjustment;
 uniform float uZoomLevel;
+uniform float uPixelRatio;
 
 // Control-map based transformation
 uniform int uControlMapEnabled;
@@ -38,7 +39,6 @@ uniform vec2 uControlMapMin;
 uniform vec2 uControlMapMax;
 uniform vec2 uControlMapSize;
 uniform float uLineThickness;
-uniform float uPixelRatio;
 
 out vec2 v_pointCoord;
 out vec3 v_colour;
@@ -146,7 +146,7 @@ void main() {
 
     vec2 offset = getOffsetFromId(gl_VertexID);
     v_pointCoord = vec2(offset.x, -offset.y) + 0.5;
-    posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment);
+    posImageSpace += offset * point_size / (uZoomLevel * uScaleAdjustment) * vec2(1.0 / uPixelRatio, 1.0);
 
     // Scale and rotate
     vec2 pos = rotate2D(posImageSpace, uRotationAngle) * uScaleAdjustment * uRangeScale + uRangeOffset;


### PR DESCRIPTION
**Description**

Fixed #2107 by including pixel ratio in the vertex shader calculation.

Note: I think this does not exist in the latest version, so we don't need to update changelog.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~