### PR TITLE
Bias contrast widget regression

### DIFF
--- a/src/components/Shared/ScrollShadow/ScrollShadow.scss
+++ b/src/components/Shared/ScrollShadow/ScrollShadow.scss
@@ -29,17 +29,21 @@
 }
 
 .scroll-shadow {
+    all: inherit;
     @include scroll-shadow-background(black);
 
     .scroll-shadow-cover {
+        all: inherit;
         @include scroll-shadow-cover-background($pt-app-background-color);
     }
 }
 
 .#{$ns}-dark .scroll-shadow {
+    all: inherit;
     @include scroll-shadow-background(white);
 
     .scroll-shadow-cover {
+        all: inherit;
         @include scroll-shadow-cover-background($pt-dark-app-background-color);
     }
 }


### PR DESCRIPTION
**Description**

Fixed regression from #2447: incorrect bias/contrast widget position in the render config widget. Fixed by inheriting css properties from parent div to scroll shadow divs.

**Checklist**

~For linked issues (if there are):~
- [x] ~assignee and label added~
- [x] ~GitHub Project estimate added~

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependencies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~