### PR TITLE
KSW/switching Splatalogue test URL to production URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support animation playback with matched images in multi-panel view ([#1860](https://github.com/CARTAvis/carta-frontend/issues/1860)).
 * Modified spectral matching type selector in Image List Settings won't affact global preferences ([#2098](https://github.com/CARTAvis/carta-frontend/issues/2098)).
 * Enabled enter key to trigger filtering in the filter fields, and modified the buttons in the spectral line query widget and catalog widget ([#2046](https://github.com/CARTAvis/carta-frontend/issues/2046)).
+* Switched the Splatalogue URL from test to production ([#2238](https://github.com/CARTAvis/carta-frontend/issues/2238))
 ### Fixed
 * Fixed bug where line region computation width cannot be changed in spatial profile setting widget ([#2000](https://github.com/CARTAvis/carta-frontend/issues/2000)).
 * Fixed when multiple images are open, PV generator can only produce PV preview with live update for one of the images ([#2171](https://github.com/CARTAvis/carta-frontend/issues/2171)).

--- a/src/services/SplatalogueService.ts
+++ b/src/services/SplatalogueService.ts
@@ -10,7 +10,7 @@ export interface SpectralLineResponse {
 }
 
 export class SplatalogueService {
-    private static BaseUrl = "https://almahd-staging.cv.nrao.edu/splata-slap/advanceded/false/";
+    private static BaseUrl = "https://splatalogue.online/splata-slap/advanced/false/";
     private readonly axiosInstance: AxiosInstance;
 
     private static SplatalogueHeaderTypeMap = new Map<SpectralLineHeaders, CARTA.ColumnType>([

--- a/src/services/SplatalogueService.ts
+++ b/src/services/SplatalogueService.ts
@@ -72,7 +72,8 @@ export class SplatalogueService {
 
     query = async (freqMin: number, freqMax: number, intensityLimit?: number): Promise<SpectralLineResponse> => {
         const params = SplatalogueService.GetParams(freqMin, freqMax, intensityLimit);
-        const response = await this.axiosInstance.post("", {body: JSON.stringify(params), headers: {"Accept-Encoding": "gzip"}});
+        const headers = {"Accept-Encoding": "gzip"};
+        const response = await this.axiosInstance.post("", {body: JSON.stringify(params), headers: headers});
         return SplatalogueService.ConvertTable(response?.data);
     };
 

--- a/src/services/SplatalogueService.ts
+++ b/src/services/SplatalogueService.ts
@@ -72,8 +72,7 @@ export class SplatalogueService {
 
     query = async (freqMin: number, freqMax: number, intensityLimit?: number): Promise<SpectralLineResponse> => {
         const params = SplatalogueService.GetParams(freqMin, freqMax, intensityLimit);
-        const headers = {"Accept-Encoding": "gzip"};
-        const response = await this.axiosInstance.post("", {body: JSON.stringify(params), headers: headers});
+        const response = await this.axiosInstance.post("", {body: JSON.stringify(params)});
         return SplatalogueService.ConvertTable(response?.data);
     };
 

--- a/src/services/SplatalogueService.ts
+++ b/src/services/SplatalogueService.ts
@@ -10,7 +10,7 @@ export interface SpectralLineResponse {
 }
 
 export class SplatalogueService {
-    private static BaseUrl = "https://splatalogue.online/splata-slap/advanced/false/";
+    private static BaseUrl = "https://splatalogue.online/splata-slap/advanceded/false/";
     private readonly axiosInstance: AxiosInstance;
 
     private static SplatalogueHeaderTypeMap = new Map<SpectralLineHeaders, CARTA.ColumnType>([

--- a/src/services/SplatalogueService.ts
+++ b/src/services/SplatalogueService.ts
@@ -72,7 +72,7 @@ export class SplatalogueService {
 
     query = async (freqMin: number, freqMax: number, intensityLimit?: number): Promise<SpectralLineResponse> => {
         const params = SplatalogueService.GetParams(freqMin, freqMax, intensityLimit);
-        const response = await this.axiosInstance.post("", {body: JSON.stringify(params)});
+        const response = await this.axiosInstance.post("", {body: JSON.stringify(params), headers: {"Accept-Encoding": "gzip"}});
         return SplatalogueService.ConvertTable(response?.data);
     };
 


### PR DESCRIPTION
**Description**
Close #2238 


This is just to switch the Splatalogue SLAP service URL from test to production. ~In addition, in the POST request, a header to request gzip data stream is added. This is currently not effective because the service server does not enable zipping yet.~

The production URL has been tested with a long run of e2e test. The service is quite stable so far.

Having external service URLs (incl. SIMBAD, VizieR, Splatalogue) as user configurable should be considered as a separate issue.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~
- [x] changelog updated / ~no changelog update needed~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~