### PR TITLE
carli/2000_width_setting_in_spatial_profile_bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the hanging problem for computed stokes animation ([#1238](https://github.com/CARTAvis/carta-backend/issues/1238)).
 * Fixed the AST grid rendering issues in different reference systems due to missing explicit equinox in the setup ([#2106](https://github.com/CARTAvis/carta-frontend/issues/2106)).
 * Fixed crash when sending spectral line queries without network connection ([#2119](https://github.com/CARTAvis/carta-frontend/issues/2119)).
+* Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 ### Changed
 * Re-arranged the order of File menu ([#2092](https://github.com/CARTAvis/carta-frontend/issues/2092)).
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
+
 ## [4.0.0-beta.1]
 
 ### Added
@@ -47,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the hanging problem for computed stokes animation ([#1238](https://github.com/CARTAvis/carta-backend/issues/1238)).
 * Fixed the AST grid rendering issues in different reference systems due to missing explicit equinox in the setup ([#2106](https://github.com/CARTAvis/carta-frontend/issues/2106)).
 * Fixed crash when sending spectral line queries without network connection ([#2119](https://github.com/CARTAvis/carta-frontend/issues/2119)).
-* Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 ### Changed
 * Re-arranged the order of File menu ([#2092](https://github.com/CARTAvis/carta-frontend/issues/2092)).
 * Increased the upper limit of averaging width for line/polyline spatial profiles or PV images calculations ([#1949](https://github.com/CARTAvis/carta-frontend/issues/1949)).

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -201,7 +201,7 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
                         title="Computation"
                         panel={
                             <FormGroup label={"Width"} inline={true}>
-                                <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.lineRegionSampleWidth} onValueChange={value => this.widgetStore.setLineRegionSampleWidth(value)} />
+                                <SafeNumericInput min={1} max={20} stepSize={1} value={this.widgetStore.effectiveRegion.lineRegionSampleWidth} onValueChange={value => this.widgetStore.setLineRegionSampleWidth(value)} />
                             </FormGroup>
                         }
                     />

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -34,6 +34,7 @@ export class RegionStore {
     @observable locked: boolean = false;
     @observable isSimplePolygon: boolean;
     @observable activeFrame: FrameStore;
+    @observable lineRegionSampleWidth: number = 3;
 
     static readonly MIN_LINE_WIDTH = 0.5;
     static readonly MAX_LINE_WIDTH = 10;

--- a/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
@@ -35,7 +35,6 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
     @observable linePlotInitXYBoundaries: {minXVal: number; maxXVal: number; minYVal: number; maxYVal: number};
     readonly smoothingStore: ProfileSmoothingStore;
     @observable settingsTabId: SpatialProfilerSettingsTabs;
-    @observable lineRegionSampleWidth: number;
 
     @override setRegionId = (fileId: number, regionId: number) => {
         this.regionIdMap.set(fileId, regionId);
@@ -113,14 +112,15 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
     };
 
     @action setLineRegionSampleWidth = (val: number) => {
-        this.lineRegionSampleWidth = val;
+        if (this.effectiveRegion) {
+            this.effectiveRegion.lineRegionSampleWidth = val;
+        }
     };
 
     constructor(coordinate: string = "x") {
         super(RegionsType.POINT_AND_LINES);
         makeObservable(this);
         // Describes which data is being visualised
-        this.lineRegionSampleWidth = 3;
         this.coordinate = coordinate;
         this.selectedStokes = DEFAULT_STOKES;
 
@@ -244,7 +244,7 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
                 if (existingConfig) {
                     // TODO: Merge existing configs, rather than only allowing a single one
                 } else {
-                    regionRequirements.spatialProfiles.push(SpatialProfileWidgetStore.GetSpatialConfig(frame, widgetStore.fullCoordinate, region, widgetStore.lineRegionSampleWidth));
+                    regionRequirements.spatialProfiles.push(SpatialProfileWidgetStore.GetSpatialConfig(frame, widgetStore.fullCoordinate, region, region.lineRegionSampleWidth));
                 }
             }
         });


### PR DESCRIPTION
**Description**

Spatial requirements are map of the shape Map<fileId, Map<regionId, {coordinate: string, mip: number, width: number}>>. Originally, the ``width`` is stored in ``SpatialProfileWidgetStore`` as ``lineSampleWidth``. Since each widget, no matter the regionId, has its own widgetStore, each widget can set multiple width for the same regionId. The fix is to move ``lineSampleWidth`` to regionStore, so that each region have unique averaging width. This pr resolves bug #2000.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~