### PR TITLE
update user manual url to 4.0

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -80,7 +80,7 @@ export class AboutDialogComponent extends React.Component {
                         </li>
                         <li>
                             Documentation is available{" "}
-                            <a href="https://carta.readthedocs.io/en/3.0" rel="noopener noreferrer" target="_blank">
+                            <a href="https://carta.readthedocs.io/en/4.0" rel="noopener noreferrer" target="_blank">
                                 online
                             </a>
                         </li>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -371,7 +371,7 @@ export class RootMenuComponent extends React.Component {
 
         const helpMenu = (
             <Menu>
-                <Menu.Item text="Online Manual" icon={"manual"} onClick={() => this.handleDocumentationClicked("https://carta.readthedocs.io/en/3.0")} />
+                <Menu.Item text="Online Manual" icon={"manual"} onClick={() => this.handleDocumentationClicked("https://carta.readthedocs.io/en/4.0")} />
                 <Menu.Item text="Controls and Shortcuts" icon={"key-control"} label={"Shift + ?"} onClick={appStore.dialogStore.showHotkeyDialog} />
                 <Menu.Item text="About" icon={"info-sign"} onClick={appStore.dialogStore.showAboutDialog} />
             </Menu>


### PR DESCRIPTION
**Description**

trivial change for the readthedoc URL for user manual v4.0


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] ~ZenHub issue connection, board status, and estimate updated~

For the pull request:
- [x] reviewers and assignee added
- [ ] ~ZenHub estimate, milestone, and release (if needed) added~
- [x] e2e test passing / ~corresponding fix added~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~