### PR TITLE
Mark/2216 Added the frontend version info in register viewer message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Added the frontend version info in register viewer message ([#2216](https://github.com/CARTAvis/carta-frontend/issues/2216)).
+
 ## [4.0.0]
 
 ### Added

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -56,6 +56,7 @@ export class BackendService {
     }
 
     private static readonly IcdVersion = 28;
+    private static readonly FrontendVersion = "4.0.0";
     private static readonly DefaultFeatureFlags = CARTA.ClientFeatureFlags.WEB_ASSEMBLY | CARTA.ClientFeatureFlags.WEB_GL;
     private static readonly MaxConnectionAttempts = 15;
     private static readonly ConnectionAttemptDelay = 1000;
@@ -211,7 +212,7 @@ export class BackendService {
                 this.connectionDropped = true;
             }
             this.connectionStatus = ConnectionStatus.ACTIVE;
-            const message = CARTA.RegisterViewer.create({sessionId: this.sessionId, clientFeatureFlags: BackendService.DefaultFeatureFlags});
+            const message = CARTA.RegisterViewer.create({sessionId: this.sessionId, version: BackendService.FrontendVersion, clientFeatureFlags: BackendService.DefaultFeatureFlags});
             // observer map is cleared, so that old subscriptions don't get incorrectly fired
 
             this.logEvent(CARTA.EventType.REGISTER_VIEWER, requestId, message, false);
@@ -229,6 +230,10 @@ export class BackendService {
         };
 
         return await deferredResponse.promise;
+    }
+
+    disconnect() {
+        this.connection.close();
     }
 
     sendPing = () => {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -224,6 +224,8 @@ export class AppStore {
             this.logStore.addInfo(`Connected to server ${wsURL} with session ID ${ack.sessionId}`, ["network"]);
         } catch (err) {
             console.error(err);
+            AppToaster.show(ErrorToast(`${err}`));
+            this.backendService.disconnect();
         }
     };
 
@@ -2245,6 +2247,8 @@ export class AppStore {
         } catch (err) {
             this.telemetryService.addTelemetryEntry(TelemetryAction.RetryConnection, {status: "failed"});
             console.log(err);
+            AppToaster.show(ErrorToast(`${err}`));
+            this.backendService.disconnect();
         }
     };
 


### PR DESCRIPTION
**Description**

linked issues and companion PRs (if there are), what is implemented or fixed, how to test it, …

Fixes #2216. When connecting with the backend, the frontend sends its version info to the backend in the `RegisterViewer` message. The backend then checks if the frontend version is compatible with it or not. If not, the frontend will receive the `RegisterViewerAck` message from the backend with the `success === false`. In such case, the error message will shown on the panel, and the frontend will disconnect from the backend. This PR accompanies the [backed PR](https://github.com/CARTAvis/carta-backend/pull/1316) and [protobuf PR](https://github.com/CARTAvis/carta-protobuf/pull/89).

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [ ] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] changelog updated ~/ no changelog update needed~
- [x] protobuf updated to the latest dev commit ~/ no protobuf update needed~
- [ ] ~`BackendService` unchanged /~ `BackendService` changed and corresponding ICD test fix added
