### PR TITLE
Yuhsuan/readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We recommend using [Docker](https://www.docker.com) or [Singularity](https://sin
 Initialise submodules and install package dependencies:
 ```
 git submodule update --init --recursive
-npm install
+npm install --legacy-peer-deps
 ```
 WebAssembly libraries can be built with `npm run build-libs-docker` or `npm run build-libs-singularity`.
 Additional build steps (building WebAssembly wrappers, protocol buffer modules and compiling the Typescript code) are performed by `npm run build-docker` or `npm run build-singularity`. This produces a production build in the `build` folder.
@@ -97,7 +97,7 @@ If your build environment does not have access to Docker or Singularity, WebAsse
 Initialise submodules and install package dependencies:
 ```
 git submodule update --init --recursive
-npm install
+npm install --legacy-peer-deps
 ```
 
 WebAssembly libraries can be built with `npm run build-libs`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you wish to modify or develop the CARTA frontend, you may build a production 
 
 The build process relies heavily on `npm` and `nodejs`, so make sure they are installed and accessible.
 
-We recommend using [Docker](https://www.docker.com) or [Singularity](https://singularity.lbl.gov/index.html) to perform WebAssembly compilation. If neither is available, the Emscripten compiler (`emcc` version 2.0.14 recommended) needs to be available in the build environment. Installation instructions are available on the [Emscripten homepage](https://emscripten.org/docs/getting_started/downloads.html).
+We recommend using [Docker](https://www.docker.com) or [Singularity](https://apptainer.org/docs/) to perform WebAssembly compilation. If neither is available, the Emscripten compiler (`emcc` version 2.0.14 recommended) needs to be available in the build environment. Installation instructions are available on the [Emscripten homepage](https://emscripten.org/docs/getting_started/downloads.html).
 
 ### Build process (using Docker/Singularity)
 Initialise submodules and install package dependencies:


### PR DESCRIPTION
**Description**

Minor adjustment of the readme file based on user's feedback.
* Added `--legacy-peer-deps` flag. To be changed back after https://github.com/CARTAvis/carta-frontend/issues/1982 is fixed.
* Updated Singularity link.

**Checklist**

For linked issues (if there are):
- [x] ~assignee and label added~
- [x] ~ZenHub issue connection, board status, and estimate updated~

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing / corresponding fix added / new e2e test created~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~
