### PR TITLE
Fixes the layout with histogram widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 * Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).
 * Fixed incorrect beam-related and frequency-related intensity unit conversions in the spectral profiler ([#2033](https://github.com/CARTAvis/carta-frontend/issues/2033)).
+* Fixed the blank screen when using layout with histogram widget ([#2178](https://github.com/CARTAvis/carta-frontend/issues/2178)).
 
 ## [4.0.0-beta.1]
 

--- a/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
+++ b/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
@@ -164,13 +164,13 @@ export class HistogramWidgetStore extends RegionWidgetStore {
 
     resetBounds = () => {
         if (this.cachedMinPix === undefined) {
-            this.currentMinPix = this.effectiveFrame.renderConfig.histogramMin;
+            this.currentMinPix = this.effectiveFrame?.renderConfig.histogramMin;
         } else {
             this.currentMinPix = this.cachedMinPix;
         }
 
         if (this.cachedMaxPix === undefined) {
-            this.currentMaxPix = this.effectiveFrame.renderConfig.histogramMax;
+            this.currentMaxPix = this.effectiveFrame?.renderConfig.histogramMax;
         } else {
             this.currentMaxPix = this.cachedMaxPix;
         }
@@ -178,7 +178,7 @@ export class HistogramWidgetStore extends RegionWidgetStore {
 
     resetNumBins = () => {
         if (this.cachedNumBins === undefined) {
-            this.currentNumBins = this.effectiveFrame.renderConfig.histogram.numBins;
+            this.currentNumBins = this.effectiveFrame?.renderConfig.histogram.numBins;
         } else {
             this.currentNumBins = this.cachedNumBins;
         }
@@ -348,7 +348,7 @@ export class HistogramWidgetStore extends RegionWidgetStore {
         this.maxPix = 0;
 
         // Initialize the maximum number of histogram bins on the slider
-        this.maxNumBins = this.effectiveFrame.renderConfig.histogram.numBins * 2;
+        this.maxNumBins = this.effectiveFrame?.renderConfig.histogram.numBins * 2;
 
         autorun(() => {
             // Update the config parameters


### PR DESCRIPTION
**Description**

Closes #2178. By adding a check for the existence of the `FrameSotre` object before getting parameters from it. The user's customized layout with histogram widgets would work now.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated ~/ no changelog update needed~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] `BackendService` unchanged ~/ `BackendService` changed and corresponding ICD test fix added~