### PR TITLE
set true of skipUpdate in the initializeStyles of setLength

### DIFF
--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -407,7 +407,7 @@ export class CompassAnnotationStore extends RegionStore {
         this.setFont(annotationStyles.font ?? this.font);
         this.setPointerWidth(annotationStyles.pointerWidth ?? this.pointerWidth);
         this.setPointerLength(annotationStyles.pointerLength ?? this.pointerLength);
-        this.setLength(annotationStyles.length ?? this.length);
+        this.setLength(annotationStyles.length ?? this.length, true);
         this.setNorthTextOffset(annotationStyles.northTextOffset?.x ?? this.northTextOffset.x, true);
         this.setNorthTextOffset(annotationStyles.northTextOffset?.y ?? this.northTextOffset.y, false);
         this.setEastTextOffset(annotationStyles.eastTextOffset?.x ?? this.eastTextOffset.x, true);


### PR DESCRIPTION
**Description**

Fixed Issue #2147 . I trace the `BackendService.ts` and try to find out why the frontend send additional setRegion ICD message when importing Annotation Compass. 
It is because in the `carta-frontend/src/stores/Frame/Region/RegionStore.ts` line 499 `!skipUpdate = true`, and call `this.updateRegion()`

Because the updateRegion() is called when importing the existing. Following is my tracing method to fix the issue:
(1) check which file call "importRegion" in the `BackendService.ts` => stores/AppStore/AppStore.ts
(2) check `AppStore.ts` and find there is a function called "addExistingRegion" inside "addRegionsInBatch"
(3) check "addExistingRegion" in `RegionSetStore.ts` and find the "initializeStyles" in CARTA.RegionType.ANNCOMPASS
(4) check "initializeStyles" in `AnnotationStore.ts` and find there is a `this.setLength(annotationStyles.length ?? this.length)` does not be defined the skipUpdate?, so I set it as `true`

Then, this bug issue disappears.
So far I have tested several setRegion, export Region, and import Region, the frontend behavior and ICD messages flow is what I expected.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [ ] changelog updated / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~