### PR TITLE
ksw/2326 using shifted frequency data for filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
-<<<<<<< HEAD
 * Fixed a bug when applying a filter to the shifted frequency column in the spectral line query widget ([#2326](https://github.com/CARTAvis/carta-frontend/issues/2326)).
-=======
 * Fixed the crash when plotting online Vizier catalog data. ([#2321](https://github.com/CARTAvis/carta-frontend/pull/2321))
 
->>>>>>> dev
 
 ## [4.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the performance issue when panning images ([#2291](https://github.com/CARTAvis/carta-frontend/issues/2291)).
 * Improved the dragging performance of 'Export Region' widget when the list of region/annotation to be exported is large. ([#1867](https://github.com/CARTAvis/carta-frontend/issues/1867)).
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
+* Fixed a bug when applying a filter to the shifted frequency column in the spectral line query widget ([#2326](https://github.com/CARTAvis/carta-frontend/issues/2326)).
 
 ## [4.0.0]
 

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -110,6 +110,7 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
         if (isFinite(value) && value !== existingValue) {
             if ((this.widgetStore.redshiftType === RedshiftType.Z && value >= 0) || this.widgetStore.redshiftType === RedshiftType.V) {
                 this.widgetStore.setRedshiftInput(value);
+                this.widgetStore.filter();
                 return;
             }
         }

--- a/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
+++ b/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
@@ -317,7 +317,12 @@ export class SpectralLineQueryWidgetStore {
             if (filterString !== "") {
                 const column = this.queryResult.get(controlHeader.columnIndex);
                 const dataType = column.dataType;
-                const data = column.data;
+                const data =
+                    controlHeader.columnIndex !== SHIFTIED_FREQUENCY_COLUMN_INDEX
+                        ? column.data
+                        : column.data.map(value => {
+                              return isFinite(value) ? value * this.redshiftFactor : undefined;
+                          });
                 if (dataType === CARTA.ColumnType.Double) {
                     filteredRowIndexes = numericFiltering(data as Array<number>, filteredRowIndexes, filterString);
                 } else if (dataType === CARTA.ColumnType.Bool) {

--- a/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
+++ b/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
@@ -317,12 +317,7 @@ export class SpectralLineQueryWidgetStore {
             if (filterString !== "") {
                 const column = this.queryResult.get(controlHeader.columnIndex);
                 const dataType = column.dataType;
-                const data =
-                    controlHeader.columnIndex !== SHIFTIED_FREQUENCY_COLUMN_INDEX
-                        ? column.data
-                        : column.data.map(value => {
-                              return isFinite(value) ? value * this.redshiftFactor : undefined;
-                          });
+                const data = controlHeader.columnIndex !== SHIFTIED_FREQUENCY_COLUMN_INDEX ? column.data : column.data.map(value => (isFinite(value) ? value * this.redshiftFactor : undefined));
                 if (dataType === CARTA.ColumnType.Double) {
                     filteredRowIndexes = numericFiltering(data as Array<number>, filteredRowIndexes, filterString);
                 } else if (dataType === CARTA.ColumnType.Bool) {


### PR DESCRIPTION
**Description**
This is to close #2326. The root cause is when we do `filter`, the data used for filtering the "shifted frequency" column is always with v=0 (ie no doppler shift). Therefore we see unexpected results as described in #2326. This simple (but may not be ideal) solution is to apply doppler shift to the data and use it instead for filtering. 

Tested by applying filters to the shifted frequency column, rest frequency column, and any combination of the two as well as other string/number columns. The results are fine as far as I can tell.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added~ (for functions with no dependenies)
- [x] ~API documentation added~ (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared~ (for large new features)