### PR TITLE
Enable cursor events on the cursor info overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the flashing contour rendering during animation ([#579](https://github.com/CARTAvis/carta-frontend/issues/579)).
 * Fixed incorrect range values in the save image dialog with non-convertible spectral axis images by supporting native/channel options in the spectral coordinate selector for non-convertible spectral axis images ([#2225](https://github.com/CARTAvis/carta-frontend/issues/2225)).
 * Fixed a bug when applying a filter to the shifted frequency column in the spectral line query widget ([#2326](https://github.com/CARTAvis/carta-frontend/issues/2326)).
+* Improved the cursor interaction area in the image view widget ([#1794](https://github.com/CARTAvis/carta-frontend/issues/1794)).
 
 ## [4.1.0]
 

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.scss
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.scss
@@ -1,6 +1,7 @@
 @import "~@blueprintjs/core/lib/scss/variables.scss";
 
 .cursor-overlay-div {
+    pointer-events: none;
     position: absolute;
     background-color: rgba($gray1, 0.6);
     padding-left: 5px;
@@ -13,5 +14,9 @@
     user-select: text;
     &.docked {
         z-index: 4;
+    }
+
+    span {
+        pointer-events: auto;
     }
 }

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -88,7 +88,7 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
 
         return (
             <div className={className} style={styleProps}>
-                {infoStrings.length ? infoStrings.join("; ") : "\u00a0"}
+                <span>{infoStrings.length ? infoStrings.join("; ") : "\u00a0"}</span>
             </div>
         );
     }

--- a/src/components/ImageView/Toolbar/ToolbarComponent.scss
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.scss
@@ -1,6 +1,12 @@
 @import "~@blueprintjs/core/lib/scss/variables.scss";
 
 .image-toolbar {
+    pointer-events: none;
+
+    span {
+        pointer-events: auto;
+    }
+
     position: absolute;
     margin: 5px;
     transition: opacity 400ms;


### PR DESCRIPTION
**Description**

Enable cursor events on the cursor info overlay and the area around the toolbar with simple css changes.

Users can pan/zoom images and create/drag regions on the grey blank area where there is no cursor info text. They can still highlight and copy the text as usual.
Same fix for the area around the toolbar. They can still hover and click toolbar buttons as usual.

Closes #1794.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~