### PR TITLE
Thchang/ 2403 fix the unit for fwhm in the fitting log

### DIFF
--- a/wasm_src/gsl_wrapper/gsl_wrapper.cc
+++ b/wasm_src/gsl_wrapper/gsl_wrapper.cc
@@ -551,11 +551,11 @@ char * EMSCRIPTEN_KEEPALIVE fitting(
             index = gsl_matrix_get(parameterIndexes, i, 2);
             fwhm = gsl_vector_get(x, index);
             fwhmError = sqrt(residualVariance * gsl_matrix_get(covar, index, index));
-            snprintf(logBuffer + strlen(logBuffer), sizeof(logBuffer) - strlen(logBuffer), " fwhm%zu                = %.12e @yUnit \u00b1 %.12e (%.3g%%)\n", i + 1, fwhm, fwhmError, 100 * fwhmError / abs(fwhm));
+            snprintf(logBuffer + strlen(logBuffer), sizeof(logBuffer) - strlen(logBuffer), " fwhm%zu                = %.12e @xUnit \u00b1 %.12e (%.3g%%)\n", i + 1, fwhm, fwhmError, 100 * fwhmError / abs(fwhm));
         } else {
             fwhm = inputs[i][2];
             fwhmError = NAN;
-            snprintf(logBuffer + strlen(logBuffer), sizeof(logBuffer) - strlen(logBuffer), " fwhm%zu        (fixed) = %.12e @yUnit\n", i + 1, fwhm);
+            snprintf(logBuffer + strlen(logBuffer), sizeof(logBuffer) - strlen(logBuffer), " fwhm%zu        (fixed) = %.12e @xUnit\n", i + 1, fwhm);
         }
 
         if (function == 0) {


### PR DESCRIPTION
**Description**

Closes #2403. This PR fix the unit for fwhm in the spectral profile fitting log.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [X] GitHub Project estimate added

For the pull request:
- [X] reviewers and assignee added
- [X] GitHub Project estimate added
- [ ] changelog updated / ~no changelog update needed~
- [X] ~unit test added (for functions with no dependenies)~
- [X] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [X] ~protobuf version bumped~ / no protobuf version bumped needed
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [X] ~user manual prepared (for large new features)~