### PR TITLE
Yuhsuan/2015 scripting set channels

### DIFF
--- a/src/components/Animator/AnimatorComponent.tsx
+++ b/src/components/Animator/AnimatorComponent.tsx
@@ -60,7 +60,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
             if (val >= frame.frameInfo.fileInfoExtended.depth) {
                 val = 0;
             }
-            frame.setChannels(val, frame.requiredStokes, true);
+            frame.setChannel(val);
         }
     };
 
@@ -75,10 +75,7 @@ export class AnimatorComponent extends React.Component<WidgetProps> {
 
     onStokesChanged = (val: number) => {
         const frame = AppStore.Instance.activeFrame;
-        const isComputedPolarization = val >= frame.frameInfo.fileInfoExtended.stokes;
-        // request standard polarization by the stokes index of image. (eg. "I": 0)
-        // request computed polarization by PolarizationDefinition. (eg. "Pangle": 17)
-        frame?.setChannels(frame.requiredChannel, isComputedPolarization ? frame.polarizations[val] : val, true);
+        frame?.setStokesByIndex(val, true);
     };
 
     onFrameChanged = (val: number) => {

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -109,7 +109,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         }
         const nearestIndex = frame.findChannelIndexByValue(x);
         if (frame && isFinite(nearestIndex) && nearestIndex >= 0 && nearestIndex < frame.numChannels) {
-            frame.setChannels(nearestIndex, frame.requiredStokes, true);
+            frame.setChannel(nearestIndex);
             if (!_.isEqual(frame, appStore.activeFrame)) {
                 appStore.setChannelsByFrame(frame);
             }

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -199,7 +199,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 }
             }
             if (nearestIndex !== null && nearestIndex !== undefined) {
-                frame.setChannels(nearestIndex, frame.requiredStokes, true);
+                frame.setChannel(nearestIndex);
             }
         }
     };
@@ -227,7 +227,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 }
             }
             if (nearestIndex !== null && nearestIndex !== undefined) {
-                frame.setChannels(nearestIndex, frame.requiredStokes, true);
+                frame.setChannel(nearestIndex);
             }
         }
     };

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2226,30 +2226,52 @@ export class FrameStore {
         }
     }
 
+    /**
+     * Sets the channel of the frame.
+     * @param channel - The channel index to set.
+     * @param recursive - Whether to update channels of spectrally matched frames. Default value is true.
+     */
     @action setChannel = (channel: number, recursive: boolean = true) => {
         this.setChannels(channel, this.requiredStokes, recursive);
     };
 
