### PR TITLE
Thchang/ hide the blinking toolbar when animating images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the right ascension label in the image view ([#2192](https://github.com/CARTAvis/carta-frontend/issues/2192)).
 * Fixed the multi-spectral-profile intensity unit conversion ([#1758](https://github.com/CARTAvis/carta-frontend/issues/1758)).
 * Fixed the Jy/beam to K intensity unit conversion ([#1907](https://github.com/CARTAvis/carta-frontend/issues/1907)).
+* Fixed the blinking toolbar in the image view during animating images ([#2163](https://github.com/CARTAvis/carta-frontend/issues/2163)).
 
 ## [4.0.0-beta.1]
 

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -5,7 +5,7 @@ import {observer} from "mobx-react";
 
 import {ImageViewLayer} from "components";
 import {CursorInfo, CursorInfoVisibility, Zoom} from "models";
-import {AppStore} from "stores";
+import {AnimationMode, AppStore} from "stores";
 import {FrameStore} from "stores/Frame";
 
 import {BeamProfileOverlayComponent} from "../BeamProfileOverlay/BeamProfileOverlayComponent";
@@ -194,7 +194,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                     />
                     <ToolbarComponent
                         docked={this.props.docked}
-                        visible={this.imageToolbarVisible}
+                        visible={this.imageToolbarVisible && !(appStore.animatorStore.animationActive && appStore.animatorStore.animationMode === AnimationMode.FRAME)}
                         frame={frame}
                         activeLayer={activeLayer}
                         onActiveLayerChange={appStore.updateActiveLayer}

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -192,15 +192,17 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                         dragPanningEnabled={appStore.preferenceStore.dragPanning}
                         docked={this.props.docked && activeLayer !== ImageViewLayer.Catalog}
                     />
-                    <ToolbarComponent
-                        docked={this.props.docked}
-                        visible={this.imageToolbarVisible && !(appStore.animatorStore.animationActive && appStore.animatorStore.animationMode === AnimationMode.FRAME)}
-                        frame={frame}
-                        activeLayer={activeLayer}
-                        onActiveLayerChange={appStore.updateActiveLayer}
-                        onRegionViewZoom={this.onRegionViewZoom}
-                        onZoomToFit={this.fitZoomFrameAndRegion}
-                    />
+                    {!(appStore.animatorStore.animationActive && appStore.animatorStore.animationMode === AnimationMode.FRAME) && (
+                        <ToolbarComponent
+                            docked={this.props.docked}
+                            visible={this.imageToolbarVisible}
+                            frame={frame}
+                            activeLayer={activeLayer}
+                            onActiveLayerChange={appStore.updateActiveLayer}
+                            onRegionViewZoom={this.onRegionViewZoom}
+                            onZoomToFit={this.fitZoomFrameAndRegion}
+                        />
+                    )}
                 </div>
             );
         } else {


### PR DESCRIPTION
**Description**

closes #2163. The toolbar blinked during animating images.

The blinking was caused by property `imageToolbarVisible`, which controlled the visibility of the toolbar in ImagePanelComponent, being reset to `false` when the next image is displayed during animating images. After we have grid view function, the ImageViewComponent computes list of new ImagePanelComponent when displayed images change. 

This part could be fixed by passing properties from ImageViewComponent. But another problem raised, that the toolbar might still be remained after the cursor leaving the image view, since the `onMouseLeave` won't be triggered when the node of images gets detached. (refer the [issue](https://github.com/facebook/react/issues/6807) from React)

As a result, hiding the toolbar when animating images to fix this issue.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~