### PR TITLE
ajm/build libs update

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,21 +29,6 @@ jobs:
         run: |
           chown -R $(id -u):$(id -g) $PWD
 
-      - name: Copy pre-downloaded .tar.gz file to wasm_libs folder
-        shell: bash
-        run: |
-          ls -sort ./wasm_libs/
-          echo "Check1"
-          uname -a
-          ls -l /opt
-          echo "Check2"
-          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi
-          echo "Here: $PWD"
-          ls -sort ./wasm_libs/
-
       - name: Build libs
         shell: bash        
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,6 +33,10 @@ jobs:
         shell: bash        
         run: |
           source /emsdk/emsdk_env.sh
+          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 12
@@ -80,6 +84,10 @@ jobs:
         shell: bash
         run: |
           source /emsdk/emsdk_env.sh
+          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi          
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 14
@@ -128,6 +136,10 @@ jobs:
         shell: bash        
         run: |
           source /emsdk/emsdk_env.sh
+          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi          
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 16

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,6 +33,10 @@ jobs:
         shell: bash
         run: |
           ls -sort ./wasm_libs/
+          echo "Check1"
+          uname -a
+          ls -l /opt
+          echo "Check2"
           if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
           if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
           if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -30,7 +30,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Copy pre-downloaded .tar.gz file to wasm_libs folder
+        shell: bash
         run: |
+          ls -sort ./wasm_libs/
           if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
           if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
           if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,14 +29,19 @@ jobs:
         run: |
           chown -R $(id -u):$(id -g) $PWD
 
+      - name: Copy pre-downloaded .tar.gz file to wasm_libs folder
+        run: |
+          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
+          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi
+          echo "Here: $PWD"
+          ls -sort ./wasm_libs/
+
       - name: Build libs
         shell: bash        
         run: |
           source /emsdk/emsdk_env.sh
-          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 12
@@ -84,10 +89,6 @@ jobs:
         shell: bash
         run: |
           source /emsdk/emsdk_env.sh
-          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi          
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 14
@@ -136,10 +137,6 @@ jobs:
         shell: bash        
         run: |
           source /emsdk/emsdk_env.sh
-          if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/gsl-2.6.tar.gz ]]; then cp /opt/gsl-2.6.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zfp-0.5.5.tar.gz ]]; then cp /opt/zfp-0.5.5.tar.gz ./wasm_libs/; fi
-          if [[ -f /opt/zstd-1.4.4.tar.gz ]]; then cp /opt/zstd-1.4.4.tar.gz ./wasm_libs/; fi          
           ./wasm_libs/build_libs.sh
 
       - name: npm install with node 16

--- a/wasm_libs/build_ast.sh
+++ b/wasm_libs/build_ast.sh
@@ -30,4 +30,5 @@ if [[ $(find ../built/lib/libast.a -type f -size +1000000c 2>/dev/null) ]]; then
     echo "Found"
 else
     echo "Not found!"
+    exit 1
 fi

--- a/wasm_libs/build_ast.sh
+++ b/wasm_libs/build_ast.sh
@@ -4,7 +4,7 @@ cd "${0%/*}"
 if ! [[ $(find ast-9.1.1.tar.gz -type f 2>/dev/null && md5sum -c ast.md5 &>/dev/null) ]]; then
     echo "Fetching AST 9.1.1"
     retry_count=0
-    max_retries=3
+    max_retries=2
     while (( retry_count < max_retries )); do
         wget https://github.com/Starlink/ast/releases/download/v9.1.1/ast-9.1.1.tar.gz && break
         ((retry_count++))
@@ -13,7 +13,7 @@ if ! [[ $(find ast-9.1.1.tar.gz -type f 2>/dev/null && md5sum -c ast.md5 &>/dev/
             exit 1
         fi
         echo "Download failed. Trying again."
-        sleep 30
+        sleep 10
     done
 fi
 

--- a/wasm_libs/build_ast.sh
+++ b/wasm_libs/build_ast.sh
@@ -3,7 +3,18 @@ command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not ins
 cd "${0%/*}"
 if ! [[ $(find ast-9.1.1.tar.gz -type f 2>/dev/null && md5sum -c ast.md5 &>/dev/null) ]]; then
     echo "Fetching AST 9.1.1"
-    wget https://github.com/Starlink/ast/releases/download/v9.1.1/ast-9.1.1.tar.gz
+    retry_count=0
+    max_retries=3
+    while (( retry_count < max_retries )); do
+        wget https://github.com/Starlink/ast/releases/download/v9.1.1/ast-9.1.1.tar.gz && break
+        ((retry_count++))
+        if (( retry_count == max_retries )); then
+            echo "Failed to fetch AST 9.1.1."
+            exit 1
+        fi
+        echo "Download failed. Trying again."
+        sleep 30
+    done
 fi
 
 mkdir -p ast; tar -xf ast-9.1.1.tar.gz --directory ./ast --strip-components=1

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -15,9 +15,15 @@ if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/nu
         echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org"
         if ! wget https://mirror.ossplanet.net/gnu/gsl/gsl-2.6.tar.gz; then
             echo "Failed to fetch GSL 2.6 from https://mirror.ossplanet.net"
-            if ! wget https://mirrors.ocf.berkeley.edu/gnu/gsl/gsl-2.6.tar.gz; then
-                echo "Failed to fetch GSL 2.6 from https://mirrors.ocf.berkeley.edu"
-                exit 1
+            if ! wget https://ftp.jaist.ac.jp/pub/GNU/gsl/gsl-2.6.tar.gz; then
+                echo "Failed to fetch GSL 2.6 from https://ftp.jaist.ac.jp" 
+                if ! wget https://mirrors.ocf.berkeley.edu/gnu/gsl/gsl-2.6.tar.gz; then
+                    echo "Failed to fetch GSL 2.6 from https://mirrors.ocf.berkeley.edu"
+                     if ! wget https://mirror.dogado.de/gnu/gsl/gsl-2.6.tar.gz; then
+                         echo "Failed to fetch GSL 2.6 from https://mirror.dogado.de"
+                         exit 1
+                     fi
+                fi
             fi
         fi
     fi

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -4,16 +4,16 @@ cd "${0%/*}"
 if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/null) ]]; then
     echo "Fetching GSL 2.6"
     retry_count=0
