### PR TITLE
Normalize directory and filename in loadFile using a path library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect range values in the save image dialog with non-convertible spectral axis images by supporting native/channel options in the spectral coordinate selector for non-convertible spectral axis images ([#2225](https://github.com/CARTAvis/carta-frontend/issues/2225)).
 * Fixed a bug when applying a filter to the shifted frequency column in the spectral line query widget ([#2326](https://github.com/CARTAvis/carta-frontend/issues/2326)).
 * Improved the cursor interaction area in the image view widget ([#1794](https://github.com/CARTAvis/carta-frontend/issues/1794)).
+* Fixed saving or opening CASA image with a trailing slash using the URL parameter or the snippets ([#1816](https://github.com/CARTAvis/carta-frontend/issues/1816) and [#1357](https://github.com/CARTAvis/carta-backend/issues/1357)).
 
 ## [4.1.0]
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -7,6 +7,7 @@ import {CARTA} from "carta-protobuf";
 import * as _ from "lodash";
 import * as Long from "long";
 import {action, autorun, computed, flow, makeObservable, observable, ObservableMap, when} from "mobx";
+import * as Path from "path-browserify";
 import * as Semver from "semver";
 
 import {getImageViewCanvas, ImageViewLayer, PvGeneratorComponent} from "components";
@@ -645,18 +646,10 @@ export class AppStore {
 
         if (imageArithmetic) {
             hdu = "";
-        } else if (!filename) {
-            const lastDirSeparator = path.lastIndexOf("/");
-            if (lastDirSeparator >= 0) {
-                filename = path.substring(lastDirSeparator + 1);
-                path = path.substring(0, lastDirSeparator);
-            }
-        } else if (!path && filename.includes("/")) {
-            const lastDirSeparator = filename.lastIndexOf("/");
-            if (lastDirSeparator >= 0) {
-                path = filename.substring(0, lastDirSeparator);
-                filename = filename.substring(lastDirSeparator + 1);
-            }
+        } else {
+            const fullPath = Path.join(path, filename || "");
+            path = Path.dirname(fullPath);
+            filename = Path.basename(fullPath);
         }
 
         // Separate HDU and filename if no HDU is specified

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -647,7 +647,7 @@ export class AppStore {
         if (imageArithmetic) {
             hdu = "";
         } else {
-            const fullPath = Path.join(path, filename || "");
+            const fullPath = Path.join(path || "", filename || "");
             path = Path.dirname(fullPath);
             filename = Path.basename(fullPath);
         }


### PR DESCRIPTION
**Description**

This fixes [backend bug #1357](https://github.com/CARTAvis/carta-backend/issues/1357) and #1816 by using (the browser port of) node's `path` module to normalize the directory and filename in the `loadFile` function.

The library correctly handles edge cases such as the one causing the bug. Since it's already available to us as a dependency, I would recommend making use of it instead of hand-coding path parsing (which is error-prone!). The browser version only implements posix paths, which I think is what we always need.

Step by step instructions for reproducing the backend bug can be found [in the bug's description](https://github.com/CARTAvis/carta-backend/issues/1357#issue-2107173165). ~I have not yet tested the issue in #1816, but I believe that it has the same underlying cause.~ I have confirmed that this also fixes #1816 (or at least I can see that it prevents the initial incorrect image request which later causes errors).

Outstanding questions:

1. I'm not sure if I'm importing `path-browserify` in the optimal way. It's [intended to be imported as `path`](https://github.com/browserify/path-browserify), because it's the browser port of node's `path` module, and webpack is supposed to provide it as a fallback transparently. I know that webpack 5 no longer sets this up automatically, and it looks like we have a fix for this in a patch -- but when I attempt to import `path`, I get an error about `path-browserify` being outside the `src` tree. This doesn't happen when I import `path-browserify` directly, and doesn't happen with other dependencies in `node_modules`. I'm not sure if this is some weird interaction with the alias, and I haven't been able to find a solution. @veggiesaurus, is there a piece missing somewhere?
2. This code always performs the same normalization step, regardless of what the original directory and filename parameters are. This includes cases where the directory is empty and the filename does not contain a slash (which are skipped in the previous code). The effect of this is to change the directory to `"."`. I did some tests in the previous code, and from what I understand, a directory which is `""` or `"."` is evaluated as the top-level directory. Is that correct? If that's the case, then changing `""` to `"."` shouldn't make a difference.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] ZenHub issue connection, board status, and estimate updated

For the pull request:
- [x] reviewers and assignee added
- [x] ZenHub estimate, milestone, and release (if needed) added
- [x] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [X] ~protobuf version bumped~ / no protobuf version bumped needed
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [x] user manual prepared (for large new features)