### PR TITLE
Carli/1223 zfp compression artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added a shortcut button for image annotation ([#2167](https://github.com/CARTAvis/carta-frontend/issues/2167)).
 * Added support for AIPS beam images ([#2164](https://github.com/CARTAvis/carta-frontend/issues/2164)).
+* Added an increase to the default compression ratio to 32 when the header unit of the image is km/s ([#1223](https://github.com/CARTAvis/carta-frontend/issues/1223)).
 ### Changed
 * Changed the default title string in the image viewer ([#2168](https://github.com/CARTAvis/carta-frontend/issues/2168)).
 * Modified text annotation textbox to stay the same dimension as user zoom the image ([#2162](https://github.com/CARTAvis/carta-frontend/issues/2162)).

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1525,7 +1525,7 @@ export class AppStore {
                 const tileSizeFullRes = reqView.mip * 256;
                 const midPointTileCoords = {x: midPointImageCoords.x / tileSizeFullRes - 0.5, y: midPointImageCoords.y / tileSizeFullRes - 0.5};
 
-                // If Bunit = km/s, default compressionQuality is set to 20 instead of 11
+                // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
                 const bunitVariant = ["km/s", "km s-1", "km s^-1"];
                 let compressionQuality = this.preferenceStore.imageCompressionQuality;
                 if (bunitVariant.includes(frame.headerUnit)) {
@@ -1572,7 +1572,7 @@ export class AppStore {
 
     private updateView = (tiles: TileCoordinate[], fileId: number, channel: number, stokes: number, focusPoint: Point2D, headerUnit: string) => {
         const isAnimating = this.animatorStore.serverAnimationActive;
-        // If Bunit = km/s, default compressionQuality is set to 20 instead of 11
+        // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
         const bunitVariant = ["km/s", "km s-1", "km s^-1"];
         const compressionQuality = bunitVariant.includes(headerUnit) ? Math.max(this.preferenceStore.imageCompressionQuality, 32) : this.preferenceStore.imageCompressionQuality;
         if (isAnimating) {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1526,7 +1526,7 @@ export class AppStore {
                 const midPointTileCoords = {x: midPointImageCoords.x / tileSizeFullRes - 0.5, y: midPointImageCoords.y / tileSizeFullRes - 0.5};
 
                 // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
-                const bunitVariant = ["km/s", "km s-1", "km s^-1"];
+                const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
                 let compressionQuality = this.preferenceStore.imageCompressionQuality;
                 if (bunitVariant.includes(frame.headerUnit)) {
                     compressionQuality = Math.max(compressionQuality, 32);
@@ -1573,7 +1573,7 @@ export class AppStore {
     private updateView = (tiles: TileCoordinate[], fileId: number, channel: number, stokes: number, focusPoint: Point2D, headerUnit: string) => {
         const isAnimating = this.animatorStore.serverAnimationActive;
         // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
-        const bunitVariant = ["km/s", "km s-1", "km s^-1"];
+        const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
         const compressionQuality = bunitVariant.includes(headerUnit) ? Math.max(this.preferenceStore.imageCompressionQuality, 32) : this.preferenceStore.imageCompressionQuality;
         if (isAnimating) {
             this.backendService.addRequiredTiles(

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -71,7 +71,7 @@ interface ViewUpdate {
     channel: number;
     stokes: number;
     focusPoint: Point2D;
-    headerUnit?: string;
+    headerUnit: string;
 }
 
 interface ChannelUpdate {
@@ -1527,10 +1527,7 @@ export class AppStore {
 
                 // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
                 const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
-                let compressionQuality = this.preferenceStore.imageCompressionQuality;
-                if (bunitVariant.includes(frame.headerUnit)) {
-                    compressionQuality = Math.max(compressionQuality, 32);
-                }
+                const compressionQuality = bunitVariant.includes(frame.headerUnit) ? Math.max(this.preferenceStore.imageCompressionQuality, 32) : this.preferenceStore.imageCompressionQuality;
                 this.tileService.requestTiles(tiles, frame.frameInfo.fileId, frame.channel, frame.stokes, midPointTileCoords, compressionQuality, true);
             } else {
                 this.tileService.updateHiddenFileChannels(frame.frameInfo.fileId, frame.channel, frame.stokes);
@@ -1572,9 +1569,6 @@ export class AppStore {
 
     private updateView = (tiles: TileCoordinate[], fileId: number, channel: number, stokes: number, focusPoint: Point2D, headerUnit: string) => {
         const isAnimating = this.animatorStore.serverAnimationActive;
-        // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
-        const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
-        const compressionQuality = bunitVariant.includes(headerUnit) ? Math.max(this.preferenceStore.imageCompressionQuality, 32) : this.preferenceStore.imageCompressionQuality;
         if (isAnimating) {
             this.backendService.addRequiredTiles(
                 fileId,
@@ -1582,6 +1576,9 @@ export class AppStore {
                 this.preferenceStore.animationCompressionQuality
             );
         } else {
+            // If BUNIT = km/s, adopted compressionQuality is set to 32 regardless the preferences setup
+            const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
+            const compressionQuality = bunitVariant.includes(headerUnit) ? Math.max(this.preferenceStore.imageCompressionQuality, 32) : this.preferenceStore.imageCompressionQuality;
             this.tileService.requestTiles(tiles, fileId, channel, stokes, focusPoint, compressionQuality);
         }
     };


### PR DESCRIPTION
**Description**

This PR fixes #1223 by increase the default compression ratio to 32 when the header unit of the image is km/s.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~~no changelog update needed~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~