### PR TITLE
Yuhsuan/ci upgrade

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: 20
           cache: 'npm'
       - run: npm install --legacy-peer-deps
       - run: npm run checkformat
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run checkformat
@@ -38,52 +38,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies
         run: npm ci
       - name: Test build website
         run: npm run build
-
-  node-v16:
-    runs-on: [self-hosted, Linux, X64, Docker]
-    needs: format-check
-    container: 
-      image: carta/frontend-builder
-      options: --security-opt seccomp=unconfined
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Fix ownership
-        run: |
-          chown -R $(id -u):$(id -g) $PWD
-
-      - name: Build libs
-        shell: bash        
-        run: |
-          source /emsdk/emsdk_env.sh
-          ./wasm_libs/build_libs.sh
-
-      - name: npm install with node 16
-        shell: bash        
-        run: |
-          n 16
-          n exec 16 node -v
-          n exec 16 npm install --legacy-peer-deps
-
-      - name: Production build with node 16
-        shell: bash        
-        run: |
-          source /emsdk/emsdk_env.sh
-          n exec 16 npm run build
-
-      - name: Run unit tests
-        shell: bash
-        run: n exec 16 npm test
 
   node-v18:
     runs-on: [self-hosted, Linux, X64, Docker]
@@ -124,10 +85,49 @@ jobs:
         shell: bash
         run: n exec 18 npm test
 
+  node-v20:
+    runs-on: [self-hosted, Linux, X64, Docker]
+    needs: format-check
+    container:
+      image: carta/frontend-builder
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Fix ownership
+        run: |
+          chown -R $(id -u):$(id -g) $PWD
+
+      - name: Build libs
+        shell: bash
+        run: |
+          source /emsdk/emsdk_env.sh
+          ./wasm_libs/build_libs.sh
+
+      - name: npm install with node 20
+        shell: bash
+        run: |
+          n 20
+          n exec 20 node -v
+          n exec 20 npm install --legacy-peer-deps
+
+      - name: Production build with node 20
+        shell: bash
+        run: |
+          source /emsdk/emsdk_env.sh
+          n exec 20 npm run build
+
+      - name: Run unit tests
+        shell: bash
+        run: n exec 20 npm test
+
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, node-v16, node-v18]
+    needs: [format-check, node-v18, node-v20]
     if: always()
     steps:
       - name: Notify Slack

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,8 +5,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
           cache: 'npm'
@@ -19,8 +19,8 @@ jobs:
       run:
         working-directory: ./docs_website
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -35,8 +35,8 @@ jobs:
         working-directory: ./docs_website
     needs: doc-format-check
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -54,7 +54,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -93,7 +93,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build website
         run: npm run build
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs_website/build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,8 @@ jobs:
       run:
         working-directory: ./docs_website
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
**Description**

This PR is for CI upgrade:

* Upgraded `actions/checkout` and `actions/setup-node` from v3 to v4. This removes the [deprecation warnings](https://github.com/CARTAvis/carta-frontend/actions/runs/9886174568) (`The following actions uses Node.js version which is deprecated and will be forced to run on node20...`) on dev branch. We still get deprecation warnings from `baijunyao/action-slack-notify`, but it looks like the package has not been maintained for a while.
* Upgraded node version from 16/18 to 18/20. Node 16 produces some [deprecation warnings](https://github.com/CARTAvis/carta-frontend/actions/runs/10034296728/job/27728629032) (`npm WARN EBADENGINE Unsupported engine...` in the step `npm install with node 16`) after we upgrade some packages (in progress).
* Note that we need to check if the documentation website deployment works as usual after the PR is merged into dev.
* Also [tested with node 22](https://github.com/CARTAvis/carta-frontend/actions/runs/10002907516/job/27727602491) by creating [a temporary branch](https://github.com/CARTAvis/carta-frontend/compare/dev...yuhsuan/ci_upgrade_test_node22), and all checks have passed. There are extra warnings when running unit tests, but these might be resolved after we continue upgrading our packages.

**Checklist**

~For linked issues (if there are):~
- [x] ~assignee and label added~
- [x] ~GitHub Project estimate added~

For the pull request:
- [x] ~reviewers and assignee added~
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~