### PR TITLE
KSW/bump url version

### DIFF
--- a/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
+++ b/src/components/Dialogs/AboutDialog/AboutDialogComponent.tsx
@@ -92,7 +92,7 @@ export class AboutDialogComponent extends React.Component {
                         </li>
                         <li>
                             Documentation is available{" "}
-                            <a href="https://carta.readthedocs.io/en/4.1" rel="noopener noreferrer" target="_blank">
+                            <a href="https://carta.readthedocs.io/en/5.0" rel="noopener noreferrer" target="_blank">
                                 online
                             </a>
                         </li>

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -357,7 +357,7 @@ export class RootMenuComponent extends React.Component {
 
         const helpMenu = (
             <Menu>
-                <MenuItem text="Online Manual" icon={"manual"} onClick={() => this.handleDocumentationClicked("https://carta.readthedocs.io/en/4.1")} />
+                <MenuItem text="Online Manual" icon={"manual"} onClick={() => this.handleDocumentationClicked("https://carta.readthedocs.io/en/5.0")} />
                 <MenuItem text="Controls and Shortcuts" icon={"key-control"} label={"Shift + ?"} onClick={() => appStore.dialogStore.showDialog(DialogId.Hotkey)} />
                 <MenuItem text="About" icon={"info-sign"} onClick={() => appStore.dialogStore.showDialog(DialogId.About)} />
             </Menu>


### PR DESCRIPTION
**Description**

This PR bumps the online user manual url version from 4.1 to 5.0. 

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [ ] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] protobuf version bumped / no protobuf version bumped needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)