### PR TITLE
Yuhsuan/2156 scripting starting directory

### DIFF
--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -479,7 +479,7 @@ export class AppStore {
         return frameMap;
     }
 
-    @action addFrame = (ack: CARTA.IOpenFileAck, directory: string, lelExpr: boolean, hdu: string, generated: boolean = false, setAsActive: boolean = true): boolean => {
+    @action addFrame = (ack: CARTA.IOpenFileAck, directory: string, lelExpr: boolean, hdu: string, generated: boolean = false, setAsActive: boolean = true, updateStartingDirectory: boolean = true): boolean => {
         if (!ack) {
             return false;
         }
@@ -551,7 +551,10 @@ export class AppStore {
                 this.setSpectralMatchingEnabled(newFrame, true);
             }
         }
-        this.fileBrowserStore.saveStartingDirectory(newFrame.frameInfo.directory);
+
+        if (updateStartingDirectory) {
+            this.fileBrowserStore.saveStartingDirectory(newFrame.frameInfo.directory);
+        }
 
         return true;
     };
@@ -588,7 +591,7 @@ export class AppStore {
     };
 
     @flow.bound
-    *loadFile(path: string, filename: string, hdu: string, imageArithmetic: boolean, setAsActive: boolean = true) {
+    *loadFile(path: string, filename: string, hdu: string, imageArithmetic: boolean, setAsActive: boolean = true, updateStartingDirectory: boolean = true) {
         this.startFileLoading();
 
         if (imageArithmetic) {
@@ -621,7 +624,7 @@ export class AppStore {
         try {
             const ack = yield this.backendService.loadFile(path, filename, hdu, this.fileCounter, imageArithmetic);
             this.fileCounter++;
-            if (!this.addFrame(ack, path, imageArithmetic, hdu, setAsActive)) {
+            if (!this.addFrame(ack, path, imageArithmetic, hdu, false, setAsActive, updateStartingDirectory)) {
                 AppToaster.show({icon: "warning-sign", message: "Load file failed.", intent: "danger", timeout: 3000});
             }
             this.endFileLoading();
@@ -684,10 +687,10 @@ export class AppStore {
      * @return {Promise<FrameStore>} [async] the FrameStore the opened file
      */
     @flow.bound
-    *appendFile(path: string, filename?: string, hdu?: string, imageArithmetic: boolean = false, setAsActive: boolean = true) {
+    *appendFile(path: string, filename?: string, hdu?: string, imageArithmetic: boolean = false, setAsActive: boolean = true, updateStartingDirectory: boolean = true) {
         // Stop animations playing before loading a new frame
         this.animatorStore.stopAnimation();
-        return yield this.loadFile(path, filename, hdu, imageArithmetic, setAsActive);
+        return yield this.loadFile(path, filename, hdu, imageArithmetic, setAsActive, updateStartingDirectory);
     }
 
     /**
@@ -699,9 +702,9 @@ export class AppStore {
      * @return {Promise<FrameStore>} [async] the FrameStore of the opened file
      */
     @flow.bound
-    *openFile(path: string, filename?: string, hdu?: string, imageArithmetic?: boolean) {
+    *openFile(path: string, filename?: string, hdu?: string, imageArithmetic?: boolean, updateStartingDirectory: boolean = true) {
         this.removeAllFrames();
-        return yield this.loadFile(path, filename, hdu, imageArithmetic);
+        return yield this.loadFile(path, filename, hdu, imageArithmetic, true, updateStartingDirectory);
     }
 
     @flow.bound

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -479,6 +479,18 @@ export class AppStore {
         return frameMap;
     }
 
+    /**
+     * Adds a frame to the frame array based on the provided parameters.
+     *
+     * @param ack - The ack message received after opening a file.
+     * @param directory - The path to the parent directory of the file.
+     * @param lelExpr - Whether the file is opened with an image arithmetic (CASA lattice expression) string.
+     * @param hdu - The Header Data Unit (HDU) identifier of the file.
+     * @param generated - Whether the frame is a generated in-memory image. Used for the telemetry message.
+     * @param setAsActive - Whether the frame should be set as the active frame.
+     * @param updateStartingDirectory - Whether to update the starting directory in the file browser. Required for carta-python.
+     * @returns Whether the frame was successfully added.
+     */
     @action addFrame = (ack: CARTA.IOpenFileAck, directory: string, lelExpr: boolean, hdu: string, generated: boolean = false, setAsActive: boolean = true, updateStartingDirectory: boolean = true): boolean => {
         if (!ack) {
             return false;
@@ -590,6 +602,19 @@ export class AppStore {
         return newFrame;
     };
 
+    /**
+     * Loads a file at the given path and adds it as a frame to the application.
+     *
+     * @param path - The path to the parent directory of the file to load, or of the file itself.
+     * @param filename - The filename of the file to load.
+     * @param hdu - The Header Data Unit (HDU) to load. If left blank, the first image HDU will be loaded.
+     * @param imageArithmetic - Whether to treat the file as an image arithmetic (CASA lattice expression) string.
+     * @param setAsActive - Whether the loaded frame should be set as the active frame.
+     * @param updateStartingDirectory - Whether to update the starting directory in the file browser. Required for carta-python.
+     * @returns The added frame.
+     *
+     * @throws {Error} If there is an error loading the file.
+     */
     @flow.bound
     *loadFile(path: string, filename: string, hdu: string, imageArithmetic: boolean, setAsActive: boolean = true, updateStartingDirectory: boolean = true) {
         this.startFileLoading();
@@ -677,14 +702,19 @@ export class AppStore {
     };
 
     /**
-     * Appends a file at the given path to the list of existing open files
-     * @access public
-     * @async
-     * @param path - path to the parent directory of the file to open, or of the file itself
-     * @param {string=} filename - filename of the file to open
-     * @param {string=} hdu - HDU to open. If left blank, the first image HDU will be opened
-     * @param {boolean=} imageArithmetic - Whether to treat the filename as an image arithmetic (CASA lattice expression) string
-     * @return {Promise<FrameStore>} [async] the FrameStore the opened file
+     * Appends a file at the given path to the list of existing open files.
+     *
+     * @param path - The path to the parent directory of the file to open, or of the file itself.
+     * @param filename - The filename of the file to open.
+     * @param hdu - The Header Data Unit (HDU) to open. If left blank, the first image HDU will be opened.
+     * @param imageArithmetic - Whether to treat the filename as an image arithmetic (CASA lattice expression) string.
+     * @param setAsActive - Whether to set the appended file as the active frame.
+     * @param updateStartingDirectory - Whether to update the starting directory in the file browser. Required for carta-python.
+     * @returns A promise that resolves to the FrameStore of the opened file.
+     *
+     * @example
+     * // Append a file with the given path and filename
+     * const file = await appendFile("/path/to/directory", "example.fits");
      */
     @flow.bound
     *appendFile(path: string, filename?: string, hdu?: string, imageArithmetic: boolean = false, setAsActive: boolean = true, updateStartingDirectory: boolean = true) {
@@ -694,12 +724,18 @@ export class AppStore {
     }
 
     /**
-     * Closes all existing files and opens a file at the given path
-     * @param path - path to the parent directory of the file to open, or of the file itself
-     * @param {string=} filename - filename of the file to open
-     * @param {string=} hdu - HDU to open. If left blank, the first image HDU will be opened
-     * @param {boolean=} imageArithmetic - Whether to treat the filename as an image arithmetic (CASA lattice expression) string
-     * @return {Promise<FrameStore>} [async] the FrameStore of the opened file
+     * Closes all existing files and opens a file at the given path.
+     *
+     * @param path - The path to the parent directory of the file to open, or of the file itself.
+     * @param filename - The filename of the file to open.
+     * @param hdu - The Header Data Unit (HDU) to open. If left blank, the first image HDU will be opened.
+     * @param imageArithmetic - Whether to treat the filename as an image arithmetic (CASA lattice expression) string.
+     * @param updateStartingDirectory - Whether to update the starting directory in the file browser. Required for carta-python.
+     * @returns A promise that resolves to the FrameStore of the opened file.
+     *
+     * @example
+     * // Open a file with the given path and filename
+     * const openedFile = await openFile("/path/to/directory", "example.fits");
      */
     @flow.bound
     *openFile(path: string, filename?: string, hdu?: string, imageArithmetic?: boolean, updateStartingDirectory: boolean = true) {
@@ -750,8 +786,9 @@ export class AppStore {
     }
 
     /**
-     * Closes the currently active image
-     * @param confirmClose [boolean=] - Flag indicating whether to display a confirmation dialog before closing
+     * Closes the currently active image.
+     *
+     * @param confirmClose - Flag indicating whether to display a confirmation dialog before closing.
      */
     @action closeCurrentFile = (confirmClose: boolean = false) => {
         if (!this.appendFileDisabled) {


### PR DESCRIPTION
**Description**

Closes #2156 by adding flags to `openFile` and `appendFile`:

```
// open files without changing the starting directory
const file = await app.openFile(PATH, FILENAME, HDU, IS_LEL, false);

// append files without changing the starting directory
const file2 = await app.appendFile(PATH, FILENAME, HDU, IS_LEL, SET_ACTIVE, false);
```

Documentation of the methods is added (or revised from jsdoc to tsdoc) in the codebase.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~