### PR TITLE
Thchang/2098 spectral matching type selectors improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the default title string in the image viewer ([#2168](https://github.com/CARTAvis/carta-frontend/issues/2168)).
 * Modified text annotation textbox to stay the same dimension as user zoom the image ([#2162](https://github.com/CARTAvis/carta-frontend/issues/2162)).
 * Disabled spell check in text input ([#2138](https://github.com/CARTAvis/carta-frontend/issues/2138)).
+* Modified spectral matching type selector in Image List Settings won't affact global preferences ([#2098](https://github.com/CARTAvis/carta-frontend/issues/2098)).
 ### Fixed
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 * Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -215,8 +215,7 @@ export class PreferenceDialogComponent extends React.Component {
                     <Tooltip2
                         content={
                             <span>
-                                Need to apply an instant change? <br />
-                                Please change in the <b>Image List Settings</b>.
+                                Please modify the settings in the <b>Image List Settings</b>.
                             </span>
                         }
                         position={Position.RIGHT}

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -212,26 +212,13 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Spectral matching">
-                    <Tooltip2
-                        content={
-                            <span>
-                                For instant changes,
-                                <br />
-                                please modify the settings
-                                <br />
-                                in the <b>Image List Settings</b>.
-                            </span>
-                        }
-                        position={Position.RIGHT}
-                    >
-                        <HTMLSelect value={preference.spectralMatchingType} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, ev.currentTarget.value)}>
-                            {SPECTRAL_MATCHING_TYPES.map(type => (
-                                <option key={type} value={type}>
-                                    {SPECTRAL_TYPE_STRING.get(type)}
-                                </option>
-                            ))}
-                        </HTMLSelect>
-                    </Tooltip2>
+                    <HTMLSelect value={preference.spectralMatchingType} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, ev.currentTarget.value)}>
+                        {SPECTRAL_MATCHING_TYPES.map(type => (
+                            <option key={type} value={type}>
+                                {SPECTRAL_TYPE_STRING.get(type)}
+                            </option>
+                        ))}
+                    </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Transparent image background">
                     <Switch checked={preference.transparentImageBackground} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND, ev.currentTarget.checked)} />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -12,23 +12,7 @@ import tinycolor from "tinycolor2";
 
 import {DraggableDialogComponent} from "components/Dialogs";
 import {AppToaster, AutoColorPickerComponent, ColormapComponent, ColorPickerComponent, PointShapeSelectComponent, SafeNumericInput, ScalingSelectComponent, SuccessToast} from "components/Shared";
-import {
-    CompressionQuality,
-    CursorInfoVisibility,
-    CursorPosition,
-    Event,
-    FileFilterMode,
-    RegionCreationMode,
-    SPECTRAL_MATCHING_TYPES,
-    SPECTRAL_TYPE_STRING,
-    SpectralType,
-    Theme,
-    TileCache,
-    WCSMatchingType,
-    WCSType,
-    Zoom,
-    ZoomPoint
-} from "models";
+import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, FileFilterMode, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatchingType, WCSType, Zoom, ZoomPoint} from "models";
 import {TelemetryMode} from "services";
 import {AppStore, BeamType, HelpType, PreferenceKeys, PreferenceStore} from "stores";
 import {ContourGeneratorType, FrameScaling, RegionStore, RenderConfigStore} from "stores/Frame";
