### PR TITLE
Yuhsuan/2144 native wcs channel value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
 * Fixed tsv and txt file export naming ([#1987](https://github.com/CARTAvis/carta-frontend/issues/1987)).
 * Fixed the alignment in workspace dialog ([#2155](https://github.com/CARTAvis/carta-frontend/issues/2155)).
+* Fixed the spectral axis for images with headers in `CDi_j` format ([#2144](https://github.com/CARTAvis/carta-frontend/issues/2144)).
 
 ## [4.0.0-beta.1]
 

--- a/src/models/ChannelInfo/ChannelInfo.ts
+++ b/src/models/ChannelInfo/ChannelInfo.ts
@@ -1,6 +1,5 @@
 export interface ChannelInfo {
     fromWCS: boolean;
-    delta: number;
     indexes: number[];
     values: number[];
     getChannelIndexWCS: (x: number) => number;

--- a/src/models/ChannelInfo/ChannelInfo.ts
+++ b/src/models/ChannelInfo/ChannelInfo.ts
@@ -3,7 +3,6 @@ export interface ChannelInfo {
     delta: number;
     indexes: number[];
     values: number[];
-    rawValues: number[];
     getChannelIndexWCS: (x: number) => number;
     getChannelIndexSimple: (x: number) => number;
 }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1485,10 +1485,12 @@ export class FrameStore {
         return Array.from(values?.z);
     };
 
-    private getSpectralIndexFromNativeWcs = (index: number): number => {
+    private getSpectralIndexFromNativeWcs = (value: number): number => {
         const refPix = this.getSpatialRefPix();
-        const value = AST.transform3DPoint(this.wcsInfo3D, refPix?.x, refPix?.y, index, false);
-        return value?.z;
+        const refValue = AST.transform3DPoint(this.wcsInfo3D, refPix?.x, refPix?.y, 0);
+
+        const index = AST.transform3DPoint(this.wcsInfo3D, refValue?.x, refValue?.y, value, false);
+        return index?.z;
     };
 
     private getSpatialRefPix = (): Point2D => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -499,28 +499,30 @@ export class FrameStore {
         if (this.spectralAxis && this.wcsInfo3D) {
             const values = this.getSpectralValuesInNativeWcs(indexes);
 
-            return {
-                fromWCS: true,
-                indexes,
-                values,
-                getChannelIndexWCS: (value: number): number => {
-                    if (!isFinite(value)) {
-                        return null;
-                    }
-
-                    const index = this.getSpectralIndexFromNativeWcs(value);
-                    if (index < 0) {
-                        return 0;
-                    } else if (index > values.length - 1) {
-                        return values.length - 1;
-                    }
-
-                    const ceil = Math.ceil(index);
-                    const floor = Math.floor(index);
-                    return Math.abs(values[ceil] - value) < Math.abs(value - values[floor]) ? ceil : floor;
-                },
-                getChannelIndexSimple: getChannelIndexSimple
-            };
+            if (values) {
+                return {
+                    fromWCS: true,
+                    indexes,
+                    values,
+                    getChannelIndexWCS: (value: number): number => {
+                        if (!isFinite(value)) {
+                            return null;
+                        }
+    
+                        const index = this.getSpectralIndexFromNativeWcs(value);
+                        if (index < 0) {
+                            return 0;
+                        } else if (index > values.length - 1) {
+                            return values.length - 1;
+                        }
+    
+                        const ceil = Math.ceil(index);
+                        const floor = Math.floor(index);
+                        return Math.abs(values[ceil] - value) < Math.abs(value - values[floor]) ? ceil : floor;
+                    },
+                    getChannelIndexSimple: getChannelIndexSimple
+                };
+            }
         }
 
         // return channels
@@ -1480,13 +1482,13 @@ export class FrameStore {
         const zIndexes = new Float64Array(indexes);
 
         const values = AST.transform3DPointArrays(this.wcsInfo3D, xIndexes, yIndexes, zIndexes);
-        return Array.from(values.z);
+        return Array.from(values?.z);
     };
 
     private getSpectralIndexFromNativeWcs = (index: number): number => {
         const refPix = this.getSpatialRefPix();
         const value = AST.transform3DPoint(this.wcsInfo3D, refPix?.x, refPix?.y, index, false);
-        return value.z;
+        return value?.z;
     };
 
     private getSpatialRefPix = (): Point2D => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -477,10 +477,9 @@ export class FrameStore {
             return undefined;
         }
         const N = this.frameInfo.fileInfoExtended.depth;
-        const indexes = new Array<number>(N);
-        const values = new Array<number>(N);
+        const indexes = Array.from({length: N}, (x, i) => i);
 
-        let getChannelIndexSimple = (value: number): number => {
+        const getChannelIndexSimple = (value: number): number => {
             if (!value && value !== 0) {
                 return null;
             }
@@ -498,6 +497,8 @@ export class FrameStore {
 
         // By default, we try to use the WCS information to determine channel info.
         if (this.spectralAxis) {
+            const values = new Array<number>(N);
+
             const refPixHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${this.spectralNumber}`) !== -1);
             const refValHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRVAL${this.spectralNumber}`) !== -1);
             const deltaHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CDELT${this.spectralNumber}`) !== -1);
@@ -510,7 +511,6 @@ export class FrameStore {
                 if (isFinite(refPix) && isFinite(refVal) && isFinite(delta)) {
                     for (let i = 0; i < N; i++) {
                         const channelOffset = i - refPix;
-                        indexes[i] = i;
                         values[i] = channelOffset * delta + refVal;
                     }
                     return {
@@ -541,10 +541,8 @@ export class FrameStore {
         }
 
         // return channels
-        for (let i = 0; i < N; i++) {
-            indexes[i] = i;
-            values[i] = i;
-        }
+        const values = indexes.slice(0);
+
         return {
             fromWCS: false,
             delta: undefined,

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -508,14 +508,14 @@ export class FrameStore {
                         if (!isFinite(value)) {
                             return null;
                         }
-    
+
                         const index = this.getSpectralIndexFromNativeWcs(value);
                         if (index < 0) {
                             return 0;
                         } else if (index > values.length - 1) {
                             return values.length - 1;
                         }
-    
+
                         const ceil = Math.ceil(index);
                         const floor = Math.floor(index);
                         return Math.abs(values[ceil] - value) < Math.abs(value - values[floor]) ? ceil : floor;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -501,7 +501,6 @@ export class FrameStore {
             return {
                 fromWCS: true,
                 indexes,
-                delta: undefined,
                 values,
                 getChannelIndexWCS: (value: number): number => {
                     if (!isFinite(value)) {
@@ -528,7 +527,6 @@ export class FrameStore {
 
         return {
             fromWCS: false,
-            delta: undefined,
             indexes,
             values,
             getChannelIndexWCS: null,

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -479,7 +479,6 @@ export class FrameStore {
         const N = this.frameInfo.fileInfoExtended.depth;
         const indexes = new Array<number>(N);
         const values = new Array<number>(N);
-        const rawValues = new Array<number>(N);
 
         let getChannelIndexSimple = (value: number): number => {
             if (!value && value !== 0) {
@@ -512,15 +511,13 @@ export class FrameStore {
                     for (let i = 0; i < N; i++) {
                         const channelOffset = i - refPix;
                         indexes[i] = i;
-                        rawValues[i] = channelOffset * delta + refVal;
-                        values[i] = rawValues[i];
+                        values[i] = channelOffset * delta + refVal;
                     }
                     return {
                         fromWCS: true,
                         indexes,
                         delta,
                         values,
-                        rawValues,
                         getChannelIndexWCS: (value: number): number => {
                             if (!value) {
                                 return null;
@@ -547,14 +544,12 @@ export class FrameStore {
         for (let i = 0; i < N; i++) {
             indexes[i] = i;
             values[i] = i;
-            rawValues[i] = i;
         }
         return {
             fromWCS: false,
             delta: undefined,
             indexes,
             values,
-            rawValues,
             getChannelIndexWCS: null,
             getChannelIndexSimple: getChannelIndexSimple
         };
@@ -581,7 +576,7 @@ export class FrameStore {
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const restFreq = this.restFreqStore.restFreqInHz;
 
-                    const freqVal = channelInfo.rawValues[spectralInfo.channel];
+                    const freqVal = channelInfo.values[spectralInfo.channel];
                     // convert frequency value to unit in GHz
                     if (this.isSpectralCoordinateConvertible && spectralType.unit !== SPECTRAL_DEFAULT_UNIT.get(SpectralType.FREQ)) {
                         const freqGHz = this.astSpectralTransform(SpectralType.FREQ, SpectralUnit.GHZ, this.spectralSystem, freqVal);
@@ -595,7 +590,7 @@ export class FrameStore {
                         spectralInfo.velocityString = `Velocity: ${toFixed(velocityVal, 4)} km/s`;
                     }
                 } else if (spectralType.code === "VRAD") {
-                    const velocityVal = channelInfo.rawValues[spectralInfo.channel];
+                    const velocityVal = channelInfo.values[spectralInfo.channel];
                     // convert velocity value to unit in km/s
                     if (this.isSpectralCoordinateConvertible && spectralType.unit !== SPECTRAL_DEFAULT_UNIT.get(SpectralType.VRAD)) {
                         const volecityKMS = this.astSpectralTransform(SpectralType.VRAD, SpectralUnit.KMS, this.spectralSystem, velocityVal);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1477,20 +1477,26 @@ export class FrameStore {
         const refPix = this.getSpatialRefPix();
 
         const N = indexes.length;
-        const xIndexes = new Float64Array(N).fill(refPix?.x);
-        const yIndexes = new Float64Array(N).fill(refPix?.y);
-        const zIndexes = new Float64Array(indexes);
+        const xIndexes = this.spectral === 1 ? new Float64Array(indexes) : new Float64Array(N).fill(this.dirX === 1 ? refPix?.x : refPix?.y);
+        const yIndexes = this.spectral === 2 ? new Float64Array(indexes) : new Float64Array(N).fill(this.dirX === 2 ? refPix?.x : refPix?.y);
+        const zIndexes = this.spectral === 3 ? new Float64Array(indexes) : new Float64Array(N).fill(this.dirX === 3 ? refPix?.x : refPix?.y);
 
         const values = AST.transform3DPointArrays(this.wcsInfo3D, xIndexes, yIndexes, zIndexes);
-        return Array.from(values?.z);
+        return Array.from(this.spectral === 1 ? values?.x : this.spectral === 2 ? values?.y : values?.z);
     };
 
     private getSpectralIndexFromNativeWcs = (value: number): number => {
         const refPix = this.getSpatialRefPix();
-        const refValue = AST.transform3DPoint(this.wcsInfo3D, refPix?.x, refPix?.y, 0);
+        const xIndex = this.spectral === 1 ? 0 : this.dirX === 1 ? refPix?.x : refPix?.y;
+        const yIndex = this.spectral === 2 ? 0 : this.dirX === 2 ? refPix?.x : refPix?.y;
+        const zIndex = this.spectral === 3 ? 0 : this.dirX === 3 ? refPix?.x : refPix?.y;
+        const refValue = AST.transform3DPoint(this.wcsInfo3D, xIndex, yIndex, zIndex);
 
-        const index = AST.transform3DPoint(this.wcsInfo3D, refValue?.x, refValue?.y, value, false);
-        return index?.z;
+        const xValue = this.spectral === 1 ? value : this.dirX === 1 ? refValue?.x : refValue?.y;
+        const yValue = this.spectral === 2 ? value : this.dirX === 2 ? refValue?.x : refValue?.y;
+        const zValue = this.spectral === 3 ? value : this.dirX === 3 ? refValue?.x : refValue?.y;
+        const index = AST.transform3DPoint(this.wcsInfo3D, xValue, yValue, zValue, false);
+        return this.spectral === 1 ? index?.x : this.spectral === 2 ? index?.y : index?.z;
     };
 
     private getSpatialRefPix = (): Point2D => {

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -94,19 +94,25 @@ export function getTransformedChannel(srcTransform: AST.FrameSet, destTransform:
     }
 
     // Set common spectral
-    AST.set(srcTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
-    AST.set(destTransform, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
+    const copySrc = AST.copy(srcTransform);
+    const copyDest = AST.copy(destTransform);
+    AST.set(copySrc, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
+    AST.set(copyDest, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
 
     // Get spectral value from forward transform
-    const sourceSpectralValue = AST.transform3DPoint(srcTransform, 0, 0, srcChannel, true);
+    const sourceSpectralValue = AST.transform3DPoint(copySrc, 0, 0, srcChannel, true);
     if (!sourceSpectralValue || !isFinite(sourceSpectralValue.z)) {
         return NaN;
     }
 
     // Get a sensible pixel coordinate for the reverse transform by forward transforming first pixel in image
-    const dummySpectralValue = AST.transform3DPoint(destTransform, 0, 0, 0, true);
+    const dummySpectralValue = AST.transform3DPoint(copyDest, 0, 0, 0, true);
     // Get pixel value from destination transform (reverse)
-    const destPixelValue = AST.transform3DPoint(destTransform, dummySpectralValue.x, dummySpectralValue.y, sourceSpectralValue.z, false);
+    const destPixelValue = AST.transform3DPoint(copyDest, dummySpectralValue.x, dummySpectralValue.y, sourceSpectralValue.z, false);
+
+    AST.deleteObject(copySrc);
+    AST.deleteObject(copyDest);
+
     if (!destPixelValue || !isFinite(destPixelValue.z)) {
         return NaN;
     }

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -535,6 +535,29 @@ EMSCRIPTEN_KEEPALIVE int transform3D(AstSpecFrame* wcsinfo, double x, double y, 
     return 0;
 }
 
+EMSCRIPTEN_KEEPALIVE int transform3DArray(AstFrameSet* wcsinfo, int npoint, double x[], double y[], double z[], const int forward, double out[])
+{
+    if (!wcsinfo)
+    {
+        return 1;
+    }
+
+    double in[3][npoint];
+    memcpy(in[0], x, npoint * sizeof(double));
+    memcpy(in[1], y, npoint * sizeof(double));
+    memcpy(in[2], z, npoint * sizeof(double));
+    const double* inPtr = in[0];
+
+    astTranN(wcsinfo, npoint, 3, npoint, inPtr, forward, 3, npoint, out);
+    
+    if (!astOK)
+    {
+        astClearStatus;
+        return 1;
+    }
+    return 0;
+}
+
 EMSCRIPTEN_KEEPALIVE int spectralTransform(AstSpecFrame* specFrameFrom, const char* specTypeTo, const char* specUnitTo, const char* specSysTo, const int npoint, const double zIn[], const int forward, double zOut[])
 {
     if (!specFrameFrom)

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -535,21 +535,14 @@ EMSCRIPTEN_KEEPALIVE int transform3D(AstSpecFrame* wcsinfo, double x, double y, 
     return 0;
 }
 
-EMSCRIPTEN_KEEPALIVE int transform3DArray(AstFrameSet* wcsinfo, int npoint, double x[], double y[], double z[], const int forward, double out[])
+EMSCRIPTEN_KEEPALIVE int transform3DArray(AstFrameSet* wcsinfo, int npoint, double in[], const int forward, double out[])
 {
     if (!wcsinfo)
     {
         return 1;
     }
 
-    double in[3][npoint];
-    memcpy(in[0], x, npoint * sizeof(double));
-    memcpy(in[1], y, npoint * sizeof(double));
-    memcpy(in[2], z, npoint * sizeof(double));
-    const double* inPtr = in[0];
-
-    astTranN(wcsinfo, npoint, 3, npoint, inPtr, forward, 3, npoint, out);
-    
+    astTranN(wcsinfo, npoint, 3, npoint, in, forward, 3, npoint, out);  
     if (!astOK)
     {
         astClearStatus;

--- a/wasm_src/ast_wrapper/index.d.ts
+++ b/wasm_src/ast_wrapper/index.d.ts
@@ -76,5 +76,6 @@ export function transformSpectralPoint(specFrame: SpecFrame, specType: string, s
 export function transformSpectralPointArray(specFrame: SpecFrame, specType: string, specUnit: string, specSys: string, zIn: Float64Array | Array<number>, forward?: boolean): Float64Array;
 export function normalizeCoordinates(frameSet: FrameSet, x: number, y: number): {x: number; y: number};
 export function getTransformGrid(transformFrameSet: FrameSet, xMin: number, xMax: number, numX: number, yMin: number, yMax: number, numY: number, forward: boolean);
+export function transform3DPointArrays(frameSet: FrameSet, xIn: Float64Array, yIn: Float64Array, zIn: Float64Array, forward?: boolean): {x: Float64Array, y: Float64Array, z: Float64Array};
 
 export const onReady: Promise<void>;

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -223,9 +223,7 @@ Module.transform3DPointArrays = function (wcsInfo: number, xIn: Float64Array, yI
     const result = {x: out.slice(0, N), y: out.slice(N, 2 * N), z: out.slice(2 * N, 3 * N)};
 
     // Free WASM memory
-    Module._free(xInPtr);
-    Module._free(yInPtr);
-    Module._free(zInPtr);
+    Module._free(inPtr);
     Module._free(outPtr);
     return result;
 };

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -113,7 +113,7 @@ Module.format = Module.cwrap("format", "string", ["number", "number", "number"])
 Module.unformat = Module.cwrap("unformat", "number", ["number", "number", "string", "number"]);
 Module.transform = Module.cwrap("transform", "number", ["number", "number", "number", "number", "number", "number", "number"]);
 Module.transform3D = Module.cwrap("transform3D", "number", ["number", "number", "number", "number", "number", "number"]);
-Module.transform3DArray = Module.cwrap("transform3DArray", "number", ["number", "number", "number", "number", "number", "number", "number"]);
+Module.transform3DArray = Module.cwrap("transform3DArray", "number", ["number", "number", "number", "number", "number"]);
 Module.spectralTransform = Module.cwrap("spectralTransform", "number", ["number", "string", "string", "string", "number", "number", "number", "number"]);
 Module.getLastErrorMessage = Module.cwrap("getLastErrorMessage", "string");
 Module.clearLastErrorMessage = Module.cwrap("clearLastErrorMessage", null);
@@ -206,16 +206,17 @@ Module.transform3DPointArrays = function (wcsInfo: number, xIn: Float64Array, yI
 
     // Allocate and assign WASM memory
     const N = xIn.length;
-    const xInPtr = Module._malloc(N * 8);
-    const yInPtr = Module._malloc(N * 8);
-    const zInPtr = Module._malloc(N * 8);
+    const inPtr = Module._malloc(N * 8 * 3);
+    const xInPtr = inPtr;
+    const yInPtr = xInPtr + 8 * N;
+    const zInPtr = yInPtr + 8 * N;
     const outPtr = Module._malloc(N * 8 * 3);
     Module.HEAPF64.set(xIn, xInPtr / 8);
     Module.HEAPF64.set(yIn, yInPtr / 8);
     Module.HEAPF64.set(zIn, zInPtr / 8);
 
     // Perform the AST transform
-    Module.transform3DArray(wcsInfo, N, xInPtr, yInPtr, zInPtr, forward, outPtr);
+    Module.transform3DArray(wcsInfo, N, inPtr, forward, outPtr);
 
     // Copy result out to an object
     const out = new Float64Array(Module.HEAPF64.buffer, outPtr, N * 3);


### PR DESCRIPTION
**Description**

Closes #2144. The issue is caused by the calculation of the channel values in native wcs. There are two kinds of format that defines the pixel size in FITS header: `PCi_j + CDELTi` format and `CDi_j` format, and we only consider `CDELTi` in the calculation.

If the header is in `CDi_j` format, the calculation fails and channel indexes are returned (as in the example of the issue). Frontend crashes if we try to convert the channel indexes to other units.

Another problem in the calculation is that we do not consider `PCi_j`, and the pixel size is a constant. Non-linear spectral axis is not supported (although it's rare in radio images).

In order to solve the problems, obtain the channel values by AST library transformation instead of directly checking the header.

Implementation:

* In `channelInfo`, transform `(xRef, yRef, 0), (xRef, yRef, 1), ...,  (xRef, yRef, channel num - 1)` from pixel coordinate to world coordinate with the 3 dimensional AST FrameSet created from the header entries. `xRef` and `yRef` are constants defined by `CRPIXi` in the header. Origin (0, 0) is used if `CRPIXi` are not found.
* In `getChannelIndexWCS`, convert the wcs value back to pixel coordinate with the same FrameSet, `xRef`, and `yRef`. Adjusted `getTransformedChannel` and `getTransformedChannelList` so that the frameSet remains unchanged.
* Considered rotated cubes when applying transformation.

Code maintenance:

* `delta` is removed from `ChannelInfo` because it's not used.
* `rawValues` is removed from `ChannelInfo` because it's the same with `values`. It was for unit conversion in `ChannelInfo`, but the conversion is moved to other place.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~