### PR TITLE
Yuhsuan/inactive frame channel

### DIFF
--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1812,10 +1812,10 @@ export class AppStore {
                         const isVisible = this.visibleFrames.includes(frame);
                         const siblingUpdateRequired = frame.requiredChannel !== frame.channel || frame.requiredStokes !== frame.stokes;
                         if (!isVisible && siblingUpdateRequired) {
-                            updates.push({ frame, channel: frame.requiredChannel, stokes: frame.requiredStokes });
+                            updates.push({frame, channel: frame.requiredChannel, stokes: frame.requiredStokes});
                         }
                     });
-                }   
+                }
             }
 
             if (updates.length) {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1796,26 +1796,30 @@ export class AppStore {
         // TODO: Move setChannels actions to AppStore and remove this autorun
         // Update channels when manually changed
         autorun(() => {
-            if (this.activeFrame) {
-                const updates: ChannelUpdate[] = [];
-                // Calculate if new data is required for the active channel
-                const updateRequiredChannels = this.activeFrame.requiredChannel !== this.activeFrame.channel || this.activeFrame.requiredStokes !== this.activeFrame.stokes;
-                // Don't auto-update when animation is playing
-                if (!this.animatorStore.animationActive && updateRequiredChannels) {
-                    updates.push({frame: this.activeFrame, channel: this.activeFrame.requiredChannel, stokes: this.activeFrame.requiredStokes});
-                }
+            const updates: ChannelUpdate[] = [];
 
-                // Update any sibling channels
-                this.activeFrame.spectralSiblings.forEach(frame => {
-                    const siblingUpdateRequired = frame.requiredChannel !== frame.channel || frame.requiredStokes !== frame.stokes;
-                    if (siblingUpdateRequired) {
-                        updates.push({frame, channel: frame.requiredChannel, stokes: frame.requiredStokes});
+            for (const visibleFrame of this.visibleFrames) {
+                if (visibleFrame) {
+                    // Calculate if new data is required for the active channel
+                    const updateRequiredChannels = visibleFrame.requiredChannel !== visibleFrame?.channel || visibleFrame.requiredStokes !== visibleFrame.stokes;
+                    // Don't auto-update when animation is playing
+                    if (!this.animatorStore.animationActive && updateRequiredChannels) {
+                        updates.push({frame: visibleFrame, channel: visibleFrame.requiredChannel, stokes: visibleFrame.requiredStokes});
                     }
-                });
 
-                if (updates.length) {
-                    throttledSetChannels(updates);
-                }
+                    // Update any sibling channels
+                    visibleFrame.spectralSiblings.forEach(frame => {
+                        const isVisible = this.visibleFrames.includes(frame);
+                        const siblingUpdateRequired = frame.requiredChannel !== frame.channel || frame.requiredStokes !== frame.stokes;
+                        if (!isVisible && siblingUpdateRequired) {
+                            updates.push({ frame, channel: frame.requiredChannel, stokes: frame.requiredStokes });
+                        }
+                    });
+                }   
+            }
+
+            if (updates.length) {
+                throttledSetChannels(updates);
             }
         });
 


### PR DESCRIPTION
**Description**

Closes https://github.com/CARTAvis/carta-python/issues/103: setting the channel/stokes of inactive frames. Fixed by adjusting the criteria for requesting tiles when channel/stokes is manually changed.

Instead of only checking the active frame and its spectrally matched frames, we now check all visible frames and their spectrally matched frames. When checking the spectrally matched frames, we skip the visible frames to avoid duplicate requests.

Currently, users cannot set the channel/stokes of inactive frames through UI, but it is possible to do so using the code snippet feature or the console. For example:
```javascript
// in multi-panel mode showing >= 2 frames
const file = await app.openFile("[path]", "[filename1]");
const file2 = await app.appendFile("[path]", "[filename2]");

// set inactive frame channel
file.setChannel(1);
// set inactive frame stokes
file.setStokes(1);
```
In this branch, the above code snippet will immediately request new tiles for the inactive frame. In the dev branch, it will request new tiles after the frame becomes active.

@acdo2002 There will be additional tile request messages with this change, so you might want to check it.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~