### PR TITLE
make default "region" in moment generator to "image"

### DIFF
--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -392,7 +392,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         autorun(() => {
             if (this.effectiveFrame) {
                 this.updateRanges();
-                this.selectMomentRegion(RegionId.ACTIVE);
+                this.selectMomentRegion(RegionId.IMAGE);
             }
         });
 


### PR DESCRIPTION
**Description**

This PR is for the sugguestion #2260 changing the default "Region" value to "Image" instead of "Active" in moment generator.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~
