### PR TITLE
Yuhsuan/2235 center input format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the incorrect coordinate system when loading or appending images after a coordinate system being specified ([#582](https://github.com/CARTAvis/carta-frontend/issues/582)).
 * Upgraded blueprintjs from v3 to v5 ([#2029](https://github.com/CARTAvis/carta-frontend/issues/1395)).
 * Fixed the catalog load button status after double clicking catalog files ([#2378](https://github.com/CARTAvis/carta-frontend/issues/2378)).
+* Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
 
 ## [4.1.0]
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1144,9 +1144,12 @@ export class FrameStore {
     }
 
     @computed get centerWCS(): WCSPoint2D {
-        // re-calculate with different wcs system
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // re-calculate with different wcs system and format
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const system = AppStore.Instance.overlayStore.global.explicitSystem;
+        const formatX = AppStore.Instance.overlayStore.numbers.formatTypeX;
+        const formatY = AppStore.Instance.overlayStore.numbers.formatTypeY;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
         if (!this.wcsInfoForTransformation) {
             return null;
         }


### PR DESCRIPTION
**Description**

Simple fix for closing #2235. Trigger re-calculation for the center wcs coordinates when the x/y format is changed.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~