### PR TITLE
carli/2251_contour_incorrect_deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Removed unused help button for PV preview widget ([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
 * Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
+* Fixed the incorrect deletion of contour levels ([#2251](https://github.com/CARTAvis/carta-frontend/issues/2251)).
 
 ## [4.0.0]
 

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -223,7 +223,7 @@ export class ContourDialogComponent extends React.Component {
 
     private handleGraphClicked = (x: number) => {
         this.levels.push(x);
-        this.levels.sort();
+        this.levels.sort((a, b) => a - b);
     };
 
     private handleGraphRightClicked = (x: number) => {

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -251,7 +251,7 @@ export class ContourDialogComponent extends React.Component {
                 const val = parseFloat(valueString);
                 if (isFinite(val)) {
                     this.levels.push(val);
-                    this.levels.sort();
+                    this.levels.sort((a, b) => a - b);
                 }
             }
         } catch (e) {


### PR DESCRIPTION
**Description**

Closes #2251. The levels array is sorted incorrectly. For instance, [10, 20, 40, 3] will be sorted as [10, 20, 3, 40], causing the deletion of incorrect indexed level.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / ~corresponding fix added~ / new e2e test to be created
- [ ] changelog updated / no changelog update needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~protobuf version bumped~~ / protobuf version not bumped
- [x] `BackendService` unchanged / ~~`BackendService` changed and corresponding ICD test fix added~~
