### PR TITLE
carli/2135_image_position_in_fixed_grid_size

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -225,7 +225,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
         return (
             <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}>
-                <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`}}>
+                <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, ${appStore.overlayStore.viewWidth}px)`, gridTemplateRows: `repeat(${appStore.numImageRows}, ${appStore.overlayStore.viewHeight}px)`}}>
                     {divContents}
                 </div>
             </ReactResizeDetector>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -225,10 +225,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
         return (
             <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}>
-                <div
-                    className="image-view-div"
-                    style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`, gridTemplateRows: `repeat(${appStore.numImageRows}, 1fr)`}}
-                >
+                <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`, gridTemplateRows: `repeat(${appStore.numImageRows}, 1fr)`}}>
                     {divContents}
                 </div>
             </ReactResizeDetector>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -225,7 +225,10 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
 
         return (
             <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}>
-                <div className="image-view-div" style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, ${appStore.overlayStore.viewWidth}px)`, gridTemplateRows: `repeat(${appStore.numImageRows}, ${appStore.overlayStore.viewHeight}px)`}}>
+                <div
+                    className="image-view-div"
+                    style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, ${appStore.overlayStore.viewWidth}px)`, gridTemplateRows: `repeat(${appStore.numImageRows}, ${appStore.overlayStore.viewHeight}px)`}}
+                >
                     {divContents}
                 </div>
             </ReactResizeDetector>

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -227,7 +227,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
             <ReactResizeDetector handleWidth handleHeight onResize={this.onResize} refreshMode={"throttle"} refreshRate={33}>
                 <div
                     className="image-view-div"
-                    style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, ${appStore.overlayStore.viewWidth}px)`, gridTemplateRows: `repeat(${appStore.numImageRows}, ${appStore.overlayStore.viewHeight}px)`}}
+                    style={{gridTemplateColumns: `repeat(${appStore.numImageColumns}, auto)`, gridTemplateRows: `repeat(${appStore.numImageRows}, 1fr)`}}
                 >
                     {divContents}
                 </div>


### PR DESCRIPTION
**Description**

Originally, the gridTemplateRows was not set, only the gridTemplateColumns was set. Adding the gridTemplateRows for ImageViewComponent would fix the problem. Resolves #2135.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~