### PR TITLE
Thchang/2046 improving filterable table widgets ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disabled spell check in text input ([#2138](https://github.com/CARTAvis/carta-frontend/issues/2138)).
 * Support animation playback with matched images in multi-panel view ([#1860](https://github.com/CARTAvis/carta-frontend/issues/1860)).
 * Modified spectral matching type selector in Image List Settings won't affact global preferences ([#2098](https://github.com/CARTAvis/carta-frontend/issues/2098)).
+* Enabled enter key to trigger filtering in the filter fields, and modified the buttons in the spectral line query widget and catalog widget ([#2046](https://github.com/CARTAvis/carta-frontend/issues/2046)).
 ### Fixed
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 * Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -836,9 +836,9 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
                     </div>
                     <div className="bp3-dialog-footer">
                         <div className="bp3-dialog-footer-actions">
-                            <AnchorButton intent={Intent.SUCCESS} text="Apply Filter" onClick={this.handleFilterRequest} disabled={disable || !profileStore.updateTableView || !profileStore.hasFilter} />
-                            <AnchorButton intent={Intent.WARNING} text="Reset Filter" onClick={this.handleResetClick} disabled={disable} />
-                            <AnchorButton text="Close Catalog" onClick={this.handleFileCloseClick} disabled={disable} />
+                            <AnchorButton intent={Intent.SUCCESS} text="Apply filter" onClick={this.handleFilterRequest} disabled={disable || !profileStore.updateTableView || !profileStore.hasFilter} />
+                            <AnchorButton intent={Intent.WARNING} text="Reset filter" onClick={this.handleResetClick} disabled={disable} />
+                            <AnchorButton text="Close catalog" onClick={this.handleFileCloseClick} disabled={disable} />
                             <AnchorButton intent={Intent.PRIMARY} text="Plot" onClick={this.handlePlotClick} disabled={!this.enablePlotButton} />
                         </div>
                     </div>

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -648,7 +648,8 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
             disableSort: profileStore.loadOntoImage,
             tableHeaders: profileStore.catalogHeader,
             onCompleteRender: this.onCompleteRender,
-            catalogType: profileStore.catalogType
+            catalogType: profileStore.catalogType,
+            applyFilterWithEnter: this.handleFilterRequest
         };
 
         if (!profileStore.isFileBasedCatalog) {

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -832,9 +832,9 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
                     </div>
                     <div className="bp3-dialog-footer">
                         <div className="bp3-dialog-footer-actions">
-                            <AnchorButton intent={Intent.PRIMARY} text="Filter" onClick={this.handleFilterRequest} disabled={disable || !profileStore.updateTableView || !profileStore.hasFilter} />
-                            <AnchorButton intent={Intent.PRIMARY} text="Reset" onClick={this.handleResetClick} disabled={disable} />
-                            <AnchorButton intent={Intent.PRIMARY} text="Close" onClick={this.handleFileCloseClick} disabled={disable} />
+                            <AnchorButton intent={Intent.SUCCESS} text="Apply Filter" onClick={this.handleFilterRequest} disabled={disable || !profileStore.updateTableView || !profileStore.hasFilter} />
+                            <AnchorButton intent={Intent.WARNING} text="Reset Filter" onClick={this.handleResetClick} disabled={disable} />
+                            <AnchorButton text="Close Catalog" onClick={this.handleFileCloseClick} disabled={disable} />
                             <AnchorButton intent={Intent.PRIMARY} text="Plot" onClick={this.handlePlotClick} disabled={!this.enablePlotButton} />
                         </div>
                     </div>

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -401,6 +401,9 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
     private handleFilterRequest = () => {
         const profileStore = this.profileStore;
+        if (profileStore.loadOntoImage || !profileStore.updateTableView || !profileStore.hasFilter) {
+            return;
+        }
         const catalogWidgetStore = this.widgetStore;
         const appStore = AppStore.Instance;
         if (profileStore && appStore) {

--- a/src/components/Shared/Tables/FilterableTableComponent.tsx
+++ b/src/components/Shared/Tables/FilterableTableComponent.tsx
@@ -24,6 +24,8 @@ enum RowSelectionType {
     All
 }
 
+const KEYCODE_ENTER = 13;
+
 export class FilterableTableComponentProps {
     dataset: Map<number, ProcessedColumnData>;
     filter?: Map<string, ControlHeader>;
@@ -47,6 +49,7 @@ export class FilterableTableComponentProps {
     sortedIndices?: Array<number>;
     onCompleteRender?: () => void;
     catalogType?: CatalogType;
+    applyFilterWithEnter?: () => void;
 }
 
 @observer
@@ -264,11 +267,24 @@ export class FilterableTableComponent extends React.Component<FilterableTableCom
                 <ColumnHeaderCell className={"column-name"} nameRenderer={nameRenderer} />
                 <ColumnHeaderCell isActive={controlheader?.filter !== ""}>
                     <Tooltip2 hoverOpenDelay={250} hoverCloseDelay={0} content={filterSyntax} position={Position.BOTTOM}>
-                        <InputGroup key={"column-popover-" + columnIndex} small={true} placeholder="Click to filter" value={controlheader?.filter ?? ""} onChange={ev => this.props.updateColumnFilter(ev.currentTarget.value, column.name)} />
+                        <InputGroup
+                            key={"column-popover-" + columnIndex}
+                            small={true}
+                            placeholder="Click to filter"
+                            value={controlheader?.filter ?? ""}
+                            onChange={ev => this.props.updateColumnFilter(ev.currentTarget.value, column.name)}
+                            onKeyDown={this.handleKeyDown}
+                        />
                     </Tooltip2>
                 </ColumnHeaderCell>
             </ColumnHeaderCell>
         );
+    };
+
+    private handleKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+        if (ev.type === "keydown" && ev.keyCode === KEYCODE_ENTER && this.props.applyFilterWithEnter) {
+            this.props.applyFilterWithEnter();
+        }
     };
 
     private isLoading(rowIndex: number): boolean {

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -350,7 +350,8 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
             updateColumnFilter: widgetStore.setColumnFilter,
             columnWidths: widgetStore.resultTableColumnWidths,
             updateTableColumnWidth: widgetStore.setResultTableColumnWidth,
-            tableHeaders: widgetStore.columnHeaders
+            tableHeaders: widgetStore.columnHeaders,
+            applyFilterWithEnter: this.handleFilter
         };
 
         const className = classNames("spectral-line-query-widget", {"bp3-dark": appStore.darkTheme});

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -390,18 +390,12 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
                         <FormGroup inline={true} label={this.width < MINIMUM_WIDTH ? "" : "Spectral profiler"}>
                             {widgetMenu}
                         </FormGroup>
-                        <Tooltip2 content="Apply filter" position={Position.BOTTOM}>
-                            <AnchorButton text="Filter" intent={Intent.PRIMARY} disabled={widgetStore.numDataRows <= 0} onClick={this.handleFilter} />
-                        </Tooltip2>
-                        <Tooltip2 content="Reset filter" position={Position.BOTTOM}>
-                            <AnchorButton text="Reset" intent={Intent.PRIMARY} onClick={this.handleResetFilter} />
-                        </Tooltip2>
+                        <AnchorButton text="Apply filter" intent={Intent.SUCCESS} disabled={widgetStore.numDataRows <= 0} onClick={this.handleFilter} />
+                        <AnchorButton text="Reset filter" intent={Intent.WARNING} onClick={this.handleResetFilter} />
                         <Tooltip2 content={plotTip} position={Position.BOTTOM}>
                             <AnchorButton text="Plot" intent={Intent.PRIMARY} disabled={!appStore.activeFrame || widgetStore.filterResult.size <= 0 || !isSelectedWidgetExisted || !isSelectedLinesUnderLimit} onClick={this.handlePlot} />
                         </Tooltip2>
-                        <Tooltip2 content="Clear plotted lines" position={Position.BOTTOM}>
-                            <AnchorButton text="Clear" intent={Intent.PRIMARY} disabled={!appStore.activeFrame || !isSelectedWidgetExisted || widgetStore.filterResult.size <= 0} onClick={this.handleClear} />
-                        </Tooltip2>
+                        <AnchorButton text="Clear plot" disabled={!appStore.activeFrame || !isSelectedWidgetExisted || widgetStore.filterResult.size <= 0} onClick={this.handleClear} />
                     </div>
                 </div>
                 <Overlay className={Classes.OVERLAY_SCROLL_CONTAINER} autoFocus={true} canEscapeKeyClose={false} canOutsideClickClose={false} isOpen={widgetStore.isQuerying} usePortal={false}>

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -202,6 +202,9 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
     };
 
     private handleFilter = () => {
+        if (this.widgetStore.numDataRows <= 0) {
+            return;
+        }
         this.widgetStore.filter();
         clearTimeout(this.scrollToTopHandle);
         this.scrollToTopHandle = setTimeout(() => this.resultTableRef?.scrollToRegion(Regions.row(0)), 20);


### PR DESCRIPTION
**Description**

1. Closes #2046. 

2. Enabled applying filtering with enter/return in the filter fields.

3. Changed ambiguous text and colors of buttons in the catalog widget and the spectral line query widget. 
<img width="1307" alt="截圖 2023-07-25 下午4 23 35" src="https://github.com/CARTAvis/carta-frontend/assets/20379662/e3c1f6e2-f7fd-4611-8fcf-80249ba67dd7">


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing~ / corresponding fix added
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~