-    max_retries=3
+    max_retries=2
     while (( retry_count < max_retries )); do
-        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz && break
+        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gzz && break
         ((retry_count++))
         if (( retry_count == max_retries )); then
             echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org."
             exit 1
         fi
         echo "Download failed. Trying again."
-        sleep 30
+        sleep 10
     done
 fi
 

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -3,7 +3,18 @@ command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not ins
 cd "${0%/*}"
 if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/null) ]]; then
     echo "Fetching GSL 2.6"
-    wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz
+    retry_count=0
+    max_retries=3
+    while (( retry_count < max_retries )); do
+        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz && break
+        ((retry_count++))
+        if (( retry_count == max_retries )); then
+            echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org."
+            exit 1
+        fi
+        echo "Download failed. Trying again."
+        sleep 30
+    done
 fi
 
 mkdir -p gsl; tar -xf gsl-2.6.tar.gz --directory ./gsl --strip-components=1

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -30,4 +30,5 @@ if [[ $(find -L ../built/lib/libgsl.a -type f -size +192000c 2>/dev/null) ]]; th
     echo "Found"
 else
     echo "Not found!"
+    exit 1
 fi

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -6,7 +6,7 @@ if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/nu
     retry_count=0
     max_retries=2
     while (( retry_count < max_retries )); do
-        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gzz && break
+        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz && break
         ((retry_count++))
         if (( retry_count == max_retries )); then
             echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org."

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -8,13 +8,19 @@ if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/nu
     while (( retry_count < max_retries )); do
         wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz && break
         ((retry_count++))
-        if (( retry_count == max_retries )); then
-            echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org."
-            exit 1
-        fi
         echo "Download failed. Trying again."
         sleep 10
     done
+    if (( retry_count == max_retries )); then
+        echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org"
+        if ! wget https://mirror.ossplanet.net/gnu/gsl/gsl-2.6.tar.gz; then
+            echo "Failed to fetch GSL 2.6 from https://mirror.ossplanet.net"
+            if ! wget https://mirrors.ocf.berkeley.edu/gnu/gsl/gsl-2.6.tar.gz; then
+                echo "Failed to fetch GSL 2.6 from https://mirrors.ocf.berkeley.edu"
+                exit 1
+            fi
+        fi
+    fi
 fi
 
 mkdir -p gsl; tar -xf gsl-2.6.tar.gz --directory ./gsl --strip-components=1

--- a/wasm_libs/build_zfp.sh
+++ b/wasm_libs/build_zfp.sh
@@ -3,7 +3,18 @@ command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not ins
 cd "${0%/*}"
 if ! [[ $(find zfp-0.5.5.tar.gz -type f 2>/dev/null && md5sum -c zfp.md5 &>/dev/null) ]]; then
     echo "Fetching ZFP 0.5.5"
-    wget https://github.com/LLNL/zfp/releases/download/0.5.5/zfp-0.5.5.tar.gz
+    retry_count=0
+    max_retries=3
+    while (( retry_count < max_retries )); do
+        wget https://github.com/LLNL/zfp/releases/download/0.5.5/zfp-0.5.5.tar.gz && break
+        ((retry_count++))
+        if (( retry_count == max_retries )); then
+            echo "Failed to fetch ZFP 0.5.5."
+            exit 1
+        fi
+        echo "Download failed. Trying again."
+        sleep 30
+    done
 fi
 
 mkdir -p zfp; tar -xf zfp-0.5.5.tar.gz --directory ./zfp --strip-components=1

--- a/wasm_libs/build_zfp.sh
+++ b/wasm_libs/build_zfp.sh
@@ -4,7 +4,7 @@ cd "${0%/*}"
 if ! [[ $(find zfp-0.5.5.tar.gz -type f 2>/dev/null && md5sum -c zfp.md5 &>/dev/null) ]]; then
     echo "Fetching ZFP 0.5.5"
     retry_count=0
