### PR TITLE
Kuanchou/2395 wcs crash after reading a file with a bad header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed inconsistent label offsets of ruler annotations ([#2472](https://github.com/CARTAvis/carta-frontend/issues/2472)).
+* Fixed no WCS overaly after opening a file with a non-standard header ([#2395](https://github.com/CARTAvis/carta-frontend/issues/2395)).
 
 ## [5.0.0-beta.1c]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the misplaced spectral line labels in the PNG export with the Retina display ([#2423](https://github.com/CARTAvis/carta-frontend/issues/2423)).
 * Fixed no WCS overaly after opening a file with a non-standard header ([#2395](https://github.com/CARTAvis/carta-frontend/issues/2395)).
 ### Added
-* Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492
-](https://github.com/CARTAvis/carta-frontend/issues/2492)).
+* Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492](https://github.com/CARTAvis/carta-frontend/issues/2492)).
 
 ## [5.0.0-beta.1c]
 

--- a/wasm_src/ast_wrapper/ast_wrapper.cc
+++ b/wasm_src/ast_wrapper/ast_wrapper.cc
@@ -47,6 +47,7 @@ EMSCRIPTEN_KEEPALIVE AstFrameSet* getFrameFromFitsChan(AstFitsChan* fitschan, bo
     if (!frameSet || !astIsAFrameSet(frameSet))
     {
         cout << "Creating frame set failed." << endl;
+        astClearStatus;
         return nullptr;
     }
 


### PR DESCRIPTION
**Description**

Close #2395. Clearing AST error status solves the issue after reading a file with non-standard Types in the header. The WCS coordinate system will apply a pixel frame instead of a sky frame. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)`

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~