### PR TITLE
Kuahchou/2396 new RESTFQ for moment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for multi-color blending ([#1204](https://github.com/CARTAvis/carta-frontend/issues/1204)).
 * Added support for showing relative coordinates in image view ([[#681](https://github.com/CARTAvis/carta-frontend/issues/681)])
 * Added a button for deleting all regions ([#1040](https://github.com/CARTAvis/carta-frontend/issues/1040)).
+* Supported the customized rest frequency for the moment maps ([[#2396](https://github.com/CARTAvis/carta-frontend/issues/2396)]).
 ### Fixed
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Fixed compass and ruler annotations update bug in the spatially matched image when changing the coordinate ([#2270](https://github.com/CARTAvis/carta-frontend/issues/2270)).

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.scss
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.scss
@@ -35,9 +35,8 @@
             flex-direction: row;
 
             .#{$ns}-form-group {
-                margin-right: 10px;
+                margin: 0px;
                 .#{$ns}-label {
-                    margin: 0px;
                     width: 3em;
                 }
             }
@@ -50,6 +49,19 @@
 
         .moment-generate {
             float: right;
+        }
+
+        .freq-input {
+            display: flex;
+            flex-direction: row;
+
+            .#{$ns}-form-group {
+                margin-right: 10px;
+                .#{$ns}-input-group {
+                    min-width: 130px;
+                    width: 130px;
+                }
+            }
         }
     }
 }

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -8,7 +8,7 @@ import {observer} from "mobx-react";
 import {TaskProgressDialogComponent} from "components/Dialogs";
 import {ClearableNumericInputComponent, SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
 import {FrequencyUnit, MOMENT_TEXT} from "models";
-import {AppStore} from "stores";
+import {AppStore, FrameStore} from "stores";
 import {MomentSelectingMode, SpectralProfileWidgetStore} from "stores/Widgets";
 
 import "./MomentGeneratorComponent.scss";
@@ -81,10 +81,9 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         return momentContent ? <MenuItem text={`${momentContent.tag}: ${momentContent.text}`} onClick={handleClick} key={moment} icon={this.props.widgetStore.isMomentSelected(moment) ? "tick" : "blank"} /> : undefined;
     };
 
-    private renderRestFreqInput = frame => {
+    private renderRestFreqInput = (frame: FrameStore) => {
         const disableCoordinateSetting = !frame || frame?.isPVImage || !frame?.isSpectralChannel;
-        const widgetStore = this.props.widgetStore;
-        const restFreqStore = widgetStore.effectiveFrame?.restFreqStore;
+        const restFreqStore = frame?.restFreqStore;
         return (
             <div className="freq-input">
                 <ClearableNumericInputComponent
@@ -93,9 +92,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                     disabled={disableCoordinateSetting}
                     placeholder="Rest frequency"
                     selectAllOnFocus={true}
-                    onValueChanged={val => {
-                        restFreqStore?.setCustomVal(val);
-                    }}
+                    onValueChanged={restFreqStore?.setCustomVal}
                     onValueCleared={restFreqStore?.restoreDefaults}
                     resetDisabled={restFreqStore?.resetDisable}
                     tooltipContent={restFreqStore?.defaultInfo}

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -81,25 +81,27 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
         return momentContent ? <MenuItem text={`${momentContent.tag}: ${momentContent.text}`} onClick={handleClick} key={moment} icon={this.props.widgetStore.isMomentSelected(moment) ? "tick" : "blank"} /> : undefined;
     };
 
-    private renderRestFreqInput = () => {
+    private renderRestFreqInput = frame => {
+        const disableCoordinateSetting = !frame || frame?.isPVImage || !frame?.isSpectralChannel;
         const widgetStore = this.props.widgetStore;
-        const restFreqStore = widgetStore.effectiveFrame.restFreqStore;
+        const restFreqStore = widgetStore.effectiveFrame?.restFreqStore;
         return (
             <div className="freq-input">
                 <ClearableNumericInputComponent
                     label="Rest frequency"
-                    value={restFreqStore.customRestFreq.value}
+                    value={restFreqStore?.customRestFreq.value ?? NaN}
+                    disabled={disableCoordinateSetting}
                     placeholder="Rest frequency"
                     selectAllOnFocus={true}
                     onValueChanged={val => {
-                        restFreqStore.setCustomVal(val);
+                        restFreqStore?.setCustomVal(val);
                     }}
-                    onValueCleared={restFreqStore.restoreDefaults}
-                    resetDisabled={restFreqStore.resetDisable}
-                    tooltipContent={restFreqStore.defaultInfo}
+                    onValueCleared={restFreqStore?.restoreDefaults}
+                    resetDisabled={restFreqStore?.resetDisable}
+                    tooltipContent={restFreqStore?.defaultInfo}
                     tooltipPlacement={"bottom"}
                 />
-                <HTMLSelect options={Object.values(FrequencyUnit)} value={restFreqStore.customRestFreq.unit} onChange={ev => restFreqStore.setCustomUnit(ev.currentTarget.value as FrequencyUnit)} />
+                <HTMLSelect disabled={disableCoordinateSetting} options={Object.values(FrequencyUnit)} value={restFreqStore?.customRestFreq.unit} onChange={ev => restFreqStore?.setCustomUnit(ev.currentTarget.value as FrequencyUnit)} />
             </div>
         );
     };
@@ -196,7 +198,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                         </div>
                     </FormGroup>
                 )}
-                <React.Fragment>{this.renderRestFreqInput()}</React.Fragment>
+                <React.Fragment>{this.renderRestFreqInput(frame)}</React.Fragment>
             </React.Fragment>
         );
 

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -6,8 +6,8 @@ import classNames from "classnames";
 import {observer} from "mobx-react";
 
 import {TaskProgressDialogComponent} from "components/Dialogs";
-import {SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
-import {MOMENT_TEXT} from "models";
+import {ClearableNumericInputComponent, SafeNumericInput, SpectralSettingsComponent} from "components/Shared";
+import {FrequencyUnit, MOMENT_TEXT} from "models";
 import {AppStore} from "stores";
 import {MomentSelectingMode, SpectralProfileWidgetStore} from "stores/Widgets";
 
@@ -79,6 +79,29 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
     private renderMomentSelectItem: ItemRenderer<CARTA.Moment> = (moment: CARTA.Moment, {modifiers, handleClick}) => {
         const momentContent = MOMENT_TEXT.get(moment);
         return momentContent ? <MenuItem text={`${momentContent.tag}: ${momentContent.text}`} onClick={handleClick} key={moment} icon={this.props.widgetStore.isMomentSelected(moment) ? "tick" : "blank"} /> : undefined;
+    };
+
+    private renderRestFreqInput = () => {
+        const widgetStore = this.props.widgetStore;
+        const restFreqStore = widgetStore.effectiveFrame.restFreqStore;
+        return (
+            <div className="freq-input">
+                <ClearableNumericInputComponent
+                    label="Rest frequency"
+                    value={restFreqStore.customRestFreq.value}
+                    placeholder="Rest frequency"
+                    selectAllOnFocus={true}
+                    onValueChanged={val => {
+                        restFreqStore.setCustomVal(val);
+                    }}
+                    onValueCleared={restFreqStore.restoreDefaults}
+                    resetDisabled={restFreqStore.resetDisable}
+                    tooltipContent={restFreqStore.defaultInfo}
+                    tooltipPlacement={"bottom"}
+                />
+                <HTMLSelect options={Object.values(FrequencyUnit)} value={restFreqStore.customRestFreq.unit} onChange={ev => restFreqStore.setCustomUnit(ev.currentTarget.value as FrequencyUnit)} />
+            </div>
+        );
     };
 
     private handleMomentTagRemove = (tag: string, index: number) => {
@@ -173,6 +196,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
                         </div>
                     </FormGroup>
                 )}
+                <React.Fragment>{this.renderRestFreqInput()}</React.Fragment>
             </React.Fragment>
         );
 

--- a/src/stores/Frame/RestFreqStore/RestFreqStore.ts
+++ b/src/stores/Frame/RestFreqStore/RestFreqStore.ts
@@ -45,11 +45,7 @@ export class RestFreqStore {
      * @param val - Unit of rest frequency in {@link FrequencyUnit}.
      */
     @action setCustomUnit = (val: FrequencyUnit) => {
-        const oriFreq = Freq.convertUnitToHz(this.customRestFreq);
         this.customRestFreq.unit = val;
-        const newFreq = Freq.convertUnitToHz(this.customRestFreq);
-        const convertFactor = oriFreq / newFreq;
-        this.setCustomVal(this.customRestFreq.value * convertFactor);
     };
 
     /**

--- a/src/stores/Frame/RestFreqStore/RestFreqStore.ts
+++ b/src/stores/Frame/RestFreqStore/RestFreqStore.ts
@@ -32,10 +32,18 @@ export class RestFreqStore {
         this.customRestFreq = defaultRestFreq;
     }
 
+    /**
+     * Customize the rest frequency value. Set unit using {@link setCustomUnit}.
+     * @param val - Value of rest frequency.
+     */
     @action setCustomVal = (val: number) => {
         this.customRestFreq.value = val;
     };
 
+    /**
+     * Set the unit of the rest frequency. Customize the rest frequency value using {@link setCustomVal}.
+     * @param val - Unit of rest frequency in {@link FrequencyUnit}.
+     */
     @action setCustomUnit = (val: FrequencyUnit) => {
         const oriFreq = Freq.convertUnitToHz(this.customRestFreq);
         this.customRestFreq.unit = val;
@@ -44,6 +52,9 @@ export class RestFreqStore {
         this.setCustomVal(this.customRestFreq.value * convertFactor);
     };
 
+    /**
+     * Reset the rest frequency to the value and unit of the header.
+     */
     @action restoreDefaults = () => {
         this.customRestFreq = this.headerRestFreq;
     };

--- a/src/stores/Frame/RestFreqStore/RestFreqStore.ts
+++ b/src/stores/Frame/RestFreqStore/RestFreqStore.ts
@@ -37,7 +37,11 @@ export class RestFreqStore {
     };
 
     @action setCustomUnit = (val: FrequencyUnit) => {
+        const oriFreq = Freq.convertUnitToHz(this.customRestFreq);
         this.customRestFreq.unit = val;
+        const newFreq = Freq.convertUnitToHz(this.customRestFreq);
+        const convertFactor = oriFreq / newFreq;
+        this.setCustomVal(this.customRestFreq.value * convertFactor);
     };
 
     @action restoreDefaults = () => {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -83,11 +83,22 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     readonly profileSelectionStore: SpectralProfileSelectionStore;
     readonly fittingStore: ProfileFittingStore;
 
+    /**
+     * Set region for generating moment maps.
+     *
+     * @param fileId - File ID number.
+     * @param regionId - Region ID number.
+     */
     @override setRegionId = (fileId: number, regionId: number) => {
         this.regionIdMap.set(fileId, regionId);
         this.clearXYBounds();
     };
 
+    /**
+     * Set spectral coordinates for moment maps.
+     *
+     * @param coordStr - A string of <i>Spectral type (unit)</i> like Frequency (GHz).
+     */
     @action setSpectralCoordinate = (coordStr: string) => {
         if (this.effectiveFrame?.setSpectralCoordinate(coordStr)) {
             this.clearXBounds();
@@ -100,6 +111,11 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         }
     };
 
+    /**
+     * Set the spectral system.
+     *
+     * @param specsys - Spectral system {@link SpectralSystem}.
+     */
     @action setSpectralSystem = (specsys: SpectralSystem) => {
         if (this.effectiveFrame?.setSpectralSystem(specsys)) {
             this.clearXBounds();
@@ -110,6 +126,11 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.intensityUnit = intensityUnitStr;
     };
 
+    /**
+     * Select region for generating moment maps.
+     *
+     * @param regionId -  Region ID number.
+     */
     @action selectMomentRegion = (regionId: number) => {
         this.momentRegionId = regionId;
     };
@@ -124,6 +145,12 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.selectingMode = MomentSelectingMode.NONE;
     };
 
+    /**
+     * Set the channel range for generating moment maps.
+     *
+     * @param min - Number of first channel.
+     * @param max - Number of last channel.
+     */
     @action setSelectedChannelRange = (min: number, max: number) => {
         if (isFinite(min) && isFinite(max)) {
             this.channelValueRange[0] = min;
@@ -150,16 +177,31 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         }
     };
 
+    /**
+     * Mask for generating moment maps.
+     *
+     * @param momentMask - enum {@link CARTA.MomentMask}.
+     */
     @action setMomentMask = (momentMask: CARTA.MomentMask) => {
         this.momentMask = momentMask;
     };
 
+    /**
+     * Add moments to generate maps.
+     *
+     * @param selected - Moment in {@link CARTA.Moment}.
+     */
     @action selectMoment = (selected: CARTA.Moment) => {
         if (!this.selectedMoments.includes(selected)) {
             this.selectedMoments.push(selected);
         }
     };
 
+    /**
+     * Delete moments to generate maps.
+     *
+     * @param deselected - Moment in {@link CARTA.Moment}.
+     */
     @action deselectMoment = (deselected: CARTA.Moment) => {
         if (this.selectedMoments.includes(deselected)) {
             this.selectedMoments = this.selectedMoments.filter(momentType => momentType !== deselected);
@@ -180,6 +222,9 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         return this.selectedMoments.includes(momentType);
     };
 
+    /**
+     * Request the moment maps.
+     */
     @action requestMoment = () => {
         const frame = this.effectiveFrame;
         if (frame && this.isMomentRegionValid) {
@@ -215,6 +260,9 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         }
     };
 
+    /**
+     * Cancel the moment maps request.
+     */
     @action requestingMomentCancelled = () => {
         const frame = this.effectiveFrame;
         if (frame) {
@@ -306,6 +354,11 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.secondaryAxisCursorInfoVisible = val;
     };
 
+    /**
+     * Keep previous moment maps.
+     *
+     * @param bool - A boolean. Set true to keep previous moment maps.
+     */
     @action setKeep = (bool: boolean) => {
         this.keep = bool;
     };

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -84,7 +84,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     readonly fittingStore: ProfileFittingStore;
 
     /**
-     * Set region for generating moment maps.
+     * Set region for the spectral profiler.
      *
      * @param fileId - File ID number.
      * @param regionId - Region ID number.
@@ -95,7 +95,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     };
 
     /**
-     * Set spectral coordinates for moment maps.
+     * Set spectral coordinates.
      *
      * @param coordStr - A string of <i>Spectral type (unit)</i> like Frequency (GHz).
      */

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -199,7 +199,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                     spectralRange: channelIndexRange,
                     mask: this.momentMask,
                     pixelRange: new CARTA.FloatBounds({min: this.maskRange[0], max: this.maskRange[1]}),
-                    keep: this.keep
+                    keep: this.keep,
+                    restFreq: frame.restFreqStore?.restFreqInHz
                 };
                 frame.resetMomentRequestState();
                 frame.setIsRequestingMoments(true);


### PR DESCRIPTION
**Description**

This closed #2396 together with backend [PR](https://github.com/CARTAvis/carta-backend/pull/1387) and its companion protobuf. This PR adds the rest frequency GUI to the moment generator. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] protobuf version bumped / ~no protobuf version bumped needed~
- [x] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [x] user manual prepared (for large new features)