### PR TITLE
Yuhsuan/948 edge pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Upgraded blueprintjs from v3 to v5 ([#2029](https://github.com/CARTAvis/carta-frontend/issues/1395)).
 * Fixed the catalog load button status after double clicking catalog files ([#2378](https://github.com/CARTAvis/carta-frontend/issues/2378)).
 * Synchronized the value format in the pan and zoom tab in the image view settings widget ([#2235](https://github.com/CARTAvis/carta-frontend/issues/2235)).
-* Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
-* Fix incorrect rendering of image view when moving the window to monitors with different screen resolution ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)])
+* Fixed save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
+* Fixed incorrect rendering of image view when moving the window to monitors with different screen resolution ([[#2285](https://github.com/CARTAvis/carta-frontend/issues/2285)]).
+* Fixed missing raster images when panning images to the top edge and right edge ([[#948](https://github.com/CARTAvis/carta-frontend/issues/948)]).
 ### Changed
 * Changed the limitation of plotting up-to-10 profiles in the spectral profiler multi-profile mode to up-to-16 ([#2440](https://github.com/CARTAvis/carta-frontend/issues/2440))
 * Fixed the unit label of the y axis for flux density in the spectral profiles ([#2355](https://github.com/CARTAvis/carta-frontend/issues/2355)).

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -183,10 +183,10 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private renderTiledCanvas(frame) {
         const imageSize = {x: frame.frameInfo.fileInfoExtended.width, y: frame.frameInfo.fileInfoExtended.height};
         const boundedView: FrameView = {
-            xMin: Math.max(0, frame.requiredFrameView.xMin),
-            xMax: Math.min(frame.requiredFrameView.xMax, imageSize.x),
-            yMin: Math.max(0, frame.requiredFrameView.yMin),
-            yMax: Math.min(frame.requiredFrameView.yMax, imageSize.y),
+            xMin: Math.max(-0.5, frame.requiredFrameView.xMin),
+            xMax: Math.min(frame.requiredFrameView.xMax, imageSize.x - 0.5),
+            yMin: Math.max(-0.5, frame.requiredFrameView.yMin),
+            yMax: Math.min(frame.requiredFrameView.yMax, imageSize.y - 0.5),
             mip: frame.requiredFrameView.mip
         };
 

--- a/src/stores/AnimatorStore/AnimatorStore.ts
+++ b/src/stores/AnimatorStore/AnimatorStore.ts
@@ -79,10 +79,10 @@ export class AnimatorStore {
         const reqView = frame.requiredFrameView;
 
         const croppedReq: FrameView = {
-            xMin: Math.max(0, reqView.xMin),
-            xMax: Math.min(frame.frameInfo.fileInfoExtended.width, reqView.xMax),
-            yMin: Math.max(0, reqView.yMin),
-            yMax: Math.min(frame.frameInfo.fileInfoExtended.height, reqView.yMax),
+            xMin: Math.max(-0.5, reqView.xMin),
+            xMax: Math.min(frame.frameInfo.fileInfoExtended.width - 0.5, reqView.xMax),
+            yMin: Math.max(-0.5, reqView.yMin),
+            yMax: Math.min(frame.frameInfo.fileInfoExtended.height - 0.5, reqView.yMax),
             mip: reqView.mip
         };
         const imageSize: Point2D = {x: frame.frameInfo.fileInfoExtended.width, y: frame.frameInfo.fileInfoExtended.height};

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1724,10 +1724,10 @@ export class AppStore {
                 const reqView = frame.requiredFrameView;
 
                 const croppedReq: FrameView = {
-                    xMin: Math.max(0, reqView.xMin),
-                    xMax: Math.min(frame.frameInfo.fileInfoExtended.width, reqView.xMax),
-                    yMin: Math.max(0, reqView.yMin),
-                    yMax: Math.min(frame.frameInfo.fileInfoExtended.height, reqView.yMax),
+                    xMin: Math.max(-0.5, reqView.xMin),
+                    xMax: Math.min(frame.frameInfo.fileInfoExtended.width - 0.5, reqView.xMax),
+                    yMin: Math.max(-0.5, reqView.yMin),
+                    yMax: Math.min(frame.frameInfo.fileInfoExtended.height - 0.5, reqView.yMax),
                     mip: reqView.mip
                 };
                 const imageSize: Point2D = {x: frame.frameInfo.fileInfoExtended.width, y: frame.frameInfo.fileInfoExtended.height};
@@ -1972,11 +1972,11 @@ export class AppStore {
                 const viewUpdates: ViewUpdate[] = [];
                 for (const frame of this.imageViewConfigStore.visibleFrames) {
                     const reqView = frame.requiredFrameView;
-                    let croppedReq: FrameView = {
-                        xMin: Math.max(0, reqView.xMin),
-                        xMax: Math.min(frame.frameInfo.fileInfoExtended.width, reqView.xMax),
-                        yMin: Math.max(0, reqView.yMin),
-                        yMax: Math.min(frame.frameInfo.fileInfoExtended.height, reqView.yMax),
+                    const croppedReq: FrameView = {
+                        xMin: Math.max(-0.5, reqView.xMin),
+                        xMax: Math.min(frame.frameInfo.fileInfoExtended.width - 0.5, reqView.xMax),
+                        yMin: Math.max(-0.5, reqView.yMin),
+                        yMax: Math.min(frame.frameInfo.fileInfoExtended.height - 0.5, reqView.yMax),
                         mip: reqView.mip
                     };
 

--- a/src/utilities/tiling/tiling.ts
+++ b/src/utilities/tiling/tiling.ts
@@ -58,7 +58,7 @@ export function GetRequiredTiles(frameView: FrameView, imageSize: Point2D, tileS
     }
 
     // Check if view is out of image range
-    if (frameView.xMax < 0 || frameView.xMin > imageSize.x || frameView.yMax < 0 || frameView.yMin > imageSize.y) {
+    if (frameView.xMax < -0.5 || frameView.xMin > imageSize.x - 0.5 || frameView.yMax < -0.5 || frameView.yMin > imageSize.y - 0.5) {
         return [];
     }
 
@@ -68,10 +68,10 @@ export function GetRequiredTiles(frameView: FrameView, imageSize: Point2D, tileS
     }
 
     const boundedFrameView: FrameView = {
-        xMin: Math.max(0, frameView.xMin),
-        xMax: Math.min(frameView.xMax, imageSize.x),
-        yMin: Math.max(0, frameView.yMin),
-        yMax: Math.min(frameView.yMax, imageSize.y),
+        xMin: Math.max(-0.5, frameView.xMin),
+        xMax: Math.min(frameView.xMax, imageSize.x - 0.5),
+        yMin: Math.max(-0.5, frameView.yMin),
+        yMax: Math.min(frameView.yMax, imageSize.y - 0.5),
         mip: frameView.mip
     };
 
@@ -80,10 +80,10 @@ export function GetRequiredTiles(frameView: FrameView, imageSize: Point2D, tileS
         y: frameView.mip * tileSize.y
     };
 
-    const xStart = Math.floor(boundedFrameView.xMin / adjustedTileSize.x);
-    const xEnd = Math.ceil(boundedFrameView.xMax / adjustedTileSize.x);
-    const yStart = Math.floor(boundedFrameView.yMin / adjustedTileSize.y);
-    const yEnd = Math.ceil(boundedFrameView.yMax / adjustedTileSize.y);
+    const xStart = Math.floor((boundedFrameView.xMin + 0.5) / adjustedTileSize.x);
+    const xEnd = Math.ceil((boundedFrameView.xMax + 0.5) / adjustedTileSize.x);
+    const yStart = Math.floor((boundedFrameView.yMin + 0.5) / adjustedTileSize.y);
+    const yEnd = Math.ceil((boundedFrameView.yMax + 0.5) / adjustedTileSize.y);
 
     const numTilesX = xEnd - xStart;
     const numTilesY = yEnd - yStart;


### PR DESCRIPTION
**Description**

Closes #948. I could only reproduce the issue when panning the image to the top edge and the right edge.

The root cause is the calculation of the required tiles. `frame.requiredFrameView` is defined such that the pixel centers are at [0, 1, ..., size - 1], and the raster image borders are at [-0.5, size - 0.5]. However, `GetRequiredTiles` assumes the borders are at [0, size], so it returns an empty array for the range [-0.5, 0].

Tested that: when the image is at the top edge or right edge (with only half of pixels visible),
- the image does not disappear.
- the image does not disappear after we click next channel.
- the image does not disappear after we start animation.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependencies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~