### PR TITLE
Update Google auth approach to use new libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
                 "@testing-library/jest-dom": "^5.11.9",
                 "@testing-library/react": "^12.0.0",
                 "@testing-library/user-event": "^13.1.9",
-                "@types/gapi": "^0.0.44",
-                "@types/gapi.auth2": "^0.0.57",
                 "@types/jest": "^29.4.0",
                 "@types/jquery": "^3.5.16",
                 "@types/lodash": "^4.14.191",
@@ -4205,21 +4203,6 @@
                 "@types/node": "*",
                 "@types/qs": "*",
                 "@types/range-parser": "*"
-            }
-        },
-        "node_modules/@types/gapi": {
-            "version": "0.0.44",
-            "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.44.tgz",
-            "integrity": "sha512-hsgJMfZ/pMwI15UlAYHMNwj8DRoigo1odhbPwEXdp19ZQwQAXbcRrpzaDsfc+9XM6RtGpvl4Ja7uW8A+KPCa7w==",
-            "dev": true
-        },
-        "node_modules/@types/gapi.auth2": {
-            "version": "0.0.57",
-            "resolved": "https://registry.npmjs.org/@types/gapi.auth2/-/gapi.auth2-0.0.57.tgz",
-            "integrity": "sha512-2nYF2OZlEqWvF5rLk0nrQlAkk51Abe9zLHvA85NZqpIauYT/TluDNsPWkncI969BR/Ts5mdKrXgiWE/f4N6mMQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/gapi": "*"
             }
         },
         "node_modules/@types/graceful-fs": {
@@ -11183,7 +11166,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
             "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -16688,6 +16671,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -16881,6 +16865,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -17906,7 +17891,7 @@
             "version": "1.58.3",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
             "integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -17976,6 +17961,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -19715,6 +19701,7 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -22437,14 +22424,12 @@
         "@csstools/postcss-unset-value": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-            "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
-            "requires": {}
+            "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
         },
         "@csstools/selector-specificity": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
-            "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
-            "requires": {}
+            "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw=="
         },
         "@emotion/babel-plugin": {
             "version": "11.3.0",
@@ -22643,8 +22628,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
             "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -23057,8 +23041,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
             "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@mapbox/point-geometry": {
             "version": "0.1.0",
@@ -23779,21 +23762,6 @@
                 "@types/node": "*",
                 "@types/qs": "*",
                 "@types/range-parser": "*"
-            }
-        },
-        "@types/gapi": {
-            "version": "0.0.44",
-            "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.44.tgz",
-            "integrity": "sha512-hsgJMfZ/pMwI15UlAYHMNwj8DRoigo1odhbPwEXdp19ZQwQAXbcRrpzaDsfc+9XM6RtGpvl4Ja7uW8A+KPCa7w==",
-            "dev": true
-        },
-        "@types/gapi.auth2": {
-            "version": "0.0.57",
-            "resolved": "https://registry.npmjs.org/@types/gapi.auth2/-/gapi.auth2-0.0.57.tgz",
-            "integrity": "sha512-2nYF2OZlEqWvF5rLk0nrQlAkk51Abe9zLHvA85NZqpIauYT/TluDNsPWkncI969BR/Ts5mdKrXgiWE/f4N6mMQ==",
-            "dev": true,
-            "requires": {
-                "@types/gapi": "*"
             }
         },
         "@types/graceful-fs": {
@@ -24671,14 +24639,12 @@
         "acorn-import-assertions": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-            "requires": {}
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "requires": {}
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
         },
         "acorn-node": {
             "version": "1.8.2",
@@ -24746,8 +24712,7 @@
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "requires": {}
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "almost-equal": {
             "version": "1.1.0",
@@ -25147,8 +25112,7 @@
         "babel-plugin-named-asset-import": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-            "requires": {}
+            "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.3.3",
@@ -26220,8 +26184,7 @@
         "css-declaration-sorter": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-            "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-            "requires": {}
+            "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
         },
         "css-font": {
             "version": "1.2.0",
@@ -26339,8 +26302,7 @@
         "css-prefers-color-scheme": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-            "requires": {}
+            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
         },
         "css-select": {
             "version": "4.3.0",
@@ -26456,8 +26418,7 @@
         "cssnano-utils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-            "requires": {}
+            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
         },
         "csso": {
             "version": "4.2.0",
@@ -27737,15 +27698,13 @@
         "eslint-plugin-react-hooks": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "requires": {}
+            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
         },
         "eslint-plugin-simple-import-sort": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
             "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-testing-library": {
             "version": "5.10.1",
@@ -29191,8 +29150,7 @@
         "icss-utils": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "requires": {}
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
         },
         "idb": {
             "version": "7.1.1",
@@ -29227,7 +29185,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
             "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-            "devOptional": true
+            "dev": true
         },
         "import-fresh": {
             "version": "3.3.0",
@@ -30087,8 +30045,7 @@
         "jest-pnp-resolver": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-            "requires": {}
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -31231,8 +31188,7 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
             "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "moment": {
             "version": "2.29.4",
@@ -32186,8 +32142,7 @@
         "postcss-browser-comments": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-            "requires": {}
+            "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
         },
         "postcss-calc": {
             "version": "8.2.4",
@@ -32285,26 +32240,22 @@
         "postcss-discard-comments": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-            "requires": {}
+            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
         },
         "postcss-discard-duplicates": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-            "requires": {}
+            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
         },
         "postcss-discard-empty": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-            "requires": {}
