### PR TITLE
Yuhsuan/2314 telemetry dialog display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
+* Avoided showing the telemetry dialog temporarily ([#2314](https://github.com/CARTAvis/carta-frontend/issues/2314)).
 
 ## [4.0.0]
 

--- a/src/components/Dialogs/TelemetryDialog/TelemetryDialogComponent.tsx
+++ b/src/components/Dialogs/TelemetryDialog/TelemetryDialogComponent.tsx
@@ -30,10 +30,11 @@ export class TelemetryDialogComponent extends React.Component {
         const appStore = AppStore.Instance;
         const appReady = appStore.apiService?.authenticated;
         const consentRequired = appStore.telemetryService.consentRequired;
+        const preferenceReady = appStore.preferenceStore?.preferenceReady;
         const classes = classNames("telemetry-dialog", {"bp3-dark": appStore.darkTheme});
 
         return (
-            <Dialog icon="data-connection" canOutsideClickClose={false} isCloseButtonShown={false} lazy={true} isOpen={appReady && consentRequired} className={classes} canEscapeKeyClose={false} title="CARTA Usage Data">
+            <Dialog icon="data-connection" canOutsideClickClose={false} isCloseButtonShown={false} lazy={true} isOpen={appReady && consentRequired && preferenceReady} className={classes} canEscapeKeyClose={false} title="CARTA Usage Data">
                 <div className={Classes.DIALOG_BODY}>
                     <div className="image-div">
                         <img src={"carta_logo.png"} width={80} alt={"carta logo"} />

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -264,7 +264,7 @@ export class RootMenuComponent extends React.Component {
                 <Menu.Item text="Open Workspace" disabled={appStore.openFileDisabled} onClick={() => appStore.dialogStore.showWorkspaceDialog(WorkspaceDialogMode.Open)} />
                 <Menu.Item text="Save Workspace" disabled={appStore.openFileDisabled} onClick={() => appStore.dialogStore.showWorkspaceDialog(WorkspaceDialogMode.Save)} />
                 <Menu.Divider />
-                <Menu.Item text="Preferences" onClick={appStore.dialogStore.showPreferenceDialog} disabled={appStore.preferenceStore.supportsServer && connectionStatus !== ConnectionStatus.ACTIVE} />
+                <Menu.Item text="Preferences" onClick={appStore.dialogStore.showPreferenceDialog} />
                 {serverSubMenu}
             </Menu>
         );

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -264,7 +264,6 @@ export class PreferenceStore {
     }
 
     @observable preferences: Map<PreferenceKeys, any>;
-    @observable supportsServer: boolean;
 
     // getters for global settings
     @computed get theme(): string {

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -265,6 +265,11 @@ export class PreferenceStore {
 
     @observable preferences: Map<PreferenceKeys, any>;
 
+    /**
+     * Whether the preference data is initialized from the preference file or localStorage.
+     */
+    @observable preferenceReady: boolean = false;
+
     // getters for global settings
     @computed get theme(): string {
         return this.preferences.get(PreferenceKeys.GLOBAL_THEME) ?? DEFAULTS.GLOBAL.theme;
@@ -889,6 +894,7 @@ export class PreferenceStore {
                 this.preferences.set(key as PreferenceKeys, val);
             }
         }
+        this.preferenceReady = true;
     }
 
     private upgradePreferences = async () => {


### PR DESCRIPTION
**Description**

Fixed #2314. Check if the preference data is initialized before showing the dialog.
Also removed unused variable `supportsServer`.

Tested that:
* (without carta-controller) The dialog is not shown temporarily (behind the splash screen) when the preference file contains "telemetryConsentShown: true".
* (without carta-controller) The dialog is shown when there is no preference file, or when the preference file does not contain "telemetryConsentShown", or when the preference file contains "telemetryConsentShown: false".
* (with carta-controller) The dialog is not shown temporarily.

~To be tested with carta-controller.~
Update: tested with carta-controller, thanks to help from @ajm-asiaa.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / ~new e2e test created~
- [x] protobuf version bumped / ~no protobuf version bumped needed~
- [x] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~