### PR TITLE
carli/2171_two_image_one_pv_widget_bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
+* Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).
 
 ## [4.0.0-beta.1]
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1249,6 +1249,7 @@ export class AppStore {
                 const pvGeneratorWidgetStore = WidgetsStore.Instance.pvGeneratorWidgets.get(id);
                 if (pvGeneratorWidgetStore.previewFrame) {
                     pvGeneratorWidgetStore.previewFrame.updatePreviewDataGenerator = pvGeneratorWidgetStore.previewFrame.updatePreviewData(ack.previewData);
+                    pvGeneratorWidgetStore.setPvCutRegionId(message.regionId);
                     // The initial next() function call executes the FrameStore.updatePreviewData until the first yield keyword
                     pvGeneratorWidgetStore.previewFrame.updatePreviewDataGenerator.next();
                 } else {


### PR DESCRIPTION
**Description**

When user requests a preview, the code first checks if there is an existing preview frame, if there is, then the code skips the steps of creating a FrameStore and updating the regionId in the PvGeneratorWidgetStore. The bug is caused by this implementation, because if the same Pv widget is first used to create a preview in imageA, then when we try to create preview for a pv cut on imageB, the code would fail to update the regionId in the widget store for that particular Pv generator widget, resulting in failing to recognize that the pv cut on image B is a preview cut, which allows the code to skip live update. The fix would be simply updating the regionId every time the user requests a preview. The PR resolves #2171.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~