### PR TITLE
Yuhsuan/1652 large catalog

### DIFF
--- a/src/stores/Catalog/CatalogProfileStore.ts
+++ b/src/stores/Catalog/CatalogProfileStore.ts
@@ -116,7 +116,6 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
         const subsetEndIndex = catalogFilter.subsetEndIndex;
         const startIndex = subsetEndIndex - subsetDataSize;
 
-        const totalDataSize = catalogFilter.requestEndIndex;
         this.filterDataSize = catalogFilter.filterDataSize;
 
         if (this.subsetEndIndex <= this.filterDataSize) {
@@ -129,17 +128,17 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
                     if (currentData.dataType === CARTA.ColumnType.String) {
                         const currentArr = currentData.data as Array<string>;
                         const newArr = newData.data as Array<string>;
-                        currentData.data = CatalogProfileStore.FillAllocatedArray<string>(currentArr, newArr, startIndex, totalDataSize);
+                        currentData.data = CatalogProfileStore.FillAllocatedArray<string>(currentArr, newArr, startIndex, subsetEndIndex);
                     } else if (currentData.dataType === CARTA.ColumnType.Bool) {
                         const currentArr = currentData.data as Array<boolean>;
                         const newArr = newData.data as Array<boolean>;
-                        currentData.data = CatalogProfileStore.FillAllocatedArray<boolean>(currentArr, newArr, startIndex, totalDataSize);
+                        currentData.data = CatalogProfileStore.FillAllocatedArray<boolean>(currentArr, newArr, startIndex, subsetEndIndex);
                     } else if (currentData.dataType === CARTA.ColumnType.UnsupportedType) {
                         return;
                     } else {
                         const currentArr = currentData.data as Array<number>;
                         const newArr = newData.data as Array<number>;
-                        currentData.data = CatalogProfileStore.FillAllocatedArray<number>(currentArr, newArr, startIndex, totalDataSize);
+                        currentData.data = CatalogProfileStore.FillAllocatedArray<number>(currentArr, newArr, startIndex, subsetEndIndex);
                     }
                 }
             });


### PR DESCRIPTION
**Description**

Fixed the error `Invalid array length` in #1652 by setting the array size to the current received source number instead of the entire source number.

However, loading 100M source catalogs still crashes when ~30M sources are loaded (possibly caused by running out of memory). Do we need to fully support 100M source catalogs?

Update: closes #1652.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [ ] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] `BackendService` unchanged / ~`BackendService` changed and corresponding ICD test fix added~