@@ -228,13 +212,23 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Spectral matching">
-                    <HTMLSelect value={preference.spectralMatchingType} onChange={ev => appStore.setSpectralMatchingType(ev.currentTarget.value as SpectralType)}>
-                        {SPECTRAL_MATCHING_TYPES.map(type => (
-                            <option key={type} value={type}>
-                                {SPECTRAL_TYPE_STRING.get(type)}
-                            </option>
-                        ))}
-                    </HTMLSelect>
+                    <Tooltip2
+                        content={
+                            <span>
+                                Need to apply an instant change? <br />
+                                Please change in the <b>Image List Settings</b>.
+                            </span>
+                        }
+                        position={Position.RIGHT}
+                    >
+                        <HTMLSelect value={preference.spectralMatchingType} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, ev.currentTarget.value)}>
+                            {SPECTRAL_MATCHING_TYPES.map(type => (
+                                <option key={type} value={type}>
+                                    {SPECTRAL_TYPE_STRING.get(type)}
+                                </option>
+                            ))}
+                        </HTMLSelect>
+                    </Tooltip2>
                 </FormGroup>
                 <FormGroup inline={true} label="Transparent image background">
                     <Switch checked={preference.transparentImageBackground} onChange={ev => preference.setPreference(PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND, ev.currentTarget.checked)} />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -215,7 +215,11 @@ export class PreferenceDialogComponent extends React.Component {
                     <Tooltip2
                         content={
                             <span>
-                                Please modify the settings in the <b>Image List Settings</b>.
+                                For instant changes,
+                                <br />
+                                please modify the settings
+                                <br />
+                                in the <b>Image List Settings</b>.
                             </span>
                         }
                         position={Position.RIGHT}

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -118,7 +118,6 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
 
     render() {
         const appStore = AppStore.Instance;
-        const preferenceStore = appStore.preferenceStore;
         const overlay = appStore.overlayStore;
         const dialogStore = appStore.dialogStore;
         const frame = this.props.frame;
@@ -193,7 +192,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const wcsButtonSuperscript = (spatialMatchingEnabled ? "x" : "") + (spectralMatchingEnabled ? "z" : "");
         const wcsButtonTooltipEntries = [];
         if (spectralMatchingEnabled) {
-            wcsButtonTooltipEntries.push(`Spectral (${preferenceStore.spectralMatchingType})`);
+            wcsButtonTooltipEntries.push(`Spectral (${appStore.spectralMatchingType})`);
         }
         if (spatialMatchingEnabled) {
             wcsButtonTooltipEntries.push("Spatial");
@@ -203,13 +202,13 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         const wcsMatchingMenu = (
             <Menu>
                 <MenuItem
-                    text={`Spectral (${preferenceStore.spectralMatchingType}) and spatial`}
+                    text={`Spectral (${appStore.spectralMatchingType}) and spatial`}
                     disabled={!canEnableSpatialMatching || !canEnableSpectralMatching}
                     active={spectralMatchingEnabled && spatialMatchingEnabled}
                     onClick={() => appStore.setMatchingEnabled(true, true)}
                 />
                 <MenuItem
-                    text={`Spectral (${preferenceStore.spectralMatchingType})  only`}
+                    text={`Spectral (${appStore.spectralMatchingType})  only`}
                     disabled={!canEnableSpectralMatching}
                     active={spectralMatchingEnabled && !spatialMatchingEnabled}
                     onClick={() => appStore.setMatchingEnabled(false, true)}

--- a/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
+++ b/src/components/LayerList/LayerListSettingsPanelComponent/LayerListSettingsPanelComponent.tsx
@@ -87,7 +87,7 @@ export class LayerListSettingsPanelComponent extends React.Component<WidgetProps
         const matchingPanel = (
             <div className="panel-container">
                 <FormGroup inline={true} label="Spectral matching type">
-                    <HTMLSelect value={appStore.preferenceStore.spectralMatchingType} onChange={ev => appStore.setSpectralMatchingType(ev.currentTarget.value as SpectralType)}>
+                    <HTMLSelect value={appStore.spectralMatchingType} onChange={ev => appStore.setSpectralMatchingType(ev.currentTarget.value as SpectralType)}>
                         {SPECTRAL_MATCHING_TYPES.map(type => (
                             <option key={type} value={type}>
                                 {SPECTRAL_TYPE_STRING.get(type)}

--- a/src/stores/AnimatorStore/AnimatorStore.ts
+++ b/src/stores/AnimatorStore/AnimatorStore.ts
@@ -97,7 +97,7 @@ export class AnimatorStore {
         // Calculate matched frames for the animation range
         const matchedFrames = new Map<number, CARTA.IMatchedFrameList>();
         for (const sibling of frame.spectralSiblings) {
-            const frameNumbers = getTransformedChannelList(frame.wcsInfo3D, sibling.wcsInfo3D, preferenceStore.spectralMatchingType, animationFrames.firstFrame.channel, animationFrames.lastFrame.channel);
+            const frameNumbers = getTransformedChannelList(frame.wcsInfo3D, sibling.wcsInfo3D, appStore.spectralMatchingType, animationFrames.firstFrame.channel, animationFrames.lastFrame.channel);
             matchedFrames.set(sibling.frameInfo.fileId, {frameNumbers});
         }
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -344,6 +344,9 @@ export class AppStore {
         }
     }
 
+    // Spectral matching type, initialized by global preferences, modified by the Image List Settings
+    @observable spectralMatchingType: SpectralType;
+
     @computed get openFileDisabled(): boolean {
         return this.backendService?.connectionStatus !== ConnectionStatus.ACTIVE || this.fileLoading;
     }
@@ -1549,10 +1552,10 @@ export class AppStore {
                 await this.loadDefaultFiles();
                 this.setCursorFrozen(this.preferenceStore.isCursorFrozen);
                 this.updateASTColors();
+                this.setSpectralMatchingType(this.preferenceStore.spectralMatchingType);
                 if (this.preferenceStore.checkNewRelease) {
                     await this.checkNewRelease();
                 }
-                this.setSpectralMatchingType(this.preferenceStore.spectralMatchingType);
             } catch (err) {
                 console.error(err);
             }
@@ -2712,8 +2715,6 @@ export class AppStore {
 
         this.setSpectralMatchingEnabled(frame, !frame.spectralReference);
     };
-
-    @observable spectralMatchingType: SpectralType;
 
     @action setSpectralMatchingType = (spectralMatchingType: SpectralType) => {
         this.spectralMatchingType = spectralMatchingType;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1552,6 +1552,7 @@ export class AppStore {
                 if (this.preferenceStore.checkNewRelease) {
                     await this.checkNewRelease();
                 }
+                this.setSpectralMatchingType(this.preferenceStore.spectralMatchingType);
             } catch (err) {
                 console.error(err);
             }
@@ -2702,8 +2703,10 @@ export class AppStore {
         this.setSpectralMatchingEnabled(frame, !frame.spectralReference);
     };
 
-    setSpectralMatchingType = (spectralMatchingType: SpectralType) => {
-        this.preferenceStore.setPreference(PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE, spectralMatchingType);
+    @observable spectralMatchingType: SpectralType;
+
+    @action setSpectralMatchingType = (spectralMatchingType: SpectralType) => {
+        this.spectralMatchingType = spectralMatchingType;
         for (const f of this.frames) {
             if (f.spectralReference) {
                 this.setSpectralMatchingEnabled(f, true);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2293,7 +2293,7 @@ export class FrameStore {
 
         if (recursive) {
             this.spectralSiblings.forEach(frame => {
-                const siblingChannel = getTransformedChannel(this.wcsInfo3D, frame.wcsInfo3D, PreferenceStore.Instance.spectralMatchingType, sanitizedChannel);
+                const siblingChannel = getTransformedChannel(this.wcsInfo3D, frame.wcsInfo3D, AppStore.Instance.spectralMatchingType, sanitizedChannel);
                 frame.setChannels(siblingChannel, frame.requiredStokes, false);
             });
         }
@@ -2728,12 +2728,12 @@ export class FrameStore {
         // For now, this is just done to ensure a mapping can be constructed
         const copySrc = AST.copy(this.wcsInfo3D);
         const copyDest = AST.copy(frame.wcsInfo3D);
-        const preferenceStore = PreferenceStore.Instance;
-        const spectralMatchingType = preferenceStore.spectralMatchingType;
+        const appStore = AppStore.Instance;
+        const spectralMatchingType = appStore.spectralMatchingType;
         // Ensure that a mapping for the current alignment system is possible
         if (spectralMatchingType !== SpectralType.CHANNEL) {
-            AST.set(copySrc, `AlignSystem=${preferenceStore.spectralMatchingType}`);
-            AST.set(copyDest, `AlignSystem=${preferenceStore.spectralMatchingType}`);
+            AST.set(copySrc, `AlignSystem=${appStore.spectralMatchingType}`);
+            AST.set(copyDest, `AlignSystem=${appStore.spectralMatchingType}`);
         }
         AST.invert(copySrc);
         AST.invert(copyDest);
@@ -2749,7 +2749,7 @@ export class FrameStore {
 
         this.spectralReference = frame;
         this.spectralReference.addSecondarySpectralImage(this);
-        const matchedChannel = getTransformedChannel(frame.wcsInfo3D, this.wcsInfo3D, preferenceStore.spectralMatchingType, frame.requiredChannel);
+        const matchedChannel = getTransformedChannel(frame.wcsInfo3D, this.wcsInfo3D, appStore.spectralMatchingType, frame.requiredChannel);
         this.setChannel(matchedChannel, false);
 
         // Align spectral settings to spectral reference


### PR DESCRIPTION
**Description**

Closes #2098: Not to sync the selector of spectral matching type in **Image List Settings** with the one in the global preferences. Modified by adding `spectralMatchingType` in AppStore.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~