### PR TITLE
Kuanchou/2278_crash_when_deleting_annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Removed unused help button for PV preview widget ([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
 * Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
+* Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278))
+
 
 ## [4.0.0]
 

--- a/src/stores/FileBrowserStore/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore/FileBrowserStore.ts
@@ -817,6 +817,6 @@ export class FileBrowserStore {
     }
 
     @computed get exportAnnotationNum(): number {
-        return this.exportRegionIndexes?.reduce((accum, exportIndex, i) => accum + (AppStore.Instance.activeFrame.regionSet.regions[exportIndex].isAnnotation ? 1 : 0), 0);
+        return this.exportRegionIndexes?.reduce((accum, exportIndex, i) => accum + (AppStore.Instance.activeFrame.regionSet.regions[exportIndex]?.isAnnotation ? 1 : 0), 0);
     }
 }


### PR DESCRIPTION
**Description**

Fix #2278. The frontend will crash when deleting annotations if the export window is opened. The crash is due to that undefined was found in the index of the deleted annotation when the system counted annotation object numbers in the file browser store. 


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] changelog updated / no changelog update needed
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] protobuf version bumped / protobuf version not bumped
- [x] `BackendService` unchanged / `BackendService` changed and corresponding ICD test fix added
