### PR TITLE
Yuhsuan/2033 beam related unit conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 * Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).
+* Fixed incorrect beam-related and frequency-related intensity unit conversions in the spectral profiler ([#2033](https://github.com/CARTAvis/carta-frontend/issues/2033)).
 
 ## [4.0.0-beta.1]
 

--- a/src/models/Spectral/SpectralDefinition.ts
+++ b/src/models/Spectral/SpectralDefinition.ts
@@ -207,14 +207,14 @@ export const IsIntensitySupported = (unitStr: string): boolean => {
     return FindIntensityUnitType(unitStr) !== IntensityUnitType.Unsupported;
 };
 
-export type IntensityConfig = {nativeIntensityUnit: string; bmaj?: number[]; bmin?: number[]; cdelta1?: number; cdelta2?: number; freqGHz?: number};
+export type IntensityConfig = {nativeIntensityUnit: string; bmaj?: number[]; bmin?: number[]; cdelta1?: number; cdelta2?: number; freqGHz?: number[]};
 const FindConvertibleIntensityTypes = (config: IntensityConfig): IntensityUnitType[] => {
     let options: IntensityUnitType[] = [];
     const type = FindIntensityUnitType(config?.nativeIntensityUnit);
     if (type !== IntensityUnitType.Unsupported) {
         if (type === IntensityUnitType.Kelvin) {
             options.push(IntensityUnitType.Kelvin);
-            if (config?.bmaj?.every(x => isFinite(x)) && config?.bmin?.every(x => isFinite(x)) && isFinite(config?.freqGHz)) {
+            if (config?.bmaj?.every(x => isFinite(x)) && config?.bmin?.every(x => isFinite(x)) && config?.freqGHz?.every(x => isFinite(x))) {
                 options.push(IntensityUnitType.JyBeam);
                 options.push(IntensityUnitType.JySr);
                 options.push(IntensityUnitType.JyArcsec2);
@@ -224,7 +224,7 @@ const FindConvertibleIntensityTypes = (config: IntensityConfig): IntensityUnitTy
             if (config?.bmaj?.every(x => isFinite(x)) && config?.bmin?.every(x => isFinite(x))) {
                 options.push(IntensityUnitType.JySr);
                 options.push(IntensityUnitType.JyArcsec2);
-                if (isFinite(config?.freqGHz)) {
+                if (config?.freqGHz?.every(x => isFinite(x))) {
                     options.push(IntensityUnitType.Kelvin);
                 }
             }
@@ -233,7 +233,7 @@ const FindConvertibleIntensityTypes = (config: IntensityConfig): IntensityUnitTy
             options.push(IntensityUnitType.JyArcsec2);
             if (config?.bmaj?.every(x => isFinite(x)) && config?.bmin?.every(x => isFinite(x))) {
                 options.push(IntensityUnitType.JyBeam);
-                if (isFinite(config?.freqGHz)) {
+                if (config?.freqGHz?.every(x => isFinite(x))) {
                     options.push(IntensityUnitType.Kelvin);
                 }
             }
@@ -288,15 +288,15 @@ const FindIntensityConversion = (unitFromType: IntensityUnitType, unitToType: In
     let conversion = undefined;
     if (unitFromType === IntensityUnitType.Kelvin) {
         if (unitToType === IntensityUnitType.JyBeam) {
-            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i], false);
+            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i], false);
         } else if (unitToType === IntensityUnitType.JySr) {
-            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i], false) * JyBeamToJySr(config.bmaj[i], config.bmin[i]);
+            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i], false) * JyBeamToJySr(config.bmaj[i], config.bmin[i]);
         } else if (unitToType === IntensityUnitType.JyArcsec2) {
-            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i], false) * JyBeamToJySr(config.bmaj[i], config.bmin[i]) * JySrToJyArcsec2();
+            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i], false) * JyBeamToJySr(config.bmaj[i], config.bmin[i]) * JySrToJyArcsec2();
         }
     } else if (unitFromType === IntensityUnitType.JyBeam) {
         if (unitToType === IntensityUnitType.Kelvin) {
-            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i]);
+            conversion = (value, i) => value * scale * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i]);
         } else if (unitToType === IntensityUnitType.JySr) {
             conversion = (value, i) => value * scale * JyBeamToJySr(config.bmaj[i], config.bmin[i]);
         } else if (unitToType === IntensityUnitType.JyArcsec2) {
@@ -304,7 +304,7 @@ const FindIntensityConversion = (unitFromType: IntensityUnitType, unitToType: In
         }
     } else if (unitFromType === IntensityUnitType.JySr) {
         if (unitToType === IntensityUnitType.Kelvin) {
-            conversion = (value, i) => value * scale * JyBeamToJySr(config.bmaj[i], config.bmin[i], false) * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i]);
+            conversion = (value, i) => value * scale * JyBeamToJySr(config.bmaj[i], config.bmin[i], false) * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i]);
         } else if (unitToType === IntensityUnitType.JyBeam) {
             conversion = (value, i) => value * scale * JyBeamToJySr(config.bmaj[i], config.bmin[i], false);
         } else if (unitToType === IntensityUnitType.JyArcsec2) {
@@ -314,7 +314,7 @@ const FindIntensityConversion = (unitFromType: IntensityUnitType, unitToType: In
         }
     } else if (unitFromType === IntensityUnitType.JyArcsec2) {
         if (unitToType === IntensityUnitType.Kelvin) {
-            conversion = (value, i) => value * scale * JySrToJyArcsec2(false) * JyBeamToJySr(config.bmaj[i], config.bmin[i], false) * JyBeamToKelvin(config.freqGHz, config.bmaj[i], config.bmin[i]);
+            conversion = (value, i) => value * scale * JySrToJyArcsec2(false) * JyBeamToJySr(config.bmaj[i], config.bmin[i], false) * JyBeamToKelvin(config.freqGHz[i], config.bmaj[i], config.bmin[i]);
         } else if (unitToType === IntensityUnitType.JyBeam) {
             conversion = (value, i) => value * scale * JySrToJyArcsec2(false) * JyBeamToJySr(config.bmaj[i], config.bmin[i], false);
         } else if (unitToType === IntensityUnitType.JySr) {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -18,3 +18,16 @@ Object.defineProperty(window, "matchMedia", {
         dispatchEvent: () => {}
     })
 });
