### PR TITLE
ajm/copyright year auto

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {build_year,CARTA_INFO} from "models";
+import {build_year, CARTA_INFO} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {CARTA_INFO, year} from "models";
+import {CARTA_INFO} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";
@@ -93,7 +93,7 @@ export class AboutDialogComponent extends React.Component {
                     </ul>
                     <h3>License</h3>
                     <p className={Classes.TEXT_SMALL}>
-                        Copyright (C) 2018-{year} ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
+                        Copyright (C) 2018-{CARTA_INFO.year} ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
                         <a href="http://www.gnu.org/copyleft/gpl.html" rel="noopener noreferrer" target="_blank">
                             GNU General Public License version 3
                         </a>

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {CARTA_INFO} from "models";
+import {build_year,CARTA_INFO} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";
@@ -93,7 +93,7 @@ export class AboutDialogComponent extends React.Component {
                     </ul>
                     <h3>License</h3>
                     <p className={Classes.TEXT_SMALL}>
-                        Copyright (C) 2018-2022 ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
+                        Copyright (C) 2018-{build_year} ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
                         <a href="http://www.gnu.org/copyleft/gpl.html" rel="noopener noreferrer" target="_blank">
                             GNU General Public License version 3
                         </a>

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {CARTA_INFO,year} from "models";
+import {CARTA_INFO, year} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {build_year, CARTA_INFO} from "models";
+import {year, CARTA_INFO} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -93,7 +93,7 @@ export class AboutDialogComponent extends React.Component {
                     </ul>
                     <h3>License</h3>
                     <p className={Classes.TEXT_SMALL}>
-                        Copyright (C) 2018-{build_year} ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
+                        Copyright (C) 2018-{year} ASIAA, IDIA, NRAO, and Department of Physics, University of Alberta. This program is free software; you can redistribute it and/or modify it under the terms of the&#160;
                         <a href="http://www.gnu.org/copyleft/gpl.html" rel="noopener noreferrer" target="_blank">
                             GNU General Public License version 3
                         </a>

--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -3,7 +3,7 @@ import {AnchorButton, Classes, IDialogProps, Intent} from "@blueprintjs/core";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
-import {year, CARTA_INFO} from "models";
+import {CARTA_INFO,year} from "models";
 import {DialogStore} from "stores";
 
 import "./AboutDialogComponent.scss";

--- a/src/models/CARTAInfo/CARTAInfo.ts
+++ b/src/models/CARTAInfo/CARTAInfo.ts
@@ -6,7 +6,7 @@ const {version} = require("../../../package.json");
 const build_date = preval`module.exports = new Date()`;
 const date = moment(build_date).format("D MMM YYYY");
 
-export const build_year = moment(build_date).year();
+export const year = moment(build_date).year();
 
 export const CARTA_INFO = {
     acronym: "CARTA",

--- a/src/models/CARTAInfo/CARTAInfo.ts
+++ b/src/models/CARTAInfo/CARTAInfo.ts
@@ -5,12 +5,12 @@ const {version} = require("../../../package.json");
 
 const build_date = preval`module.exports = new Date()`;
 const date = moment(build_date).format("D MMM YYYY");
-
-export const year = moment(build_date).year();
+const year = moment(build_date).year();
 
 export const CARTA_INFO = {
     acronym: "CARTA",
     version,
     date,
+    year,
     fullName: "Cube Analysis and Rendering Tool for Astronomy"
 };

--- a/src/models/CARTAInfo/CARTAInfo.ts
+++ b/src/models/CARTAInfo/CARTAInfo.ts
@@ -6,6 +6,8 @@ const {version} = require("../../../package.json");
 const build_date = preval`module.exports = new Date()`;
 const date = moment(build_date).format("D MMM YYYY");
 
+export const build_year = moment(build_date).year();
+
 export const CARTA_INFO = {
     acronym: "CARTA",
     version,


### PR DESCRIPTION
**Description**

This should be a solution to #2243 

It remains to be decided whether to squeeze this in to v4.0.0, or wait for v5.0.0-beta.1. I am OK either way.

@YuHsuan-Hwang Is this what you meant about using `year` instead of `build_year`?

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x]  no changelog update needed
- [x]  no protobuf update needed
- [x] `BackendService` unchanged
