### PR TITLE
ksw/convert fitting Gaussian fwhm to semi-axes to render ellipse region

### DIFF
--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -428,7 +428,8 @@ export class ImageFittingStore {
     private getRegionParams = (values: CARTA.IGaussianComponent[]): {points: Point2D[]; rotation: number}[] => {
         return values.map(value => {
             const center = {x: value?.center?.x, y: value?.center?.y};
-            const size = {x: value?.fwhm?.x, y: value?.fwhm?.y};
+            // Half lengths of major and minor axes are used to defined an ellipse region. Divide FWHM of Gaussian by 2.
+            const size = {x: value?.fwhm?.x / 2.0, y: value?.fwhm?.y / 2.0};
             return {points: [center, size], rotation: value?.pa};
         });
     };


### PR DESCRIPTION
**Description**
This is to fix #2212. The root cause is the ellipse region takes semi-axes length to define the size. So we need to convert the fitted Gaussian FHWM by multiplying 0.5.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~