### PR TITLE
error handling for the header without CTYPE keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
+* Fixed the crush when loading fits files without CTYPE keywords in their header ([#2481](https://github.com/CARTAvis/carta-frontend/issues/2481))
 
 ## [5.0.0-beta.1c]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
-* Fixed the crush when loading fits files without CTYPE keywords in their header ([#2481](https://github.com/CARTAvis/carta-frontend/issues/2481))
+* Fixed the crash when loading fits files without CTYPE keywords in their header ([#2481](https://github.com/CARTAvis/carta-frontend/issues/2481))
 
 ## [5.0.0-beta.1c]
 

--- a/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
@@ -152,7 +152,7 @@ export class LayoutDialogComponent extends React.Component {
                         <Tooltip content="Layout name cannot be empty!" disabled={!this.isEmpty}>
                             <AnchorButton intent={Intent.PRIMARY} onClick={this.saveLayout} text={"Save"} disabled={this.isEmpty || !this.validName} />
                         </Tooltip>
-                        <Collapse isOpen={PreferenceStore.Instance.dynamicLayoutEnable}>
+                        <Collapse isOpen={PreferenceStore.Instance.dynamicLayoutEnable && !!activeFrame}>
                             <Tooltip content={`If on, apply layout when images with type (${activeFrame?.dynamicLayout.ctype.replace(",", ", ")}) are loaded`} disabled={!activeFrame}>
                                 <FormGroup inline={true} disabled={!activeFrame || this.isEmpty}>
                                     <Switch innerLabel="dynamic" checked={this.saveDynamicLayoutEnable} disabled={!activeFrame || this.isEmpty} onChange={() => this.toggleSaveDynamicLayoutEnable()} />

--- a/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
@@ -102,14 +102,14 @@ export class LayoutDialogComponent extends React.Component {
                 const confirmed = yield appStore.alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`);
                 if (confirmed) {
                     yield appStore.layoutStore.saveLayout();
-                    if (this.saveDynamicLayoutEnable && appStore.activeFrame.dynamicLayout.ctype !== "") {
+                    if (this.saveDynamicLayoutEnable && appStore.activeFrame && appStore.activeFrame?.dynamicLayout.ctype !== "") {
                         yield dyLayoutStore.saveLayoutMapping(this.layoutName, appStore.activeFrame.dynamicLayout.ctype);
                     }
                 }
             }
         } else {
             yield appStore.layoutStore.saveLayout();
-            if (this.saveDynamicLayoutEnable && appStore.activeFrame.dynamicLayout.ctype !== "") {
+            if (this.saveDynamicLayoutEnable && appStore.activeFrame && appStore.activeFrame?.dynamicLayout.ctype !== "") {
                 yield dyLayoutStore.saveLayoutMapping(this.layoutName, appStore.activeFrame.dynamicLayout.ctype);
             }
         }

--- a/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
@@ -152,10 +152,15 @@ export class LayoutDialogComponent extends React.Component {
                         <Tooltip content="Layout name cannot be empty!" disabled={!this.isEmpty}>
                             <AnchorButton intent={Intent.PRIMARY} onClick={this.saveLayout} text={"Save"} disabled={this.isEmpty || !this.validName} />
                         </Tooltip>
-                        <Collapse isOpen={PreferenceStore.Instance.dynamicLayoutEnable && !!activeFrame}>
-                            <Tooltip content={`If on, apply layout when images with type (${activeFrame?.dynamicLayout.ctype.replace(",", ", ")}) are loaded`} disabled={!activeFrame}>
+                        <Collapse isOpen={PreferenceStore.Instance.dynamicLayoutEnable && !!activeFrame && activeFrame?.dynamicLayout.ctype !== ""}>
+                            <Tooltip content={`If on, apply layout when images with type (${activeFrame?.dynamicLayout.ctype.replace(",", ", ")}) are loaded`} disabled={!activeFrame || activeFrame?.dynamicLayout.ctype === ""}>
                                 <FormGroup inline={true} disabled={!activeFrame || this.isEmpty}>
-                                    <Switch innerLabel="dynamic" checked={this.saveDynamicLayoutEnable} disabled={!activeFrame || this.isEmpty} onChange={() => this.toggleSaveDynamicLayoutEnable()} />
+                                    <Switch
+                                        innerLabel="dynamic"
+                                        checked={this.saveDynamicLayoutEnable}
+                                        disabled={!activeFrame || this.isEmpty || activeFrame?.dynamicLayout.ctype === ""}
+                                        onChange={() => this.toggleSaveDynamicLayoutEnable()}
+                                    />
                                 </FormGroup>
                             </Tooltip>
                         </Collapse>

--- a/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
+++ b/src/components/Dialogs/LayoutDialog/LayoutDialogComponent.tsx
@@ -102,14 +102,14 @@ export class LayoutDialogComponent extends React.Component {
                 const confirmed = yield appStore.alertStore.showInteractiveAlert(`Are you sure to overwrite the existing layout ${this.layoutName}?`);
                 if (confirmed) {
                     yield appStore.layoutStore.saveLayout();
-                    if (this.saveDynamicLayoutEnable) {
+                    if (this.saveDynamicLayoutEnable && appStore.activeFrame.dynamicLayout.ctype !== "") {
                         yield dyLayoutStore.saveLayoutMapping(this.layoutName, appStore.activeFrame.dynamicLayout.ctype);
                     }
                 }
             }
         } else {
             yield appStore.layoutStore.saveLayout();
-            if (this.saveDynamicLayoutEnable) {
+            if (this.saveDynamicLayoutEnable && appStore.activeFrame.dynamicLayout.ctype !== "") {
                 yield dyLayoutStore.saveLayoutMapping(this.layoutName, appStore.activeFrame.dynamicLayout.ctype);
             }
         }
@@ -216,7 +216,7 @@ export class LayoutDialogComponent extends React.Component {
         const appStore = AppStore.Instance;
         const {preferenceStore, layoutStore} = appStore;
 
-        if (preferenceStore.dynamicLayoutEnable && (appStore.activeFrame || appStore.dynamicLayoutStore.isMappingExisted)) {
+        if (preferenceStore.dynamicLayoutEnable && ((appStore.activeFrame && appStore.activeFrame.dynamicLayout.ctype !== "") || appStore.dynamicLayoutStore.isMappingExisted)) {
             return (
                 <ScrollShadow>
                     <Tabs>
@@ -343,8 +343,9 @@ export const LayoutMappingComponent = React.memo((props: LayoutMappingComponentP
         const ctypes = Object.keys(props.existLayoutMapping).reverse();
         const layoutNames = ctypes.map(ctype => props.existLayoutMapping[ctype]);
 
-        ctypeList = props.activeFrame ? (ctypes.includes(props.activeFrame.dynamicLayout.ctype) ? ctypes : [props.activeFrame.dynamicLayout.ctype, ...ctypes]) : ctypes;
-        layoutNameList = props.activeFrame ? (ctypes.includes(props.activeFrame.dynamicLayout.ctype) ? layoutNames : [props.activeFrame.dynamicLayout.layoutName, ...layoutNames]) : layoutNames;
+        ctypeList = props.activeFrame && props.activeFrame.dynamicLayout.ctype !== "" ? (ctypes.includes(props.activeFrame.dynamicLayout.ctype) ? ctypes : [props.activeFrame.dynamicLayout.ctype, ...ctypes]) : ctypes;
+        layoutNameList =
+            props.activeFrame && props.activeFrame.dynamicLayout.ctype !== "" ? (ctypes.includes(props.activeFrame.dynamicLayout.ctype) ? layoutNames : [props.activeFrame.dynamicLayout.layoutName, ...layoutNames]) : layoutNames;
     }
 
     const LayoutMappingRows = () => {

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -560,7 +560,7 @@ export class PreferenceDialogComponent extends React.Component {
                             <Switch checked={preference.isHighDimPriority} onChange={() => preference.setPreference(PreferenceKeys.LAYOUT_IS_HIGH_DIM_PRIORITY, !preference.isHighDimPriority)} />
                         </Tooltip>
                     </FormGroup>
-                    <Collapse isOpen={appStore.dynamicLayoutStore.isMappingExisted || !!appStore.activeFrame}>
+                    <Collapse isOpen={appStore.dynamicLayoutStore.isMappingExisted || (appStore.activeFrame && appStore.activeFrame.dynamicLayout.ctype !== "")}>
                         <LayoutMappingComponent orderedLayoutNames={layoutStore.orderedLayoutNames} existLayoutMapping={preference.existLayoutMapping} activeFrame={appStore.activeFrame} />
                     </Collapse>
                 </Collapse>

--- a/src/models/Ctype/CtypeDefinition.ts
+++ b/src/models/Ctype/CtypeDefinition.ts
@@ -54,6 +54,7 @@ export function CtypeAbbrToName(ctypes: string): string {
 
 export function FileCtypeInfo(headerEntries: CARTA.IFileInfoExtended | CARTA.IHeaderEntry[] | null): {ctype: string; rank: number} {
     if (headerEntries === null) {
+        console.log("no header");
         return {ctype: "", rank: 0};
     }
 
@@ -71,6 +72,12 @@ export function FileCtypeInfo(headerEntries: CARTA.IFileInfoExtended | CARTA.IHe
             tempNaxes[header.name] = `${header.value}`;
         }
     });
+
+    // error handling for the files with minimal headers
+    if (Object.keys(tempCtypes).length === 0 || Object.keys(tempNaxes).length === 0) {
+        console.log("no CTYPE or NAXIS keys in the header");
+        return {ctype: "", rank: 0};
+    }
 
     // deal with that CTYPE and NAXIS have different dimensions
     const extraNaxis = Object.keys(tempNaxes).includes("NAXIS") ? 1 : 0; // for 'NAXIS' itself

--- a/src/models/Ctype/CtypeDefinition.ts
+++ b/src/models/Ctype/CtypeDefinition.ts
@@ -54,7 +54,7 @@ export function CtypeAbbrToName(ctypes: string): string {
 
 export function FileCtypeInfo(headerEntries: CARTA.IFileInfoExtended | CARTA.IHeaderEntry[] | null): {ctype: string; rank: number} {
     if (headerEntries === null) {
-        console.log("no header");
+        console.debug("no header");
         return {ctype: "", rank: 0};
     }
 
@@ -75,7 +75,7 @@ export function FileCtypeInfo(headerEntries: CARTA.IFileInfoExtended | CARTA.IHe
 
     // error handling for the files with minimal headers
     if (Object.keys(tempCtypes).length === 0 || Object.keys(tempNaxes).length === 0) {
-        console.log("no CTYPE or NAXIS keys in the header");
+        console.debug("no CTYPE or NAXIS keys in the header");
         return {ctype: "", rank: 0};
     }
 


### PR DESCRIPTION
**Description**

Close #2481. The frontend crushes when loading fits files without CTYPE keywords in their header. The CTYPE keywords are necessary for the dynamic layout, therefore the dynamic layout is disabled for files without CTYPE keywords.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~