### PR TITLE
Duplicate CI steps

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -75,18 +75,6 @@ jobs:
           n exec 16 node -v
           n exec 16 npm install --legacy-peer-deps
 
-      - name: Build wrappers
-        shell: bash        
-        run: |
-          source /emsdk/emsdk_env.sh
-          ./wasm_src/build_wrappers.sh
-
-      - name: Build protobuf
-        shell: bash        
-        run: |
-          source /emsdk/emsdk_env.sh
-          ./protobuf/build_proto.sh
-
       - name: Production build with node 16
         shell: bash        
         run: |
@@ -125,18 +113,6 @@ jobs:
           n 18
           n exec 18 node -v
           n exec 18 npm install --legacy-peer-deps
-
-      - name: Build wrappers
-        shell: bash
-        run: |
-          source /emsdk/emsdk_env.sh
-          ./wasm_src/build_wrappers.sh
-
-      - name: Build protobuf
-        shell: bash
-        run: |
-          source /emsdk/emsdk_env.sh
-          ./protobuf/build_proto.sh
 
       - name: Production build with node 18
         shell: bash


### PR DESCRIPTION
**Description**

Looks like we have duplicate steps in node-v16 and node-v18 runs. The steps take about 1min, which is smaller than the fluctuation of the total used time, so the total used time does not change much.