### PR TITLE
carli/2120_moment_selection_1_result_in_-1

### DIFF
--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -67,7 +67,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         if (exactMatch) {
             return normalizedMoment === normalizedQuery;
         } else {
-            return momentContent.tag.indexOf(normalizedQuery) >= 0;
+            return momentContent.tag.indexOf(normalizedQuery) === 0;
         }
     };
 


### PR DESCRIPTION
**Description**
The ``filterMoment`` function selects the matching moment tag when users type in a tag. For instance, when users type in "1", the result would be "-1", "1", "10", etc. When users click enter, the first result, "-1" would be selected instead of "1". To resolve the problem, the query is matched to only the first character. For instance, query "1" would result in "1", and "10". This PR resolves #2120.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~