### PR TITLE
Yuhsuan/2293 vector on matched frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed distance measurement tool render from PV preview frames ([#2267](https://github.com/CARTAvis/carta-frontend/issues/2267)).
 * Fixed bug that the frontend crashes when deleting annotations if the export window is opened ([#2278](https://github.com/CARTAvis/carta-frontend/issues/2278)).
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
-* Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
+* Improved the dragging performance of the Export Region widget when the list of region/annotation to be exported is large ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
+* Fixed missing vector overlays on matched images ([#2293](https://github.com/CARTAvis/carta-frontend/issues/2293)).
 
 ## [4.0.0]
 

--- a/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
+++ b/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
@@ -31,8 +31,13 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
     }
 
     componentDidUpdate() {
-        AppStore.Instance.resetImageRatio();
-        if (this.props.frame.vectorOverlayStore?.isComplete) {
+        const appStore = AppStore.Instance;
+
+        appStore.resetImageRatio();
+
+        const baseFrame = this.props.frame;
+        const vectorOverlayFrames = appStore.vectorOverlayFrames?.get(baseFrame);
+        if (vectorOverlayFrames?.every(f => f?.vectorOverlayStore?.isComplete)) {
             requestAnimationFrame(this.updateCanvas);
         }
     }


### PR DESCRIPTION
**Description**

Fixed #2293. The issue is that the image does not show any vectors if the user did not apply vector overlay to the base frame (the raster data frame).

Fixed by updating the vector overlay when all the required vectors are ready instead of when the base frame vectors are ready.

Tested that:
* When applying vectors on the first image and then matching a second image, vectors from the first image is shown on the second image.
* When matching two images and applying vectors on the first image, vectors from the first image is shown on the second image.

Please note that this changes the timing of updating the vector overlay. The vector overlay will be updated only when all the required vectors from the frames are ready.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~