### PR TITLE
Yuhsuan/2252 fix spatial match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
+* Fixed failing to match images spatially ([2252](https://github.com/CARTAvis/carta-frontend/issues/2252)).
 
 ## [4.0.0]
 

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -178,8 +178,6 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         const axesStyleString = this.props.overlaySettings.axes.styleString;
         const numbersStyleString = this.props.overlaySettings.numbers.styleString;
         const labelsStyleString = this.props.overlaySettings.labels.styleString;
-        const formatStringX = this.props.overlaySettings.numbers.formatStringX;
-        const formatStyingY = this.props.overlaySettings.numbers.formatStringY;
 
         if (frame.isSwappedZ) {
             const requiredChannel = frame.requiredChannel;

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -201,7 +201,12 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         } else if (frame.isSwappedZ && frame.spectralAxis?.valid) {
             AST.set(frame.wcsInfo, spectralAxisSetting + dirAxesSetting);
         } else {
-            AST.set(frame.wcsInfo, dirAxesSetting);
+            const formatStringX = this.props.overlaySettings.numbers.formatStringX;
+            const formatStyingY = this.props.overlaySettings.numbers.formatStringY;
+            const explicitSystem = this.props.overlaySettings.global.explicitSystem;
+            if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
+                AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem},` + dirAxesSetting);
+            }
         }
 
         const className = classNames("overlay-canvas", {docked: this.props.docked});

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -178,6 +178,8 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         const axesStyleString = this.props.overlaySettings.axes.styleString;
         const numbersStyleString = this.props.overlaySettings.numbers.styleString;
         const labelsStyleString = this.props.overlaySettings.labels.styleString;
+        const formatStringX = this.props.overlaySettings.numbers.formatStringX;
+        const formatStyingY = this.props.overlaySettings.numbers.formatStringY;
 
         if (frame.isSwappedZ) {
             const requiredChannel = frame.requiredChannel;
@@ -199,12 +201,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         } else if (frame.isSwappedZ && frame.spectralAxis?.valid) {
             AST.set(frame.wcsInfo, spectralAxisSetting + dirAxesSetting);
         } else {
-            const formatStringX = this.props.overlaySettings.numbers.formatStringX;
-            const formatStyingY = this.props.overlaySettings.numbers.formatStringY;
-            const explicitSystem = this.props.overlaySettings.global.explicitSystem;
-            if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
-                AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem},` + dirAxesSetting);
-            }
+            AST.set(frame.wcsInfo, dirAxesSetting);
         }
 
         const className = classNames("overlay-canvas", {docked: this.props.docked});

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -35,7 +35,7 @@ import {
     ZoomPoint
 } from "models";
 import {BackendService, CatalogWebGLService, ContourWebGLService, TILE_SIZE, TileService} from "services";
-import {AnimatorStore, AppStore, ASTSettingsString, LogStore, OverlayStore, PreferenceStore} from "stores";
+import {AnimatorStore, AppStore, ASTSettingsString, LogStore, OverlayStore, PreferenceStore, SystemType} from "stores";
 import {
     CENTER_POINT_INDEX,
     ColorbarStore,
@@ -1424,6 +1424,13 @@ export class FrameStore {
             }
         );
 
+        autorun(() => {
+            const formatStringX = this.overlayStore?.numbers?.formatStringX;
+            const formatStyingY = this.overlayStore?.numbers?.formatStringY;
+            const explicitSystem = this.overlayStore?.global?.explicitSystem;
+            this.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
+        });
+
         // requiredFrameViewForRegionRender is a copy of requiredFrameView in non-observable version,
         // to avoid triggering wasted render() in PointRegionComponent/SimpleShapeRegionComponent/LineSegmentRegionComponent
         autorun(() => {
@@ -1481,6 +1488,16 @@ export class FrameStore {
             }
         });
     }
