### PR TITLE
bug of catalog plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278)).
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
-* Fixed the crash when plotting some online query catalog data. ([#2321](https://github.com/CARTAvis/carta-frontend/pull/2321))
+* Fixed the crash when plotting online Vizier catalog data. ([#2321](https://github.com/CARTAvis/carta-frontend/pull/2321))
 
 ## [4.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278)).
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
+* Fixed the crash when plotting some online query catalog data. ([#2321](https://github.com/CARTAvis/carta-frontend/pull/2321))
 
 ## [4.0.0]
 

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -880,8 +880,8 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             layout.xaxis.range = [border.xMin, border.xMax];
             layout.yaxis.range = [border.yMin, border.yMax];
             layout.yaxis.title = widgetStore.yColumnName;
-            layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
-            layout.yaxis.tickformat = this.formatTickValues(layout.yaxis.range);
+            layout.xaxis.tickformat = this.formatTickValues([border.xMin, border.xMax]);
+            layout.yaxis.tickformat = this.formatTickValues([border.yMin, border.yMax]);
         } else {
             data = this.histogramData.data;
             let border: XBorder;
@@ -891,7 +891,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
                 border = widgetStore.histogramBorder;
             }
             layout.xaxis.range = [border.xMin, border.xMax];
-            layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
+            layout.xaxis.tickformat = this.formatTickValues([border.xMin, border.xMax]);
             layout.yaxis.range = [this.histogramY?.yMin, this.histogramY?.yMax];
             layout.yaxis.fixedrange = true;
             // autorange will trigger y axis range change

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -604,8 +604,8 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
         const difference = range[1] - range[0];
         const exponential = difference.toExponential(2);
         const power = parseFloat(exponential.split("e")[1]);
-        const maxPower = parseFloat(range[1].toExponential(1).split("e")[1]);
-        const minPower = parseFloat(range[0].toExponential(1).split("e")[1]);
+        const maxPower = parseFloat(Number(range[1]).toExponential(1).split("e")[1]);
+        const minPower = parseFloat(Number(range[0]).toExponential(1).split("e")[1]);
         if (maxPower >= 5) {
             return `e`;
         } else if (minPower <= -5) {

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -871,7 +871,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             const scatter = this.scatterData;
             data = scatter.data;
             data[catalogDataIndex].marker.size = 5 * ratio;
-            let border;
+            let border: Border;
             if (widgetStore.isScatterAutoScaled) {
                 border = scatter.border;
             } else {
@@ -880,11 +880,11 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             layout.xaxis.range = [border.xMin, border.xMax];
             layout.yaxis.range = [border.yMin, border.yMax];
             layout.yaxis.title = widgetStore.yColumnName;
-            layout.yaxis.tickformat = this.formatTickValues(layout.yaxis.range);
             layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
+            layout.yaxis.tickformat = this.formatTickValues(layout.yaxis.range);
         } else {
             data = this.histogramData.data;
-            let border;
+            let border: XBorder;
             if (widgetStore.isHistogramAutoScaledX) {
                 border = this.histogramData.border;
             } else {

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -880,8 +880,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             layout.xaxis.range = [border.xMin, border.xMax];
             layout.yaxis.range = [border.yMin, border.yMax];
             layout.yaxis.title = widgetStore.yColumnName;
-            // layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
-            layout.xaxis.tickformat = this.formatTickValues([border.xMin, border.xMax]);
+            layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
             layout.yaxis.tickformat = this.formatTickValues(layout.yaxis.range);
         } else {
             data = this.histogramData.data;

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -604,8 +604,8 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
         const difference = range[1] - range[0];
         const exponential = difference.toExponential(2);
         const power = parseFloat(exponential.split("e")[1]);
-        const maxPower = parseFloat(Number(range[1]).toExponential(1).split("e")[1]);
-        const minPower = parseFloat(Number(range[0]).toExponential(1).split("e")[1]);
+        const maxPower = parseFloat(range[1].toExponential(1).split("e")[1]);
+        const minPower = parseFloat(range[0].toExponential(1).split("e")[1]);
         if (maxPower >= 5) {
             return `e`;
         } else if (minPower <= -5) {
@@ -880,7 +880,8 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
             layout.xaxis.range = [border.xMin, border.xMax];
             layout.yaxis.range = [border.yMin, border.yMax];
             layout.yaxis.title = widgetStore.yColumnName;
-            layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
+            // layout.xaxis.tickformat = this.formatTickValues(layout.xaxis.range);
+            layout.xaxis.tickformat = this.formatTickValues([border.xMin, border.xMax]);
             layout.yaxis.tickformat = this.formatTickValues(layout.yaxis.range);
         } else {
             data = this.histogramData.data;

--- a/src/utilities/CatalogApiProcessed/CatalogApiProcessed.ts
+++ b/src/utilities/CatalogApiProcessed/CatalogApiProcessed.ts
@@ -192,10 +192,12 @@ export class CatalogApiProcessing {
             const columns = data[index].getElementsByTagName("TD");
             for (let j = 0; j < columns.length; j++) {
                 //textContent is faster than innerHTML
-                if (headers[j]["dataType"] !== CARTA.ColumnData["String"] || headers[j]["dataType"] !== CARTA.ColumnData["UnsupportedType"] || headers[j]["dataType"] !== CARTA.ColumnData["Bool"]) {
-                    dataMap.get(j).data[index] = Number(columns[j].textContent);
-                } else {
+                if (headers[j]["dataType"] === CARTA.ColumnType.String || headers[j]["dataType"] === CARTA.ColumnType.UnsupportedType || headers[j]["dataType"] === CARTA.ColumnType.Bool) {
                     dataMap.get(j).data[index] = columns[j].textContent;
+                } else if (headers[j]["dataType"] === CARTA.ColumnType.Float || headers[j]["dataType"] === CARTA.ColumnType.Double) {
+                    dataMap.get(j).data[index] = parseFloat(columns[j].textContent);
+                } else {
+                    dataMap.get(j).data[index] = parseInt(columns[j].textContent);
                 }
             }
         }

--- a/src/utilities/CatalogApiProcessed/CatalogApiProcessed.ts
+++ b/src/utilities/CatalogApiProcessed/CatalogApiProcessed.ts
@@ -192,7 +192,11 @@ export class CatalogApiProcessing {
             const columns = data[index].getElementsByTagName("TD");
             for (let j = 0; j < columns.length; j++) {
                 //textContent is faster than innerHTML
-                dataMap.get(j).data[index] = columns[j].textContent;
+                if (headers[j]["dataType"] !== CARTA.ColumnData["String"] || headers[j]["dataType"] !== CARTA.ColumnData["UnsupportedType"] || headers[j]["dataType"] !== CARTA.ColumnData["Bool"]) {
+                    dataMap.get(j).data[index] = Number(columns[j].textContent);
+                } else {
+                    dataMap.get(j).data[index] = columns[j].textContent;
+                }
             }
         }
         return {headers, dataMap, size};


### PR DESCRIPTION
**Description**

Fix #2299. Somehow the axis ranges from VizierR downloaded data will be the string type and makes the crash.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~ New test will be added in a later stage shortly
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] user manual prepared (for large new features)