### PR TITLE
supporting polyline as a pv cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the raster matching setting to the preference and improved the raster matching function ([#2004](https://github.com/CARTAvis/carta-frontend/issues/2004) and [#1959](https://github.com/CARTAvis/carta-frontend/issues/1959)).
 * Added support for sorting the spectral line table ([#2262](https://github.com/CARTAvis/carta-frontend/issues/2262)).
 * Added additional mono-color colormaps with a customized option for the raster image ([#2300](https://github.com/CARTAvis/carta-frontend/issues/2300))
+* Added support for PV image generation using polyline ([[#2302](https://github.com/CARTAvis/carta-frontend/issues/2302)])
 ### Fixed
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Fixed compass and ruler annotations update bug in the spatially matched image when changing the coordinate ([#2270](https://github.com/CARTAvis/carta-frontend/issues/2270)).

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -293,11 +293,11 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                         <br />
                         1. Animation playback is stopped.
                         <br />
-                        2. Line region is selected.
+                        2. Line/Polyline region is selected.
                         <br />
-                        3. Line region has intersection with image.
+                        3. Line/Polyline region has intersection with image.
                         <br />
-                        4. Line region is not in one pixel.
+                        4. Line/Polyline region is not in one pixel.
                     </small>
                 </i>
             </span>

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -284,7 +284,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         }
 
         const isAbleToGenerate = this.widgetStore.effectiveRegion && !appStore.animatorStore.animationActive && this.isLineIntersectedWithImage && !this.isLineInOnePixel && this.isValidSpectralRange;
-        const isAbleToGeneratePreview = isAbleToGenerate && this.isCubeSizeBelowLimit;
+        const isAbleToGeneratePreview = isAbleToGenerate && this.isCubeSizeBelowLimit && this.widgetStore.effectiveRegion?.regionType === CARTA.RegionType.LINE;
         const hint = (
             <span>
                 <i>

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -604,8 +604,8 @@ export class FrameStore {
             const entries = this.frameInfo.fileInfoExtended.headerEntries;
             const axis1 = entries.find(entry => entry.name.includes(`CTYPE${this.renderedAxesNumbers[0]}`));
             const axis2 = entries.find(entry => entry.name.includes(`CTYPE${this.renderedAxesNumbers[1]}`));
-            const axis1SpectralAxis2Spatial = axis1?.value?.match(/offset|position|offset position/i) && axis2?.value?.match(/freq/i);
-            const axis1SpatialAxis2Spectral = axis2?.value?.match(/offset|position|offset position/i) && axis1?.value?.match(/freq/i);
+            const axis1SpectralAxis2Spatial = axis1?.value?.match(/offset|position|offset position|distance/i) && axis2?.value?.match(/freq/i);
+            const axis1SpatialAxis2Spectral = axis2?.value?.match(/offset|position|offset position|distance/i) && axis1?.value?.match(/freq/i);
             return !!(axis1SpatialAxis2Spectral || axis1SpectralAxis2Spatial);
         }
         return false;

--- a/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
+++ b/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
@@ -33,7 +33,7 @@ export class PvGeneratorWidgetStore extends RegionWidgetStore {
             const selectedFrame = appStore.getFrame(this.fileId);
             if (selectedFrame?.regionSet) {
                 const validRegionOptions = selectedFrame.regionSet.regions
-                    ?.filter(r => !r.isTemporary && r.regionType === CARTA.RegionType.LINE)
+                    ?.filter(r => !r.isTemporary && (r.regionType === CARTA.RegionType.LINE || r.regionType === CARTA.RegionType.POLYLINE))
                     ?.map(region => {
                         return {value: region?.regionId, label: region?.nameString};
                     });


### PR DESCRIPTION
**Description**

Close #2302. Supporting the polyline region as a PV cut in frontend. This is the companion PR to CARTAvis/carta-backend#1355.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [ ] `corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)