+
+jest.mock("ast_wrapper", () => {
+    return {
+        fonts: [],
+        onReady: new Promise(() => {}),
+        emptyFitsChan: () => {},
+        getFrameFromFitsChan: () => {},
+        initDummyFrame: () => {},
+        putFits: () => {},
+        setColor: () => {},
+        geodesicDistance: () => {}
+    };
+});

--- a/src/stores/Frame/FrameStore.test.ts
+++ b/src/stores/Frame/FrameStore.test.ts
@@ -1,0 +1,92 @@
+import {CARTA} from "carta-protobuf";
+import {FrameInfo, FrameStore} from "stores";
+
+jest.mock("ast_wrapper", () => {
+    return {
+        fonts: [],
+        onReady: new Promise(() => {}),
+        emptyFitsChan: () => {},
+        getFrameFromFitsChan: () => {},
+        initDummyFrame: () => {},
+        putFits: () => {},
+        setColor: () => {},
+        geodesicDistance: () => {}
+    };
+});
+
+const stokesCubeframeInfo: FrameInfo = {
+    fileId: 0,
+    directory: "",
+    hdu: "",
+    fileInfo: new CARTA.FileInfo({HDUList: ["0"], name: "", size: 17280, type: 3}),
+    fileInfoExtended: new CARTA.FileInfoExtended({
+        dimensions: 4,
+        height: 2,
+        width: 2,
+        depth: 3,
+        stokes: 2,
+        axesNumbers: {spatialX: 1, spatialY: 2, spectral: 3, stokes: 4, depth: 3},
+        headerEntries: [
+            {name: "CTYPE1", value: "RA---SIN"},
+            {name: "CRVAL1", value: "1.469895377994E+02", entryType: 1, numericValue: 146.9895377994},
+            {name: "CDELT1", value: "-5.000000000000E-05", entryType: 1, numericValue: -0.00005},
+            {name: "CRPIX1", value: "-2", entryType: 1, numericValue: -2},
+            {name: "CUNIT1", value: "deg"},
+            {name: "CTYPE2", value: "DEC--SIN"},
+            {name: "CRVAL2", value: "1.327891127641E+01", entryType: 1, numericValue: 13.27891127641},
+            {name: "CDELT2", value: "5.000000000000E-05", entryType: 1, numericValue: 0.00005},
+            {name: "CRPIX2", value: "2", entryType: 1, numericValue: 2},
+            {name: "CUNIT2", value: "deg"},
+            {name: "CTYPE3", value: "FREQ"},
+            {name: "CRVAL3", value: "3.440912937187E+11", entryType: 1, numericValue: 344091293718.7},
+            {name: "CDELT3", value: "3.906722973755E+06", entryType: 1, numericValue: 3906722.973755},
+            {name: "CRPIX3", value: "1", entryType: 1, numericValue: 1},
+            {name: "CUNIT3", value: "Hz"},
+            {name: "CTYPE4", value: "STOKES"},
+            {name: "CRVAL4", value: "1.000000000000E+00", entryType: 1, numericValue: 1},
+            {name: "CDELT4", value: "1.000000000000E+00", entryType: 1, numericValue: 1},
+            {name: "CRPIX4", value: "1", entryType: 1, numericValue: 1},
+            {name: "CUNIT4"}
+        ]
+    }),
+    fileFeatureFlags: 0,
+    renderMode: CARTA.RenderMode.RASTER,
+    beamTable: [
+        new CARTA.Beam({majorAxis: 0.9315811991691589, minorAxis: 0.8433393239974976, pa: 42.576087951660156}),
+        new CARTA.Beam({channel: 1, majorAxis: 0.9315744042396545, minorAxis: 0.8433324098587036, pa: 42.5771484375}),
+        new CARTA.Beam({channel: 2, majorAxis: 0.9315680265426636, minorAxis: 0.843326985836029, pa: 42.57808303833008}),
+        new CARTA.Beam({stokes: 1, majorAxis: 0.931560754776001, minorAxis: 0.8433191776275635, pa: 42.579010009765625}),
+        new CARTA.Beam({channel: 1, stokes: 1, majorAxis: 0.9315542578697205, minorAxis: 0.8433099985122681, pa: 42.58040237426758}),
+        new CARTA.Beam({channel: 2, stokes: 1, majorAxis: 0.9315447807312012, minorAxis: 0.8433027863502502, pa: 42.58256912231445})
+    ]
+};
+
+describe("FrameStore", () => {
+    describe("beamProperties", () => {
+        test("returns the beam of the current channel and stokes", () => {
+            const frame = new FrameStore(stokesCubeframeInfo);
+            const beam = frame.beamProperties;
+            expect(beam).toHaveProperty("majorAxis", 0.9315811991691589);
+            expect(beam).toHaveProperty("minorAxis", 0.8433393239974976);
+            expect(beam).toHaveProperty("angle", 42.576087951660156);
+        });
+    });
+
+    describe("beamAllChannels", () => {
+        test("returns a list of beams from all channels with the current stokes", () => {
+            const frame = new FrameStore(stokesCubeframeInfo);
+            let beams = frame.beamAllChannels;
+            expect(beams).toHaveLength(3);
+            expect(beams[1]).toHaveProperty("majorAxis", 0.9315744042396545);
+            expect(beams[1]).toHaveProperty("minorAxis", 0.8433324098587036);
+            expect(beams[1]).toHaveProperty("pa", 42.5771484375);
+
+            frame.setChannels(0, 1, false);
+            beams = frame.beamAllChannels;
+            expect(beams).toHaveLength(3);
+            expect(beams[2]).toHaveProperty("majorAxis", 0.9315447807312012);
+            expect(beams[2]).toHaveProperty("minorAxis", 0.8433027863502502);
+            expect(beams[2]).toHaveProperty("pa", 42.58256912231445);
+        });
+    });
+});

