### PR TITLE
Kuanchou/2285 devicepixelratio bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog load button status after double clicking catalog files ([#2378](https://github.com/CARTAvis/carta-frontend/issues/2378)).
 * Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
-* Fix incorrect rendering of image view when moving the window from Retina to non-Retina monitor, and vice versa ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
+* Fix incorrect rendering of image view when moving the window to monitors with different screen resolution ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
 
 ## [4.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog load button status after double clicking catalog files ([#2378](https://github.com/CARTAvis/carta-frontend/issues/2378)).
 * Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
+* Fix incorrect rendering of image view when moving the window from Retina to non-Retina monitor, and vice versa ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
 
 ## [4.1.0]
 

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -123,8 +123,8 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
             return;
         }
 
-        const reqWidth = Math.round(Math.max(1, frame.renderWidth * devicePixelRatio * AppStore.Instance.imageRatio));
-        const reqHeight = Math.round(Math.max(1, frame.renderHeight * devicePixelRatio * AppStore.Instance.imageRatio));
+        const reqWidth = Math.round(Math.max(1, frame.renderWidth * AppStore.Instance.pixelRatio));
+        const reqHeight = Math.round(Math.max(1, frame.renderHeight * AppStore.Instance.pixelRatio));
         // Resize canvas if necessary
         if (this.canvas.width !== reqWidth || this.canvas.height !== reqHeight) {
             this.canvas.width = reqWidth;
@@ -175,8 +175,8 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                 const isActive = frame === destinationFrame;
 
                 const shape = catalogWidgetStore.shapeSettings;
-                const featherWidth = shape.featherWidth * devicePixelRatio * AppStore.Instance.imageRatio;
-                const lineThickness = catalogWidgetStore.thickness * shape.thicknessBase * devicePixelRatio * AppStore.Instance.imageRatio;
+                const featherWidth = shape.featherWidth * AppStore.Instance.pixelRatio;
+                const lineThickness = catalogWidgetStore.thickness * shape.thicknessBase * AppStore.Instance.pixelRatio;
                 let color = tinycolor(catalogWidgetStore.catalogColor).toRgb();
                 let selectedSourceColor = tinycolor(catalogWidgetStore.highlightColor).toRgb();
                 let pointSize = catalogWidgetStore.catalogSize + shape.diameterBase;
@@ -309,7 +309,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
                     this.gl.uniform3f(shaderUniforms.PointColor, color.r / 255.0, color.g / 255.0, color.b / 255.0);
                     this.gl.uniform3f(shaderUniforms.SelectedSourceColor, selectedSourceColor.r / 255.0, selectedSourceColor.g / 255.0, selectedSourceColor.b / 255.0);
                     this.gl.uniform1i(shaderUniforms.ShapeType, catalogWidgetStore.catalogShape);
-                    this.gl.uniform1f(shaderUniforms.PointSize, pointSize * devicePixelRatio * AppStore.Instance.imageRatio);
+                    this.gl.uniform1f(shaderUniforms.PointSize, pointSize * AppStore.Instance.pixelRatio);
 
                     this.gl.drawArrays(GL2.TRIANGLES, 0, count * 6);
                     this.gl.finish();

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -54,9 +54,8 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         }
 
         const appStore = AppStore.Instance;
-        const pixelRatio = devicePixelRatio * appStore.imageRatio;
-        const requiredWidth = Math.max(1, frame.renderWidth * pixelRatio);
-        const requiredHeight = Math.max(1, frame.renderHeight * pixelRatio);
+        const requiredWidth = Math.max(1, frame.renderWidth * appStore.pixelRatio);
+        const requiredHeight = Math.max(1, frame.renderHeight * appStore.pixelRatio);
 
         // Resize and clear the canvas if needed
         if (frame?.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
@@ -72,14 +71,14 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.canvas.height = requiredHeight;
         }
         // Otherwise just clear it
-        const xOffset = this.props.column * frame.renderWidth * pixelRatio;
+        const xOffset = this.props.column * frame.renderWidth * appStore.pixelRatio;
         // y-axis is inverted
-        const yOffset = (appStore.imageViewConfigStore.numImageRows - 1 - this.props.row) * frame.renderHeight * pixelRatio;
-        this.gl.viewport(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+        const yOffset = (appStore.imageViewConfigStore.numImageRows - 1 - this.props.row) * frame.renderHeight * appStore.pixelRatio;
+        this.gl.viewport(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
         this.gl.clearColor(0, 0, 0, 0);
         // Clear a scissored rectangle limited to the current frame
         this.gl.enable(GL2.SCISSOR_TEST);
-        this.gl.scissor(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+        this.gl.scissor(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
         const clearMask = GL2.COLOR_BUFFER_BIT | GL2.DEPTH_BUFFER_BIT | GL2.STENCIL_BUFFER_BIT;
         this.gl.clear(clearMask);
         this.gl.disable(GL2.SCISSOR_TEST);
@@ -109,7 +108,6 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
     };
 
     private renderFrameContours = (frame: FrameStore, baseFrame: FrameStore) => {
-        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
         const isActive = frame === baseFrame;
         let lineThickness: number;
         let dashFactor: number;
@@ -135,7 +133,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform1f(this.contourWebGLService.shaderUniforms.RotationAngle, -baseFrame.spatialTransform.rotation);
             this.gl.uniform1f(this.contourWebGLService.shaderUniforms.ScaleAdjustment, baseFrame.spatialTransform.scale);
 
-            lineThickness = (pixelRatio * frame.contourConfig.thickness) / (baseFrame.spatialReference.zoomLevel * baseFrame.spatialTransform.scale);
+            lineThickness = (AppStore.Instance.pixelRatio * frame.contourConfig.thickness) / (baseFrame.spatialReference.zoomLevel * baseFrame.spatialTransform.scale);
             dashFactor = ceilToPower(1.0 / baseFrame.spatialReference.zoomLevel, 3.0);
         } else {
             const baseRequiredView = baseFrame.requiredFrameView;
@@ -154,7 +152,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
             this.gl.uniform1f(this.contourWebGLService.shaderUniforms.RotationAngle, 0.0);
             this.gl.uniform1f(this.contourWebGLService.shaderUniforms.ScaleAdjustment, 1.0);
 
-            lineThickness = (pixelRatio * frame.contourConfig.thickness) / baseFrame.zoomLevel;
+            lineThickness = (AppStore.Instance.pixelRatio * frame.contourConfig.thickness) / baseFrame.zoomLevel;
             dashFactor = ceilToPower(1.0 / baseFrame.zoomLevel, 3.0);
         }
 
@@ -212,7 +210,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
                 // Dash length in canvas pixels
                 const dashMode = frame.contourConfig.dashMode;
                 const dashLength = dashMode === ContourDashMode.Dashed || (dashMode === ContourDashMode.NegativeOnly && level < 0) ? 8 : 0;
-                this.gl.uniform1f(this.contourWebGLService.shaderUniforms.DashLength, pixelRatio * dashLength * dashFactor);
+                this.gl.uniform1f(this.contourWebGLService.shaderUniforms.DashLength, AppStore.Instance.pixelRatio * dashLength * dashFactor);
 
                 // Update buffers
                 for (let i = 0; i < contourStore.chunkCount; i++) {

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -64,7 +64,7 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
             const updateDpr = () => this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
             let media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
             media.addEventListener("change", updateDpr);
-            this.frame.setPixelRatio(this.state.pixelRatio);
+            AppStore.Instance.setPixelRatio(this.state.pixelRatio);
         }
     }
 

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,7 +29,7 @@ interface ImagePanelComponentProps {
 
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
-    state = {pixelRatio: 1.0};
+    state = {pixelRatio: 0.0};
 
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -61,18 +61,19 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
         // to trigger re-render when changing devicePixelRatio (switching monitor)
         if (prevState.pixelRatio !== devicePixelRatio * AppStore.Instance.imageRatio) {
-            // beware of the order between zoomLevel and pixelRatio.
-            // change the zoomLevel first for re-rendering regions properly.
-            const zoom = (this.frame.zoomLevel * devicePixelRatio) / prevState.pixelRatio;
-            if (zoom) {
-                this.frame.setZoom(zoom, true);
-                this.onRegionViewZoom(zoom);
-            }
-
             const updateDpr = () => this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
             let media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
             media.addEventListener("change", updateDpr);
             AppStore.Instance.setPixelRatio(this.state.pixelRatio);
+
+            // make the rendered image size invariant
+            if (!this.frame.spatialReference) {
+                const zoom = (this.frame.zoomLevel * devicePixelRatio) / prevState.pixelRatio;
+                if (zoom) {
+                    this.frame.setZoom(zoom, true);
+                    this.onRegionViewZoom(zoom);
+                }
+            }
         }
     }
 

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,6 +29,8 @@ interface ImagePanelComponentProps {
 
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
+    state = {pixelRatio: 1.0};
+
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;
 
@@ -51,10 +53,19 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
     componentDidMount() {
         this.fitZoomOfLoadingMultipleFiles();
+        this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps, prevState) {
         this.fitZoomOfLoadingMultipleFiles();
+
+        // to trigger re-render when changing devicePixelRatio (switching monitor)
+        if (prevState.pixelRatio !== devicePixelRatio * AppStore.Instance.imageRatio) {
+            const updateDpr = () => this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
+            let media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+            media.addEventListener("change", updateDpr);
+            this.frame.setPixelRatio(this.state.pixelRatio);
+        }
     }
 
     private fitZoomOfLoadingMultipleFiles = () => {

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,7 +29,7 @@ interface ImagePanelComponentProps {
 
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
-    state = {pixelRatio: undefined};
+    // state = {pixelRatio: undefined};
 
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;
@@ -53,28 +53,10 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
     componentDidMount() {
         this.fitZoomOfLoadingMultipleFiles();
-        this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate() {
         this.fitZoomOfLoadingMultipleFiles();
-
-        // to trigger re-render when changing devicePixelRatio (switching monitor)
-        if (prevState.pixelRatio !== devicePixelRatio * AppStore.Instance.imageRatio) {
-            const updateDpr = () => this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
-            let media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
-            media.addEventListener("change", updateDpr);
-            AppStore.Instance.setPixelRatio(this.state.pixelRatio);
-
-            // make the rendered image size invariant
-            if (!this.frame.spatialReference) {
-                const zoom = (this.frame.zoomLevel * devicePixelRatio) / prevState.pixelRatio;
-                if (zoom) {
-                    this.frame.setZoom(zoom, true);
-                    this.onRegionViewZoom(zoom);
-                }
-            }
-        }
     }
 
     private fitZoomOfLoadingMultipleFiles = () => {

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,7 +29,7 @@ interface ImagePanelComponentProps {
 
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
-    state = {pixelRatio: 0.0};
+    state = {pixelRatio: undefined};
 
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;
@@ -61,6 +61,14 @@ export class ImagePanelComponent extends React.Component<ImagePanelComponentProp
 
         // to trigger re-render when changing devicePixelRatio (switching monitor)
         if (prevState.pixelRatio !== devicePixelRatio * AppStore.Instance.imageRatio) {
+            // beware of the order between zoomLevel and pixelRatio.
+            // change the zoomLevel first for re-rendering regions properly.
+            const zoom = (this.frame.zoomLevel * devicePixelRatio) / prevState.pixelRatio;
+            if (zoom) {
+                this.frame.setZoom(zoom, true);
+                this.onRegionViewZoom(zoom);
+            }
+
             const updateDpr = () => this.setState({pixelRatio: devicePixelRatio * AppStore.Instance.imageRatio});
             let media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
             media.addEventListener("change", updateDpr);

--- a/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
+++ b/src/components/ImageView/ImagePanel/ImagePanelComponent.tsx
@@ -29,8 +29,6 @@ interface ImagePanelComponentProps {
 
 @observer
 export class ImagePanelComponent extends React.Component<ImagePanelComponentProps> {
-    // state = {pixelRatio: undefined};
-
     @observable pixelHighlightValue: number = NaN;
     @observable imageToolbarVisible: boolean = false;
 

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -25,9 +25,8 @@ export function getImageViewCanvas(padding: Padding, colorbarPosition: string, b
     const overlay = appStore.overlayStore;
 
     const imageViewCanvas = document.createElement("canvas") as HTMLCanvasElement;
-    const pixelRatio = devicePixelRatio * appStore.imageRatio;
-    imageViewCanvas.width = overlay.fullViewWidth * pixelRatio;
-    imageViewCanvas.height = overlay.fullViewHeight * pixelRatio;
+    imageViewCanvas.width = overlay.fullViewWidth * appStore.pixelRatio;
+    imageViewCanvas.height = overlay.fullViewHeight * appStore.pixelRatio;
     const ctx = imageViewCanvas.getContext("2d");
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, imageViewCanvas.width, imageViewCanvas.height);
@@ -36,7 +35,7 @@ export function getImageViewCanvas(padding: Padding, colorbarPosition: string, b
         const row = Math.floor(index / config.numImageColumns);
         const panelCanvas = getPanelCanvas(column, row, padding, colorbarPosition, backgroundColor);
         if (panelCanvas) {
-            ctx.drawImage(panelCanvas, overlay.viewWidth * column * pixelRatio, overlay.viewHeight * row * pixelRatio);
+            ctx.drawImage(panelCanvas, overlay.viewWidth * column * appStore.pixelRatio, overlay.viewHeight * row * appStore.pixelRatio);
         }
     });
 
@@ -62,7 +61,7 @@ export function getPanelCanvas(column: number, row: number, padding: Padding, co
     const beamProfileCanvas = panelElement.find(".beam-profile-stage")?.children()?.children("canvas")?.[0] as HTMLCanvasElement;
     const regionCanvas = panelElement.find(".region-stage")?.children()?.children("canvas")?.[0] as HTMLCanvasElement;
 
-    const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
+    const appStore = AppStore.Instance;
     const composedCanvas = document.createElement("canvas") as HTMLCanvasElement;
     composedCanvas.width = overlayCanvas.width;
     composedCanvas.height = overlayCanvas.height;
@@ -70,23 +69,23 @@ export function getPanelCanvas(column: number, row: number, padding: Padding, co
     const ctx = composedCanvas.getContext("2d");
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
-    ctx.drawImage(rasterCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
-    ctx.drawImage(contourCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
-    ctx.drawImage(vectorOverlayCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
+    ctx.drawImage(rasterCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
+    ctx.drawImage(contourCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
+    ctx.drawImage(vectorOverlayCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
     if (colorbarCanvas) {
         let xPos, yPos;
         switch (colorbarPosition) {
             case "top":
                 xPos = 0;
-                yPos = padding.top * pixelRatio - colorbarCanvas.height;
+                yPos = padding.top * appStore.pixelRatio - colorbarCanvas.height;
                 break;
             case "bottom":
                 xPos = 0;
-                yPos = overlayCanvas.height - colorbarCanvas.height - AppStore.Instance.overlayStore.colorbarHoverInfoHeight * pixelRatio;
+                yPos = overlayCanvas.height - colorbarCanvas.height - AppStore.Instance.overlayStore.colorbarHoverInfoHeight * appStore.pixelRatio;
                 break;
             case "right":
             default:
-                xPos = padding.left * pixelRatio + rasterCanvas.width;
+                xPos = padding.left * appStore.pixelRatio + rasterCanvas.width;
                 yPos = 0;
                 break;
         }
@@ -94,18 +93,18 @@ export function getPanelCanvas(column: number, row: number, padding: Padding, co
     }
 
     if (beamProfileCanvas) {
-        ctx.drawImage(beamProfileCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
+        ctx.drawImage(beamProfileCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
     }
 
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.drawImage(overlayCanvas, 0, 0);
 
     if (catalogCanvas) {
-        ctx.drawImage(catalogCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
+        ctx.drawImage(catalogCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
     }
 
     if (regionCanvas) {
-        ctx.drawImage(regionCanvas, padding.left * pixelRatio, padding.top * pixelRatio);
+        ctx.drawImage(regionCanvas, padding.left * appStore.pixelRatio, padding.top * appStore.pixelRatio);
     }
 
     return composedCanvas;

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -43,15 +43,15 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
     updateImageDimensions() {
         if (this.canvas) {
             const frame = this.props.image?.type === ImageType.COLOR_BLENDING ? this.props.image.store?.baseFrame : this.props.image?.store;
-            this.canvas.width = (frame?.isPreview ? frame?.previewViewWidth : this.props.overlaySettings.viewWidth) * devicePixelRatio * AppStore.Instance.imageRatio;
-            this.canvas.height = (frame?.isPreview ? frame?.previewViewHeight : this.props.overlaySettings.viewHeight) * devicePixelRatio * AppStore.Instance.imageRatio;
+            this.canvas.width = (frame?.isPreview ? frame?.previewViewWidth : this.props.overlaySettings.viewWidth) * AppStore.Instance.pixelRatio;
+            this.canvas.height = (frame?.isPreview ? frame?.previewViewHeight : this.props.overlaySettings.viewHeight) * AppStore.Instance.pixelRatio;
         }
     }
 
     renderCanvas = () => {
         const settings = this.props.overlaySettings;
         const frame = this.props.image?.type === ImageType.COLOR_BLENDING ? this.props.image.store?.baseFrame : this.props.image?.store;
-        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
+        const appStore = AppStore.Instance;
 
         const wcsInfoSelected = frame.isOffsetCoord ? frame.wcsInfoShifted : frame.wcsInfo;
         const wcsInfo = frame.spatialReference ? frame.transformedWcsInfo : wcsInfoSelected;
@@ -102,12 +102,12 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                     frameView.xMax,
                     frameView.yMin / frame.aspectRatio,
                     frameView.yMax / frame.aspectRatio,
-                    (frame.isPreview ? frame?.previewViewWidth : this.props.overlaySettings.viewWidth) * pixelRatio,
-                    (frame.isPreview ? frame?.previewViewHeight : this.props.overlaySettings.viewHeight) * pixelRatio,
-                    settings.padding.left * pixelRatio,
-                    settings.padding.right * pixelRatio,
-                    settings.padding.top * pixelRatio,
-                    settings.padding.bottom * pixelRatio,
+                    (frame.isPreview ? frame?.previewViewWidth : this.props.overlaySettings.viewWidth) * appStore.pixelRatio,
+                    (frame.isPreview ? frame?.previewViewHeight : this.props.overlaySettings.viewHeight) * appStore.pixelRatio,
+                    settings.padding.left * appStore.pixelRatio,
+                    settings.padding.right * appStore.pixelRatio,
+                    settings.padding.top * appStore.pixelRatio,
+                    settings.padding.bottom * appStore.pixelRatio,
                     styleString
                 );
             };

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -92,7 +92,6 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const shaderUniforms = frame.isPreview ? PreviewWebGLService.Instance.shaderUniforms : TileWebGLService.Instance.shaderUniforms;
         const tileRenderService = frame.isPreview ? PreviewWebGLService.Instance : TileWebGLService.Instance;
         const renderConfig = frame.renderConfig;
-        const pixelRatio = devicePixelRatio * appStore.imageRatio;
 
         if (renderConfig && shaderUniforms) {
             if (renderConfig.colorMapIndex === -1) {
@@ -110,8 +109,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             this.gl.uniform1i(shaderUniforms.UseSmoothedBiasContrast, appStore.preferenceStore.useSmoothedBiasContrast ? 1 : 0);
             this.gl.uniform1f(shaderUniforms.Gamma, renderConfig.gamma);
             this.gl.uniform1f(shaderUniforms.Alpha, renderConfig.alpha);
-            this.gl.uniform1f(shaderUniforms.CanvasWidth, frame.renderWidth * pixelRatio);
-            this.gl.uniform1f(shaderUniforms.CanvasHeight, frame.renderHeight * pixelRatio);
+            this.gl.uniform1f(shaderUniforms.CanvasWidth, frame.renderWidth * appStore.pixelRatio);
+            this.gl.uniform1f(shaderUniforms.CanvasHeight, frame.renderHeight * appStore.pixelRatio);
 
             const nanColor = tinycolor(appStore.preferenceStore.nanColorHex).setAlpha(appStore.preferenceStore.nanAlpha);
             if (nanColor.isValid()) {
@@ -141,9 +140,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         }
 
         const appStore = AppStore.Instance;
-        const pixelRatio = devicePixelRatio * appStore.imageRatio;
-        const requiredWidth = Math.max(1, frame.renderWidth * pixelRatio);
-        const requiredHeight = Math.max(1, frame.renderHeight * pixelRatio);
+        const requiredWidth = Math.max(1, frame.renderWidth * appStore.pixelRatio);
+        const requiredHeight = Math.max(1, frame.renderHeight * appStore.pixelRatio);
 
         const tileRenderService = frame.isPreview ? PreviewWebGLService.Instance : TileWebGLService.Instance;
         // Resize and clear the canvas if needed
@@ -163,16 +161,15 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         // Only clear and render if we're in animation or tiled mode
         if (frame?.isRenderable) {
             const appStore = AppStore.Instance;
-            const pixelRatio = devicePixelRatio * appStore.imageRatio;
-            const xOffset = this.props.column * frame.renderWidth * pixelRatio;
+            const xOffset = this.props.column * frame.renderWidth * appStore.pixelRatio;
             // y-axis is inverted
-            const yOffset = this.gl.canvas.height - frame.renderHeight * (this.props.row + 1) * pixelRatio;
-            this.gl.viewport(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+            const yOffset = this.gl.canvas.height - frame.renderHeight * (this.props.row + 1) * appStore.pixelRatio;
+            this.gl.viewport(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
             this.gl.enable(GL2.DEPTH_TEST);
 
             // Clear a scissored rectangle limited to the current frame
             this.gl.enable(GL2.SCISSOR_TEST);
-            this.gl.scissor(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+            this.gl.scissor(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
             this.gl.clear(GL2.COLOR_BUFFER_BIT | GL2.DEPTH_BUFFER_BIT);
             this.gl.disable(GL2.SCISSOR_TEST);
 
@@ -355,13 +352,12 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         let zoom;
         let zoomFactor = 1.0;
         let aspectRatio = 1.0;
-        const pixelRatio = devicePixelRatio * appStore.imageRatio;
         if (frame.spatialReference) {
             zoomFactor = frame.spatialTransform.scale;
-            zoom = (frame.spatialReference.zoomLevel / pixelRatio) * zoomFactor;
+            zoom = (frame.spatialReference.zoomLevel / appStore.pixelRatio) * zoomFactor;
         } else {
             aspectRatio = frame.aspectRatio;
-            zoom = frame.zoomLevel / pixelRatio;
+            zoom = frame.zoomLevel / appStore.pixelRatio;
         }
 
         const pixelGridZoomLow = 6.0;

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -154,6 +154,7 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
     const system = AppStore.Instance.overlayStore.global.explicitSystem;
     const darktheme = AppStore.Instance.darkTheme;
     const title = frame.titleCustomText;
+    const pixelRatio = frame.pixelRatio;
     /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
     const updateOffset = () => {
@@ -423,6 +424,7 @@ export const RulerAnnotation = observer((props: CompassRulerAnnotationProps) => 
     const system = AppStore.Instance.overlayStore.global.explicitSystem;
     const darktheme = AppStore.Instance.darkTheme;
     const title = frame.titleCustomText;
+    const pixelRatio = frame.pixelRatio;
     /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
     const [textOffsetX, setTextOffsetX] = React.useState(0);

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -154,7 +154,7 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
     const system = AppStore.Instance.overlayStore.global.explicitSystem;
     const darktheme = AppStore.Instance.darkTheme;
     const title = frame.titleCustomText;
-    const pixelRatio = frame.pixelRatio;
+    const pixelRatio = AppStore.Instance.pixelRatio;
     /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
     const updateOffset = () => {
@@ -424,7 +424,7 @@ export const RulerAnnotation = observer((props: CompassRulerAnnotationProps) => 
     const system = AppStore.Instance.overlayStore.global.explicitSystem;
     const darktheme = AppStore.Instance.darkTheme;
     const title = frame.titleCustomText;
-    const pixelRatio = frame.pixelRatio;
+    const pixelRatio = AppStore.Instance.pixelRatio;
     /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
     const [textOffsetX, setTextOffsetX] = React.useState(0);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -277,13 +277,11 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         let anchors = null;
         let newAnchor = null;
         let pointArray: Array<number>;
-        // trigger re-render when exporting images
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // trigger re-render when exporting images and changing devicePixelRatio (switching monitor)
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const imageRatio = AppStore.Instance.imageRatio;
-
-        // trigger re-render when changing devicePixelRatio (switching monitor)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const pixelRatio = AppStore.Instance.pixelRatio;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -281,6 +281,10 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const imageRatio = AppStore.Instance.imageRatio;
 
+        // trigger re-render when changing devicePixelRatio (switching monitor)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const pixelRatio = frame.pixelRatio;
+
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);
             const centerSecondaryImage = transformPoint(frame.spatialTransformAST, centerReferenceImage, false);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -283,7 +283,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
 
         // trigger re-render when changing devicePixelRatio (switching monitor)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const pixelRatio = frame.pixelRatio;
+        const pixelRatio = AppStore.Instance.pixelRatio;
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -277,11 +277,10 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         let anchors = null;
         let newAnchor = null;
         let pointArray: Array<number>;
-        // trigger re-render when exporting images and changing devicePixelRatio (switching monitor)
-        /* eslint-disable @typescript-eslint/no-unused-vars */
         const imageRatio = AppStore.Instance.imageRatio;
+        // trigger re-render when exporting images and changing devicePixelRatio (switching monitor)
+        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         const pixelRatio = AppStore.Instance.pixelRatio;
-        /* eslint-enable @typescript-eslint/no-unused-vars */
 
         if (frame.spatialReference) {
             const centerReferenceImage = average2D(controlPoints);

--- a/src/components/ImageView/RegionView/PointRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/PointRegionComponent.tsx
@@ -70,8 +70,10 @@ export class PointRegionComponent extends React.Component<PointRegionComponentPr
         const imageRatio = AppStore.Instance.imageRatio;
 
         // trigger re-render when changing devicePixelRatio (switching monitor)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const pixelRatio = AppStore.Instance.pixelRatio;
+        const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
 
         if (frame.spatialReference) {
             const pointReferenceImage = region.center;

--- a/src/components/ImageView/RegionView/PointRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/PointRegionComponent.tsx
@@ -65,12 +65,9 @@ export class PointRegionComponent extends React.Component<PointRegionComponentPr
         let centerPixelSpace: Point2D;
         let rotation: number;
 
-        // trigger re-render when exporting images
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const imageRatio = AppStore.Instance.imageRatio;
-
-        // trigger re-render when changing devicePixelRatio (switching monitor)
+        // trigger re-render when exporting images and  changing devicePixelRatio (switching monitor)
         /* eslint-disable @typescript-eslint/no-unused-vars */
+        const imageRatio = AppStore.Instance.imageRatio;
         const pixelRatio = AppStore.Instance.pixelRatio;
         const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
         /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/components/ImageView/RegionView/PointRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/PointRegionComponent.tsx
@@ -71,7 +71,7 @@ export class PointRegionComponent extends React.Component<PointRegionComponentPr
 
         // trigger re-render when changing devicePixelRatio (switching monitor)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const pixelRatio = frame.pixelRatio;
+        const pixelRatio = AppStore.Instance.pixelRatio;
 
         if (frame.spatialReference) {
             const pointReferenceImage = region.center;

--- a/src/components/ImageView/RegionView/PointRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/PointRegionComponent.tsx
@@ -67,7 +67,6 @@ export class PointRegionComponent extends React.Component<PointRegionComponentPr
 
         // trigger re-render when exporting images and  changing devicePixelRatio (switching monitor)
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const imageRatio = AppStore.Instance.imageRatio;
         const pixelRatio = AppStore.Instance.pixelRatio;
         const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
         /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/components/ImageView/RegionView/PointRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/PointRegionComponent.tsx
@@ -69,6 +69,10 @@ export class PointRegionComponent extends React.Component<PointRegionComponentPr
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const imageRatio = AppStore.Instance.imageRatio;
 
+        // trigger re-render when changing devicePixelRatio (switching monitor)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const pixelRatio = frame.pixelRatio;
+
         if (frame.spatialReference) {
             const pointReferenceImage = region.center;
             const pointSecondaryImage = transformPoint(frame.spatialTransformAST, pointReferenceImage, false);

--- a/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
@@ -565,7 +565,6 @@ export class SimpleShapeRegionComponent extends React.Component<SimpleShapeRegio
 
         // trigger re-render when exporting images and changing devicePixelRatio (switching monitor)
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const imageRatio = AppStore.Instance.imageRatio;
         const pixelRatio = AppStore.Instance.pixelRatio;
         const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
         /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
@@ -568,8 +568,10 @@ export class SimpleShapeRegionComponent extends React.Component<SimpleShapeRegio
         const imageRatio = AppStore.Instance.imageRatio;
 
         // trigger re-render when changing devicePixelRatio (switching monitor)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const pixelRatio = AppStore.Instance.pixelRatio;
+        const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
+        /* eslint-enable @typescript-eslint/no-unused-vars */
 
         if (frame.spatialReference) {
             const centerSecondaryImage = transformPoint(frame.spatialTransformAST, centerReferenceImage, false);

--- a/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
@@ -569,7 +569,7 @@ export class SimpleShapeRegionComponent extends React.Component<SimpleShapeRegio
 
         // trigger re-render when changing devicePixelRatio (switching monitor)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const pixelRatio = frame.pixelRatio;
+        const pixelRatio = AppStore.Instance.pixelRatio;
 
         if (frame.spatialReference) {
             const centerSecondaryImage = transformPoint(frame.spatialTransformAST, centerReferenceImage, false);

--- a/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
@@ -563,12 +563,9 @@ export class SimpleShapeRegionComponent extends React.Component<SimpleShapeRegio
         let shapeNode: React.ReactNode;
         const centerReferenceImage = region.center;
 
-        // trigger re-render when exporting images
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const imageRatio = AppStore.Instance.imageRatio;
-
-        // trigger re-render when changing devicePixelRatio (switching monitor)
+        // trigger re-render when exporting images and changing devicePixelRatio (switching monitor)
         /* eslint-disable @typescript-eslint/no-unused-vars */
+        const imageRatio = AppStore.Instance.imageRatio;
         const pixelRatio = AppStore.Instance.pixelRatio;
         const zoomLevel = frame.spatialReference?.zoomLevel || frame.zoomLevel;
         /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/SimpleShapeRegionComponent.tsx
@@ -567,6 +567,10 @@ export class SimpleShapeRegionComponent extends React.Component<SimpleShapeRegio
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const imageRatio = AppStore.Instance.imageRatio;
 
+        // trigger re-render when changing devicePixelRatio (switching monitor)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const pixelRatio = frame.pixelRatio;
+
         if (frame.spatialReference) {
             const centerSecondaryImage = transformPoint(frame.spatialTransformAST, centerReferenceImage, false);
             const centerPixelSpace = transformedImageToCanvasPos(centerSecondaryImage, frame, this.props.layerWidth, this.props.layerHeight, this.props.stageRef.current);

--- a/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
+++ b/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
@@ -49,9 +49,8 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         }
 
         const appStore = AppStore.Instance;
-        const pixelRatio = devicePixelRatio * appStore.imageRatio;
-        const requiredWidth = Math.max(1, frame.renderWidth * pixelRatio);
-        const requiredHeight = Math.max(1, frame.renderHeight * pixelRatio);
+        const requiredWidth = Math.max(1, frame.renderWidth * appStore.pixelRatio);
+        const requiredHeight = Math.max(1, frame.renderHeight * appStore.pixelRatio);
 
         // Resize and clear the canvas if needed
         if (frame?.isRenderable && (this.canvas.width !== requiredWidth || this.canvas.height !== requiredHeight)) {
@@ -67,14 +66,14 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
             this.canvas.height = requiredHeight;
         }
         // Otherwise just clear it
-        const xOffset = this.props.column * frame.renderWidth * pixelRatio;
+        const xOffset = this.props.column * frame.renderWidth * appStore.pixelRatio;
         // y-axis is inverted
-        const yOffset = (appStore.imageViewConfigStore.numImageRows - 1 - this.props.row) * frame.renderHeight * pixelRatio;
-        this.gl.viewport(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+        const yOffset = (appStore.imageViewConfigStore.numImageRows - 1 - this.props.row) * frame.renderHeight * appStore.pixelRatio;
+        this.gl.viewport(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
         this.gl.clearColor(0, 0, 0, 0);
         // Clear a scissored rectangle limited to the current frame
         this.gl.enable(GL2.SCISSOR_TEST);
-        this.gl.scissor(xOffset, yOffset, frame.renderWidth * pixelRatio, frame.renderHeight * pixelRatio);
+        this.gl.scissor(xOffset, yOffset, frame.renderWidth * appStore.pixelRatio, frame.renderHeight * appStore.pixelRatio);
         const clearMask = GL2.COLOR_BUFFER_BIT | GL2.DEPTH_BUFFER_BIT | GL2.STENCIL_BUFFER_BIT;
         this.gl.clear(clearMask);
         this.gl.disable(GL2.SCISSOR_TEST);
@@ -105,7 +104,7 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
 
     private renderFrameVectorOverlay = (frame: FrameStore, baseFrame: FrameStore) => {
         const shaderUniforms = this.vectorOverlayWebGLService.shaderUniforms;
-        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
+        const appStore = AppStore.Instance;
         const isActive = frame === baseFrame;
 
         if (baseFrame.spatialReference) {
@@ -167,9 +166,9 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         }
 
         this.gl.uniform1i(shaderUniforms.DataTexture, 0);
-        this.gl.uniform1f(shaderUniforms.CanvasSpaceLineWidth, pixelRatio * frame.vectorOverlayConfig.thickness);
+        this.gl.uniform1f(shaderUniforms.CanvasSpaceLineWidth, appStore.pixelRatio * frame.vectorOverlayConfig.thickness);
         const baseScale = baseFrame.spatialTransform?.scale ?? 1.0;
-        this.gl.uniform1f(shaderUniforms.FeatherWidth, pixelRatio / baseScale);
+        this.gl.uniform1f(shaderUniforms.FeatherWidth, appStore.pixelRatio / baseScale);
         if (isFinite(frame.vectorOverlayConfig.rotationOffset)) {
             this.gl.uniform1f(shaderUniforms.RotationOffset, (frame.vectorOverlayConfig.rotationOffset * Math.PI) / 180.0);
         } else {
@@ -182,20 +181,20 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         if (frame.vectorOverlayConfig.angularSource === VectorOverlaySource.None) {
             this.gl.uniform1f(shaderUniforms.IntensityMin, intensityMin);
             this.gl.uniform1f(shaderUniforms.IntensityMax, intensityMax);
-            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMin * pixelRatio);
-            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMin * appStore.pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * appStore.pixelRatio);
             this.gl.uniform1i(shaderUniforms.IntensityPlot, 1);
         } else if (frame.vectorOverlayConfig.intensitySource === VectorOverlaySource.None) {
             this.gl.uniform1f(shaderUniforms.IntensityMin, 0);
             this.gl.uniform1f(shaderUniforms.IntensityMax, 1);
-            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMax * pixelRatio);
-            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMax * appStore.pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * appStore.pixelRatio);
             this.gl.uniform1i(shaderUniforms.IntensityPlot, 0);
         } else {
             this.gl.uniform1f(shaderUniforms.IntensityMin, intensityMin);
             this.gl.uniform1f(shaderUniforms.IntensityMax, intensityMax);
-            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMin * pixelRatio);
-            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMin, frame.vectorOverlayConfig.lengthMin * appStore.pixelRatio);
+            this.gl.uniform1f(shaderUniforms.LengthMax, frame.vectorOverlayConfig.lengthMax * appStore.pixelRatio);
             this.gl.uniform1i(shaderUniforms.IntensityPlot, 0);
         }
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -156,7 +156,7 @@ export class AppStore {
     @observable imageRatio = 1;
     @observable isExportingImage = false;
     @observable private isCanvasUpdated: boolean;
-    @observable pixelRatio: number;
+    @observable private devicePixelRatio: number;
 
     // dynamic zIndex
     public zIndexManager = new FloatingObjzIndexManager();
@@ -512,6 +512,10 @@ export class AppStore {
             frameMap.set(frame, group);
         }
         return frameMap;
+    }
+
+    @computed get pixelRatio(): number {
+        return this.devicePixelRatio * this.imageRatio;
     }
 
     /**
@@ -1869,7 +1873,7 @@ export class AppStore {
         this.initRequirements();
         this.momentToMatch = true;
 
-        this.pixelRatio = devicePixelRatio;
+        this.devicePixelRatio = devicePixelRatio;
 
         AST.onReady.then(
             action(() => {
@@ -2125,7 +2129,7 @@ export class AppStore {
                 media.removeEventListener("change", updatePixelRatio);
             };
 
-            this.handleDevicePixelRatioChange(this.pixelRatio);
+            this.handleDevicePixelRatioChange(this.devicePixelRatio);
         };
         updatePixelRatio();
     }
@@ -2142,7 +2146,7 @@ export class AppStore {
             previewFrameStore.setZoom((previewFrameStore.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
         });
 
-        this.pixelRatio = devicePixelRatio;
+        this.devicePixelRatio = devicePixelRatio;
     }
 
     // region Subscription handlers
@@ -3262,10 +3266,9 @@ export class AppStore {
     };
 
     updateLayerPixelRatio = layerRef => {
-        const pixelRatio = devicePixelRatio * this.imageRatio;
         const canvas = layerRef?.current?.getCanvas();
-        if (canvas && canvas.pixelRatio !== pixelRatio) {
-            canvas.setPixelRatio(pixelRatio);
+        if (canvas && canvas.pixelRatio !== this.pixelRatio) {
+            canvas.setPixelRatio(this.pixelRatio);
         }
     };
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -156,6 +156,7 @@ export class AppStore {
     @observable imageRatio = 1;
     @observable isExportingImage = false;
     @observable private isCanvasUpdated: boolean;
+    @observable pixelRatio: {current: number; previous: number};
 
     // dynamic zIndex
     public zIndexManager = new FloatingObjzIndexManager();
@@ -3462,11 +3463,4 @@ export class AppStore {
             regionProfileStoreMap.get(regionId)?.resetProfilesProgress();
         });
     };
-
-    // @observable pixelRatio: number;
-    @observable pixelRatio: {current: number; previous: number};
-
-    // @action setPixelRatio = (pixelRatio: number) => {
-    //     this.pixelRatio = pixelRatio;
-    // };
 }

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -3440,5 +3440,4 @@ export class AppStore {
     @action setPixelRatio = (pixelRatio: number) => {
         this.pixelRatio = pixelRatio;
     };
-
 }

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2125,16 +2125,15 @@ export class AppStore {
                 media.removeEventListener("change", updatePixelRatio);
             };
 
-            this.handleInvariantImageSize(this.pixelRatio);
-            this.pixelRatio = devicePixelRatio;
+            this.handleDevicePixelRatioChange(this.pixelRatio);
         };
         updatePixelRatio();
     }
 
-    // to make the image size invariant on screen
-    private handleInvariantImageSize(prevPixelRatio: number) {
+    // update devicePixelRatio and make the image size invariant on screen
+    @action private handleDevicePixelRatioChange(prevPixelRatio: number) {
         this.frames.forEach(frame => {
-            if (frame === this.spatialReference || !this.spatialReference) {
+            if (frame === this.spatialReference || !frame.spatialReference) {
                 frame.setZoom((frame.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
             }
         });
@@ -2142,6 +2141,8 @@ export class AppStore {
         this.previewFrames.forEach((previewFrameStore, previewFrameId) => {
             previewFrameStore.setZoom((previewFrameStore.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
         });
+
+        this.pixelRatio = devicePixelRatio;
     }
 
     // region Subscription handlers

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -514,6 +514,9 @@ export class AppStore {
         return frameMap;
     }
 
+    /**
+     * This is devicePixelRatio * imageRatio, which is used to make image rendering consistent across different devices.
+     */
     @computed get pixelRatio(): number {
         return this.devicePixelRatio * this.imageRatio;
     }
@@ -2135,15 +2138,15 @@ export class AppStore {
     }
 
     // update devicePixelRatio and make the image size invariant on screen
-    @action private handleDevicePixelRatioChange(prevPixelRatio: number) {
+    @action private handleDevicePixelRatioChange(prevDevicePixelRatio: number) {
         this.frames.forEach(frame => {
             if (frame === this.spatialReference || !frame.spatialReference) {
-                frame.setZoom((frame.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
+                frame.setZoom((frame.zoomLevel * devicePixelRatio) / prevDevicePixelRatio, true);
             }
         });
 
         this.previewFrames.forEach((previewFrameStore, previewFrameId) => {
-            previewFrameStore.setZoom((previewFrameStore.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
+            previewFrameStore.setZoom((previewFrameStore.zoomLevel * devicePixelRatio) / prevDevicePixelRatio, true);
         });
 
         this.devicePixelRatio = devicePixelRatio;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2138,6 +2138,10 @@ export class AppStore {
                 frame.setZoom((frame.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
             }
         });
+
+        this.previewFrames.forEach((previewFrameStore, previewFrameId) => {
+            previewFrameStore.setZoom((previewFrameStore.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
+        });
     }
 
     // region Subscription handlers

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -156,7 +156,7 @@ export class AppStore {
     @observable imageRatio = 1;
     @observable isExportingImage = false;
     @observable private isCanvasUpdated: boolean;
-    @observable pixelRatio: {current: number; previous: number};
+    @observable pixelRatio: number;
 
     // dynamic zIndex
     public zIndexManager = new FloatingObjzIndexManager();
@@ -1869,7 +1869,7 @@ export class AppStore {
         this.initRequirements();
         this.momentToMatch = true;
 
-        this.pixelRatio = {current: devicePixelRatio, previous: undefined};
+        this.pixelRatio = devicePixelRatio;
 
         AST.onReady.then(
             action(() => {
@@ -2125,18 +2125,17 @@ export class AppStore {
                 media.removeEventListener("change", updatePixelRatio);
             };
 
-            this.pixelRatio.previous = this.pixelRatio.current;
-            this.pixelRatio.current = devicePixelRatio;
-            this.handleInvariantImageSize();
+            this.handleInvariantImageSize(this.pixelRatio);
+            this.pixelRatio = devicePixelRatio;
         };
         updatePixelRatio();
     }
 
     // to make the image size invariant on screen
-    private handleInvariantImageSize() {
+    private handleInvariantImageSize(prevPixelRatio: number) {
         this.frames.forEach(frame => {
             if (frame === this.spatialReference || !this.spatialReference) {
-                frame.setZoom((frame.zoomLevel * this.pixelRatio.current) / this.pixelRatio.previous, true);
+                frame.setZoom((frame.zoomLevel * devicePixelRatio) / prevPixelRatio, true);
             }
         });
     }

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1868,7 +1868,7 @@ export class AppStore {
         this.initRequirements();
         this.momentToMatch = true;
 
-        this.pixelRatio = devicePixelRatio * this.imageRatio;
+        this.pixelRatio = {current: devicePixelRatio * this.imageRatio, previous: undefined};
 
         AST.onReady.then(
             action(() => {
@@ -2109,6 +2109,34 @@ export class AppStore {
 
         autorun(() => {
             this.activateStatsPanel(this.preferenceStore.statsPanelEnabled);
+        });
+
+        // listen devicePixelRatio
+        let remove = null;
+        const updatePixelRatio = () => {
+            if (remove != null) {
+                remove();
+            }
+            const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
+            const media = matchMedia(mqString);
+            media.addEventListener("change", updatePixelRatio);
+            remove = () => {
+                media.removeEventListener("change", updatePixelRatio);
+            };
+
+            this.pixelRatio.previous = this.pixelRatio.current;
+            this.pixelRatio.current = devicePixelRatio;
+            this.handleInvariantImageSize();
+        };
+        updatePixelRatio();
+    }
+
+    // to make the image size invariant on screen
+    private handleInvariantImageSize() {
+        this.frames.forEach(frame => {
+            if (frame === this.spatialReference || !this.spatialReference) {
+                frame.setZoom((frame.zoomLevel * this.pixelRatio.current) / this.pixelRatio.previous, true);
+            }
         });
     }
 
@@ -3435,9 +3463,10 @@ export class AppStore {
         });
     };
 
-    @observable pixelRatio: number;
+    // @observable pixelRatio: number;
+    @observable pixelRatio: {current: number; previous: number};
 
-    @action setPixelRatio = (pixelRatio: number) => {
-        this.pixelRatio = pixelRatio;
-    };
+    // @action setPixelRatio = (pixelRatio: number) => {
+    //     this.pixelRatio = pixelRatio;
+    // };
 }

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1869,7 +1869,7 @@ export class AppStore {
         this.initRequirements();
         this.momentToMatch = true;
 
-        this.pixelRatio = {current: devicePixelRatio * this.imageRatio, previous: undefined};
+        this.pixelRatio = {current: devicePixelRatio, previous: undefined};
 
         AST.onReady.then(
             action(() => {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1868,6 +1868,8 @@ export class AppStore {
         this.initRequirements();
         this.momentToMatch = true;
 
+        this.pixelRatio = devicePixelRatio * this.imageRatio;
+
         AST.onReady.then(
             action(() => {
                 this.setAstReady(true);
@@ -3433,8 +3435,10 @@ export class AppStore {
         });
     };
 
-    // helper function for getting the current devicePixelRatio value
-    get pixelRatio() {
-        return devicePixelRatio;
-    }
+    @observable pixelRatio: number;
+
+    @action setPixelRatio = (pixelRatio: number) => {
+        this.pixelRatio = pixelRatio;
+    };
+
 }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -249,10 +249,6 @@ export class FrameStore {
         }
     }
 
-    @observable pixelRatio: number;
-    @action setPixelRatio = (pixelRatio: number) => {
-        this.pixelRatio = pixelRatio;
-    };
 
     @computed get aspectRatio(): number {
         if (isFinite(this.framePixelRatio)) {
@@ -272,8 +268,8 @@ export class FrameStore {
     // Frame view of center = initial center && zoom = 1
     @computed get unitFrameView(): FrameView {
         // Required image dimensions
-        const imageWidth = (this.pixelRatio * this.renderWidth) / this.aspectRatio;
-        const imageHeight = this.pixelRatio * this.renderHeight;
+        const imageWidth = (AppStore.Instance.pixelRatio * this.renderWidth) / this.aspectRatio;
+        const imageHeight = AppStore.Instance.pixelRatio * this.renderHeight;
 
         const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
         const mipExact = Math.max(1.0, mipAdjustment);
@@ -329,8 +325,8 @@ export class FrameStore {
             }
 
             // Required image dimensions
-            const imageWidth = (this.pixelRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
-            const imageHeight = (this.pixelRatio * this.renderHeight) / this.zoomLevel;
+            const imageWidth = (AppStore.Instance.pixelRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
+            const imageHeight = (AppStore.Instance.pixelRatio * this.renderHeight) / this.zoomLevel;
 
             const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
@@ -1024,7 +1020,7 @@ export class FrameStore {
         if (imageWidth <= 0) {
             return 1.0;
         }
-        return (this.renderWidth * this.pixelRatio) / this.aspectRatio / imageWidth;
+        return (this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / imageWidth;
     }
 
     @computed
@@ -1033,7 +1029,7 @@ export class FrameStore {
         if (imageHeight <= 0) {
             return 1.0;
         }
-        return (this.renderHeight * this.pixelRatio) / imageHeight;
+        return (this.renderHeight * AppStore.Instance.pixelRatio) / imageHeight;
     }
 
     @computed get contourProgress(): number {
@@ -1257,8 +1253,6 @@ export class FrameStore {
 
         this.isOffsetCoord = false;
         this.offsetCenter = null;
-
-        this.pixelRatio = devicePixelRatio;
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preferenceStore.astColor;
@@ -2553,7 +2547,7 @@ export class FrameStore {
 
     @action zoomToSizeX = (x: number): boolean => {
         if (x > 0 && isFinite(x)) {
-            this.setZoom((this.renderWidth * this.pixelRatio) / this.aspectRatio / x);
+            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / x);
             return true;
         }
         return false;
@@ -2565,7 +2559,7 @@ export class FrameStore {
 
     @action zoomToSizeY = (y: number): boolean => {
         if (y > 0 && isFinite(y)) {
-            this.setZoom((this.renderHeight * this.pixelRatio) / y);
+            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio) / y);
             return true;
         }
         return false;
@@ -2695,8 +2689,8 @@ export class FrameStore {
             const {minPoint, maxPoint} = minMax2D(corners);
             const rangeX = maxPoint.x - minPoint.x;
             const rangeY = maxPoint.y - minPoint.y;
-            const zoomX = (this.spatialReference.renderWidth * this.pixelRatio) / rangeX;
-            const zoomY = (this.spatialReference.renderHeight * this.pixelRatio) / rangeY;
+            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio) / rangeX;
+            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio) / rangeY;
             const zoom = Math.min(zoomX, zoomY);
             this.spatialReference.setZoom(zoom, true);
             return zoom;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -249,7 +249,6 @@ export class FrameStore {
         }
     }
 
-
     @computed get aspectRatio(): number {
         if (isFinite(this.framePixelRatio)) {
             return this.framePixelRatio;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -267,8 +267,8 @@ export class FrameStore {
     // Frame view of center = initial center && zoom = 1
     @computed get unitFrameView(): FrameView {
         // Required image dimensions
-        const imageWidth = (AppStore.Instance.pixelRatio * this.renderWidth) / this.aspectRatio;
-        const imageHeight = AppStore.Instance.pixelRatio * this.renderHeight;
+        const imageWidth = (AppStore.Instance.pixelRatio.current * this.renderWidth) / this.aspectRatio;
+        const imageHeight = AppStore.Instance.pixelRatio.current * this.renderHeight;
 
         const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
         const mipExact = Math.max(1.0, mipAdjustment);
@@ -324,8 +324,8 @@ export class FrameStore {
             }
 
             // Required image dimensions
-            const imageWidth = (AppStore.Instance.pixelRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
-            const imageHeight = (AppStore.Instance.pixelRatio * this.renderHeight) / this.zoomLevel;
+            const imageWidth = (AppStore.Instance.pixelRatio.current * this.renderWidth) / this.zoomLevel / this.aspectRatio;
+            const imageHeight = (AppStore.Instance.pixelRatio.current * this.renderHeight) / this.zoomLevel;
 
             const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
@@ -1019,7 +1019,7 @@ export class FrameStore {
         if (imageWidth <= 0) {
             return 1.0;
         }
-        return (this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / imageWidth;
+        return (this.renderWidth * AppStore.Instance.pixelRatio.current) / this.aspectRatio / imageWidth;
     }
 
     @computed
@@ -1028,7 +1028,7 @@ export class FrameStore {
         if (imageHeight <= 0) {
             return 1.0;
         }
-        return (this.renderHeight * AppStore.Instance.pixelRatio) / imageHeight;
+        return (this.renderHeight * AppStore.Instance.pixelRatio.current) / imageHeight;
     }
 
     @computed get contourProgress(): number {
@@ -2546,7 +2546,7 @@ export class FrameStore {
 
     @action zoomToSizeX = (x: number): boolean => {
         if (x > 0 && isFinite(x)) {
-            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / x);
+            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio.current) / this.aspectRatio / x);
             return true;
         }
         return false;
@@ -2558,7 +2558,7 @@ export class FrameStore {
 
     @action zoomToSizeY = (y: number): boolean => {
         if (y > 0 && isFinite(y)) {
-            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio) / y);
+            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio.current) / y);
             return true;
         }
         return false;
@@ -2688,8 +2688,8 @@ export class FrameStore {
             const {minPoint, maxPoint} = minMax2D(corners);
             const rangeX = maxPoint.x - minPoint.x;
             const rangeY = maxPoint.y - minPoint.y;
-            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio) / rangeX;
-            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio) / rangeY;
+            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio.current) / rangeX;
+            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio.current) / rangeY;
             const zoom = Math.min(zoomX, zoomY);
             this.spatialReference.setZoom(zoom, true);
             return zoom;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -150,7 +150,6 @@ export class FrameStore {
     // Region set for the current frame. Accessed via regionSet, to take into account region sharing
     @observable private readonly frameRegionSet: RegionSetStore;
 
-    @observable renderHiDPI: boolean;
     @observable spectralType: SpectralType;
     @observable spectralUnit: SpectralUnit;
     @observable spectralTypeSecondary: SpectralType;
@@ -250,8 +249,8 @@ export class FrameStore {
         }
     }
 
-    @computed get pixelRatio(): number {
-        return this.renderHiDPI ? devicePixelRatio * AppStore.Instance.imageRatio : 1.0;
+    get pixelRatio(): number {
+        return devicePixelRatio * AppStore.Instance.imageRatio;
     }
 
     @computed get aspectRatio(): number {
@@ -1212,7 +1211,6 @@ export class FrameStore {
         this.validWcs = false;
         this.frameInfo = frameInfo;
         this.initialCenter = {x: (this.frameInfo.fileInfoExtended.width - 1) / 2.0, y: (this.frameInfo.fileInfoExtended.height - 1) / 2.0};
-        this.renderHiDPI = true;
         this.center = {x: 0, y: 0};
         this.stokes = 0;
         this.channel = 0;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -267,8 +267,8 @@ export class FrameStore {
     // Frame view of center = initial center && zoom = 1
     @computed get unitFrameView(): FrameView {
         // Required image dimensions
-        const imageWidth = (AppStore.Instance.pixelRatio.current * this.renderWidth) / this.aspectRatio;
-        const imageHeight = AppStore.Instance.pixelRatio.current * this.renderHeight;
+        const imageWidth = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderWidth) / this.aspectRatio;
+        const imageHeight = AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderHeight;
 
         const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
         const mipExact = Math.max(1.0, mipAdjustment);
@@ -324,8 +324,8 @@ export class FrameStore {
             }
 
             // Required image dimensions
-            const imageWidth = (AppStore.Instance.pixelRatio.current * this.renderWidth) / this.zoomLevel / this.aspectRatio;
-            const imageHeight = (AppStore.Instance.pixelRatio.current * this.renderHeight) / this.zoomLevel;
+            const imageWidth = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
+            const imageHeight = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderHeight) / this.zoomLevel;
 
             const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
@@ -1019,7 +1019,7 @@ export class FrameStore {
         if (imageWidth <= 0) {
             return 1.0;
         }
-        return (this.renderWidth * AppStore.Instance.pixelRatio.current) / this.aspectRatio / imageWidth;
+        return (this.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / this.aspectRatio / imageWidth;
     }
 
     @computed
@@ -1028,7 +1028,7 @@ export class FrameStore {
         if (imageHeight <= 0) {
             return 1.0;
         }
-        return (this.renderHeight * AppStore.Instance.pixelRatio.current) / imageHeight;
+        return (this.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / imageHeight;
     }
 
     @computed get contourProgress(): number {
@@ -2546,7 +2546,7 @@ export class FrameStore {
 
     @action zoomToSizeX = (x: number): boolean => {
         if (x > 0 && isFinite(x)) {
-            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio.current) / this.aspectRatio / x);
+            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / this.aspectRatio / x);
             return true;
         }
         return false;
@@ -2558,7 +2558,7 @@ export class FrameStore {
 
     @action zoomToSizeY = (y: number): boolean => {
         if (y > 0 && isFinite(y)) {
-            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio.current) / y);
+            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / y);
             return true;
         }
         return false;
@@ -2688,8 +2688,8 @@ export class FrameStore {
             const {minPoint, maxPoint} = minMax2D(corners);
             const rangeX = maxPoint.x - minPoint.x;
             const rangeY = maxPoint.y - minPoint.y;
-            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio.current) / rangeX;
-            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio.current) / rangeY;
+            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / rangeX;
+            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / rangeY;
             const zoom = Math.min(zoomX, zoomY);
             this.spatialReference.setZoom(zoom, true);
             return zoom;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -267,8 +267,9 @@ export class FrameStore {
     // Frame view of center = initial center && zoom = 1
     @computed get unitFrameView(): FrameView {
         // Required image dimensions
-        const imageWidth = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderWidth) / this.aspectRatio;
-        const imageHeight = AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderHeight;
+        const appStore = AppStore.Instance;
+        const imageWidth = (appStore.pixelRatio * appStore.imageRatio * this.renderWidth) / this.aspectRatio;
+        const imageHeight = appStore.pixelRatio * appStore.imageRatio * this.renderHeight;
 
         const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
         const mipExact = Math.max(1.0, mipAdjustment);
@@ -324,8 +325,9 @@ export class FrameStore {
             }
 
             // Required image dimensions
-            const imageWidth = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
-            const imageHeight = (AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio * this.renderHeight) / this.zoomLevel;
+            const appStore = AppStore.Instance;
+            const imageWidth = (appStore.pixelRatio * appStore.imageRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
+            const imageHeight = (appStore.pixelRatio * appStore.imageRatio * this.renderHeight) / this.zoomLevel;
 
             const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
@@ -1019,7 +1021,7 @@ export class FrameStore {
         if (imageWidth <= 0) {
             return 1.0;
         }
-        return (this.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / this.aspectRatio / imageWidth;
+        return (this.renderWidth * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / this.aspectRatio / imageWidth;
     }
 
     @computed
@@ -1028,7 +1030,7 @@ export class FrameStore {
         if (imageHeight <= 0) {
             return 1.0;
         }
-        return (this.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / imageHeight;
+        return (this.renderHeight * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / imageHeight;
     }
 
     @computed get contourProgress(): number {
@@ -2546,7 +2548,7 @@ export class FrameStore {
 
     @action zoomToSizeX = (x: number): boolean => {
         if (x > 0 && isFinite(x)) {
-            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / this.aspectRatio / x);
+            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / this.aspectRatio / x);
             return true;
         }
         return false;
@@ -2558,7 +2560,7 @@ export class FrameStore {
 
     @action zoomToSizeY = (y: number): boolean => {
         if (y > 0 && isFinite(y)) {
-            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / y);
+            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / y);
             return true;
         }
         return false;
@@ -2688,8 +2690,9 @@ export class FrameStore {
             const {minPoint, maxPoint} = minMax2D(corners);
             const rangeX = maxPoint.x - minPoint.x;
             const rangeY = maxPoint.y - minPoint.y;
-            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / rangeX;
-            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio.current * AppStore.Instance.imageRatio) / rangeY;
+            const appStore = AppStore.Instance;
+            const zoomX = (this.spatialReference.renderWidth * appStore.pixelRatio * appStore.imageRatio) / rangeX;
+            const zoomY = (this.spatialReference.renderHeight * appStore.pixelRatio * appStore.imageRatio) / rangeY;
             const zoom = Math.min(zoomX, zoomY);
             this.spatialReference.setZoom(zoom, true);
             return zoom;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -249,9 +249,10 @@ export class FrameStore {
         }
     }
 
-    get pixelRatio(): number {
-        return devicePixelRatio * AppStore.Instance.imageRatio;
-    }
+    @observable pixelRatio: number;
+    @action setPixelRatio = (pixelRatio: number) => {
+        this.pixelRatio = pixelRatio;
+    };
 
     @computed get aspectRatio(): number {
         if (isFinite(this.framePixelRatio)) {
@@ -1256,6 +1257,8 @@ export class FrameStore {
 
         this.isOffsetCoord = false;
         this.offsetCenter = null;
+
+        this.pixelRatio = devicePixelRatio;
 
         // synchronize AST overlay's color/grid/label with preference when frame is created
         const astColor = preferenceStore.astColor;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -268,8 +268,8 @@ export class FrameStore {
     @computed get unitFrameView(): FrameView {
         // Required image dimensions
         const appStore = AppStore.Instance;
-        const imageWidth = (appStore.pixelRatio * appStore.imageRatio * this.renderWidth) / this.aspectRatio;
-        const imageHeight = appStore.pixelRatio * appStore.imageRatio * this.renderHeight;
+        const imageWidth = (appStore.pixelRatio * this.renderWidth) / this.aspectRatio;
+        const imageHeight = appStore.pixelRatio * this.renderHeight;
 
         const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
         const mipExact = Math.max(1.0, mipAdjustment);
@@ -325,9 +325,8 @@ export class FrameStore {
             }
 
             // Required image dimensions
-            const appStore = AppStore.Instance;
-            const imageWidth = (appStore.pixelRatio * appStore.imageRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
-            const imageHeight = (appStore.pixelRatio * appStore.imageRatio * this.renderHeight) / this.zoomLevel;
+            const imageWidth = (AppStore.Instance.pixelRatio * this.renderWidth) / this.zoomLevel / this.aspectRatio;
+            const imageHeight = (AppStore.Instance.pixelRatio * this.renderHeight) / this.zoomLevel;
 
             const mipAdjustment = PreferenceStore.Instance.lowBandwidthMode ? 2.0 : 1.0;
             const mipExact = Math.max(1.0, mipAdjustment / this.zoomLevel);
@@ -1021,7 +1020,7 @@ export class FrameStore {
         if (imageWidth <= 0) {
             return 1.0;
         }
-        return (this.renderWidth * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / this.aspectRatio / imageWidth;
+        return (this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / imageWidth;
     }
 
     @computed
@@ -1030,7 +1029,7 @@ export class FrameStore {
         if (imageHeight <= 0) {
             return 1.0;
         }
-        return (this.renderHeight * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / imageHeight;
+        return (this.renderHeight * AppStore.Instance.pixelRatio) / imageHeight;
     }
 
     @computed get contourProgress(): number {
@@ -2548,7 +2547,7 @@ export class FrameStore {
 
     @action zoomToSizeX = (x: number): boolean => {
         if (x > 0 && isFinite(x)) {
-            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / this.aspectRatio / x);
+            this.setZoom((this.renderWidth * AppStore.Instance.pixelRatio) / this.aspectRatio / x);
             return true;
         }
         return false;
@@ -2560,7 +2559,7 @@ export class FrameStore {
 
     @action zoomToSizeY = (y: number): boolean => {
         if (y > 0 && isFinite(y)) {
-            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio * AppStore.Instance.imageRatio) / y);
+            this.setZoom((this.renderHeight * AppStore.Instance.pixelRatio) / y);
             return true;
         }
         return false;
@@ -2690,9 +2689,8 @@ export class FrameStore {
             const {minPoint, maxPoint} = minMax2D(corners);
             const rangeX = maxPoint.x - minPoint.x;
             const rangeY = maxPoint.y - minPoint.y;
-            const appStore = AppStore.Instance;
-            const zoomX = (this.spatialReference.renderWidth * appStore.pixelRatio * appStore.imageRatio) / rangeX;
-            const zoomY = (this.spatialReference.renderHeight * appStore.pixelRatio * appStore.imageRatio) / rangeY;
+            const zoomX = (this.spatialReference.renderWidth * AppStore.Instance.pixelRatio) / rangeX;
+            const zoomY = (this.spatialReference.renderHeight * AppStore.Instance.pixelRatio) / rangeY;
             const zoom = Math.min(zoomX, zoomY);
             this.spatialReference.setZoom(zoom, true);
             return zoom;

--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -383,7 +383,6 @@ export class ImageFittingStore {
         let rotation = 0;
         const baseFrame = frame.spatialReference ?? frame;
         let center = baseFrame.center;
-        // const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
         const imageWidth = (AppStore.Instance.pixelRatio * baseFrame.renderWidth) / baseFrame.zoomLevel / baseFrame.aspectRatio;
         const imageHeight = (AppStore.Instance.pixelRatio * baseFrame.renderHeight) / baseFrame.zoomLevel;
         let size = {x: imageWidth, y: imageHeight};

--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -383,9 +383,9 @@ export class ImageFittingStore {
         let rotation = 0;
         const baseFrame = frame.spatialReference ?? frame;
         let center = baseFrame.center;
-        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
-        const imageWidth = (pixelRatio * baseFrame.renderWidth) / baseFrame.zoomLevel / baseFrame.aspectRatio;
-        const imageHeight = (pixelRatio * baseFrame.renderHeight) / baseFrame.zoomLevel;
+        // const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
+        const imageWidth = (AppStore.Instance.pixelRatio * baseFrame.renderWidth) / baseFrame.zoomLevel / baseFrame.aspectRatio;
+        const imageHeight = (AppStore.Instance.pixelRatio * baseFrame.renderHeight) / baseFrame.zoomLevel;
         let size = {x: imageWidth, y: imageHeight};
 
         // transform from the base frame to the effective frame

--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -383,7 +383,7 @@ export class ImageFittingStore {
         let rotation = 0;
         const baseFrame = frame.spatialReference ?? frame;
         let center = baseFrame.center;
-        const pixelRatio = baseFrame.renderHiDPI ? devicePixelRatio * AppStore.Instance.imageRatio : 1.0;
+        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
         const imageWidth = (pixelRatio * baseFrame.renderWidth) / baseFrame.zoomLevel / baseFrame.aspectRatio;
         const imageHeight = (pixelRatio * baseFrame.renderHeight) / baseFrame.zoomLevel;
         let size = {x: imageWidth, y: imageHeight};

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -681,16 +681,7 @@ export class CatalogWidgetStore {
         if (!this.disableSizeMap && column?.length && this.sizeColumnMin.clipd !== undefined && this.sizeColumnMax.clipd !== undefined) {
             const pointSize = this.pointSizebyType;
             let min = (this.sizeArea ? this.shapeSettings?.areaBase : this.shapeSettings?.diameterBase) ?? NaN;
-            return CARTACompute.CalculateCatalogSize(
-                column,
-                this.sizeColumnMin.clipd,
-                this.sizeColumnMax.clipd,
-                pointSize.min + min,
-                pointSize.max + min,
-                this.sizeScalingType,
-                this.sizeArea,
-                devicePixelRatio * AppStore.Instance.imageRatio
-            );
+            return CARTACompute.CalculateCatalogSize(column, this.sizeColumnMin.clipd, this.sizeColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeScalingType, this.sizeArea, AppStore.Instance.pixelRatio);
         }
         return new Float32Array(0);
     }
@@ -708,7 +699,7 @@ export class CatalogWidgetStore {
                 pointSize.max + min,
                 this.sizeMinorScalingType,
                 this.sizeMinorArea,
-                devicePixelRatio * AppStore.Instance.imageRatio
+                AppStore.Instance.pixelRatio
             );
         }
         return new Float32Array(0);


### PR DESCRIPTION
**Description**

Close #2285. The different devicePixelRatio between Retina and non-Retina monitors causes the components in the image viewer to not properly show. Fix the bug by listening for devicePixelRatio when it changes. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [ ] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] ~user manual prepared (for large new features)~