### PR TITLE
Yuhsuan/ra dec reference label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for loading remote FITS files from the hips2fits server ([#1379](https://github.com/CARTAvis/carta-backend/issues/1379)).
 * Supported the customized rest frequency for the moment maps ([#2396](https://github.com/CARTAvis/carta-frontend/issues/2396)).
 * Supported image coordinates for images with valid WCS headers ([#2366](https://github.com/CARTAvis/carta-frontend/issues/2366)).
+* Supported showing the coordinate system reference for RA and Dec labels in the image view panel.
 ### Fixed
 * Fixed ruler annotation matching bug ([#2242](https://github.com/CARTAvis/carta-frontend/issues/2242)).
 * Fixed compass and ruler annotations update bug in the spatially matched image when changing the coordinate ([#2270](https://github.com/CARTAvis/carta-frontend/issues/2270)).

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.scss
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.scss
@@ -93,4 +93,10 @@
             }
         }
     }
+
+    .panel-labels {
+        .#{$ns}-label {
+            width: 12em;
+        }
+    }
 }

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -503,13 +503,16 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
         );
 
         const labelsPanel = (
-            <div className="panel-container">
+            <div className="panel-labels">
                 <FormGroup inline={true} label="Visible">
                     <Switch checked={labels.visible} onChange={ev => labels.setVisible(ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} className="font-group" label="Font" disabled={!labels.visible}>
                     {this.fontSelect(labels.visible, labels.font, labels.setFont)}
                     <SafeNumericInput min={7} max={96} placeholder="Font size" value={labels.fontSize} disabled={!labels.visible} onValueChange={(value: number) => labels.setFontSize(value)} />
+                </FormGroup>
+                <FormGroup inline={true} label="Show RA/Dec reference" disabled={!labels.visible}>
+                    <Switch checked={labels.raDecReference} disabled={!labels.visible} onChange={ev => labels.setRaDecReference(ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Custom text" disabled={!labels.visible}>
                     <Switch checked={labels.customText} disabled={!labels.visible} onChange={ev => labels.setCustomText(ev.currentTarget.checked)} />

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -108,6 +108,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                     settings.padding.right * appStore.pixelRatio,
                     settings.padding.top * appStore.pixelRatio,
                     settings.padding.bottom * appStore.pixelRatio,
+                    settings.global.explicitSystem,
                     styleString
                 );
             };

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -108,7 +108,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                     settings.padding.right * appStore.pixelRatio,
                     settings.padding.top * appStore.pixelRatio,
                     settings.padding.bottom * appStore.pixelRatio,
-                    settings.global.explicitSystem,
+                    settings.labels.raDecReference ? settings.global.explicitSystem : "",
                     styleString
                 );
             };
@@ -182,6 +182,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
         const darktheme = AppStore.Instance.darkTheme;
         const title = this.props.overlaySettings.title.customText ? this.props.image?.store?.titleCustomText : this.props.image?.store?.filename;
         const ratio = AppStore.Instance.imageRatio;
+        const raDecReference = this.props.overlaySettings.labels.raDecReference;
         const titleStyleString = this.props.overlaySettings.title.styleString;
         const gridStyleString = this.props.overlaySettings.grid.styleString;
         const borderStyleString = this.props.overlaySettings.border.styleString;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1312,6 +1312,13 @@ export class FrameStore {
         } else if (this.isSwappedZ) {
             const astFrameSet = this.initSpectralVsDirectionFrame();
             if (astFrameSet) {
+                // update default system from the header
+                const entries = this.frameInfo.fileInfoExtended.headerEntries;
+                const skySystem = entries.find(entry => entry.name.includes("RADESYS"))?.value;
+                if (Object.values(SystemType).includes(skySystem as SystemType)) {
+                    this.overlayStore.global.setDefaultSystem(skySystem as SystemType);
+                }
+
                 this.spectralFrame = AST.getSpectralFrame(astFrameSet);
                 this.wcsInfo3D = AST.copy(astFrameSet);
                 this.updateDirAxisInfo();

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -622,6 +622,7 @@ export class OverlayLabelSettings {
     @observable color: string;
     @observable font: number;
     @observable fontSize: number;
+    @observable raDecReference: boolean;
     @observable customText: boolean;
     @observable customLabelX: string;
     @observable customLabelY: string;
@@ -634,6 +635,7 @@ export class OverlayLabelSettings {
         this.font = 0;
         this.customColor = false;
         this.color = AST_DEFAULT_COLOR;
+        this.raDecReference = true;
         this.customText = false;
         this.customLabelX = "";
         this.customLabelY = "";
@@ -679,6 +681,10 @@ export class OverlayLabelSettings {
 
     @action setFontSize(fontSize: number) {
         this.fontSize = fontSize;
+    }
+
+    @action setRaDecReference(raDecReference: boolean) {
+        this.raDecReference = raDecReference;
     }
 
     @action setCustomText = (val: boolean) => {

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -25,8 +25,6 @@ void astPutErr_(int status_value, const char* message)
 }
 
 #include <iostream>
-#include <string.h>
-#include <emscripten.h>
 
 using namespace std;
 

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -236,7 +236,7 @@ EMSCRIPTEN_KEEPALIVE AstFrameSet* initDummyFrame()
 }
 
 EMSCRIPTEN_KEEPALIVE int plotGrid(AstFrameSet* wcsinfo, double imageX1, double imageX2, double imageY1, double imageY2, double width, double height,
-                                        double paddingLeft, double paddingRight, double paddingTop, double paddingBottom, const char* args)
+                                        double paddingLeft, double paddingRight, double paddingTop, double paddingBottom, const char* system, const char* args)
 {
     if (!wcsinfo)
     {
@@ -261,6 +261,25 @@ EMSCRIPTEN_KEEPALIVE int plotGrid(AstFrameSet* wcsinfo, double imageX1, double i
     float gbox[] = {(float)xleft, (float)ybottom, (float)xright, (float)ytop};
     double pbox[] = {imageX1, imageY1, imageX2, imageY2};
     plot = astPlot(wcsinfo, gbox, pbox, args);
+
+    // add RA/Dec reference
+    if (strlen(system) > 0)
+    {
+        const char* symbol1 = astGetC(plot, "Symbol(1)");
+        if (strcmp(symbol1, "RA") == 0 || strcmp(symbol1, "Dec") == 0)
+        {
+            const char* label1 = astGetC(plot, "Label(1)");
+            astSet(plot, "Label(1) = %s (%s)", label1, system);
+        }
+
+        const char* symbol2 = astGetC(plot, "Symbol(2)");
+        if (strcmp(symbol2, "RA") == 0 || strcmp(symbol2, "Dec") == 0)
+        {
+            const char* label2 = astGetC(plot, "Label(2)");
+            astSet(plot, "Label(2) = %s (%s)", label2, system);
+        }
+    }
+
     astBBuf(plot);
     astGrid(plot);
 

--- a/wasm_src/ast_wrapper/index.d.ts
+++ b/wasm_src/ast_wrapper/index.d.ts
@@ -24,6 +24,7 @@ export function plot(
     paddingRight: number,
     paddingTop: number,
     paddingBottom: number,
+    system: string,
     options: string
 );
 export function emptyFitsChan(): FitsChan;

--- a/wasm_src/ast_wrapper/post.ts
+++ b/wasm_src/ast_wrapper/post.ts
@@ -95,7 +95,7 @@ Module.setCanvas = function (canvas) {
     Module.gridContext.font = Module.font;
 };
 
-Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string"]);
+Module.plot = Module.cwrap("plotGrid", "number", ["number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "number", "string", "string"]);
 Module.emptyFitsChan = Module.cwrap("emptyFitsChan", "number");
 Module.putFits = Module.cwrap("putFits", null, ["number", "string"]);
 Module.getFrameFromFitsChan = Module.cwrap("getFrameFromFitsChan", "number", ["number", "number"]);


### PR DESCRIPTION
**Description**

This PR is for showing the coordinate system reference for RA and Dec labels.

Changes:
* Added the current coordinate system string to the label when the axis symbol is "RA" or "Dec."
* Updated the default coord system from the header for rotated images.
* Added a toggle in the image view settings labels panel.

Tested that:
* The reference is shown when the label is RA or Dec.
* The reference is not shown for PV images, UV images, images without WCS info, images with pixel coord, or images with offset coord.
* The reference is shown on one axis for rotated images.
* When the label text is customized, the reference is also added.

**Checklist**

~For linked issues (if there are):~
- [x] ~assignee and label added~
- [x] ~GitHub Project estimate added~

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~