### PR TITLE
Thchang/2121 matching generated moment images toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added a shortcut button for image annotation ([#2167](https://github.com/CARTAvis/carta-frontend/issues/2167))
+* Added a toggle in the moment generator to match generated image(s) ([#2121](https://github.com/CARTAvis/carta-frontend/issues/2167)).
 ### Changed
 * Changed the default title string in the image viewer ([#2168](https://github.com/CARTAvis/carta-frontend/issues/2168)).
 * Modified text annotation textbox to stay the same dimension as user zoom the image ([#2162](https://github.com/CARTAvis/carta-frontend/issues/2162)).

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -242,19 +242,16 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                     />
                 </FormGroup>
                 <Divider />
-                <FormGroup inline={true} label={"Keep previous moment image(s)"}>
+                <FormGroup inline={true} label={"Options"}>
                     <Switch
+                        label={"Keep previous moment image(s)"}
                         onChange={event => {
                             const e = event.target as HTMLInputElement;
                             widgetStore.setKeep(e.checked);
                         }}
                     />
+                    {frame === appStore.spatialReference && <Switch label={"Auto spatial matching"} checked={appStore.momentToMatch} onChange={appStore.toggleMomentToMatch} />}
                 </FormGroup>
-                {frame === appStore.spatialReference && (
-                    <FormGroup inline={true} label={"Match to spatial reference image"}>
-                        <Switch checked={appStore.momentToMatch} onChange={appStore.toggleMomentToMatch} />
-                    </FormGroup>
-                )}
                 <div className="moment-generate">
                     <Tooltip2 disabled={isAbleToGenerate} content={msg} position={Position.BOTTOM}>
                         <AnchorButton intent="success" onClick={this.handleRequestMoment} disabled={!isAbleToGenerate}>

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -250,6 +250,11 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                         }}
                     />
                 </FormGroup>
+                {frame === appStore.spatialReference && (
+                    <FormGroup inline={true} label={"Match to spatial reference image"}>
+                        <Switch checked={appStore.momentToMatch} onChange={appStore.toggleMomentToMatch} />
+                    </FormGroup>
+                )}
                 <div className="moment-generate">
                     <Tooltip2 disabled={isAbleToGenerate} content={msg} position={Position.BOTTOM}>
                         <AnchorButton intent="success" onClick={this.handleRequestMoment} disabled={!isAbleToGenerate}>

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -347,6 +347,9 @@ export class AppStore {
     // Spectral matching type, initialized by global preferences, modified by the Image List Settings
     @observable spectralMatchingType: SpectralType;
 
+    // Match generated moment image(s) to the spatial reference image
+    @observable momentToMatch: boolean;
+
     @computed get openFileDisabled(): boolean {
         return this.backendService?.connectionStatus !== ConnectionStatus.ACTIVE || this.fileLoading;
     }
@@ -1224,7 +1227,11 @@ export class AppStore {
                 for (const openFileAck of ack.openFileAcks) {
                     if (this.addFrame(CARTA.OpenFileAck.create(openFileAck), this.fileBrowserStore.startingDirectory, false, "", true)) {
                         this.fileCounter++;
-                        frame.addMomentImage(this.frames.find(f => f.frameInfo.fileId === openFileAck.fileId));
+                        const newMomentImage = this.frames.find(f => f.frameInfo.fileId === openFileAck.fileId);
+                        frame.addMomentImage(newMomentImage);
+                        if (frame === this.spatialReference && this.momentToMatch) {
+                            newMomentImage.setSpatialReference(this.spatialReference);
+                        }
                     } else {
                         AppToaster.show({icon: "warning-sign", message: "Load file failed.", intent: "danger", timeout: 3000});
                     }
@@ -1667,6 +1674,7 @@ export class AppStore {
         this.toolbarExpanded = true;
         this.imageRatio = 1;
         this.isExportingImage = false;
+        this.momentToMatch = true;
 
         AST.onReady.then(
             action(() => {
@@ -2821,6 +2829,10 @@ export class AppStore {
     @action setMatchingEnabled = (spatial: boolean, spectral: boolean) => {
         this.setSpatialMatchingEnabled(this.activeFrame, spatial);
         this.setSpectralMatchingEnabled(this.activeFrame, spectral);
+    };
+
+    @action toggleMomentToMatch = () => {
+        this.momentToMatch = !this.momentToMatch;
     };
 
     @computed get numImagePages() {


### PR DESCRIPTION
**Description**

Closes #2121.

1. Added a toggle in the moment generator to control the generated moment image(s) to be matched to the spatial reference image.

2. The toggle only shows up when the data source image is the spatial reference image.

3. The controlling property `momentToMatch` was added to AppStore.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing~ / corresponding fix added
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~__