### PR TITLE
Thchang/2379 fix incorrect image viewer title after changing a layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix incorrect rendering of image view when moving the window to monitors with different screen resolution ([#2285](https://github.com/CARTAvis/carta-frontend/issues/2285))
 * Fix the sudden jump of dragged-out marks ([#152](https://github.com/CARTAvis/carta-frontend/issues/152)).
 * Fixed missing raster images when panning images to the top edge and right edge ([#948](https://github.com/CARTAvis/carta-frontend/issues/948)).
+* Fixed incorrect image viewer title after changing a layout ([#2379](https://github.com/CARTAvis/carta-frontend/issues/2379)).
 ### Changed
 * Changed the limitation of plotting up-to-10 profiles in the spectral profiler multi-profile mode to up-to-16 ([#2440](https://github.com/CARTAvis/carta-frontend/issues/2440))
 * Fixed the unit label of the y axis for flux density in the spectral profiles ([#2355](https://github.com/CARTAvis/carta-frontend/issues/2355)).

--- a/src/stores/LayoutStore/LayoutStore.ts
+++ b/src/stores/LayoutStore/LayoutStore.ts
@@ -138,6 +138,7 @@ export class LayoutStore {
         if (this.dockedLayout) {
             appStore.widgetsStore.initLayoutWithWidgets(this.dockedLayout);
             this.dockedLayout.init();
+            appStore.widgetsStore.updateImageWidgetTitle(this.dockedLayout);
         }
         this.currentLayoutName = layoutName;
 


### PR DESCRIPTION
**Description**

Closes #2379. This PR fix the incorrect image viewer title(No image loaded) after changing a layout.

**Checklist**

For linked issues (if there are):
- [X] assignee and label added
- [X] GitHub Project estimate added

For the pull request:
- [X] reviewers and assignee added
- [X] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [X] ~unit test added (for functions with no dependenies)~
- [X] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [X] ~protobuf version bumped~ / no protobuf version bumped needed
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [X] ~user manual prepared (for large new features)~