### PR TITLE
Yuhsuan/2140 support undefined in scripting

### DIFF
--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -112,7 +112,7 @@ export class ExecutionEntry {
             } else {
                 target = target[targetEntry];
             }
-            if (target == null) {
+            if (target === null) {
                 return null;
             }
         }

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -173,7 +173,7 @@ export class ScriptingService {
                 response: JSON.stringify(toJS(response))
             };
         } catch (err) {
-            console.error(err)
+            console.error(err);
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: false,

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -121,6 +121,9 @@ export class ExecutionEntry {
 
     private mapMacro = (parameter: any) => {
         if (typeof parameter === "object" && parameter?.macroVariable) {
+            if (parameter.macroVariable === "undefined") {
+                return undefined;
+            }
             const targetString = parameter?.macroTarget ? `${parameter.macroTarget}.${parameter.macroVariable}` : parameter.macroVariable;
             return ExecutionEntry.GetTargetObject(AppStore.Instance, targetString);
         }

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -174,10 +174,11 @@ export class ScriptingService {
                 response: JSON.stringify(toJS(response))
             };
         } catch (err) {
+            console.error(err)
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: false,
-                message: err
+                message: err?.toString()
             };
         }
     };

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -54,7 +54,7 @@ export class ExecutionEntry {
             }
             this.parameters = JSON.parse(substitutedParameterString);
         } catch (e) {
-            console.log(e);
+            console.error(e);
             return false;
         }
         return true;
@@ -88,15 +88,11 @@ export class ExecutionEntry {
         let target = baseObject;
         const targetNameArray = targetString.split(".");
 
-        console.log(targetNameArray);
-
         for (const targetEntry of targetNameArray) {
             const arrayRegex = /(\w+)(?:\[(\d+)])?/gm;
             const matches = arrayRegex.exec(targetEntry);
             // Check if there's an array index in this parameter
             if (matches && matches.length === 3 && matches[2] !== undefined) {
-                console.log(target);
-                console.log(matches);
                 target = target[matches[1]];
                 if (target == null) {
                     return null;
@@ -195,16 +191,14 @@ export class ScriptingService {
             try {
                 if (entry.async) {
                     // If entry is asynchronous, don't wait for it to complete before moving to the next entry
-                    const response = entry.execute();
-                    console.log(response);
+                    entry.execute();
                 } else {
-                    const response = await entry.execute();
-                    console.log(response);
+                    await entry.execute();
                     // TODO: more tests to see if this is really necessary
                     await ScriptingService.Delay(10);
                 }
             } catch (err) {
-                console.log(err);
+                console.error(err);
             }
         }
     };

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -120,8 +120,8 @@ export class ExecutionEntry {
     }
 
     private mapMacro = (parameter: any) => {
-        if (typeof parameter === "object" && parameter.macroVariable) {
-            const targetString = parameter.macroTarget ? `${parameter.macroTarget}.${parameter.macroVariable}` : parameter.macroVariable;
+        if (typeof parameter === "object" && parameter?.macroVariable) {
+            const targetString = parameter?.macroTarget ? `${parameter.macroTarget}.${parameter.macroVariable}` : parameter.macroVariable;
             return ExecutionEntry.GetTargetObject(AppStore.Instance, targetString);
         }
         return parameter;


### PR DESCRIPTION
**Description**

Closes #2140.

Changes (in the order of the commits):

1.
> No error message is sent back to the wrapper (I'm not sure why that is; I can see one when I inspect the scripting response in the console -- it may be a backend issue).

This is because an Error object was given to the message instead of a string in `ScriptingService.handleScriptingRequest`. Fixed by converting the Error object to a string.

2.
> Null parameters are rejected (and they shouldn't be; they could be valid values for some action parameters).

This is because `typeof null === "object"` [returns true](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null) in `ExecutionEntry.mapMacro`. `parameter.macroVariable` is not defined for null, resulting in error. Fixed by adding error handlings for `parameter`.

Now `img.call_action('vectorOverlayConfig.setIntensityRange', None, 3)` should be able to set min to 0 and max to 3.

3.
>The macro substitution converts undefined to null (undefined needs to be preserved).

This is because `undefined == null` [returns true](https://javascript.info/comparison#comparison-with-null-and-undefined) in `ExecutionEntry.GetTargetObject` and target is set to null instead of undefined. Fixed by changing to strict equality check `undefined === null`.

Now `img.call_action('vectorOverlayConfig.setIntensityRange', img.macro("vectorOverlayConfig", "intensityMin"), 3)` should be able to set min to undefined and max to 3.

4.
>It's impossible to send an explicit undefined value (perhaps we could use a macro-like placeholder for this).

I adjusted `ExecutionEntry.mapMacro` to return `undefined` when macroVariable is string `"undefined"` (I assume there won't be variables called "undefined").

Now both `img.call_action('vectorOverlayConfig.setIntensityRange', img.macro("", "undefined"), 3)` and `img.call_action('vectorOverlayConfig.setIntensityRange', Macro("", "undefined"), 3)` should be able to set min to undefined and max to 3.

@confluence If you prefer other interface for `undefined` values please let me know, and I can adjust the code.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~