### PR TITLE
carli/2246_scripting_ruler_setSize

### DIFF
--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -152,7 +152,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: Math.abs(value - region.controlPoints[1].x), y: region.size.y};
-            if (newDims.x > 0 || newDims.y > 0) {
+            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
                 region.setControlPoint(0, {x: value, y: region.controlPoints[0].y});
                 return true;
             }
@@ -179,7 +179,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: region.size.x, y: Math.abs(value - region.controlPoints[1].y)};
-            if (newDims.x > 0 || newDims.y > 0) {
+            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
                 region.setControlPoint(0, {x: region.controlPoints[0].x, y: value});
                 return true;
             }
@@ -206,7 +206,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: Math.abs(value - region.controlPoints[0].x), y: region.size.y};
-            if (newDims.x > 0 || newDims.y > 0) {
+            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
                 region.setControlPoint(1, {x: value, y: region.controlPoints[1].y});
                 return true;
             }
@@ -233,7 +233,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: region.size.x, y: Math.abs(value - region.controlPoints[0].y)};
-            if (newDims.x > 0 || newDims.y > 0) {
+            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
                 region.setControlPoint(1, {x: region.controlPoints[1].x, y: value});
                 return true;
             }

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -152,7 +152,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: Math.abs(value - region.controlPoints[1].x), y: region.size.y};
-            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
+            if (newDims.x > 0 || newDims.y > 0) {
                 region.setControlPoint(0, {x: value, y: region.controlPoints[0].y});
                 return true;
             }
@@ -179,7 +179,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: region.size.x, y: Math.abs(value - region.controlPoints[1].y)};
-            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
+            if (newDims.x > 0 || newDims.y > 0) {
                 region.setControlPoint(0, {x: region.controlPoints[0].x, y: value});
                 return true;
             }
@@ -206,7 +206,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: Math.abs(value - region.controlPoints[0].x), y: region.size.y};
-            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
+            if (newDims.x > 0 || newDims.y > 0) {
                 region.setControlPoint(1, {x: value, y: region.controlPoints[1].y});
                 return true;
             }