-    // required for carta-python
-    @action setStokes = (stokes: POLARIZATIONS, recursive: boolean = false) => {
-        const stokesIndex = this.polarizations?.indexOf(stokes);
-        if (!isFinite(stokesIndex) || stokesIndex === -1) {
+    /**
+     * Sets the Stokes parameter of the frame. Required for carta-python.
+     * If the provided `polarization` value is not found in the frame, the function will return without making any changes.
+     * @param polarization - The polarization value.
+     * @param recursive - Whether to update channels of spectrally matched frames. Default value is false.
+     */
+    @action setStokes = (polarization: POLARIZATIONS, recursive: boolean = false) => {
+        const polarizationIndex = this.polarizations?.indexOf(polarization);
+        if (!isFinite(polarizationIndex) || polarizationIndex === -1) {
             return;
         }
-        this.setStokesByIndex(stokesIndex, recursive);
+        this.setStokesByIndex(polarizationIndex, recursive);
     };
 
-    @action setStokesByIndex = (stokesIndex: number, recursive: boolean = false) => {
-        if (!isFinite(stokesIndex) || stokesIndex >= this.polarizations.length) {
+    /**
+     * Sets the Stokes parameter of the frame by the index.
+     * If the provided `polarizationIndex` is not a valid index or exceeds the range, the function will return without making any changes.
+     * @param polarizationIndex - The index of the polarization value.
+     * @param recursive - Whether to update channels of spectrally matched frames. Default value is false.
+     */
+    @action setStokesByIndex = (polarizationIndex: number, recursive: boolean = false) => {
+        if (!isFinite(polarizationIndex) || polarizationIndex >= this.polarizations.length) {
             return;
         }
 
-        const isComputedPolarization = stokesIndex >= this.frameInfo.fileInfoExtended.stokes;
+        const isComputedPolarization = polarizationIndex >= this.frameInfo.fileInfoExtended.stokes;
         // request standard polarization by the stokes index of image. (eg. "I": 0)
         // request computed polarization by PolarizationDefinition. (eg. "Pangle": 17)
-        this.setChannels(this.requiredChannel, isComputedPolarization ? this.polarizations[stokesIndex] : stokesIndex, recursive);
+        this.setChannels(this.requiredChannel, isComputedPolarization ? this.polarizations[polarizationIndex] : polarizationIndex, recursive);
     };
 
+    /**
+     * Sets the channel and the Stokes parameter of the frame.
+     * @param channel - The channel index to set.
+     * @param stokes - The Stokes parameter to set. Standard polarization requires the polarization index (eg. "I": 0). Computed polarization requires the polarization value (eg. "Pangle": 17).
+     * @param recursive - Whether to update channels of spectrally matched frames.
+     */
     @action setChannels = (channel: number, stokes: number, recursive: boolean) => {
         if (stokes < 0) {
             stokes += this.frameInfo.fileInfoExtended.stokes;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2230,6 +2230,7 @@ export class FrameStore {
         this.setChannels(channel, this.requiredStokes, recursive);
     };
 
+    // required for carta-python
     @action setStokes = (stokes: POLARIZATIONS, recursive: boolean = false) => {
         const stokesIndex = this.polarizations?.indexOf(stokes);
         if (!isFinite(stokesIndex) || stokesIndex === -1) {
@@ -2242,14 +2243,14 @@ export class FrameStore {
         if (!isFinite(stokesIndex) || stokesIndex >= this.polarizations.length) {
             return;
         }
-    
+
         const isComputedPolarization = stokesIndex >= this.frameInfo.fileInfoExtended.stokes;
         // request standard polarization by the stokes index of image. (eg. "I": 0)
         // request computed polarization by PolarizationDefinition. (eg. "Pangle": 17)
         this.setChannels(this.requiredChannel, isComputedPolarization ? this.polarizations[stokesIndex] : stokesIndex, recursive);
-    }
+    };
 
-    @action setChannels(channel: number, stokes: number, recursive: boolean) {
+    @action setChannels = (channel: number, stokes: number, recursive: boolean) => {
         if (stokes < 0) {
             stokes += this.frameInfo.fileInfoExtended.stokes;
         }
@@ -2279,9 +2280,9 @@ export class FrameStore {
         if (this.isSwappedZ) {
             this.updateSpectralVsDirectionWcs();
         }
-    }
+    };
 
-    @action incrementChannels(deltaChannel: number, deltaStokes: number, wrap: boolean = true) {
+    @action incrementChannels = (deltaChannel: number, deltaStokes: number, wrap: boolean = true) => {
         const depth = Math.max(1, this.frameInfo.fileInfoExtended.depth);
         const numStokes = Math.max(1, this.polarizations?.length);
 
@@ -2298,7 +2299,7 @@ export class FrameStore {
         // request standard polarization by the stokes index of image. (eg. "I": 0)
         // request computed polarization by PolarizationDefinition. (eg. "Pangle": 17)
         this.setChannels(newChannel, isComputedPolarization ? this.polarizations[newStokes] : newStokes, true);
-    }
+    };
 
     @action setZoom = (zoom: number, absolute: boolean = false) => {
         if (this.spatialReference) {
@@ -2727,7 +2728,7 @@ export class FrameStore {
         this.spectralReference = frame;
         this.spectralReference.addSecondarySpectralImage(this);
         const matchedChannel = getTransformedChannel(frame.wcsInfo3D, this.wcsInfo3D, preferenceStore.spectralMatchingType, frame.requiredChannel);
-        this.setChannels(matchedChannel, this.requiredStokes, false);
+        this.setChannel(matchedChannel, false);
 
         // Align spectral settings to spectral reference
         this.setSpectralCoordinate(frame.spectralCoordinate, false);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1073,7 +1073,7 @@ export class FrameStore {
     }
 
     // including standard and computed polarizations eg.[1, 2, 3, 4, 13, 14, 15, 16, 17]
-    @computed get polarizations(): number[] {
+    @computed get polarizations(): POLARIZATIONS[] {
         const polarizations = this.stokesOptions?.map(option => {
             return option.value;
         });
@@ -2224,6 +2224,29 @@ export class FrameStore {
         } else {
             this.vectorOverlayStore.setData(vectorOverlayData.intensityTiles, vectorOverlayData.angleTiles, vectorOverlayData.progress);
         }
+    }
+
+    @action setChannel = (channel: number, recursive: boolean = true) => {
+        this.setChannels(channel, this.requiredStokes, recursive);
+    };
+
+    @action setStokes = (stokes: POLARIZATIONS, recursive: boolean = false) => {
+        const stokesIndex = this.polarizations?.indexOf(stokes);
+        if (!isFinite(stokesIndex) || stokesIndex === -1) {
+            return;
+        }
+        this.setStokesByIndex(stokesIndex, recursive);
+    };
+
+    @action setStokesByIndex = (stokesIndex: number, recursive: boolean = false) => {
+        if (!isFinite(stokesIndex) || stokesIndex >= this.polarizations.length) {
+            return;
+        }
+    
+        const isComputedPolarization = stokesIndex >= this.frameInfo.fileInfoExtended.stokes;
+        // request standard polarization by the stokes index of image. (eg. "I": 0)
+        // request computed polarization by PolarizationDefinition. (eg. "Pangle": 17)
+        this.setChannels(this.requiredChannel, isComputedPolarization ? this.polarizations[stokesIndex] : stokesIndex, recursive);
     }
 
     @action setChannels(channel: number, stokes: number, recursive: boolean) {


### PR DESCRIPTION
**Description**

Closes #2015 by adding new methods `setChannel`, `setStokes`, and `setStokesByIndex`.

* The usage is documented in the codebase. I tried to clarify the usage with two terms:
    Polarization: corresponds to the options in the animator UI.
    ![image](https://github.com/CARTAvis/carta-frontend/assets/43841102/e6c363ad-3a1c-4673-883e-2b213200ef27)
    Stokes: defined as polarization index for standard polarization and polarization value for computed polarization. Used in protobuf messages.
* Refactored code to use the new added methods.
* `setStokes` is not used in frontend, so I noted “required for carta-python” to prevent deleting it.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~