### PR TITLE
Kaunchou/2270_delayed_update_compass_in_match_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Removed unused help button for PV preview widget ([#2248](https://github.com/CARTAvis/carta-frontend/issues/2248)).
 * Fixed PV preview bug where no PV preview shows up after closing a docked PV preview widget ([#2249](https://github.com/CARTAvis/carta-frontend/issues/2249)).
+* Fixed compass and ruler annotations update bug in the spatially matched image when changing the coordinate ([#2270](https://github.com/CARTAvis/carta-frontend/issues/2270))
 
 ## [4.0.0]
 

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -122,7 +122,8 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
 
     const imageRatio = AppStore.Instance.imageRatio;
     const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
-    const approxPoints = region.getCompassApproximation(frame.wcsInfo, frame.spatialReference ? true : false, frame.spatialTransformAST);
+    const wcsInfo = frame?.validWcs ? frame.wcsInfoForTransformation : 0;
+    const approxPoints = region.getCompassApproximation(wcsInfo, frame.spatialReference ? true : false, frame.spatialTransformAST);
     const northApproxPoints = approxPoints.northApproximatePoints;
     const eastApproxPoints = approxPoints.eastApproximatePoints;
     const northPointArray = [];

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -386,7 +386,8 @@ export const RulerAnnotation = observer((props: CompassRulerAnnotationProps) => 
     const canvasPosStart = transformedImageToCanvasPos(secondaryImagePointStart, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
     const canvasPosFinish = transformedImageToCanvasPos(secondaryImagePointFinish, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
 
-    const approxPoints = region.getCurveApproximation(frame.wcsInfo, frame.spatialTransformAST);
+    const wcsInfo = frame?.validWcs ? frame.wcsInfoForTransformation : 0;
+    const approxPoints = region.getCurveApproximation(wcsInfo, frame.spatialTransformAST);
 
     const xApproxPoints = approxPoints.xApproximatePoints;
     const yApproxPoints = approxPoints.yApproximatePoints;


### PR DESCRIPTION
**Description**

Fix #2270, in which compass and ruler annotations are not properly updated in the spatially matched image when changing the coordinate. The bug is in mapping the two annotations to the matched image. It seems that ```frame.wcsInfo``` is updated after rendering. Using ```frame.wcsInfoForTransformation``` instead of ```frame.wcsInfo``` solves the issue. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] changelog updated / no changelog update needed
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] protobuf version bumped / protobuf version not bumped
- [x] `BackendService` unchanged / `BackendService` changed and corresponding ICD test fix added