@@ -233,7 +233,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
         if (isFinite(value) && isFinite(existingValue) && !closeTo(value, existingValue, LineRegionForm.REGION_PIXEL_EPS)) {
             const region = this.props.region;
             const newDims = {x: region.size.x, y: Math.abs(value - region.controlPoints[0].y)};
-            if (Math.abs(newDims.x) > 0 || Math.abs(newDims.y) > 0) {
+            if (newDims.x > 0 || newDims.y > 0) {
                 region.setControlPoint(1, {x: region.controlPoints[1].x, y: value});
                 return true;
             }

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -374,9 +374,7 @@ export class RegionStore {
         }
     };
 
-    public getRegionApproximation(
-        astTransform: AST.Mapping
-    ): Point2D[] | {northApproximatePoints: number[]; eastApproximatePoints: number[]} | {xApproximatePoints: number[]; yApproximatePoints: number[]; hypotenuseApproximatePoints: number[]} {
+    public getRegionApproximation(astTransform: AST.Mapping): Point2D[] {
         let approximatePoints = this.regionApproximationMap.get(astTransform);
         if (!approximatePoints) {
             if (this.regionType === CARTA.RegionType.POINT) {
@@ -455,7 +453,7 @@ export class RegionStore {
         if (this.regionType === CARTA.RegionType.POLYGON || this.regionType === CARTA.RegionType.ANNPOLYGON) {
             this.simplePolygonTest();
         }
-        if ((this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR) && controlPoints.length === 2) {
+        if ((this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) && controlPoints.length === 2) {
             this.rotation = this.controlPoints.length === 2 ? this.getLineAngle(this.controlPoints[0], this.controlPoints[1]) : 0;
         }
         this.modifiedTimestamp = performance.now();
@@ -506,7 +504,7 @@ export class RegionStore {
                 this.simplePolygonTest(index);
             }
 
-            if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR) {
+            if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) {
                 this.rotation = this.controlPoints.length === 2 ? this.getLineAngle(this.controlPoints[0], this.controlPoints[1]) : 0;
             }
         }
@@ -531,7 +529,7 @@ export class RegionStore {
             this.simplePolygonTest();
         }
 
-        if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR) {
+        if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) {
             this.rotation = points.length === 2 ? this.getLineAngle(points[0], points[1]) : 0;
         }
 
@@ -557,7 +555,7 @@ export class RegionStore {
         if (!this.activeFrame?.hasSquarePixels) {
             return;
         }
-        if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR) {
+        if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) {
             const rotation = (((angle + 360) % 360) * Math.PI) / 180.0;
             // the rotation angle is defined to be 0 at North (mostly in +y axis) and increases counter-clockwisely. This is
             // different from the usual definition in math where 0 degree is in the +x axis. The extra 90-degree offset swaps

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -199,8 +199,8 @@ export class RegionStore {
     }
 
     /**
-     * Getter for the sizes of regions and annotations
-     * @returns A Point2D object with x and y size components.
+     * Returns the sizes of regions and annotations. For line regions and annotations, vector annotations, and ruler annotations, returns x and y absolute displacements.
+     * @returns The x and y size components.
      */
     @computed get size(): Point2D {
         switch (this.regionType) {
@@ -488,7 +488,7 @@ export class RegionStore {
      * Sets the size for regions and annotations
      *
      * @param p - Specifies the x and y size components.
-     *            For line region and annotation, vector annotation, and ruler annotation, the function sets the individual new x and y components of the linear segment.
+     *            For line regions and annotations, vector annotations, and ruler annotations, the function sets the new start and end positions while keeping the rotation within the same quadrant.
      * @param skipUpdate - Whether to update the changes with the backend.
      */
     @action setSize = (p: Point2D, skipUpdate = false) => {

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -216,7 +216,8 @@ export class RegionStore {
             case CARTA.RegionType.ANNLINE:
             case CARTA.RegionType.ANNVECTOR:
             case CARTA.RegionType.ANNRULER:
-                return subtract2D(this.controlPoints[0], this.controlPoints[1]);
+                const size = subtract2D(this.controlPoints[0], this.controlPoints[1]);
+                return {x: Math.abs(size.x), y: Math.abs(size.y)};
             default:
                 return {x: undefined, y: undefined};
         }

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -198,6 +198,10 @@ export class RegionStore {
         }
     }
 
+    /**
+     * Getter for the sizes of regions and annotations
+     * @returns A Point2D object with x and y size components.
+     */
     @computed get size(): Point2D {
         switch (this.regionType) {
             case CARTA.RegionType.RECTANGLE:
@@ -480,16 +484,23 @@ export class RegionStore {
         }
     };
 
+    /**
+     * Sets the size for regions and annotations
+     *
+     * @param p - Specifies the x and y size components.
+     *            For line region and annotation, vector annotation, and ruler annotation, the function sets the individual new x and y components of the linear segment.
+     * @param skipUpdate - Whether to update the changes with the backend.
+     */
     @action setSize = (p: Point2D, skipUpdate = false) => {
         if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) {
             const rotation = (this.rotation * Math.PI) / 180.0;
             const x = Math.abs(p.x);
             const y = Math.abs(p.y);
-            const _x = x * Math.sign(Math.sin(rotation));
-            const _y = y * -Math.sign(Math.cos(rotation));
-            const newStart = {x: this.center.x - _x / 2, y: this.center.y - _y / 2};
-            const newEnd = {x: this.center.x + _x / 2, y: this.center.y + _y / 2};
-            this.setControlPoints([newStart, newEnd]);
+            const dx = x * Math.sign(Math.sin(rotation) || 1);
+            const dy = y * -Math.sign(Math.cos(rotation) || 1);
+            const newStart = {x: this.center.x - dx / 2, y: this.center.y - dy / 2};
+            const newEnd = {x: this.center.x + dx / 2, y: this.center.y + dy / 2};
+            this.setControlPoints([newStart, newEnd], skipUpdate);
         } else {
             this.setControlPoint(SIZE_POINT_INDEX, p, skipUpdate);
         }

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -482,8 +482,13 @@ export class RegionStore {
 
     @action setSize = (p: Point2D, skipUpdate = false) => {
         if (this.regionType === CARTA.RegionType.LINE || this.regionType === CARTA.RegionType.ANNLINE || this.regionType === CARTA.RegionType.ANNVECTOR || this.regionType === CARTA.RegionType.ANNRULER) {
-            const newStart = {x: this.center.x - p.x / 2, y: this.center.y - p.y / 2};
-            const newEnd = {x: this.center.x + p.x / 2, y: this.center.y + p.y / 2};
+            const rotation = (this.rotation * Math.PI) / 180.0;
+            const x = Math.abs(p.x);
+            const y = Math.abs(p.y);
+            const _x = x * Math.sign(Math.sin(rotation));
+            const _y = y * -Math.sign(Math.cos(rotation));
+            const newStart = {x: this.center.x - _x / 2, y: this.center.y - _y / 2};
+            const newEnd = {x: this.center.x + _x / 2, y: this.center.y + _y / 2};
             this.setControlPoints([newStart, newEnd]);
         } else {
             this.setControlPoint(SIZE_POINT_INDEX, p, skipUpdate);


### PR DESCRIPTION
**Description**

Closes #2246. This PR added ANNRULER to appropriate if-statement in regionStore. Also fixed the failure to update control points when the starting and ending points of a line region have the same x or y value.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~e2e test passing~ / corresponding fix added / ~new e2e test created~
- [x] ~changelog updated~ / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~protobuf version bumped~~ / protobuf version not bumped
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~
