### PR TITLE
Thchang/2155 fixed the UI alignment in workspace dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the blank screen when using layout with histogram widget ([#2178](https://github.com/CARTAvis/carta-frontend/issues/2178)).
 * Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
 * Fixed tsv and txt file export naming ([#1987](https://github.com/CARTAvis/carta-frontend/issues/1987)).
+* Fixed the alignment in workspace dialog ([#2155](https://github.com/CARTAvis/carta-frontend/issues/2155)).
 
 ## [4.0.0-beta.1]
 

--- a/src/components/Dialogs/WorkspaceDialog/WorkspaceDialogComponent.scss
+++ b/src/components/Dialogs/WorkspaceDialog/WorkspaceDialogComponent.scss
@@ -9,7 +9,7 @@
         margin-bottom: 5px;
 
         .bp3-input-group {
-            margin-top: 10px;
+            margin: 10px 2px 2px;
         }
     }
 
@@ -17,6 +17,7 @@
         position: relative;
         height: calc(100% - 55px);
         display: flex;
+        margin: 0 2px 2px;
 
         .workspace-table-container {
             height: 100%;

--- a/src/components/Dialogs/WorkspaceDialog/WorkspaceDialogComponent.scss
+++ b/src/components/Dialogs/WorkspaceDialog/WorkspaceDialogComponent.scss
@@ -9,7 +9,7 @@
         margin-bottom: 5px;
 
         .bp3-input-group {
-            margin: 10px 5px 5px;
+            margin-top: 10px;
         }
     }
 

--- a/src/components/Dialogs/WorkspaceDialog/WorkspaceInfoComponent.scss
+++ b/src/components/Dialogs/WorkspaceDialog/WorkspaceInfoComponent.scss
@@ -36,6 +36,12 @@
         .entry-title {
             font-weight: bold;
             padding-right: 10px;
+            padding-bottom: 5px;
+        }
+
+        .entry-value {
+            overflow-wrap: anywhere;
+            padding-bottom: 5px;
         }
     }
 }


### PR DESCRIPTION
**Description**
closes #2155. Fixed overflowed long image name and text input alignment in workspace dialog by modified css file.

![ezgif com-video-to-gif (1)](https://github.com/CARTAvis/carta-frontend/assets/20379662/9429ed4b-77e5-4b60-bf50-ecbfd9f7f1cb)


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~