### PR TITLE
fix widgets menu styling regression

### DIFF
--- a/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
+++ b/src/components/Menu/ToolbarMenu/ToolbarMenuComponent.tsx
@@ -121,13 +121,14 @@ export class ToolbarMenuComponent extends React.Component {
                 <ButtonGroup className={className}>
                     {Array.from(WidgetsStore.Instance.CARTAWidgets.keys()).map(widgetType => {
                         const widgetConfig = WidgetsStore.Instance.CARTAWidgets.get(widgetType);
-                        const trimmedStr = widgetType.replace(/\s+/g, "");
+                        const trimmedStr = widgetType?.replace(/\s+/g, "");
+                        const widgetTypeTooltip = widgetType?.charAt(0) + widgetType?.slice(1)?.toLowerCase();
                         return (
                             <Tooltip2
                                 key={`${trimmedStr}Tooltip`}
                                 content={
                                     <span>
-                                        {widgetType}
+                                        {widgetTypeTooltip}
                                         {commonTooltip}
                                     </span>
                                 }

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -52,20 +52,20 @@ import {
 } from "stores/Widgets";
 
 export enum WidgetType {
-    Region = "Region list widget",
-    Log = "Log widget",
-    SpatialProfiler = "Spatial profiler",
-    SpectralProfiler = "Spectral profiler",
-    Statistics = "Statistics widget",
-    Histogram = "Histogram widget",
-    Animator = "Animator widget",
-    RenderConfig = "Render configuration widget",
-    StokesAnalysis = "Stokes analysis widget",
-    ImageList = "Image list widget",
-    Catalog = "Catalog widget",
-    SpectralLineQuery = "Spectral line query widget",
-    CursorInfo = "Cursor info widget",
-    PvGenerator = "PV generator"
+    Region = "Region List Widget",
+    Log = "Log Widget",
+    SpatialProfiler = "Spatial Profiler",
+    SpectralProfiler = "Spectral Profiler",
+    Statistics = "Statistics Widget",
+    Histogram = "Histogram Widget",
+    Animator = "Animator Widget",
+    RenderConfig = "Render Configuration Widget",
+    StokesAnalysis = "Stokes Analysis Widget",
+    ImageList = "Image List Widget",
+    Catalog = "Catalog Widget",
+    SpectralLineQuery = "Spectral Line Query Widget",
+    CursorInfo = "Cursor Info Widget",
+    PvGenerator = "PV Generator"
 }
 
 export interface DefaultWidgetConfig {


### PR DESCRIPTION
**Description**

~Not sure which commit caused this. The widgets menu contains labels in sentence-cased style, not the title-cased style. This is just to fix it.~

This issue is from regression within PR #2110. `WidgetsStore.ts` `WidgetType` was changed to sentence-case for tooltips, but menu labels (in title-case) are also using the same variable. Adjusted code to apply tooltips in sentence-case and menu labels in title-case.

**Checklist**

For linked issues (if there are):
- [x] ~assignee and label added~
- [x] ~ZenHub issue connection, board status, and estimate updated~

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~