### PR TITLE
fix bug of spectral line labels in PNG export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
+* Fixed the misplaced spectral line labels in the PNG export with the Retina display ([[#2423](https://github.com/CARTAvis/carta-frontend/issues/2423)])
 
 ## [5.0.0-beta.1c]
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -1061,9 +1061,9 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                 spectralLines.push({
                     color: marker?.color,
                     text: marker?.label,
-                    x: canvasX,
-                    yBottom: chartArea.bottom,
-                    yTop: chartArea.top
+                    x: canvasX * devicePixelRatio,
+                    yBottom: chartArea.bottom * devicePixelRatio,
+                    yTop: chartArea.top * devicePixelRatio
                 });
             }
         });


### PR DESCRIPTION
**Description**

Close #2423. The spectral line labels are misplaced in the PNG export with Retina monitors since lacking the `devicePixelRatio` correction.

**Checklist**

The spectral line labels are in the correct positions in the PNG export files.

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~