### PR TITLE
carli/2131_point_compass_annotation_creation_duplicate

### DIFF
--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -247,7 +247,7 @@ export class CompassAnnotationStore extends RegionStore {
         super(backendService, fileId, activeFrame, controlPoints, regionType, regionId, color, lineWidth, dashLength, rotation, name);
         makeObservable(this);
         this.modifiedTimestamp = performance.now();
-        this.setLength(controlPoints[1].x);
+        this.setLength(controlPoints[1].x, true);
     }
 
     @action setLabel = (label: string, isNorth: boolean) => {
@@ -296,9 +296,9 @@ export class CompassAnnotationStore extends RegionStore {
         this.modifiedTimestamp = performance.now();
     };
 
-    @action setLength = (length: number) => {
+    @action setLength = (length: number, skipUpdate: boolean = false) => {
         this.length = Math.abs(length);
-        this.setControlPoint(1, {x: length, y: length});
+        this.setControlPoint(1, {x: length, y: length}, skipUpdate);
         this.modifiedTimestamp = performance.now();
     };
 

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -605,7 +605,7 @@ export class RegionStore {
             this.regionApproximationMap.clear();
         }
 
-        if (this.regionType !== CARTA.RegionType.POINT) {
+        if (this.regionType !== CARTA.RegionType.POINT && this.regionType !== CARTA.RegionType.ANNPOINT) {
             try {
                 const ack = yield this.backendService.setRegion(this.fileId, -1, this);
                 console.log(`Updating regionID from ${this.regionId} to ${ack.regionId}`);


### PR DESCRIPTION
**Description**

Resolves #2131. In the ``CompassAnnotationStore`` constructor's ``setLength`` function, a ``skipUpdate`` boolean parameter is set, which sends ``skipUpdate`` boolean to ``setControlPoint`` function. Also, in the ``endCreating`` function in RegionStore, an if-statement is added to check for point annotation, which prevents duplicate creation of point annotation.

**Checklist**

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~