+
+    updateWcsSystem = (formatStringX: string, formatStyingY: string, explicitSystem: SystemType) => {
+        if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
+            if (!(this.isPVImage && this.spectralAxis?.valid) && !(this.isSwappedZ && this.spectralAxis?.valid)) {
+                if (this.validWcs && this.wcsInfo) {
+                    AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
+                }
+            }
+        }
+    };
 
     // This function shifts the pixel axis by 1, so that it starts at 0, rather than 1
     // For entries that are not related to the reference pixel location, the current value is returned

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1095,6 +1095,11 @@ export class OverlayStore {
 
         this.global.setDefaultSystem(AST.getString(frame.wcsInfo, "System") as SystemType);
         this.setFormatsFromSystem();
+
+        const formatStringX = this.numbers.formatStringX;
+        const formatStyingY = this.numbers.formatStringY;
+        const explicitSystem = this.global.explicitSystem;
+        this.updateFrames(formatStringX, formatStyingY, explicitSystem);
     }
 
     private updateFrames = (formatStringX: string, formatStyingY: string, explicitSystem: SystemType) => {

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -151,12 +151,6 @@ export class OverlayGlobalSettings {
 
     @action setSystem(system: SystemType) {
         this.system = system;
-
-        // update distance measuring position tranformation before plotting
-        const wcsInfo = AppStore.Instance.activeFrame?.wcsInfo;
-        if (wcsInfo && this.explicitSystem) {
-            AST.set(wcsInfo, `System=${this.explicitSystem}`);
-        }
     }
 
     @action setDefaultSystem(system: SystemType) {

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1039,13 +1039,6 @@ export class OverlayStore {
                 }
             });
         });
-
-        autorun(() => {
-            const formatStringX = this.numbers.formatStringX;
-            const formatStyingY = this.numbers.formatStringY;
-            const explicitSystem = this.global.explicitSystem;
-            this.updateFrames(formatStringX, formatStyingY, explicitSystem);
-        });
     }
 
     @action setViewDimension = (width: number, height: number) => {
@@ -1099,20 +1092,12 @@ export class OverlayStore {
         const formatStringX = this.numbers.formatStringX;
         const formatStyingY = this.numbers.formatStringY;
         const explicitSystem = this.global.explicitSystem;
-        this.updateFrames(formatStringX, formatStyingY, explicitSystem);
+        AppStore.Instance.frames.forEach(frame => {
+            if (frame) {
+                frame.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
+            }
+        });
     }
-
-    private updateFrames = (formatStringX: string, formatStyingY: string, explicitSystem: SystemType) => {
-        if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
-            AppStore.Instance.frames.forEach(frame => {
-                if (!(frame.isPVImage && frame.spectralAxis?.valid) && !(frame.isSwappedZ && frame.spectralAxis?.valid)) {
-                    if (frame?.validWcs && frame?.wcsInfo) {
-                        AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem}`);
-                    }
-                }
-            });
-        }
-    };
 
     @action toggleLabels = () => {
         const newState = !this.labelsHidden;

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1051,6 +1051,21 @@ export class OverlayStore {
                 }
             });
         });
+
+        autorun(() => {
+            const formatStringX = this.numbers.formatStringX;
+            const formatStyingY = this.numbers.formatStringY;
+            const explicitSystem = this.global.explicitSystem;
+            if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
+                AppStore.Instance.frames.forEach(frame => {
+                    if (!(frame.isPVImage && frame.spectralAxis?.valid) && !(frame.isSwappedZ && frame.spectralAxis?.valid)) {
+                        if (frame?.validWcs && frame?.wcsInfo) {
+                            AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem}`);
+                        }
+                    }
+                });
+            }
+        });
     }
 
     @action setViewDimension = (width: number, height: number) => {

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1022,8 +1022,6 @@ export class OverlayStore {
 
         // if the system is manually selected, set new default formats & update active frame's wcs settings
         autorun(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _ = this.global.system;
             this.setFormatsFromSystem();
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem) {
@@ -1033,8 +1031,6 @@ export class OverlayStore {
         });
 
         autorun(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _ = this.numbers.formatTypeX;
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeX) {
                     AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirX})=${this.numbers.formatTypeX}.${WCS_PRECISION}`);
@@ -1043,8 +1039,6 @@ export class OverlayStore {
         });
 
         autorun(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _ = this.numbers.formatTypeY;
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.numbers.formatTypeY) {
                     AST.set(frame.wcsInfoForTransformation, `Format(${frame.dirY})=${this.numbers.formatTypeY}.${WCS_PRECISION}`);

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1044,15 +1044,7 @@ export class OverlayStore {
             const formatStringX = this.numbers.formatStringX;
             const formatStyingY = this.numbers.formatStringY;
             const explicitSystem = this.global.explicitSystem;
-            if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
-                AppStore.Instance.frames.forEach(frame => {
-                    if (!(frame.isPVImage && frame.spectralAxis?.valid) && !(frame.isSwappedZ && frame.spectralAxis?.valid)) {
-                        if (frame?.validWcs && frame?.wcsInfo) {
-                            AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem}`);
-                        }
-                    }
-                });
-            }
+            this.updateFrames(formatStringX, formatStyingY, explicitSystem);
         });
     }
 
