### PR TITLE
Yuhsuan/2486 initial image position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
-* Fixed the misplaced spectral line labels in the PNG export with the Retina display ([[#2423](https://github.com/CARTAvis/carta-frontend/issues/2423)]).
-* Fixed incorrect initial position of the first loaded image ([[#2486](https://github.com/CARTAvis/carta-frontend/issues/2486)]).
+* Fixed the misplaced spectral line labels in the PNG export with the Retina display ([#2423](https://github.com/CARTAvis/carta-frontend/issues/2423)).
+* Fixed incorrect initial position of the first loaded image ([#2486](https://github.com/CARTAvis/carta-frontend/issues/2486)).
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([[#2492
 ](https://github.com/CARTAvis/carta-frontend/issues/2492)]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
 * Fixed the misplaced spectral line labels in the PNG export with the Retina display ([[#2423](https://github.com/CARTAvis/carta-frontend/issues/2423)]).
+* Fixed incorrect initial position of the first loaded image ([[#2486](https://github.com/CARTAvis/carta-frontend/issues/2486)]).
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([[#2492
 ](https://github.com/CARTAvis/carta-frontend/issues/2492)]).

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -88,13 +88,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const image = this.props.image;
         const baseFrame = this.props.image?.type === ImageType.COLOR_BLENDING ? this.props.image?.store?.baseFrame : this.props.image?.store;
         const tileRenderService = baseFrame.isPreview ? PreviewWebGLService.Instance : TileWebGLService.Instance;
-        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
         const renderWidth = this.props.renderWidth || baseFrame.renderWidth;
         const renderHeight = this.props.renderHeight || baseFrame.renderHeight;
-        const column = this.props.column;
-        const row = this.props.row;
-        const xOffset = column * renderWidth * pixelRatio;
-        const yOffset = this.gl.canvas.height - renderHeight * (row + 1) * pixelRatio;
         const canvas = this.canvas;
         const numImageColumns = AppStore.Instance.imageViewConfigStore.numImageColumns;
         const numImageRows = AppStore.Instance.imageViewConfigStore.numImageRows;
@@ -111,6 +106,12 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         if (baseFrame) {
             this.updateCanvasSize(baseFrame, renderWidth, renderHeight, numImageColumns, numImageRows);
         }
+
+        const pixelRatio = devicePixelRatio * AppStore.Instance.imageRatio;
+        const column = this.props.column;
+        const row = this.props.row;
+        const xOffset = column * renderWidth * pixelRatio;
+        const yOffset = this.gl.canvas.height - renderHeight * (row + 1) * pixelRatio;
 
         const ctx = canvas.getContext("2d");
         const w = canvas.width;


### PR DESCRIPTION
**Description**

Fixed #2486. The root cause was that the y offset was calculated before the WebGL2 canvas height was updated. Adjusted to ensure `yOffset` is computed after `updateCanvasSize` is called.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~