### PR TITLE
fix typo

### DIFF
--- a/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
+++ b/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
@@ -8,8 +8,8 @@ import {FrameStore} from "stores/Frame";
 @observer
 export class SpectralSettingsComponent extends React.Component<{
     frame: FrameStore;
-    onSpectralCoordinateChange: (cooridnate: string) => void;
-    onSpectralCoordinateChangeSecondary?: (cooridnate: string) => void;
+    onSpectralCoordinateChange: (coordinate: string) => void;
+    onSpectralCoordinateChangeSecondary?: (coordinate: string) => void;
     onSpectralSystemChange: (system: string) => void;
     disable: boolean;
     disableChannelOption?: boolean;

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -74,7 +74,7 @@ export class SpectralProfileSelectionStore {
     private genProfileLabel = (fileId: number, regionName: string, statsType: CARTA.StatsType, coordinate: string): {image: string; plot: string} => {
         return {
             image: AppStore.Instance.getFrameName(fileId),
-            plot: `${regionName}, Statistic ${StatsTypeString(statsType)}, Cooridnate ${POLARIZATION_LABELS.get(coordinate.slice(0, coordinate.length - 1))}`
+            plot: `${regionName}, Statistic ${StatsTypeString(statsType)}, Coordinate ${POLARIZATION_LABELS.get(coordinate.slice(0, coordinate.length - 1))}`
         };
     };
 

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -624,7 +624,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         const frame = this.effectiveFrame;
 
         // Ignoring plotting lines when:
-        // 1. x cooridnate is channel
+        // 1. x coordinate is channel
         // 2. showing multiple profiles of different images in radio/optical velocity.(observation sources are not aligned now)
         const disablePlot = frame?.isCoordChannel || (frame?.isCoordVelocity && this.profileSelectionStore.isShowingProfilesOfMultiImages);
 
@@ -686,7 +686,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                     frameRequirements.set(spectralConfig.regionId, regionRequirements);
                 }
 
-                // cooridnate & stats type
+                // coordinate & stats type
                 if (!regionRequirements.spectralProfiles) {
                     regionRequirements.spectralProfiles = [];
                 }


### PR DESCRIPTION
**Description**

the codebase contains a typo "Cooridnate" or "cooridnate" which is displayed in the spectral profiler.

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [ ] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / corresponding fix added
- [ ] changelog updated / no changelog update needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] `BackendService` unchanged / `BackendService` changed and corresponding ICD test fix added