### PR TITLE
carli/2248_2249_pv_preview_bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed the blank screen when clicking X/Y profile setting button without images opened ([#2247](https://github.com/CARTAvis/carta-frontend/issues/2247)).
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
-* Removed unused help button for PV preview widget ß([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
+* Removed unused help button for PV preview widget ([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
 * Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
 
 ## [4.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed the blank screen when clicking X/Y profile setting button without images opened ([#2247](https://github.com/CARTAvis/carta-frontend/issues/2247)).
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
+* Removed unused help button for PV preview widget ß([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
+* Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
 
 ## [4.0.0]
 

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -417,7 +417,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                 <div className="generate-button">
                     <div>
                         <Tooltip2 disabled={isAbleToGeneratePreview} content={previewHint} position={Position.BOTTOM}>
-                            <AnchorButton intent="success" disabled={!isAbleToGeneratePreview} text="Start Preview" onClick={this.onPreviewButtonClicked} />
+                            <AnchorButton intent="success" disabled={!isAbleToGeneratePreview} text="Start preview" onClick={this.onPreviewButtonClicked} />
                         </Tooltip2>
                     </div>
                     <div>

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -714,7 +714,7 @@ export class WidgetsStore {
             stack.on("activeContentItemChanged", (contentItem: any) => {
                 if (stack && stack.config && stack.header.controlsContainer && stack.config.content.length) {
                     const component = stack.getActiveContentItem().config.component;
-                    const stackHeaderControlButtons = stack.header.controlsContainer;
+                    const stackHeaderControlButtons = stack.header.controlsContainer[0];
 
                     // show/hide help button
                     $(stackHeaderControlButtons)

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -694,6 +694,7 @@ export class WidgetsStore {
         layout.registerComponent("catalog-plot", CatalogPlotComponent);
 
         const showCogWidgets = ["image-view", "spatial-profiler", "spectral-profiler", "histogram", "render-config", "stokes", "catalog-overlay", "layer-list"];
+        const hideHelpButtonWidgets = ["pv-preview"];
         // add drag source buttons for ToolbarMenuComponent
         this.CARTAWidgets.forEach((props, widgetType) => {
             const widgetButtonID = widgetType.replace(/\s+/g, "") + "Button";
@@ -713,7 +714,12 @@ export class WidgetsStore {
             stack.on("activeContentItemChanged", (contentItem: any) => {
                 if (stack && stack.config && stack.header.controlsContainer && stack.config.content.length) {
                     const component = stack.getActiveContentItem().config.component;
-                    const stackHeaderControlButtons = stack.header.controlsContainer[0];
+                    const stackHeaderControlButtons = stack.header.controlsContainer;
+
+                    // show/hide help button
+                    $(stackHeaderControlButtons)
+                        ?.find("li.lm-help")
+                        ?.attr("style", hideHelpButtonWidgets.includes(component) ? "display:none;" : "");
 
                     // show/hide cog button
                     $(stackHeaderControlButtons)
@@ -949,6 +955,7 @@ export class WidgetsStore {
             const config = item.config as GoldenLayout.ReactComponentConfig;
             const isCatalogTable = config.component === CatalogOverlayComponent.WIDGET_CONFIG.type;
             const isCatalogPlot = config.component === CatalogPlotComponent.WIDGET_CONFIG.type;
+            const isPvPreview = config.component === PvPreviewComponent.WIDGET_CONFIG.type;
             // Clean up removed widget's store (ignoring items that have been floated)
             const id = config.id as string;
             if (config.component !== "floated" && !isCatalogTable && !isCatalogPlot) {
@@ -964,6 +971,13 @@ export class WidgetsStore {
             // remove all catalog plots associated to current catalog plot widget
             if (isCatalogPlot) {
                 CatalogStore.Instance.clearCatalogPlotsByWidgetId(id);
+            }
+
+            // remove preview frame for current pv preview widget
+            if (isPvPreview) {
+                const regexPattern = /pv-generator-(\d+)/;
+                const pvGeneratorId = id.match(regexPattern);
+                this.pvGeneratorWidgets.get(pvGeneratorId[0])?.removePreviewFrame(parseInt(id.split("-")[2]));
             }
         }
     };


### PR DESCRIPTION
**Description**

Fixes #2248 and #2249. For #2249 the docked preview widget doesn't delete preview frameStore on close, preventing the pv generator from creating new preview frameStore. The fix is to add the code to delete the preview frameStore when closing the docked preview widget.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~ (new tests will be added later)
- [x] changelog updated / ~~no changelog update needed~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~
