### PR TITLE
add overlay visible state

### DIFF
--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -159,7 +159,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
                     <RasterViewComponent frame={frame} docked={this.props.docked} pixelHighlightValue={this.pixelHighlightValue} row={this.props.row} column={this.props.column} />
                     <ContourViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
                     <VectorOverlayViewComponent frame={frame} docked={this.props.docked} row={this.props.row} column={this.props.column} />
-                    <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />
+                    {overlayStore?.visible && <OverlayComponent frame={frame} overlaySettings={overlayStore} docked={this.props.docked} />}
                     {this.cursorInfoRequired && frame.cursorInfo && (
                         <CursorOverlayComponent
                             cursorInfo={frame.cursorInfo}

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -983,6 +983,9 @@ export class OverlayStore {
         return OverlayStore.staticInstance;
     }
 
+    /** Visibility of the overlay. */
+    @observable visible: boolean = true;
+
     // View size options
     @observable fullViewWidth: number;
     @observable fullViewHeight: number;
@@ -1039,6 +1042,14 @@ export class OverlayStore {
                 }
             });
         });
+    }
+
+    /**
+     * Hide or show the overlay.
+     * @param visible - Visibility of the overlay.
+     */
+    @action setVisible(visible: boolean) {
+        this.visible = visible;
     }
 
     @action setViewDimension = (width: number, height: number) => {


### PR DESCRIPTION
**Description**

Closes #2341. Add a variable for hiding/showing the AST overlay. The overlay can be hidden/shown by
```js
app.overlayStore.setVisible(false/true);
```

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added / new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~