### PR TITLE
Yuhsuan/GitHub project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
@@ -1,6 +1,6 @@
 **Description**
 
-This PR is for the release version bump, the final step before tagging a beta release or creating a stable release branch.
+This PR is for the version bump, the final step before tagging a release on a release branch, or the first step when starting a new dev cycle.
 
 **Checklist**
 
@@ -8,7 +8,4 @@ This PR is for the release version bump, the final step before tagging a beta re
 - [ ] `package-lock.json` version string updated (by running `npm install`)
 - [ ] changelog version string updated
 - [ ] user manual URL in the about dialog updated (for stable releases)
-
-**Note**
-
-The documentation website requires an update (following the [guidelines](https://cartavis.org/carta-frontend/docs/contributing/documentation-guidelines#versioning)) after the beta release is tagged or the stable release branch is created.
+- [ ] documentation website updated (for start of new cycle, on the dev branch after a release is tagged) ([guidelines](https://cartavis.org/carta-frontend/docs/contributing/documentation-guidelines#versioning))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,11 @@ linked issues and companion PRs (if there are), what is implemented or fixed, ho
 
 For linked issues (if there are):
 - [ ] assignee and label added
-- [ ] ZenHub issue connection, board status, and estimate updated
+- [ ] GitHub Project estimate added
 
 For the pull request:
 - [ ] reviewers and assignee added
-- [ ] ZenHub estimate, milestone, and release (if needed) added
+- [ ] GitHub Project estimate added
 - [ ] changelog updated / no changelog update needed
 - [ ] unit test added (for functions with no dependenies)
 - [ ] API documentation added (for public variables and methods in stores)

--- a/docs_website/docs/contributing/documentation-guidelines.md
+++ b/docs_website/docs/contributing/documentation-guidelines.md
@@ -8,7 +8,7 @@ Guidelines for building and writing this website.
 
 ## Building documentation
 
-The website is hosted on Github Pages, and whenever the `dev` branch is updated, the website is automatically updated using Github Actions.
+The website is hosted on GitHub Pages, and whenever the `dev` branch is updated, the website is automatically updated using GitHub Actions.
 
 To build and test the website locally, navigate to the `docs_website/` directory and install package dependencies:
 

--- a/docs_website/docs/contributing/github-workflow.md
+++ b/docs_website/docs/contributing/github-workflow.md
@@ -32,7 +32,7 @@ Before making any changes to the codebase, create and check out to a new branch.
 git checkout -b "[author]/[issue id]_[description_with_underscores]"
 ```
 
-If the issue doesn't exist yet, please create a new issue. When you start working on the issue, update the ZenHub status of the issue to "In Progress".
+If the issue doesn't exist yet, please create a new issue. When you start working on the issue, update the GitHub Project status of the issue to "In Progress".
 
 ### Pushing changes
 
@@ -63,13 +63,13 @@ For linked issues (if there are): this section is for checking the status of the
 
 -   assignee and label added: assign yourself to the issue you are working on. Add labels to the issue.
 
--   ZenHub issue connection, board status, and estimate updated: connect the issue to the pull request in ZenHub. ZenHub automatically updates the issue status from "In Progress" to "Review/QA" by default. Also, provide an estimate for the time required to complete the issue. This estimation is useful for future development planning.
+-   GitHub Project estimate added: provide an estimate for the time required to complete the issue. This estimation is useful for future development planning.
 
 For the pull request: this section is for checking the status of the pull request and reviewing the code changes.
 
 -   reviewers and assignee added: assign reviewers and an assignee to the pull request. The assignee will be responsible for merging the pull request.
 
--   ZenHub estimate, milestone, and release (if needed) added: provide an estimate for the time required to review the pull request.
+-   GitHub Project estimate added: provide an estimate for the time required to review the pull request.
 
 -   changelog updated / no changelog update needed: updating the changelog is required when the issue exists in the latest release and the changes have an impact on users. It is recommended to update the changelog when sending the pull request and to resolve changelog merge conflicts using the GitHub UI.
 

--- a/docs_website/docs/contributing/github-workflow.md
+++ b/docs_website/docs/contributing/github-workflow.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Github workflow
+# GitHub workflow
 
 The workflow for contributing to the codebase.
 

--- a/docs_website/versioned_docs/version-4.1.0/contributing/documentation-guidelines.md
+++ b/docs_website/versioned_docs/version-4.1.0/contributing/documentation-guidelines.md
@@ -8,7 +8,7 @@ Guidelines for building and writing this website.
 
 ## Building documentation
 
-The website is hosted on Github Pages, and whenever the `dev` branch is updated, the website is automatically updated using Github Actions.
+The website is hosted on GitHub Pages, and whenever the `dev` branch is updated, the website is automatically updated using GitHub Actions.
 
 To build and test the website locally, navigate to the `docs_website/` directory and install package dependencies:
 

--- a/docs_website/versioned_docs/version-4.1.0/contributing/github-workflow.md
+++ b/docs_website/versioned_docs/version-4.1.0/contributing/github-workflow.md
@@ -32,7 +32,7 @@ Before making any changes to the codebase, create and check out to a new branch.
 git checkout -b "[author]/[issue id]_[description_with_underscores]"
 ```
 
-If the issue doesn't exist yet, please create a new issue. When you start working on the issue, update the ZenHub status of the issue to "In Progress".
+If the issue doesn't exist yet, please create a new issue. When you start working on the issue, update the GitHub Project status of the issue to "In Progress".
 
 ### Pushing changes
 
@@ -63,13 +63,13 @@ For linked issues (if there are): this section is for checking the status of the
 
 -   assignee and label added: assign yourself to the issue you are working on. Add labels to the issue.
 
--   ZenHub issue connection, board status, and estimate updated: connect the issue to the pull request in ZenHub. ZenHub automatically updates the issue status from "In Progress" to "Review/QA" by default. Also, provide an estimate for the time required to complete the issue. This estimation is useful for future development planning.
+-   GitHub Project estimate added: provide an estimate for the time required to complete the issue. This estimation is useful for future development planning.
 
 For the pull request: this section is for checking the status of the pull request and reviewing the code changes.
 
 -   reviewers and assignee added: assign reviewers and an assignee to the pull request. The assignee will be responsible for merging the pull request.
 
--   ZenHub estimate, milestone, and release (if needed) added: provide an estimate for the time required to review the pull request.
+-   GitHub Project estimate added: provide an estimate for the time required to review the pull request.
 
 -   changelog updated / no changelog update needed: updating the changelog is required when the issue exists in the latest release and the changes have an impact on users. It is recommended to update the changelog when sending the pull request and to resolve changelog merge conflicts using the GitHub UI.
 

--- a/docs_website/versioned_docs/version-4.1.0/contributing/github-workflow.md
+++ b/docs_website/versioned_docs/version-4.1.0/contributing/github-workflow.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Github workflow
+# GitHub workflow
 
 The workflow for contributing to the codebase.
 


### PR DESCRIPTION
**Description**

This PR is for some minor updates when migrating to GitHub Projects:
* Updated protobuf to the latest dev commit (some GitHub Actions were added)
* Updated the PR template checkboxes
* Updated the GitHub workflow section of the documentation website

Also updated the version bump PR template based on our discussion on Slack. I assume the template could be used when updating to, for example, v5.0.0-beta (on a release branch), v5.0.0 (on a release branch, with user manual url update), and v6.0.0-dev (on the dev branch, with doc website update).

**Checklist**

For the pull request:
- [x] reviewers and assignee added
- [ ] ZenHub estimate, milestone, and release (if needed) added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~