### PR TITLE
carli/2304_slow_telemetry_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278)).
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
+* Fixed the delayed start of the program due to telemetry server error. ([#2304](https://github.com/CARTAvis/carta-frontend/issues/2304)).
 
 ## [4.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed distance measurement tool render from PV preview frames ([#2267](https://github.com/CARTAvis/carta-frontend/issues/2267)).
 * Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278)).
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
-* Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the delayed start of the program due to telemetry server error. ([#2304](https://github.com/CARTAvis/carta-frontend/issues/2304)).
 * Improved the dragging performance of the Export Region widget when the list of region/annotation to be exported is large ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).

--- a/src/services/TelemetryService.ts
+++ b/src/services/TelemetryService.ts
@@ -101,7 +101,7 @@ export class TelemetryService {
         setInterval(this.flushTelemetry, TelemetryService.SubmissionIntervalSeconds * 1000);
     }
 
-    @flow.bound *checkAndGenerateId(forceNewId: boolean = false) {
+    @flow.bound *checkAndGenerateId(flush: boolean = false, forceNewId: boolean = false) {
         const url = new URL(window.location.href);
         const skipTelemetry = url.searchParams.get("skipTelemetry");
         // Check for URL query parameter or build-time flag for skipping telemetry
@@ -148,6 +148,11 @@ export class TelemetryService {
         }
 
         this.axiosInstance.defaults.headers.common = {Authorization: `Bearer ${token}`};
+
+        if (flush) {
+            yield this.flushTelemetry();
+        }
+
         return true;
     }
 

--- a/src/services/TelemetryService.ts
+++ b/src/services/TelemetryService.ts
@@ -150,7 +150,7 @@ export class TelemetryService {
         this.axiosInstance.defaults.headers.common = {Authorization: `Bearer ${token}`};
 
         if (flush) {
-            yield this.flushTelemetry();
+            this.flushTelemetry();
         }
 
         return true;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1644,8 +1644,7 @@ export class AppStore {
         if (isAstReady && isZfpReady && isCartaComputeReady && isApiServiceAuthenticated) {
             try {
                 await this.preferenceStore.fetchPreferences();
-                this.telemetryService.checkAndGenerateId();
-                this.telemetryService.flushTelemetry();
+                this.telemetryService.checkAndGenerateId(true);
                 await this.connectToServer();
                 await this.fileBrowserStore.restoreStartingDirectory();
                 await this.layoutStore.fetchLayouts();

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1644,8 +1644,8 @@ export class AppStore {
         if (isAstReady && isZfpReady && isCartaComputeReady && isApiServiceAuthenticated) {
             try {
                 await this.preferenceStore.fetchPreferences();
-                await this.telemetryService.checkAndGenerateId();
-                await this.telemetryService.flushTelemetry();
+                this.telemetryService.checkAndGenerateId();
+                this.telemetryService.flushTelemetry();
                 await this.connectToServer();
                 await this.fileBrowserStore.restoreStartingDirectory();
                 await this.layoutStore.fetchLayouts();


### PR DESCRIPTION
**Description**

This PR is a simple solution that fixes #2304. ``checkAndGenerateId`` and ``flushTelemetry`` are two methods in  ``TelemetryService`` that are called during the start of the application. If the telemetry server had any problem that caused delayed response, the frontend would hang and wait for the response in the above mentioned methods, so they are altered to process asynchronously to avoid extended wait time for the users.

The two methods are studied to ensure that asynchrous call at the start of the program would not affect the telemetry performance.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] protobuf version bumped / no protobuf version bumped needed
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~