### PR TITLE
carli/2267_remove_distance_measurement_from_pv_preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Removed unused help button for PV preview widget ([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
 * Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
+* Removed distance measurement tool render from PV preview frames ([#2267](https://github.com/CARTAvis/carta-frontend/issues/2267)).
 
 ## [4.0.0]
 

--- a/src/components/Dialogs/DistanceMeasuringDialog/DistanceMeasuringDialog.tsx
+++ b/src/components/Dialogs/DistanceMeasuringDialog/DistanceMeasuringDialog.tsx
@@ -100,7 +100,7 @@ export class DistanceMeasuringDialog extends React.Component {
                 <CoordNumericInput
                     coord={this.WCSMode && wcsInfo ? CoordinateMode.World : CoordinateMode.Image}
                     inputType={InputType.XCoord}
-                    value={finish ? distanceMeasuringStore?.finish.x : distanceMeasuringStore?.start.x}
+                    value={finish ? distanceMeasuringStore?.finish?.x : distanceMeasuringStore?.start?.x}
                     onChange={DistanceMeasuringDialog.HandleValueChange(distanceMeasuringStore, wcsInfo, WCSStart, WCSFinish, true, finish, true) as (val: number) => boolean}
                     valueWcs={finish ? WCSFinish?.x : WCSStart?.x}
                     onChangeWcs={DistanceMeasuringDialog.HandleValueChange(distanceMeasuringStore, wcsInfo, WCSStart, WCSFinish, true, finish, false) as (val: string) => boolean}
@@ -109,7 +109,7 @@ export class DistanceMeasuringDialog extends React.Component {
                 <CoordNumericInput
                     coord={this.WCSMode && wcsInfo ? CoordinateMode.World : CoordinateMode.Image}
                     inputType={InputType.YCoord}
-                    value={finish ? distanceMeasuringStore?.finish.y : distanceMeasuringStore?.start.y}
+                    value={finish ? distanceMeasuringStore?.finish?.y : distanceMeasuringStore?.start?.y}
                     onChange={DistanceMeasuringDialog.HandleValueChange(distanceMeasuringStore, wcsInfo, WCSStart, WCSFinish, false, finish, true) as (val: number) => boolean}
                     valueWcs={finish ? WCSFinish?.y : WCSStart?.y}
                     onChangeWcs={DistanceMeasuringDialog.HandleValueChange(distanceMeasuringStore, wcsInfo, WCSStart, WCSFinish, false, finish, false) as (val: string) => boolean}

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -90,10 +90,10 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                     styleString,
                     frame.distanceMeasuring?.showCurve,
                     frame.isPVImage,
-                    frame.distanceMeasuring?.transformedStart.x,
-                    frame.distanceMeasuring?.transformedStart.y,
-                    frame.distanceMeasuring?.transformedFinish.x,
-                    frame.distanceMeasuring?.transformedFinish.y
+                    frame.distanceMeasuring?.transformedStart?.x,
+                    frame.distanceMeasuring?.transformedStart?.y,
+                    frame.distanceMeasuring?.transformedFinish?.x,
+                    frame.distanceMeasuring?.transformedFinish?.y
                 );
             };
 

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -88,12 +88,12 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                     settings.padding.top * pixelRatio,
                     settings.padding.bottom * pixelRatio,
                     styleString,
-                    frame.distanceMeasuring.showCurve,
+                    frame.distanceMeasuring?.showCurve,
                     frame.isPVImage,
-                    frame.distanceMeasuring.transformedStart.x,
-                    frame.distanceMeasuring.transformedStart.y,
-                    frame.distanceMeasuring.transformedFinish.x,
-                    frame.distanceMeasuring.transformedFinish.y
+                    frame.distanceMeasuring?.transformedStart.x,
+                    frame.distanceMeasuring?.transformedStart.y,
+                    frame.distanceMeasuring?.transformedFinish.x,
+                    frame.distanceMeasuring?.transformedFinish.y
                 );
             };
 
@@ -161,14 +161,14 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         const labelsColor = this.props.overlaySettings.labels.color;
         const darktheme = AppStore.Instance.darkTheme;
         const distanceMeasuring = frame.distanceMeasuring;
-        const distanceMeasuringShowCurve = frame.distanceMeasuring.showCurve;
-        const distanceMeasuringStart = frame.distanceMeasuring.start;
-        const distanceMeasuringFinish = frame.distanceMeasuring.finish;
-        const distanceMeasuringTransformedStart = frame.distanceMeasuring.transformedStart;
-        const distanceMeasuringTransformedFinish = frame.distanceMeasuring.transformedFinish;
-        const distanceMeasuringColor = frame.distanceMeasuring.color;
-        const distanceMeasuringFontSize = frame.distanceMeasuring.fontSize;
-        const distanceMeasuringLineWidth = frame.distanceMeasuring.lineWidth;
+        const distanceMeasuringShowCurve = frame.distanceMeasuring?.showCurve;
+        const distanceMeasuringStart = frame.distanceMeasuring?.start;
+        const distanceMeasuringFinish = frame.distanceMeasuring?.finish;
+        const distanceMeasuringTransformedStart = frame.distanceMeasuring?.transformedStart;
+        const distanceMeasuringTransformedFinish = frame.distanceMeasuring?.transformedFinish;
+        const distanceMeasuringColor = frame.distanceMeasuring?.color;
+        const distanceMeasuringFontSize = frame.distanceMeasuring?.fontSize;
+        const distanceMeasuringLineWidth = frame.distanceMeasuring?.lineWidth;
         const title = this.props.overlaySettings.title.customText ? frame.titleCustomText : frame.filename;
         const ratio = AppStore.Instance.imageRatio;
         const titleStyleString = this.props.overlaySettings.title.styleString;

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -504,8 +504,8 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         if (frame.wcsInfo && AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring && !isSecondaryClick) {
             const imagePos = this.getDistanceMeasureImagePos(mouseEvent.offsetX, mouseEvent.offsetY);
             const wcsPos = transformPoint(frame.wcsInfo, imagePos);
-            if (!isAstBadPoint(wcsPos)) {
-                const dist = frame.distanceMeasuring;
+            const dist = frame.distanceMeasuring;
+            if (!isAstBadPoint(wcsPos) && dist) {
                 if (!dist.isCreating && !dist.showCurve) {
                     dist.setStart(imagePos.x, imagePos.y);
                     dist.setIsCreating(true);
@@ -664,7 +664,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                     break;
             }
         } else {
-            if (frame.wcsInfo && AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring && frame.distanceMeasuring.isCreating) {
+            if (frame.wcsInfo && AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring && frame.distanceMeasuring?.isCreating) {
                 this.updateDistanceMeasureFinishPos(mouseEvent.offsetX, mouseEvent.offsetY);
             }
             if (!AppStore.Instance.cursorFrozen) {
@@ -739,7 +739,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         }
 
         let cursor: string;
-        if (regionSet.mode === RegionMode.CREATING || AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring) {
+        if ((regionSet.mode === RegionMode.CREATING || AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring) && !frame.isPreview) {
             cursor = "crosshair";
         } else if (regionSet.selectedRegion && regionSet.selectedRegion.editing) {
             cursor = "move";

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -739,7 +739,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         }
 
         let cursor: string;
-        if ((regionSet.mode === RegionMode.CREATING || AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring) && !frame.isPreview) {
+        if (regionSet.mode === RegionMode.CREATING || (AppStore.Instance?.activeLayer === ImageViewLayer.DistanceMeasuring && !frame.isPreview)) {
             cursor = "crosshair";
         } else if (regionSet.selectedRegion && regionSet.selectedRegion.editing) {
             cursor = "move";

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -598,14 +598,14 @@ export class AppStore {
             fileInfoExtended: new CARTA.FileInfoExtended(ack.imageInfo),
             fileFeatureFlags: ack.fileFeatureFlags,
             renderMode: CARTA.RenderMode.RASTER,
-            beamTable: ack.beamTable
+            beamTable: ack.beamTable,
+            preview: true
         };
 
         const newFrame = new FrameStore(frameInfo);
 
         if (newFrame) {
             this.previewFrames.set(ack.previewId, newFrame);
-            newFrame.setIsPreview(true);
             newFrame.updatePreviewDataGenerator = newFrame.updatePreviewData(ack);
             // The initial next() function call executes the FrameStore.updatePreviewData until the first yield keyword
             newFrame.updatePreviewDataGenerator.next();

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -87,6 +87,7 @@ export interface FrameInfo {
     fileFeatureFlags: number;
     renderMode: CARTA.RenderMode;
     beamTable: CARTA.IBeam[];
+    preview?: boolean;
 }
 
 export enum CoordinateMode {
@@ -1222,9 +1223,9 @@ export class FrameStore {
 
         this.stokesFiles = [];
 
-        this.isPreview = false;
+        this.isPreview = frameInfo.preview;
 
-        this.distanceMeasuring = new DistanceMeasuringStore();
+        this.distanceMeasuring = !frameInfo.preview && new DistanceMeasuringStore();
 
         this.dirAxis = -1;
         this.dirAxisSize = -1;
@@ -2962,11 +2963,6 @@ export class FrameStore {
         this.fittingResult = "";
         this.fittingResultRegionParams = [];
         this.fittingLog = "";
-    };
-
-    @action setIsPreview = (isPreview: boolean) => {
-        this.isPreview = isPreview;
-        this.distanceMeasuring = null;
     };
 
     @action setPreviewPVRasterData = (previewPVRasterData: Float32Array, skipUpdatePreviewData: boolean = false) => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1474,7 +1474,9 @@ export class FrameStore {
         });
 
         autorun(() => {
-            this.distanceMeasuring.updateTransformedPos(this.spatialTransform);
+            if (!this.isPreview) {
+                this.distanceMeasuring.updateTransformedPos(this.spatialTransform);
+            }
         });
     }
 
@@ -2964,6 +2966,7 @@ export class FrameStore {
 
     @action setIsPreview = (isPreview: boolean) => {
         this.isPreview = isPreview;
+        this.distanceMeasuring = null;
     };
 
     @action setPreviewPVRasterData = (previewPVRasterData: Float32Array, skipUpdatePreviewData: boolean = false) => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -198,7 +198,6 @@ export class FrameStore {
 
     @observable stokesFiles: CARTA.StokesFile[];
 
-    @observable isPreview: boolean;
     @observable previewViewWidth: number;
     @observable previewViewHeight: number;
     @observable previewPVRasterData: Float32Array;
@@ -1152,6 +1151,10 @@ export class FrameStore {
         return getFormattedWCSPoint(this.wcsInfoForTransformation, this.center);
     }
 
+    @computed get isPreview(): boolean {
+        return this.frameInfo.preview;
+    }
+
     @computed get previewCursorValue(): {position: Point2D; channel: number; value: number} | null {
         if (!this.isPreview) {
             return null;
@@ -1223,9 +1226,7 @@ export class FrameStore {
 
         this.stokesFiles = [];
 
-        this.isPreview = frameInfo.preview;
-
-        this.distanceMeasuring = !frameInfo.preview && new DistanceMeasuringStore();
+        this.distanceMeasuring = frameInfo.preview ? null : new DistanceMeasuringStore();
 
         this.dirAxis = -1;
         this.dirAxisSize = -1;


### PR DESCRIPTION
**Description**

Closes #2267. Removed distanceMeasuring store object is the frame is a preview frame.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] changelog updated / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~protobuf version bumped~~ / protobuf version not bumped
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~
