### PR TITLE
fix pv preview

### DIFF
--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -39,7 +39,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
     private triggerUpdate = () => {
         const animatorStore = AnimatorStore.Instance;
         const contourFrames = AppStore.Instance.contourFrames.get(this.props.frame);
-        if (contourFrames.every(frame => frame?.contourProgress === 1) && animatorStore.serverAnimationActive) {
+        if (contourFrames?.every(frame => frame?.contourProgress === 1) && animatorStore.serverAnimationActive) {
             requestAnimationFrame(this.updateCanvas);
         } else if (!animatorStore.serverAnimationActive) {
             requestAnimationFrame(this.updateCanvas);


### PR DESCRIPTION
**Description**

A quick fix for a regression in our latest merge: frontend crashes after creating a PV preview.

![image](https://github.com/CARTAvis/carta-frontend/assets/43841102/fb630194-c90e-42e4-9348-f62662807c6d)

**Checklist**

~For linked issues (if there are):~
- [x] ~assignee and label added~
- [x] ~ZenHub issue connection, board status, and estimate updated~

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~