### PR TITLE
move patch-package from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "react-plotly.js": "^2.6.0",
         "react-resize-detector": "^8.0.4",
         "react-rnd": "^10.4.1",
-        "react-scripts": "^5.0.1",
         "react-scroll-to-bottom": "^4.2.0",
         "react-simple-code-editor": "^0.13.1",
         "react-split-pane": "^0.1.91",
@@ -200,6 +199,7 @@
     },
     "dependencies": {
         "patch-package": "^6.5.1",
+        "react-scripts": "^5.0.1",
         "usehooks-ts": "^2.9.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "moment": "^2.27.0",
         "npm-run-all": "^4.1.3",
         "os-browserify": "^0.3.0",
-        "patch-package": "^6.5.1",
         "path-browserify": "^1.0.1",
         "plotly.js": "^2.18.2",
         "prettier": "2.8.4",
@@ -200,6 +199,7 @@
         }
     },
     "dependencies": {
+        "patch-package": "^6.5.1",
         "usehooks-ts": "^2.9.1"
     }
 }


### PR DESCRIPTION
**Description**

This minor package adjustment will hopefully fix issue #2198 (npm installation problems of carta-frontend@4.0.0-beta.1)

patch-package was simply moved from 'devDependencies' to 'dependencies'.

I see a new version of patch-package, v7.0.0 was released 2 months ago. But here I left it as the previous v6.5.1 version just in case it was to introduce new bugs which we do not want so close to the final release.

Hopefully, this will not be too difficult to test @veggiesaurus? 
I propose we generate a new carta-frontend npm package and try to install it.
I guess the version would need to be bumped up to `v4.0.1-beta.1`? 
```
sudo npm install -g --unsafe-perm carta-frontend@4.0.1-beta.1
```
Then if that installs without error, only the carta-controller version would need to be bumped up too?

@kswang1029 I'm not sure if it requires a changelog entry as the code didn't really change, only the file related to compiling it?

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / no changelog update needed
- [x] no protobuf update needed
- [x] `BackendService` unchanged