### PR TITLE
Yuhsuan/1734 submilliarcsecond scale match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
 * Fixed tsv and txt file export naming ([#1987](https://github.com/CARTAvis/carta-frontend/issues/1987)).
 * Fixed the alignment in workspace dialog ([#2155](https://github.com/CARTAvis/carta-frontend/issues/2155)).
+* Fixed spatial matching error in sub-milliarcsecond scale ([#1734](https://github.com/CARTAvis/carta-frontend/issues/1734)).
 
 ## [4.0.0-beta.1]
 

--- a/src/models/ControlMap/ControlMap.ts
+++ b/src/models/ControlMap/ControlMap.ts
@@ -37,13 +37,7 @@ export class ControlMap {
         let cleanUpTransform: boolean = false;
 
         if (!astTransform || astTransform < 0) {
-            const copySrc = AST.copy(this.source.wcsInfo);
-            const copyDest = AST.copy(this.destination.wcsInfo);
-            AST.invert(copySrc);
-            AST.invert(copyDest);
-            astTransform = AST.convert(copySrc, copyDest, "");
-            AST.deleteObject(copySrc);
-            AST.deleteObject(copyDest);
+            astTransform = AST.getSpatialMapping(this.source.wcsInfo, this.destination.wcsInfo);
             cleanUpTransform = true;
         }
 

--- a/src/models/ControlMap/ControlMap.ts
+++ b/src/models/ControlMap/ControlMap.ts
@@ -15,7 +15,7 @@ export class ControlMap {
     gl: WebGL2RenderingContext;
     private grid: Float32Array;
 
-    constructor(src: FrameStore, dst: FrameStore, astTransform: AST.FrameSet, width: number, height: number, updateBoudary: boolean = true) {
+    constructor(src: FrameStore, dst: FrameStore, astTransform: AST.Mapping, width: number, height: number, updateBoudary: boolean = true) {
         this.source = src;
         this.destination = dst;
         this.width = width;
@@ -33,7 +33,7 @@ export class ControlMap {
         this.maxPoint = {x: maxX + deltaX * 2, y: maxY + deltaY * 2};
     };
 
-    setGrid = (astTransform?: AST.FrameSet) => {
+    setGrid = (astTransform?: AST.Mapping) => {
         let cleanUpTransform: boolean = false;
 
         if (!astTransform || astTransform < 0) {

--- a/src/models/Transform2D/Transform2D.ts
+++ b/src/models/Transform2D/Transform2D.ts
@@ -9,7 +9,7 @@ export class Transform2D {
     scale: number;
     origin: Point2D;
 
-    constructor(astTransform: AST.FrameSet, refPixel: Point2D) {
+    constructor(astTransform: AST.Mapping, refPixel: Point2D) {
         const transformedRef = transformPoint(astTransform, refPixel, true);
         const delta = 1.0;
         const refTop = add2D(refPixel, {x: 0, y: delta / 2.0});

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -334,7 +334,7 @@ export class CompassAnnotationStore extends RegionStore {
         this.modifiedTimestamp = performance.now();
     };
 
-    public getRegionApproximation(astTransform: AST.FrameSet, spatiallyMatched?: boolean, spatialTransform?: AST.FrameSet): {northApproximatePoints: number[]; eastApproximatePoints: number[]} {
+    public getRegionApproximation(astTransform: AST.FrameSet, spatiallyMatched?: boolean, spatialTransform?: AST.Mapping): {northApproximatePoints: number[]; eastApproximatePoints: number[]} {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
         const transformed = AST.transformPoint(astTransform, originPoint.x, originPoint.y);
 
@@ -489,7 +489,7 @@ export class RulerAnnotationStore extends RegionStore {
         this.modifiedTimestamp = performance.now();
     };
 
-    public getRegionApproximation(astTransform: AST.FrameSet, spatiallyMatched?: boolean): {xApproximatePoints: number[]; yApproximatePoints: number[]; hypotenuseApproximatePoints: number[]} {
+    public getRegionApproximation(astTransform: AST.FrameSet | AST.Mapping, spatiallyMatched?: boolean): {xApproximatePoints: number[]; yApproximatePoints: number[]; hypotenuseApproximatePoints: number[]} {
         let xApproximatePoints;
         let yApproximatePoints;
         let hypotenuseApproximatePoints;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2604,13 +2604,7 @@ export class FrameStore {
         this.spatialReference = frame;
         console.log(`Setting spatial reference for file ${this.frameInfo.fileId} to ${frame.frameInfo.fileId}`);
 
-        const copySrc = AST.copy(this.wcsInfo);
-        const copyDest = AST.copy(frame.wcsInfo);
-        AST.invert(copySrc);
-        AST.invert(copyDest);
-        this.spatialTransformAST = AST.convert(copySrc, copyDest, "");
-        AST.deleteObject(copySrc);
-        AST.deleteObject(copyDest);
+        this.spatialTransformAST = AST.getSpatialMapping(this.wcsInfo, frame.wcsInfo);
         if (!this.spatialTransformAST) {
             console.log(`Error creating spatial transform between files ${this.frameInfo.fileId} and ${frame.frameInfo.fileId}`);
             this.spatialReference = null;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -127,7 +127,7 @@ export class FrameStore {
 
     public spectralCoordsSupported: Map<string, {type: SpectralType; unit: SpectralUnit}>;
     public spectralSystemsSupported: Array<SpectralSystem>;
-    public spatialTransformAST: AST.FrameSet;
+    public spatialTransformAST: AST.Mapping;
     private cursorMovementHandle: NodeJS.Timeout;
 
     public distanceMeasuring: DistanceMeasuringStore;

--- a/src/stores/Frame/Region/RegionSetStore.ts
+++ b/src/stores/Frame/Region/RegionSetStore.ts
@@ -314,7 +314,7 @@ export class RegionSetStore {
         this.mode = this.mode === RegionMode.MOVING ? RegionMode.CREATING : RegionMode.MOVING;
     };
 
-    @action migrateRegionsFromExistingSet = (sourceRegionSet: RegionSetStore, spatialTransformAST: AST.FrameSet, forward: boolean = false) => {
+    @action migrateRegionsFromExistingSet = (sourceRegionSet: RegionSetStore, spatialTransformAST: AST.Mapping, forward: boolean = false) => {
         if (sourceRegionSet?.regions?.length <= 1) {
             return;
         }

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -375,7 +375,7 @@ export class RegionStore {
     };
 
     public getRegionApproximation(
-        astTransform: AST.FrameSet
+        astTransform: AST.Mapping
     ): Point2D[] | {northApproximatePoints: number[]; eastApproximatePoints: number[]} | {xApproximatePoints: number[]; yApproximatePoints: number[]; hypotenuseApproximatePoints: number[]} {
         let approximatePoints = this.regionApproximationMap.get(astTransform);
         if (!approximatePoints) {

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -33,7 +33,7 @@ export function getHeaderNumericValue(headerEntry: CARTA.IHeaderEntry): number {
     }
 }
 
-export function transformPoint(astTransform: AST.FrameSet, point: Point2D, forward: boolean = true) {
+export function transformPoint(astTransform: AST.FrameSet | AST.Mapping, point: Point2D, forward: boolean = true) {
     return AST.transformPoint(astTransform, point.x, point.y, forward);
 }
 

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -154,6 +154,19 @@ EMSCRIPTEN_KEEPALIVE AstFrameSet* getSkyFrameSet(AstFrameSet* frameSet)
     return skyframeSet;
 }
 
+EMSCRIPTEN_KEEPALIVE AstCmpMap* getSpatialMapping(AstFrameSet* src, AstFrameSet* dest) {
+    astInvert(dest);
+    AstCmpMap* spatialMapping = astCmpMap(src, dest, 1, "");
+    astInvert(dest);
+
+    if (!astOK)
+    {
+        astClearStatus;
+        return nullptr;
+    }
+    return spatialMapping;
+}
+
 EMSCRIPTEN_KEEPALIVE AstFrameSet* createTransformedFrameset(AstFrameSet* wcsinfo, double offsetX, double offsetY, double angle, double originX, double originY, double scaleX, double scaleY)
 {
     // 2D scale and rotation matrix

--- a/wasm_src/ast_wrapper/index.d.ts
+++ b/wasm_src/ast_wrapper/index.d.ts
@@ -37,6 +37,7 @@ export function putFits(fitsChan: FitsChan, card: string): void;
 export function getFrameFromFitsChan(fitsChan: FitsChan, checkSkyDomain: boolean): FrameSet;
 export function getSpectralFrame(frameSet: FrameSet): SpecFrame;
 export function getSkyFrameSet(frameSet: FrameSet): FrameSet;
+export function getSpatialMapping(src: FrameSet, dest: FrameSet): Mapping;
 export function initDummyFrame(): FrameSet;
 export function set(obj: AstObject, settings: string): number;
 export function clear(obj: AstObject, attrib: string): number;

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -101,6 +101,7 @@ Module.putFits = Module.cwrap("putFits", null, ["number", "string"]);
 Module.getFrameFromFitsChan = Module.cwrap("getFrameFromFitsChan", "number", ["number", "number"]);
 Module.getSpectralFrame = Module.cwrap("getSpectralFrame", "number", ["number"]);
 Module.getSkyFrameSet = Module.cwrap("getSkyFrameSet", "number", ["number"]);
+Module.getSpatialMapping = Module.cwrap("getSpatialMapping", "number", ["number", "number"]);
 Module.initDummyFrame = Module.cwrap("initDummyFrame", "number", []);
 Module.set = Module.cwrap("set", "number", ["number", "string"]);
 Module.clear = Module.cwrap("clear", "number", ["number", "string"]);


### PR DESCRIPTION
**Description**

Closes #1734 spatial matching in sub-milliarcsecond scale. Changed the approach of spatial matching by following AST library programmer's guide section 6.5 "Example—Transforming Between Two Calibrated Images."

Instead of converting between two image frame sets, a compound mapping is created from the frame sets. I'm not sure why the former approach does not work in sub-milliarcsecond scale. It's also suggested in the programmer's guide (section 14.3).

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~