-    max_retries=3
+    max_retries=2
     while (( retry_count < max_retries )); do
         wget https://github.com/LLNL/zfp/releases/download/0.5.5/zfp-0.5.5.tar.gz && break
         ((retry_count++))
@@ -13,7 +13,7 @@ if ! [[ $(find zfp-0.5.5.tar.gz -type f 2>/dev/null && md5sum -c zfp.md5 &>/dev/
             exit 1
         fi
         echo "Download failed. Trying again."
-        sleep 30
+        sleep 10
     done
 fi
 

--- a/wasm_libs/build_zfp.sh
+++ b/wasm_libs/build_zfp.sh
@@ -31,4 +31,5 @@ if [[ $(find -L ../../built/lib/libzfp.a -type f -size +192000c 2>/dev/null) ]];
     echo "Found"
 else
     echo "Not found!"
+    exit 1  
 fi

--- a/wasm_libs/build_zstd.sh
+++ b/wasm_libs/build_zstd.sh
@@ -33,4 +33,5 @@ if [[ $(find -L ./standalone_zstd.bc -type f -size +10000c 2>/dev/null) ]]; then
     echo "Found"
 else
     echo "Not found!"
+    exit 1
 fi

--- a/wasm_libs/build_zstd.sh
+++ b/wasm_libs/build_zstd.sh
@@ -4,7 +4,7 @@ cd "${0%/*}"
 if ! [[ $(find zstd-1.4.4.tar.gz -type f 2>/dev/null && md5sum -c zstd.md5 &>/dev/null) ]]; then
     echo "Fetching Zstd 1.4.4"
     retry_count=0
-    max_retries=3
+    max_retries=2
     while (( retry_count < max_retries )); do
         wget https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz && break
         ((retry_count++))
@@ -13,7 +13,7 @@ if ! [[ $(find zstd-1.4.4.tar.gz -type f 2>/dev/null && md5sum -c zstd.md5 &>/de
             exit 1
         fi
         echo "Download failed. Trying again."
-        sleep 30
+        sleep 10
     done
 fi
 

--- a/wasm_libs/build_zstd.sh
+++ b/wasm_libs/build_zstd.sh
@@ -2,8 +2,19 @@
 command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not installed or in PATH.Aborting." >&2; exit 1; }
 cd "${0%/*}"
 if ! [[ $(find zstd-1.4.4.tar.gz -type f 2>/dev/null && md5sum -c zstd.md5 &>/dev/null) ]]; then
-  echo "Fetching Zstd 0.4.4"
-  wget https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz
+    echo "Fetching Zstd 1.4.4"
+    retry_count=0
+    max_retries=3
+    while (( retry_count < max_retries )); do
+        wget https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz && break
+        ((retry_count++))
+        if (( retry_count == max_retries )); then
+            echo "Failed to fetch Zstd 1.4.4."
+            exit 1
+        fi
+        echo "Download failed. Trying again."
+        sleep 30
+    done
 fi
 
 mkdir -p zstd; tar -xf zstd-1.4.4.tar.gz --directory ./zstd --strip-components=1


### PR DESCRIPTION
**Description**

This should address issue #2142 

Although the issue only happens for the GSL library build, I have made the same modification to the AST, ZFP, and ZSTD build scripts for consistency. 

These changes are only necessary for the carta-frontend Github Actions CI. I doubt there would ever be such an issue for individual developers, particularly because if a library source code has been previously downloaded, the script will not download it again. 

I attempted to have a local copy of the library file source code already downloaded on our self-hosted Github Runner servers, and have it simply copy over e.g. To the GitHub Actions workflow file I added:

> if [[ -f /opt/ast-9.1.1.tar.gz ]]; then cp /opt/ast-9.1.1.tar.gz ./wasm_libs/; fi

Unfortunately, this simple solution does not appear to work at all. It seems Github Actions on the self-hosted runners has no access outside its own Github Action build directory, which is probably good security-wise (Well, I suppose another option would be to have our GitHub Actions workflow file 'wget' the source code bundle from one of our local servers instead. But I did not do so and am trying to address the issue in another way).

An explanation of the changes are as follows:

- If a source code fails to download, the script will wait 10 seconds and try one more time. If it fails the 2nd time, an `exit 1` will be issued and the CI will stop and not continue.
- If a library fails to build, an `exit 1` has been added after the `echo "Not found!"` which will also stop the CI from continuing to the next stage. 

I know a 10 seconds wait and one retry may not be enough if the GSL server has already temporarily blocked our access. However, I think the issue is less likely to occur after PR #2139 where the number of parallel CI builds has been reduced from 3 to 2. Also, at least the changes in this PR will stop the CI if an error occurs during the `Build Libs` stage, and the one extra download retry may help add some robustness to the build.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [x] changelog updated / no changelog update needed
- [x]  no protobuf update needed
- [x] `BackendService` unchanged