### PR TITLE
Yuhsuan/2189 region coord format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the alignment in workspace dialog ([#2155](https://github.com/CARTAvis/carta-frontend/issues/2155)).
 * Fixed the spectral axis for images with headers in `CDi_j` format ([#2144](https://github.com/CARTAvis/carta-frontend/issues/2144)).
 * Fixed spatial matching error in sub-milliarcsecond scale ([#1734](https://github.com/CARTAvis/carta-frontend/issues/1734)).
+* Fixed inconsistent region coordinate format when images are spatially matched ([#2189](https://github.com/CARTAvis/carta-frontend/issues/2189)).
+* Fixed the right ascension label in the image view ([#2192](https://github.com/CARTAvis/carta-frontend/issues/2192)).
 
 ## [4.0.0-beta.1]
 

--- a/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
@@ -101,10 +101,13 @@ export class CompassRulerRegionForm extends React.Component<{region: RegionStore
     };
 
     render() {
-        const appStore = AppStore.Instance;
         // dummy variables related to wcs to trigger re-render
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const system = appStore.overlayStore.global.explicitSystem;
+        /* eslint-disable @typescript-eslint/no-unused-vars */
+        const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
+
         const region = this.props.region;
         const wcsInfo = this.props.wcsInfo;
         const isWCS = region.coordinate === CoordinateMode.World;

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -268,8 +268,12 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
 
     public render() {
         // dummy variables related to wcs to trigger re-render
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
+
         const region = this.props.region;
         if (!region || region.controlPoints.length !== 2 || (region.regionType !== CARTA.RegionType.LINE && region.regionType !== CARTA.RegionType.ANNLINE && region.regionType !== CARTA.RegionType.ANNVECTOR)) {
             return null;

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -71,8 +71,12 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
 
     public render() {
         // dummy variables related to wcs to trigger re-render
-        // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
+
         const region = this.props.region as PointAnnotationStore;
         if (!region || (region.regionType !== CARTA.RegionType.POINT && region.regionType !== CARTA.RegionType.ANNPOINT)) {
             return null;

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -57,8 +57,12 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
 
     public render() {
         // dummy variables related to wcs to trigger re-render
-        // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
+
         const region = this.props.region;
         if (
             !region ||

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -304,8 +304,12 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
 
     public render() {
         // dummy variables related to wcs to trigger re-render
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
+
         const region = this.props.region;
         const isTextAnnotation = region.regionType === CARTA.RegionType.ANNTEXT;
         if (!region || region.controlPoints.length !== 2 || (region.regionType !== CARTA.RegionType.RECTANGLE && region.regionType !== CARTA.RegionType.ANNRECTANGLE && region.regionType !== CARTA.RegionType.ANNTEXT)) {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1489,8 +1489,8 @@ export class FrameStore {
         const entries = this.frameInfo.fileInfoExtended.headerEntries;
         const dirXAxis = entries.find(entry => entry.name.includes(`CTYPE${axisNumber}`));
         let name = dirXAxis?.value ?? "";
-        if (name.match(/^RA/)) {
-            name = "Right Ascension"; // Customize the axis label
+        if (name.match(/^RA/) && this.isSwappedZ) {
+            name = "Right ascension"; // Customize the axis label
         } else {
             name = ""; // Use the default axis label in AST
         }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1025,28 +1025,31 @@ export class OverlayStore {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _ = this.global.system;
             this.setFormatsFromSystem();
-            const frame = AppStore.Instance.activeFrame;
-            if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem) {
-                AST.set(frame.wcsInfoForTransformation, `System=${this.global.explicitSystem}`);
-            }
+            AppStore.Instance.frames.forEach(frame => {
+                if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem) {
+                    AST.set(frame.wcsInfoForTransformation, `System=${this.global.explicitSystem}`);
+                }
+            });
         });
 
         autorun(() => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _ = this.numbers.formatTypeX;
-            const frame = AppStore.Instance.activeFrame;
-            if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeX) {
-                AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirX})=${this.numbers.formatTypeX}.${WCS_PRECISION}`);
-            }
+            AppStore.Instance.frames.forEach(frame => {
+                if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeX) {
+                    AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirX})=${this.numbers.formatTypeX}.${WCS_PRECISION}`);
+                }
+            });
         });
 
         autorun(() => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _ = this.numbers.formatTypeY;
-            const frame = AppStore.Instance.activeFrame;
-            if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeY) {
-                AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirY})=${this.numbers.formatTypeY}.${WCS_PRECISION}`);
-            }
+            AppStore.Instance.frames.forEach(frame => {
+                if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeY) {
+                    AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirY})=${this.numbers.formatTypeY}.${WCS_PRECISION}`);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
**Description**

Changes:

1. Fixed #2189 by updating the frame sets used for transformation of all the frames instead of only the active frame. Tested that the position inputs in the region dialogs updates when the coordinate system is changed via the image view toolbar or the region dialog option.

2. Trigger re-rendering of the region dialogs with the number x and y formats. This ensures that the position inputs udpates with the number x and y format settings in the image view settings widget. 

3. Fixed #2192 by customizing the ra label only for swapped-axes images. When we customize the ra label, we disable the default axis label in AST, which handles different coordinate systems.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~