+            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
         },
         "postcss-discard-overridden": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-            "requires": {}
+            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
         },
         "postcss-double-position-gradients": {
             "version": "3.1.2",
@@ -32326,8 +32277,7 @@
         "postcss-flexbugs-fixes": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-            "requires": {}
+            "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
         },
         "postcss-focus-visible": {
             "version": "6.0.4",
@@ -32348,14 +32298,12 @@
         "postcss-font-variant": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-            "requires": {}
+            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
         },
         "postcss-gap-properties": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-            "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
-            "requires": {}
+            "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
         },
         "postcss-image-set-function": {
             "version": "4.0.7",
@@ -32378,8 +32326,7 @@
         "postcss-initial": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-            "requires": {}
+            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
         },
         "postcss-js": {
             "version": "4.0.1",
@@ -32434,14 +32381,12 @@
         "postcss-logical": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-            "requires": {}
+            "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
         },
         "postcss-media-minmax": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-            "requires": {}
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
         },
         "postcss-merge-longhand": {
             "version": "5.1.7",
@@ -32502,8 +32447,7 @@
         "postcss-modules-extract-imports": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "requires": {}
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -32561,8 +32505,7 @@
         "postcss-normalize-charset": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-            "requires": {}
+            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
         },
         "postcss-normalize-display-values": {
             "version": "5.1.0",
@@ -32633,8 +32576,7 @@
         "postcss-opacity-percentage": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
-            "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
-            "requires": {}
+            "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A=="
         },
         "postcss-ordered-values": {
             "version": "5.1.3",
@@ -32656,8 +32598,7 @@
         "postcss-page-break": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-            "requires": {}
+            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
         },
         "postcss-place": {
             "version": "7.0.5",
@@ -32751,8 +32692,7 @@
         "postcss-replace-overflow-wrap": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-            "requires": {}
+            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
         },
         "postcss-selector-not": {
             "version": "6.0.1",
@@ -33138,6 +33078,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
             "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -33167,8 +33108,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
             "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-color": {
             "version": "2.19.3",
@@ -33282,6 +33222,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -33539,8 +33480,7 @@
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
             "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-split-pane": {
             "version": "0.1.92",
@@ -33578,8 +33518,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
             "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "react-window": {
             "version": "1.8.8",
@@ -34085,7 +34024,7 @@
             "version": "1.58.3",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
             "integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -34118,6 +34057,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -34867,8 +34807,7 @@
         "style-loader": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-            "requires": {}
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
         },
         "stylehacks": {
             "version": "5.1.1",
@@ -35526,7 +35465,8 @@
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true
         },
         "unbox-primitive": {
             "version": "1.0.2",
@@ -35626,8 +35566,7 @@
         "usehooks-ts": {
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
-            "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
-            "requires": {}
+            "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA=="
         },
         "util": {
             "version": "0.12.5",
@@ -35941,8 +35880,7 @@
                 "ws": {
                     "version": "8.12.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-                    "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
-                    "requires": {}
+                    "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig=="
                 }
             }
         },
@@ -36349,8 +36287,7 @@
         "ws": {
             "version": "7.5.9",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "requires": {}
+            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.1.9",
-        "@types/gapi": "^0.0.44",
-        "@types/gapi.auth2": "^0.0.57",
         "@types/jest": "^29.4.0",
         "@types/jquery": "^3.5.16",
         "@types/lodash": "^4.14.191",

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -178,7 +178,7 @@ export class RootMenuComponent extends React.Component {
         if (apiService.authenticated && ApiService.RuntimeConfig.dashboardAddress) {
             serverMenu.push(<Menu.Item key="restart" text="Restart Service" disabled={!appStore.apiService.authenticated} onClick={appStore.apiService.stopServer} />);
         }
-        if (ApiService.RuntimeConfig.logoutAddress || ApiService.RuntimeConfig.googleClientId) {
+        if (ApiService.RuntimeConfig.logoutAddress) {
             serverMenu.push(<Menu.Item key="logout" text="Logout" disabled={!appStore.apiService.authenticated} onClick={appStore.apiService.logout} />);
         }
         if (ApiService.RuntimeConfig.dashboardAddress) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,17 +39,7 @@ async function fetchConfig() {
         ApiService.SetRuntimeConfig({});
     }
 
-    if (ApiService.RuntimeConfig.googleClientId) {
-        // Lazy load google API script only when the config requires it
-        const script = document.createElement("script");
-        script.src = "https://apis.google.com/js/client.js";
-        script.onload = () => {
-            ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
-        };
-        document.body.appendChild(script);
-    } else {
-        ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
-    }
+    ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
 }
 
 fetchConfig().then(() => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -13,7 +13,6 @@ export interface RuntimeConfig {
     apiAddress?: string;
     tokenRefreshAddress?: string;
     logoutAddress?: string;
-    logoutUsingGet?: boolean;
 }
 
 export class ApiService {
@@ -145,19 +144,9 @@ export class ApiService {
     };
 
     public logout = async () => {
-        this.clearToken();
-        // The controller will assume an existing login session exists if this exists
+        // An existing login session will be assumed to exists if this is found in local storage
         localStorage.removeItem("authenticationType");
-        if (ApiService.RuntimeConfig.logoutUsingGet) {
-            window.open(ApiService.RuntimeConfig.logoutAddress, "_self");
-            return; // avoid later potential dashboard redirect
-        } else {
-            await this.axiosInstance.post(ApiService.RuntimeConfig.logoutAddress);
-        }
-        // Redirect to dashboard URL if it exists
-        if (ApiService.RuntimeConfig.dashboardAddress) {
-            window.open(ApiService.RuntimeConfig.dashboardAddress, "_self");
-        }
+        window.open(ApiService.RuntimeConfig.logoutAddress, "_self");
     };
 
     public stopServer = async () => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -91,7 +91,11 @@ export class ApiService {
     constructor() {
         makeObservable(this);
         this.axiosInstance = axios.create();
-        this.onTokenExpired();
+        if (localStorage.getItem('authenticationType')) {
+            this.onTokenExpired();
+        } else {
+            this.handleAuthLost();
+        }
     }
 
     private onTokenExpired = async () => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -91,7 +91,7 @@ export class ApiService {
     constructor() {
         makeObservable(this);
         this.axiosInstance = axios.create();
-        if (localStorage.getItem('authenticationType')) {
+        if (localStorage.getItem("authenticationType")) {
             this.onTokenExpired();
         } else {
             this.handleAuthLost();

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -90,10 +90,11 @@ export class ApiService {
     constructor() {
         makeObservable(this);
         this.axiosInstance = axios.create();
-        if (localStorage.getItem("authenticationType")) {
+        if (localStorage.getItem("authenticationType") || ApiService.RuntimeConfig.tokenRefreshAddress) {
             this.onTokenExpired();
         } else {
-            this.handleAuthLost();
+            this._accessToken = "no_auth_configured";
+            this._tokenLifetime = Number.MAX_VALUE;
         }
     }
 


### PR DESCRIPTION
**NOTE: This is a breaking change for those using Google auth and will require updates to the controller config and Google auth registration as well as a controller install with the code from the [corresponding controller pull request](https://github.com/CARTAvis/carta-controller/pull/166) to work.**

**Description**

The vast majority of this work was on the controller side, and described in the other related pull request.

As far as the new approach goes, following initial login with Google credentials sessions are persisted using access tokens + refresh tokens generated like those for the other auth methods.  As a result, this is mostly removing existing Google code and libraries no longer needed in the frontend.