--- a/src/stores/Frame/FrameStore.test.ts
+++ b/src/stores/Frame/FrameStore.test.ts
@@ -1,19 +1,6 @@
 import {CARTA} from "carta-protobuf";
 import {FrameInfo, FrameStore} from "stores";
 
-jest.mock("ast_wrapper", () => {
-    return {
-        fonts: [],
-        onReady: new Promise(() => {}),
-        emptyFitsChan: () => {},
-        getFrameFromFitsChan: () => {},
-        initDummyFrame: () => {},
-        putFits: () => {},
-        setColor: () => {},
-        geodesicDistance: () => {}
-    };
-});
-
 const stokesCubeframeInfo: FrameInfo = {
     fileId: 0,
     directory: "",

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -442,7 +442,7 @@ export class FrameStore {
         return null;
     }
 
-    @computed get beamPropertiesAllChannels(): CARTA.IBeam[] {
+    @computed get beamAllChannels(): CARTA.IBeam[] {
         const channelNum = this.channelInfo?.indexes?.length;
         if (!channelNum) {
             return [];

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -454,6 +454,30 @@ export class FrameStore {
         return null;
     }
 
+    @computed get beamPropertiesAllChannels(): CARTA.IBeam[] {
+        const channelNum = this.channelInfo?.indexes?.length;
+        if (!channelNum) {
+            return [];
+        }
+
+        const beams = this.channelInfo.indexes.map(channelIndex => {
+            let beam: CARTA.IBeam;
+            if (this.frameInfo.beamTable.length === 1 && this.frameInfo.beamTable[0].channel === -1 && this.frameInfo.beamTable[0].stokes === -1) {
+                beam = this.frameInfo.beamTable[0];
+            } else {
+                if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
+                    beam = this.frameInfo.beamTable.find(beam => beam.channel === channelIndex && beam.stokes === this.requiredStokes);
+                } else if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes <= 1) {
+                    beam = this.frameInfo.beamTable.find(beam => beam.channel === channelIndex);
+                } else if (this.frameInfo.fileInfoExtended.depth <= 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
+                    beam = this.frameInfo.beamTable.find(beam => beam.stokes === this.requiredStokes);
+                }
+            }
+            return beam;
+        });
+        return beams;
+    }
+
     @computed get hasVisibleBeam(): boolean {
         return this.beamProperties?.overlayBeamSettings?.visible;
     }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -425,19 +425,7 @@ export class FrameStore {
             const delta = getHeaderNumericValue(deltaHeader);
             if (isFinite(delta) && (unit === "deg" || unit === "rad")) {
                 if (this.frameInfo.beamTable && this.frameInfo.beamTable.length > 0) {
-                    let beam: CARTA.IBeam;
-                    if (this.frameInfo.beamTable.length === 1 && this.frameInfo.beamTable[0].channel === -1 && this.frameInfo.beamTable[0].stokes === -1) {
-                        beam = this.frameInfo.beamTable[0];
-                    } else {
-                        if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
-                            beam = this.frameInfo.beamTable.find(beam => beam.channel === this.requiredChannel && beam.stokes === this.requiredStokes);
-                        } else if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes <= 1) {
-                            beam = this.frameInfo.beamTable.find(beam => beam.channel === this.requiredChannel);
-                        } else if (this.frameInfo.fileInfoExtended.depth <= 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
-                            beam = this.frameInfo.beamTable.find(beam => beam.stokes === this.requiredStokes);
-                        }
-                    }
-
+                    const beam = this.getBeam(this.requiredChannel, this.requiredStokes);
                     if (beam && isFinite(beam.majorAxis) && beam.majorAxis > 0 && isFinite(beam.minorAxis) && beam.minorAxis > 0 && isFinite(beam.pa)) {
                         return {
                             x: beam.majorAxis / (unit === "deg" ? 3600 : (180 * 3600) / Math.PI) / Math.abs(delta),
@@ -460,23 +448,25 @@ export class FrameStore {
             return [];
         }
 
-        const beams = this.channelInfo.indexes.map(channelIndex => {
-            let beam: CARTA.IBeam;
-            if (this.frameInfo.beamTable.length === 1 && this.frameInfo.beamTable[0].channel === -1 && this.frameInfo.beamTable[0].stokes === -1) {
-                beam = this.frameInfo.beamTable[0];
-            } else {
-                if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
-                    beam = this.frameInfo.beamTable.find(beam => beam.channel === channelIndex && beam.stokes === this.requiredStokes);
-                } else if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes <= 1) {
-                    beam = this.frameInfo.beamTable.find(beam => beam.channel === channelIndex);
-                } else if (this.frameInfo.fileInfoExtended.depth <= 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
-                    beam = this.frameInfo.beamTable.find(beam => beam.stokes === this.requiredStokes);
-                }
-            }
-            return beam;
-        });
+        const beams = this.channelInfo.indexes.map(channelIndex => this.getBeam(channelIndex, this.requiredStokes));
         return beams;
     }
+
+    private getBeam = (channel: number, stokes: number): CARTA.IBeam => {
+        let beam: CARTA.IBeam;
+        if (this.frameInfo.beamTable.length === 1 && this.frameInfo.beamTable[0].channel === -1 && this.frameInfo.beamTable[0].stokes === -1) {
+            beam = this.frameInfo.beamTable[0];
+        } else {
+            if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
+                beam = this.frameInfo.beamTable.find(beam => beam.channel === channel && beam.stokes === stokes);
+            } else if (this.frameInfo.fileInfoExtended.depth > 1 && this.frameInfo.fileInfoExtended.stokes <= 1) {
+                beam = this.frameInfo.beamTable.find(beam => beam.channel === channel);
+            } else if (this.frameInfo.fileInfoExtended.depth <= 1 && this.frameInfo.fileInfoExtended.stokes > 1) {
+                beam = this.frameInfo.beamTable.find(beam => beam.stokes === stokes);
+            }
+        }
+        return beam;
+    };
 
     @computed get hasVisibleBeam(): boolean {
         return this.beamProperties?.overlayBeamSettings?.visible;

--- a/src/stores/Widgets/RegionWidgetStore/RegionWidgetStore.ts
+++ b/src/stores/Widgets/RegionWidgetStore/RegionWidgetStore.ts
@@ -59,7 +59,7 @@ export class RegionWidgetStore {
     }
 
     @computed get isEffectiveFrameEqualToActiveFrame(): boolean {
-        return this.effectiveFrame && this.appStore.activeFrame.frameInfo.fileId === this.effectiveFrame.frameInfo.fileId;
+        return this.effectiveFrame && this.appStore.activeFrame?.frameInfo.fileId === this.effectiveFrame.frameInfo.fileId;
     }
 
     @computed get effectiveRegionId(): number {
@@ -70,7 +70,7 @@ export class RegionWidgetStore {
             } else if (regionId === RegionId.NONE) {
                 return null;
             } else {
-                const selectedRegion = this.effectiveFrame.regionSet.selectedRegion;
+                const selectedRegion = this.effectiveFrame.regionSet?.selectedRegion;
                 if (selectedRegion) {
                     switch (this.type) {
                         case RegionsType.CLOSED:

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.test.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.test.ts
@@ -1,0 +1,53 @@
+import {CARTA} from "carta-protobuf";
+import * as SpectralDefinition from "models/Spectral/SpectralDefinition.ts";
+import {SpectralProfileWidgetStore, FrameStore} from "stores";
+
+const emptyframeInfo = {
+    fileId: 0,
+    directory: "",
+    hdu: "",
+    fileInfo: new CARTA.FileInfo(),
+    fileInfoExtended: new CARTA.FileInfoExtended(),
+    fileFeatureFlags: 0,
+    renderMode: 0,
+    beamTable: []
+};
+
+describe("SpectralProfileWidgetStore", () => {
+    describe("intensityConfig", () => {
+        let mockEffectiveFrame: jest.SpyInstance;
+        let mockBeamAllChannels: jest.SpyInstance;
+        let mockSpectralAxis: jest.SpyInstance;
+        let mockChannelInfo: jest.SpyInstance;
+        let mockGetFreqInGHz: jest.SpyInstance;
+        beforeAll(() => {
+            mockEffectiveFrame = jest.spyOn(SpectralProfileWidgetStore.prototype, "effectiveFrame", "get");
+            mockBeamAllChannels = jest.spyOn(FrameStore.prototype, "beamAllChannels", "get");
+            mockSpectralAxis = jest.spyOn(FrameStore.prototype, "spectralAxis", "get");
+            mockChannelInfo = jest.spyOn(FrameStore.prototype, "channelInfo", "get");
+            mockGetFreqInGHz = jest.spyOn(SpectralDefinition, "GetFreqInGHz");
+        });
+
+        test("returns correct beam config", () => {
+            mockEffectiveFrame.mockImplementation(() => new FrameStore(emptyframeInfo));
+            mockBeamAllChannels.mockImplementation(() => [
+                {majorAxis: 0.9315811991691589, minorAxis: 0.8433393239974976, pa: 42.576087951660156},
+                {channel: 1, majorAxis: 0.9315744042396545, minorAxis: 0.8433324098587036, pa: 42.5771484375},
+                {channel: 2, majorAxis: 0.9315680265426636, minorAxis: 0.843326985836029, pa: 42.57808303833008}
+            ]);
+            mockSpectralAxis.mockImplementation(() => {
+                return {type: {code: "FREQ"}};
+            });
+            mockChannelInfo.mockImplementation(() => {
+                return {values: [90.73634849111, 90.73631797353188, 90.73628745595375]};
+            });
+            mockGetFreqInGHz.mockImplementation((a, b) => b);
+
+            const widgetStore = new SpectralProfileWidgetStore();
+            const config = widgetStore.intensityConfig;
+            expect(config["bmaj"]).toEqual([0.9315811991691589, 0.9315744042396545, 0.9315680265426636]);
+            expect(config["bmin"]).toEqual([0.8433393239974976, 0.8433324098587036, 0.843326985836029]);
+            expect(config["freqGHz"]).toEqual([90.73634849111, 90.73631797353188, 90.73628745595375]);
+        });
+    });
+});

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -386,12 +386,12 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         const frame = this.effectiveFrame;
         if (frame) {
             let config: IntensityConfig = {nativeIntensityUnit: frame.headerUnit};
-            const beams = frame.beamPropertiesAllChannels;
+            const beams = frame.beamAllChannels;
             if (beams?.length) {
                 config["bmaj"] = beams.map(b => b?.majorAxis);
                 config["bmin"] = beams.map(b => b?.minorAxis);
                 if (frame.spectralAxis?.type?.code === "FREQ") {
-                    config["freqGHz"] = GetFreqInGHz(frame.spectralAxis.type.unit, frame.spectralAxis.value);
+                    config["freqGHz"] = frame.channelInfo?.values.map(x => GetFreqInGHz(frame.spectralAxis.type.unit, x));
                 }
             }
 

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -386,9 +386,10 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         const frame = this.effectiveFrame;
         if (frame) {
             let config: IntensityConfig = {nativeIntensityUnit: frame.headerUnit};
-            if (frame.beamProperties) {
-                config["bmaj"] = frame.beamProperties.majorAxis;
-                config["bmin"] = frame.beamProperties.minorAxis;
+            const beams = frame.beamPropertiesAllChannels;
+            if (beams?.length) {
+                config["bmaj"] = beams.map(b => b?.majorAxis);
+                config["bmin"] = beams.map(b => b?.minorAxis);
                 if (frame.spectralAxis?.type?.code === "FREQ") {
                     config["freqGHz"] = GetFreqInGHz(frame.spectralAxis.type.unit, frame.spectralAxis.value);
                 }

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -7,6 +7,7 @@ export * from "./CatalogOnlineQuery/CatalogOnlineQueryConfigStore";
 export * from "./CatalogOnlineQuery/CatalogOnlineQueryProfileStore";
 export * from "./DialogStore/DialogStore";
 export * from "./FileBrowserStore/FileBrowserStore";
+export * from "./Frame";
 export * from "./HelpStore/HelpStore";
 export * from "./ImageFittingStore/ImageFittingStore";
 export * from "./LayoutStore/LayoutStore";

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -19,4 +19,5 @@ export * from "./ProfileSmoothingStore/ProfileSmoothingStore";
 export * from "./Snippet/SnippetStore";
 export * from "./SpatialProfileStore/SpatialProfileStore";
 export * from "./SpectralProfileStore/SpectralProfileStore";
+export * from "./Widgets";
 export * from "./Widgets/WidgetsStore";


### PR DESCRIPTION
**Description**

Closes #2033 beam-related intensity unit conversion.
* Conversion between Jy/Beam and Jy/Sr: considers the beam size of each channel with the current stokes.
* Conversion between Jy/Beam and Kelvin: considers the beam size of each channel with the current stokes and the frequency of each channel.

Changes:

  The spectral profiler calls `intensityConversion` from the store to convert values before plotting data. `intensityConversion` is generated by `FindIntensityConversion` and `intensityConfig` when the units are different.
* Added new property `FrameStore.beamsAllChannels` to store beams from all channels with the current stokes.
* Adjusted `intensityConfig` to store arrays of beam size and freq.
* Adjusted `FindConvertibleIntensityTypes` to check validation of all array elements in `intensityConfig`.
* Adjusted `FindIntensityConversion` to set different conversions with different channels.

Code maintenance:

* Mock AST for all unit tests.
* Added test for beam related properties in `FrameStore`.
* Added test for `intensityConfig`.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~