### PR TITLE
Yuhsuan/2145 line table copy

### DIFF
--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
@@ -55,4 +55,14 @@
 .directory-path-input {
     width: 100%;
     margin-right: 25px;
+
+    .bp3-input:not(:placeholder-shown) {
+        font-family: monospace;
+    }
+}
+
+.arithmetic-input {
+    .bp3-input:not(:placeholder-shown) {
+        font-family: monospace;
+    }
 }

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.tsx
@@ -549,6 +549,7 @@ export class FileBrowserDialogComponent extends React.Component {
             if (this.enableImageArithmetic) {
                 return (
                     <InputGroup
+                        className="arithmetic-input"
                         inputRef={this.imageArithmeticInputRef}
                         autoFocus={true}
                         placeholder="Enter an image arithmetic expression"

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.scss
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.scss
@@ -128,6 +128,9 @@
                             width: inherit;
                             height: inherit;
                         }
+                        .bp3-table-bottom-container {
+                            user-select: text;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Description**

Simple CSS fixes.

1. Closes #2145: enabled user-select for the spectral line query table. Although the behavior of multiple cell selection may be a bit weird, this is still useful for copying special symbols for filtering.

    ![image](https://user-images.githubusercontent.com/43841102/235080459-468a138a-7be5-4e66-8db9-c1dfd48bcc37.png)

2. Changed the path input and the arithmetic input in the file browser dialog to `monospace`. The placeholders remain unchanged.

    ![image](https://user-images.githubusercontent.com/43841102/235079611-4aada28d-2143-47e5-89fa-6a7b143c7d0c.png)
    ![image](https://user-images.githubusercontent.com/43841102/235079662-2b5b7fb6-6fbe-4dd2-b51f-922eee1ce0d0.png)


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / corresponding fix added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~