### PR TITLE
adjust preference default

### DIFF
--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -244,8 +244,8 @@ const DEFAULTS = {
         statsPanelMode: 0
     },
     TELEMETRY: {
-        telemetryConsentShown: false,
-        telemetryMode: TelemetryMode.Usage,
+        telemetryConsentShown: true,
+        telemetryMode: TelemetryMode.None,
         telemetryLogging: false
     },
     COMPATIBILITY: {


### PR DESCRIPTION
**Description**

Fixed #2314. A quick fix to change the default setting of showing the telemetry dialog before fetching the preference json file. Also change the default telemetry mode to none, which could be safer.

~Thanks to @ajm-asiaa, we have setup this branch on our server to test it. @loveluthien Could you help testing it as a new user?~

Update: requires alternative fix.

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [ ] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [ ] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] protobuf version bumped / no protobuf version bumped needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)