### PR TITLE
Thchang/152 fix draggable marks in charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 * Fix incorrect rendering of image view when moving the window to monitors with different screen resolution ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
+* Fix a sudden jump of draggable marks by stopping marks being dragged out of chart ([[#152](https://github.com/CARTAvis/carta-frontend/issues/152)]).
 ### Changed
 * Changed the limitation of plotting up-to-10 profiles in the spectral profiler multi-profile mode to up-to-16 ([#2440](https://github.com/CARTAvis/carta-frontend/issues/2440))
 * Fixed the unit label of the y axis for flux density in the spectral profiles ([#2355](https://github.com/CARTAvis/carta-frontend/issues/2355)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 * Fix incorrect rendering of image view when moving the window to monitors with different screen resolution ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
-* Fix a sudden jump of draggable marks by stopping marks being dragged out of chart ([[#152](https://github.com/CARTAvis/carta-frontend/issues/152)]).
+* Fix the sudden jump of dragged-out marks ([[#152](https://github.com/CARTAvis/carta-frontend/issues/152)]).
 ### Changed
 * Changed the limitation of plotting up-to-10 profiles in the spectral profiler multi-profile mode to up-to-16 ([#2440](https://github.com/CARTAvis/carta-frontend/issues/2440))
 * Fixed the unit label of the y axis for flux density in the spectral profiles ([#2355](https://github.com/CARTAvis/carta-frontend/issues/2355)).

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -161,6 +161,8 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     @observable selectionBoxEnd = {x: 0, y: 0};
     @observable isMouseEntered = false;
     @observable isMarkerDragging = false;
+    @observable isDraggableCancel = false;
+    @observable cachedDragOffset: number = undefined;
 
     @computed get isSelecting() {
         return this.interactionMode === InteractionMode.SELECTING;
@@ -315,18 +317,37 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
 
     @action onMarkerDragEnd = () => {
         this.isMarkerDragging = false;
+        this.isDraggableCancel = false;
+        this.cachedDragOffset = undefined;
     };
 
     onMarkerDragged = (ev, marker: LineMarker) => {
         if (this.props.markers) {
             if (marker && marker.dragMove) {
                 let newPositionDataSpace;
+                let deltaOffset; // Handle a sudden jump of offset when the marker is dragged out of the canvas space (Konva resets the offset value)
                 if (marker.horizontal) {
-                    // Prevent dragging out of canvas space
-                    newPositionDataSpace = this.getValueForPixelY(clamp(ev.evt.offsetY, this.chartArea.top, this.chartArea.bottom), this.props.logY);
+                    deltaOffset = this.cachedDragOffset !== undefined ? ev.evt.offsetY - this.cachedDragOffset : 0;
+                    if (Math.abs(deltaOffset) > this.chartArea.height * 0.5) {
+                        newPositionDataSpace = deltaOffset > 0 ? this.getCanvasSpaceY(this.chartArea.top) : this.getValueForPixelY(this.chartArea.bottom);
+                        this.isDraggableCancel = true;
+                    } else {
+                        // Prevent dragging out of chartArea, since the canvas space is slightly longer
+                        newPositionDataSpace = this.getValueForPixelY(clamp(ev.evt.offsetY, this.chartArea.top, this.chartArea.bottom), this.props.logY);
+
+                        this.cachedDragOffset = ev.evt.offsetY;
+                    }
                 } else {
-                    // Prevent dragging out of canvas space
-                    newPositionDataSpace = this.getValueForPixelX(clamp(ev.evt.offsetX, this.chartArea.left, this.chartArea.right));
+                    deltaOffset = this.cachedDragOffset !== undefined ? ev.evt.offsetX - this.cachedDragOffset : 0;
+                    if (Math.abs(deltaOffset) > this.chartArea.width * 0.5) {
+                        newPositionDataSpace = deltaOffset < 0 ? this.getValueForPixelX(this.chartArea.right) : this.getValueForPixelX(this.chartArea.left);
+                        this.isDraggableCancel = true;
+                    } else {
+                        // Prevent dragging out of chartArea, since the canvas space is slightly wider
+                        newPositionDataSpace = this.getValueForPixelX(clamp(ev.evt.offsetX, this.chartArea.left, this.chartArea.right));
+
+                        this.cachedDragOffset = ev.evt.offsetX;
+                    }
                 }
                 marker.dragMove(newPositionDataSpace);
             }
@@ -824,7 +845,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     key={marker.id + "-draggable"}
                     x={valueCanvasSpace}
                     y={0}
-                    draggable={true}
+                    draggable={true && !this.isDraggableCancel}
                     dragBoundFunc={pos => this.dragBoundsFuncVertical(pos, marker)}
                     onDragStart={this.onMarkerDragStart}
                     onDragEnd={this.onMarkerDragEnd}

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -3,6 +3,7 @@ import {Arrow, Group, Layer, Line, Rect, Stage, Text} from "react-konva";
 import ReactResizeDetector from "react-resize-detector";
 import {Colors} from "@blueprintjs/core";
 import {Chart, ChartArea, Tick} from "chart.js";
+import Konva from "konva";
 import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
@@ -161,8 +162,6 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     @observable selectionBoxEnd = {x: 0, y: 0};
     @observable isMouseEntered = false;
     @observable isMarkerDragging = false;
-    @observable isDraggableCancel = false;
-    @observable cachedDragOffset: number = undefined;
 
     @computed get isSelecting() {
         return this.interactionMode === InteractionMode.SELECTING;
@@ -317,44 +316,23 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
 
     @action onMarkerDragEnd = () => {
         this.isMarkerDragging = false;
-        this.isDraggableCancel = false;
-        this.cachedDragOffset = undefined;
     };
 
-    onMarkerDragged = (ev, marker: LineMarker) => {
+    onMarkerDragged = (ev: Konva.KonvaEventObject<DragEvent>, marker: LineMarker) => {
         if (this.props.markers) {
             if (marker && marker.dragMove) {
                 let newPositionDataSpace;
-                let deltaOffset; // Prevent a sudden jump of offset when the marker is dragged out of the canvas space (Konva resets the offset value)
                 if (marker.horizontal) {
-                    deltaOffset = this.cachedDragOffset !== undefined ? ev.evt.offsetY - this.cachedDragOffset : 0;
-                    if (Math.abs(deltaOffset) > this.chartArea.height * 0.5) {
-                        newPositionDataSpace = deltaOffset > 0 ? this.getCanvasSpaceY(this.chartArea.top) : this.getValueForPixelY(this.chartArea.bottom);
-                        this.isDraggableCancel = true;
-                    } else {
-                        // Prevent dragging out of chartArea, since the canvas space is slightly longer
-                        newPositionDataSpace = this.getValueForPixelY(clamp(ev.evt.offsetY, this.chartArea.top, this.chartArea.bottom), this.props.logY);
-
-                        this.cachedDragOffset = ev.evt.offsetY;
-                    }
+                    newPositionDataSpace = this.getValueForPixelY(ev.target.getAbsolutePosition().y, this.props.logY);
                 } else {
-                    deltaOffset = this.cachedDragOffset !== undefined ? ev.evt.offsetX - this.cachedDragOffset : 0;
-                    if (Math.abs(deltaOffset) > this.chartArea.width * 0.5) {
-                        newPositionDataSpace = deltaOffset < 0 ? this.getValueForPixelX(this.chartArea.right) : this.getValueForPixelX(this.chartArea.left);
-                        this.isDraggableCancel = true;
-                    } else {
-                        // Prevent dragging out of chartArea, since the canvas space is slightly wider
-                        newPositionDataSpace = this.getValueForPixelX(clamp(ev.evt.offsetX, this.chartArea.left, this.chartArea.right));
-
-                        this.cachedDragOffset = ev.evt.offsetX;
-                    }
+                    newPositionDataSpace = this.getValueForPixelX(ev.target.getAbsolutePosition().x);
                 }
                 marker.dragMove(newPositionDataSpace);
             }
         }
         // Cursor move updates
         if (this.props.graphCursorMoved) {
-            const cursorPosGraphSpace = this.getValueForPixelX(ev.evt.offsetX);
+            const cursorPosGraphSpace = this.getValueForPixelX(ev.target.getAbsolutePosition().x);
             this.props.graphCursorMoved(cursorPosGraphSpace);
         }
     };
@@ -845,7 +823,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                     key={marker.id + "-draggable"}
                     x={valueCanvasSpace}
                     y={0}
-                    draggable={true && !this.isDraggableCancel}
+                    draggable={true}
                     dragBoundFunc={pos => this.dragBoundsFuncVertical(pos, marker)}
                     onDragStart={this.onMarkerDragStart}
                     onDragEnd={this.onMarkerDragEnd}

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -325,7 +325,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         if (this.props.markers) {
             if (marker && marker.dragMove) {
                 let newPositionDataSpace;
-                let deltaOffset; // Handle a sudden jump of offset when the marker is dragged out of the canvas space (Konva resets the offset value)
+                let deltaOffset; // Prevent a sudden jump of offset when the marker is dragged out of the canvas space (Konva resets the offset value)
                 if (marker.horizontal) {
                     deltaOffset = this.cachedDragOffset !== undefined ? ev.evt.offsetY - this.cachedDragOffset : 0;
                     if (Math.abs(deltaOffset) > this.chartArea.height * 0.5) {


### PR DESCRIPTION
**Description**

This PR closes #152

The draggable mark is fixed by replacing `ev.evt.offsetX/Y` with `ev.target.getAbsolutePosition()`. The `ev.evt.offsetX/Y` is the position of the mouse to the hovered HTML element. It gives wrong marker values when the cursor hovers over other elements. (Thanks @YuHsuan-Hwang spotting the change of `ev.evt.target`) On the other hand, the `ev.target.getAbsolutePosition()` gives the position of the draggable marker group to the canvas space, and it is constrained by the `dragBoundFunc`.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~