@@ -1104,6 +1096,18 @@ export class OverlayStore {
         this.global.setDefaultSystem(AST.getString(frame.wcsInfo, "System") as SystemType);
         this.setFormatsFromSystem();
     }
+
+    private updateFrames = (formatStringX: string, formatStyingY: string, explicitSystem: SystemType) => {
+        if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {
+            AppStore.Instance.frames.forEach(frame => {
+                if (!(frame.isPVImage && frame.spectralAxis?.valid) && !(frame.isSwappedZ && frame.spectralAxis?.valid)) {
+                    if (frame?.validWcs && frame?.wcsInfo) {
+                        AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem}`);
+                    }
+                }
+            });
+        }
+    };
 
     @action toggleLabels = () => {
         const newState = !this.labelsHidden;

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -1089,14 +1089,16 @@ export class OverlayStore {
         this.global.setDefaultSystem(AST.getString(frame.wcsInfo, "System") as SystemType);
         this.setFormatsFromSystem();
 
-        const formatStringX = this.numbers.formatStringX;
-        const formatStyingY = this.numbers.formatStringY;
-        const explicitSystem = this.global.explicitSystem;
-        AppStore.Instance.frames.forEach(frame => {
-            if (frame) {
-                frame.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
-            }
-        });
+        if (this.global.system === SystemType.Auto) {
+            const formatStringX = this.numbers.formatStringX;
+            const formatStyingY = this.numbers.formatStringY;
+            const explicitSystem = this.global.explicitSystem;
+            AppStore.Instance.frames.forEach(frame => {
+                if (frame) {
+                    frame.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
+                }
+            });
+        }
     }
 
     @action toggleLabels = () => {


### PR DESCRIPTION
**Description**

Fixed #2252. The root cause is that the coordinate system is updated only for rendered images. Fixed by updating all the images instead of only rendered images when the coordinate system is changed.

This is a regression from #2190. Before the PR, we create the transformation by combining two AST FrameSet. The images can still be matched when their coordinate systems are different. After the PR, we create it simply by combining the conversion of image coordinate <-> WCS coordinate of the two images. Therefore, it fails when their WCS values are different.

Please note that if we implement independent coordinate systems (#1619) in the future, for spatial matching we might need to create a temporary copy of the matched frame, set it to the same coordinate system, and then create the transformation.

Changes:
* Added coordinate system update to overlay store `autorun` function.
* Refactoring
    * Removed unused variables in overlay store `autorun` functions.
    * Removed unnecessary update in `setSystem`.

Tested that:
* All the image overlays update with the global coordinate system and the number custom XY formats.
* Pan and zoom and region inputs update with the global coordinate system and the number custom XY formats as usual.
* Distance measuring on all the images updates with the global coordinate system as usual.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~