### PR TITLE
fix multi-spectral profile colors for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the crash when loading fits files without CTYPE keywords in their header ([#2481](https://github.com/CARTAvis/carta-frontend/issues/2481)).
 * Fixed no WCS overaly after opening a file with a non-standard header ([#2395](https://github.com/CARTAvis/carta-frontend/issues/2395)).
 * Fixed no wcs grid if filename contains comma characters ([#2386](https://github.com/CARTAvis/carta-frontend/issues/2386)).
+* Colors of multi-spectral profiles do not vary with the image selection ([[#2236](https://github.com/CARTAvis/carta-frontend/issues/2236)])
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492](https://github.com/CARTAvis/carta-frontend/issues/2492)).
 * Enable the copy function in the cursor info widget ([#2468](https://github.com/CARTAvis/carta-frontend/issues/2468)).

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.tsx
@@ -105,7 +105,12 @@ class ProfileSelectionButtonComponent extends React.Component<ProfileSelectionBu
 class ProfileSelectionComponent extends React.Component<{profileSelectionStore: SpectralProfileSelectionStore}> {
     // Frame selection does not allow multiple selection
     private onFrameItemClick = (selectedFrame: number, itemIndex: number) => {
-        this.props.profileSelectionStore.selectFrame(selectedFrame);
+        const profileSelectionStore = this.props.profileSelectionStore;
+        if (profileSelectionStore.activeProfileCategory !== MultiProfileCategory.IMAGE) {
+            profileSelectionStore.selectFrame(selectedFrame);
+        } else {
+            profileSelectionStore.selectFrameMultiMode(selectedFrame);
+        }
     };
 
     private onRegionItemClick = (selectedRegion: number, itemIndex: number) => {
@@ -113,7 +118,7 @@ class ProfileSelectionComponent extends React.Component<{profileSelectionStore: 
         if (profileSelectionStore.activeProfileCategory !== MultiProfileCategory.REGION) {
             profileSelectionStore.selectRegionSingleMode(selectedRegion);
         } else {
-            profileSelectionStore.selectRegionMultiMode(selectedRegion, itemIndex + 1);
+            profileSelectionStore.selectRegionMultiMode(selectedRegion);
         }
     };
 
@@ -122,7 +127,7 @@ class ProfileSelectionComponent extends React.Component<{profileSelectionStore: 
         if (profileSelectionStore.activeProfileCategory !== MultiProfileCategory.STATISTIC) {
             profileSelectionStore.selectStatSingleMode(selectedStatsType);
         } else {
-            profileSelectionStore.selectStatMultiMode(selectedStatsType, itemIndex + 1);
+            profileSelectionStore.selectStatMultiMode(selectedStatsType);
         }
     };
 
@@ -131,7 +136,7 @@ class ProfileSelectionComponent extends React.Component<{profileSelectionStore: 
         if (profileSelectionStore.activeProfileCategory !== MultiProfileCategory.STOKES) {
             profileSelectionStore.selectCoordinateSingleMode(selectedStokes);
         } else {
-            profileSelectionStore.selectCoordinateMultiMode(selectedStokes, itemIndex + 1);
+            profileSelectionStore.selectCoordinateMultiMode(selectedStokes);
         }
     };
 
@@ -146,7 +151,7 @@ class ProfileSelectionComponent extends React.Component<{profileSelectionStore: 
                     categoryName={MultiProfileCategory.IMAGE}
                     isActiveCategory={profileSelectionStore.activeProfileCategory === MultiProfileCategory.IMAGE}
                     itemOptions={profileSelectionStore.frameOptions}
-                    itemSelected={[profileSelectionStore.selectedFrameWidgetFileId]}
+                    itemSelected={profileSelectionStore.activeProfileCategory === MultiProfileCategory.IMAGE ? profileSelectionStore.selectedFileIds : [profileSelectionStore.selectedFrameWidgetFileId]}
                     disabled={!frame}
                     isSelectingSpecificItem={profileSelectionStore.isSelectingActiveFrame}
                     onCategorySelect={() => {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
+import {action, autorun, computed, makeObservable, observable} from "mobx";
 
 import {GetIntensityOptions, IntensityConfig, LineKey, LineOption, POLARIZATION_LABELS, POLARIZATIONS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
 import {AppStore} from "stores";
@@ -48,6 +48,7 @@ type Profile = {
 export class SpectralProfileSelectionStore {
     // profile selection
     @observable activeProfileCategory: MultiProfileCategory;
+    @observable selectedFileIds: number[];
     @observable selectedRegionIds: number[];
     @observable selectedStatsTypes: CARTA.StatsType[];
     @observable selectedCoordinates: string[];
@@ -103,7 +104,7 @@ export class SpectralProfileSelectionStore {
                 if (this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined && matchedFileIds?.includes(this.selectedFrameFileId)) {
                     const appStore = AppStore.Instance;
 
-                    matchedFileIds.forEach(fileId => {
+                    this.selectedFileIds?.forEach(fileId => {
                         const frame = appStore.getFrame(fileId);
                         if (frame) {
                             const hasCommonIntensityUnit = this.widgetStore.intensityUnit && GetIntensityOptions(frame.intensityConfig).includes(this.widgetStore.intensityUnit);
@@ -244,8 +245,7 @@ export class SpectralProfileSelectionStore {
         if (this.activeProfileCategory === MultiProfileCategory.NONE) {
             return [SpectralProfileWidgetStore.PRIMARY_LINE_KEY];
         } else if (this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
-            const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-            return matchedFileIds?.includes(this.selectedFrameFileId) ? matchedFileIds : [this.selectedFrameFileId];
+            return this.selectedFileIds;
         } else if (this.activeProfileCategory === MultiProfileCategory.REGION) {
             return this.selectedRegionIds;
         } else if (this.activeProfileCategory === MultiProfileCategory.STATISTIC) {
@@ -272,7 +272,7 @@ export class SpectralProfileSelectionStore {
     }
 
     @computed get frameOptions(): LineOption[] {
-        let options: LineOption[] = [{value: ACTIVE_FILE_ID, label: "Active"}];
+        let options: LineOption[] = [{value: ACTIVE_FILE_ID, label: "Active", disabled: this.activeProfileCategory === MultiProfileCategory.IMAGE}];
 
         const appStore = AppStore.Instance;
         const frameOptions = appStore.frameOptions;
@@ -508,11 +508,14 @@ export class SpectralProfileSelectionStore {
         const widgetStore = this.widgetStore;
         const primaryLineColor = widgetStore.primaryLineColor;
         widgetStore.clearProfileColors();
+
         if (profileCategory === MultiProfileCategory.NONE) {
             // Single profile mode
             widgetStore.setProfileColor(SpectralProfileWidgetStore.PRIMARY_LINE_KEY, primaryLineColor);
         } else if (profileCategory === MultiProfileCategory.IMAGE) {
             if (this.selectedFrame && this.selectedFrameFileId !== undefined) {
+                // Reset selected frames
+                this.selectedFileIds = [this.selectedFrameFileId];
                 // Switch spectral system to Radio velocity for common use case
                 this.selectedFrame.setSpectralCoordinateToRadioVelocity();
                 widgetStore.setProfileColor(this.selectedFrameFileId, primaryLineColor);
@@ -536,6 +539,26 @@ export class SpectralProfileSelectionStore {
         }
     };
 
+    private assignColor = (selectedId: number | string) => {
+        const widgetStore = this.widgetStore;
+        const profileColors = [...widgetStore.lineColorMap.values()]; // existing profile colors
+        const profileColor = widgetStore.getProfileColor(selectedId);
+
+        if (!profileColor) {
+            let color: string;
+
+            // find color that is not used by other profiles
+            for (let i = 0; i < profileColors.length + 1; i++) {
+                color = genColorFromIndex(i);
+                if (!profileColors.includes(color)) {
+                    break;
+                }
+            }
+
+            widgetStore.setProfileColor(selectedId, color);
+        }
+    };
+
     // When frame is changed,
     // Single profile mode(None)/Multi profile mode of Stat/Stokes:
     //      * region - switch to active to ensure getting correct region
@@ -553,6 +576,35 @@ export class SpectralProfileSelectionStore {
         if (regionId !== null) {
             widgetStore.setRegionId(fileId, regionId);
             this.selectedRegionIds = [regionId];
+        }
+    };
+
+    @action selectFrameMultiMode = (fileId: number) => {
+        const widgetStore = this.widgetStore;
+        const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+
+        if (!matchedFileIds?.includes(fileId)) {
+            this.selectedFileIds = [fileId];
+            widgetStore.setFileId(fileId);
+            return;
+        }
+
+        if (this.selectedFileIds?.includes(fileId) && this.selectedFileIds?.length > 1) {
+            // remove selection
+            this.removeSelectedFileMultiMode(fileId);
+        } else if (!this.selectedFileIds?.includes(fileId) && this.selectedFileIds?.length < MAXIMUM_PROFILES) {
+            // add selection
+            this.selectedFileIds = [...this.selectedFileIds, fileId].sort((a, b) => {
+                return a - b;
+            });
+            this.assignColor(fileId);
+        }
+    };
+
+    @action removeSelectedFileMultiMode = (fileId: number) => {
+        if (this.selectedFileIds?.includes(fileId)) {
+            this.selectedFileIds = this.selectedFileIds.filter(selectedFileId => selectedFileId !== fileId);
+            this.widgetStore.removeProfileColor(fileId);
         }
     };
 
@@ -584,7 +636,7 @@ export class SpectralProfileSelectionStore {
         }
     };
 
-    @action selectRegionMultiMode = (regionId: number, itemIndex: number) => {
+    @action selectRegionMultiMode = (regionId: number) => {
         if (this.selectedRegionIds?.includes(regionId) && this.selectedRegionIds?.length > 1) {
             // remove selection
             this.removeSelectedRegionMultiMode(regionId);
@@ -593,12 +645,11 @@ export class SpectralProfileSelectionStore {
             this.selectedRegionIds = [...this.selectedRegionIds, regionId].sort((a, b) => {
                 return a - b;
             });
-            const color = this.selectedRegionIds.length === 1 ? this.widgetStore.primaryLineColor : genColorFromIndex(itemIndex);
-            this.widgetStore.setProfileColor(regionId, color);
+            this.assignColor(regionId);
         }
     };
 
-    @action selectStatMultiMode = (statsType: CARTA.StatsType, itemIndex: number) => {
+    @action selectStatMultiMode = (statsType: CARTA.StatsType) => {
         if (SUPPORTED_STATISTICS_TYPES.includes(statsType)) {
             if (this.selectedStatsTypes?.includes(statsType) && this.selectedStatsTypes?.length > 1) {
                 // remove selection
@@ -609,13 +660,12 @@ export class SpectralProfileSelectionStore {
                 this.selectedStatsTypes = [...this.selectedStatsTypes, statsType].sort((a, b) => {
                     return a - b;
                 });
-                const color = this.selectedStatsTypes.length === 1 ? this.widgetStore.primaryLineColor : genColorFromIndex(itemIndex);
-                this.widgetStore.setProfileColor(statsType, color);
+                this.assignColor(statsType as number);
             }
         }
     };
 
-    @action selectCoordinateMultiMode = (coordinate: string, itemIndex: number) => {
+    @action selectCoordinateMultiMode = (coordinate: string) => {
         if (VALID_COORDINATES.includes(coordinate)) {
             if (this.selectedCoordinates?.includes(coordinate) && this.selectedCoordinates.length > 1) {
                 // remove selection
@@ -632,8 +682,7 @@ export class SpectralProfileSelectionStore {
                     }
                     return a.charCodeAt(0) - b.charCodeAt(0);
                 });
-                const color = this.selectedCoordinates.length === 1 ? this.widgetStore.primaryLineColor : genColorFromIndex(itemIndex);
-                this.widgetStore.setProfileColor(coordinate, color);
+                this.assignColor(coordinate);
             }
         }
     };
@@ -672,7 +721,7 @@ export class SpectralProfileSelectionStore {
 
                 // Once selectedRegionIds becomes empty, add cursor region (active region is disabled in multi selection mode)
                 if (this.selectedRegionIds?.length === 0) {
-                    this.selectRegionMultiMode(RegionId.CURSOR, 0);
+                    this.selectRegionMultiMode(RegionId.CURSOR);
                 }
             } else {
                 if (this.selectedRegionIds?.length > 0 && !this.regionOptions?.find(regionOption => this.selectedRegionIds[0] === regionOption.value)) {
@@ -688,46 +737,11 @@ export class SpectralProfileSelectionStore {
             }
         });
 
-        // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
-        reaction(
-            () => {
-                // when matchedFileIds and activeProfileCategory changes, give colors to profiles
-                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-                const activeProfileCategory = this.activeProfileCategory;
-                return {matchedFileIds, activeProfileCategory};
-            },
-            () => {
-                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-                if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
-                    if (matchedFileIds.includes(this.selectedFrameFileId)) {
-                        const widgetStore = this.widgetStore;
-                        const profileColors: string[] = []; // to record existing profile colors
-
-                        matchedFileIds.forEach(fileId => {
-                            const profileColor = widgetStore.getProfileColor(fileId);
-
-                            // "auto-blue" is the default color name for the first image,
-                            // it will be replaced by the Hex code (same color) using genColorFromIndex(0)
-                            if (!profileColor || profileColor === "auto-blue") {
-                                let color: string = genColorFromIndex(0);
-
-                                // find color that is not used by other profiles
-                                for (let i = 1; i < profileColors.length + 1; i++) {
-                                    color = genColorFromIndex(i);
-                                    if (!profileColors.includes(color)) {
-                                        break;
-                                    }
-                                }
-
-                                widgetStore.setProfileColor(fileId, color);
-                                profileColors.push(color);
-                            } else {
-                                profileColors.push(profileColor);
-                            }
-                        });
-                    }
-                }
+        // Selecting active frame in the single frame mode
+        autorun(() => {
+            if (this.activeProfileCategory !== MultiProfileCategory.IMAGE) {
+                this.selectFrame(ACTIVE_FILE_ID);
             }
-        );
+        });
     }
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
 
 import {GetIntensityOptions, IntensityConfig, LineKey, LineOption, POLARIZATION_LABELS, POLARIZATIONS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
 import {AppStore} from "stores";
@@ -689,18 +689,60 @@ export class SpectralProfileSelectionStore {
         });
 
         // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
-        autorun(() => {
-            const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-            if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
-                if (matchedFileIds.includes(this.selectedFrameFileId)) {
-                    matchedFileIds.forEach((fileId, index) => {
+        // autorun(() => {
+        //     const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+        //     if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
+        //         if (matchedFileIds.includes(this.selectedFrameFileId)) {
+        //             const widgetStore = this.widgetStore;
+        //             widgetStore.clearProfileColors();
+        //             matchedFileIds.forEach((fileId, index) => {
+        //                 // index + 1 to avoid choosing blue(conflict with native primary color(auto-blue))
+        //                 // const color = fileId === this.selectedFrameFileId ? widgetStore.primaryLineColor : genColorFromIndex(index + 1);
+        //                 const color = genColorFromIndex(index);
+        //                 widgetStore.setProfileColor(fileId, color);
+        //             });
+        //         }
+        //     }
+        // });
+
+
+        reaction(
+            () => {
+                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+                const activeProfileCategory = this.activeProfileCategory;
+                return {matchedFileIds, activeProfileCategory};
+            }, 
+            () => {
+                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+                // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
+                if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
+                    if (matchedFileIds.includes(this.selectedFrameFileId)) {
                         const widgetStore = this.widgetStore;
-                        // index + 1 to avoid choosing blue(conflict with native primary color(auto-blue))
-                        const color = fileId === this.selectedFrameFileId ? widgetStore.primaryLineColor : genColorFromIndex(index + 1);
-                        widgetStore.setProfileColor(fileId, color);
-                    });
-                }
-            }
+                        const profileColors = [];
+                        
+                        matchedFileIds.forEach(fileId => {
+                            const profileColor = widgetStore.getProfileColor(fileId);
+                            
+                            if (!profileColor || profileColor === "auto-blue") {
+
+                                let color: string;
+                                for (let i = 0; i < profileColors.length + 1; i++) {
+                                    color = genColorFromIndex(i);
+                                    if (!profileColors.includes(color)) {
+                                        break;
+                                    }
+                                }
+
+                                widgetStore.setProfileColor(fileId, color);
+                                profileColors.push(color);
+
+                            } else {
+                                profileColors.push(profileColor);
+                            }
+                        });
+                    }
+                }    
+
         });
     }
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -753,13 +753,11 @@ export class SpectralProfileSelectionStore {
             matchedFileIds => {
                 if (this.activeProfileCategory === MultiProfileCategory.IMAGE) {
                     // remove the profile if it is unmatched
-                    if (this.selectedFileIds.length > 0) {
-                        this.selectedFileIds.forEach(fileId => {
-                            if (!matchedFileIds?.includes(fileId)) {
-                                this.removeSelectedFileMultiMode(fileId);
-                            }
-                        });
-                    }
+                    this.selectedFileIds.forEach(fileId => {
+                        if (!matchedFileIds?.includes(fileId)) {
+                            this.removeSelectedFileMultiMode(fileId);
+                        }
+                    });
 
                     // if no selected frame under the multi-frame mode, add the selected frame
                     if (this.selectedFileIds.length === 0 && this.selectedFrameFileId !== undefined) {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -334,7 +334,7 @@ export class SpectralProfileSelectionStore {
                     return {
                         value: r.regionId,
                         label: r.nameString,
-                        active: this.widgetStore.isEffectiveFrameEqualToActiveFrame && r.regionId === activeRegionId
+                        active: r.regionId === activeRegionId
                     };
                 })
             );

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -705,28 +705,26 @@ export class SpectralProfileSelectionStore {
         //     }
         // });
 
-
         reaction(
             () => {
                 const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
                 const activeProfileCategory = this.activeProfileCategory;
                 return {matchedFileIds, activeProfileCategory};
-            }, 
+            },
             () => {
                 const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
                 // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
                 if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
                     if (matchedFileIds.includes(this.selectedFrameFileId)) {
                         const widgetStore = this.widgetStore;
-                        const profileColors = [];
-                        
+                        const profileColors: string[] = [];
+
                         matchedFileIds.forEach(fileId => {
                             const profileColor = widgetStore.getProfileColor(fileId);
-                            
-                            if (!profileColor || profileColor === "auto-blue") {
 
-                                let color: string;
-                                for (let i = 0; i < profileColors.length + 1; i++) {
+                            if (!profileColor || profileColor === "auto-blue") {
+                                let color: string = genColorFromIndex(0);
+                                for (let i = 1; i < profileColors.length + 1; i++) {
                                     color = genColorFromIndex(i);
                                     if (!profileColors.includes(color)) {
                                         break;
@@ -735,14 +733,13 @@ export class SpectralProfileSelectionStore {
 
                                 widgetStore.setProfileColor(fileId, color);
                                 profileColors.push(color);
-
                             } else {
                                 profileColors.push(profileColor);
                             }
                         });
                     }
-                }    
-
-        });
+                }
+            }
+        );
     }
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -583,9 +583,11 @@ export class SpectralProfileSelectionStore {
         const widgetStore = this.widgetStore;
         const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
 
-        if (!matchedFileIds?.includes(fileId) || !matchedFileIds?.includes(this.selectedFrameFileId)) {
+        if (this.selectedFrameFileId !== undefined && (!matchedFileIds?.includes(fileId) || !matchedFileIds?.includes(this.selectedFrameFileId))) {
             this.selectedFileIds = [fileId];
             widgetStore.setFileId(fileId);
+            widgetStore.clearProfileColors();
+            this.assignColor(fileId);
             return;
         }
 
@@ -749,10 +751,14 @@ export class SpectralProfileSelectionStore {
                 return matchedFileIds;
             },
             matchedFileIds => {
-                if (!matchedFileIds.includes(this.selectedFrameFileId)) {
+                if (this.selectedFrameFileId !== undefined && !matchedFileIds.includes(this.selectedFrameFileId)) {
                     this.selectedFileIds = [this.selectedFrameFileId];
                 } else {
-                    this.selectedFileIds = this.selectedFileIds?.filter(fileId => matchedFileIds.includes(fileId));
+                    this.selectedFileIds.forEach(fileId => {
+                        if (!matchedFileIds.includes(fileId)) {
+                            this.removeSelectedFileMultiMode(fileId);
+                        }
+                    });
                 }
             }
         );

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
 
 import {GetIntensityOptions, IntensityConfig, LineKey, LineOption, POLARIZATION_LABELS, POLARIZATIONS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
 import {AppStore} from "stores";
@@ -583,7 +583,7 @@ export class SpectralProfileSelectionStore {
         const widgetStore = this.widgetStore;
         const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
 
-        if (!matchedFileIds?.includes(fileId)) {
+        if (!matchedFileIds?.includes(fileId) || !matchedFileIds?.includes(this.selectedFrameFileId)) {
             this.selectedFileIds = [fileId];
             widgetStore.setFileId(fileId);
             return;
@@ -594,9 +594,8 @@ export class SpectralProfileSelectionStore {
             this.removeSelectedFileMultiMode(fileId);
         } else if (!this.selectedFileIds?.includes(fileId) && this.selectedFileIds?.length < MAXIMUM_PROFILES) {
             // add selection
-            this.selectedFileIds = [...this.selectedFileIds, fileId].sort((a, b) => {
-                return a - b;
-            });
+            this.selectedFileIds = [...this.selectedFileIds, fileId];
+            widgetStore.setFileId(fileId);
             this.assignColor(fileId);
         }
     };
@@ -743,5 +742,19 @@ export class SpectralProfileSelectionStore {
                 this.selectFrame(ACTIVE_FILE_ID);
             }
         });
+
+        reaction(
+            () => {
+                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+                return matchedFileIds;
+            },
+            matchedFileIds => {
+                if (!matchedFileIds.includes(this.selectedFrameFileId)) {
+                    this.selectedFileIds = [this.selectedFrameFileId];
+                } else {
+                    this.selectedFileIds = this.selectedFileIds?.filter(fileId => matchedFileIds.includes(fileId));
+                }
+            }
+        );
     }
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -100,8 +100,7 @@ export class SpectralProfileSelectionStore {
                 const region = this.widgetStore.effectiveRegion;
                 const statsType = region?.isClosedRegion ? this.selectedStatsTypes[0] : CARTA.StatsType.Sum;
                 const selectedCoordinate = this.selectedCoordinates[0];
-                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-                if (this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined && matchedFileIds?.includes(this.selectedFrameFileId)) {
+                if (this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
                     const appStore = AppStore.Instance;
 
                     this.selectedFileIds?.forEach(fileId => {
@@ -599,7 +598,6 @@ export class SpectralProfileSelectionStore {
             this.selectedFileIds = [...this.selectedFileIds, fileId].sort((a, b) => {
                 return a - b;
             });
-            widgetStore.setFileId(fileId);
             this.assignColor(fileId);
         }
     };
@@ -742,7 +740,9 @@ export class SpectralProfileSelectionStore {
 
         // Selecting active frame in the single frame mode
         autorun(() => {
-            this.activeProfileCategory === MultiProfileCategory.IMAGE ? this.selectFrame(AppStore.Instance.activeFrameFileId) : this.selectFrame(ACTIVE_FILE_ID);
+            if (this.activeProfileCategory !== MultiProfileCategory.IMAGE) {
+                this.selectFrame(ACTIVE_FILE_ID);
+            }
         });
 
         reaction(
@@ -751,14 +751,20 @@ export class SpectralProfileSelectionStore {
                 return matchedFileIds;
             },
             matchedFileIds => {
-                if (this.selectedFrameFileId !== undefined && !matchedFileIds.includes(this.selectedFrameFileId)) {
-                    this.selectedFileIds = [this.selectedFrameFileId];
-                } else {
-                    this.selectedFileIds.forEach(fileId => {
-                        if (!matchedFileIds.includes(fileId)) {
-                            this.removeSelectedFileMultiMode(fileId);
-                        }
-                    });
+                if (this.activeProfileCategory === MultiProfileCategory.IMAGE) {
+                    // remove the profile if it is unmatched
+                    if (this.selectedFileIds.length > 0) {
+                        this.selectedFileIds.forEach(fileId => {
+                            if (!matchedFileIds?.includes(fileId)) {
+                                this.removeSelectedFileMultiMode(fileId);
+                            }
+                        });
+                    }
+
+                    // if no selected frame under the multi-frame mode, add the selected frame
+                    if (this.selectedFileIds.length === 0) {
+                        this.selectedFileIds = [this.selectedFrameFileId];
+                    }
                 }
             }
         );

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -596,7 +596,9 @@ export class SpectralProfileSelectionStore {
             this.removeSelectedFileMultiMode(fileId);
         } else if (!this.selectedFileIds?.includes(fileId) && this.selectedFileIds?.length < MAXIMUM_PROFILES) {
             // add selection
-            this.selectedFileIds = [...this.selectedFileIds, fileId];
+            this.selectedFileIds = [...this.selectedFileIds, fileId].sort((a, b) => {
+                return a - b;
+            });
             widgetStore.setFileId(fileId);
             this.assignColor(fileId);
         }
@@ -740,9 +742,7 @@ export class SpectralProfileSelectionStore {
 
         // Selecting active frame in the single frame mode
         autorun(() => {
-            if (this.activeProfileCategory !== MultiProfileCategory.IMAGE) {
-                this.selectFrame(ACTIVE_FILE_ID);
-            }
+            this.activeProfileCategory === MultiProfileCategory.IMAGE ? this.selectFrame(AppStore.Instance.activeFrameFileId) : this.selectFrame(ACTIVE_FILE_ID);
         });
 
         reaction(

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -689,41 +689,29 @@ export class SpectralProfileSelectionStore {
         });
 
         // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
-        // autorun(() => {
-        //     const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-        //     if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
-        //         if (matchedFileIds.includes(this.selectedFrameFileId)) {
-        //             const widgetStore = this.widgetStore;
-        //             widgetStore.clearProfileColors();
-        //             matchedFileIds.forEach((fileId, index) => {
-        //                 // index + 1 to avoid choosing blue(conflict with native primary color(auto-blue))
-        //                 // const color = fileId === this.selectedFrameFileId ? widgetStore.primaryLineColor : genColorFromIndex(index + 1);
-        //                 const color = genColorFromIndex(index);
-        //                 widgetStore.setProfileColor(fileId, color);
-        //             });
-        //         }
-        //     }
-        // });
-
         reaction(
             () => {
+                // when matchedFileIds and activeProfileCategory changes, give colors to profiles
                 const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
                 const activeProfileCategory = this.activeProfileCategory;
                 return {matchedFileIds, activeProfileCategory};
             },
             () => {
                 const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-                // When in Multi profile mode of Image and there are matched files(may change dynamically), assign them colors
                 if (matchedFileIds?.length > 1 && this.activeProfileCategory === MultiProfileCategory.IMAGE && this.selectedFrameFileId !== undefined) {
                     if (matchedFileIds.includes(this.selectedFrameFileId)) {
                         const widgetStore = this.widgetStore;
-                        const profileColors: string[] = [];
+                        const profileColors: string[] = []; // to record existing profile colors
 
                         matchedFileIds.forEach(fileId => {
                             const profileColor = widgetStore.getProfileColor(fileId);
 
+                            // "auto-blue" is the default color name for the first image,
+                            // it will be replaced by the Hex code (same color) using genColorFromIndex(0)
                             if (!profileColor || profileColor === "auto-blue") {
                                 let color: string = genColorFromIndex(0);
+
+                                // find color that is not used by other profiles
                                 for (let i = 1; i < profileColors.length + 1; i++) {
                                     color = genColorFromIndex(i);
                                     if (!profileColors.includes(color)) {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -545,7 +545,7 @@ export class SpectralProfileSelectionStore {
         const profileColor = widgetStore.getProfileColor(selectedId);
 
         if (!profileColor) {
-            let color: string;
+            let color: string = genColorFromIndex(0);
 
             // find color that is not used by other profiles
             for (let i = 0; i < profileColors.length + 1; i++) {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -762,7 +762,7 @@ export class SpectralProfileSelectionStore {
                     }
 
                     // if no selected frame under the multi-frame mode, add the selected frame
-                    if (this.selectedFileIds.length === 0) {
+                    if (this.selectedFileIds.length === 0 && this.selectedFrameFileId !== undefined) {
                         this.selectedFileIds = [this.selectedFrameFileId];
                     }
                 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -375,7 +375,6 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.meanRmsVisible = false;
         this.secondaryAxisCursorInfoVisible = false;
         this.markerTextVisible = false;
-        // this.primaryLineColor = "auto-blue";
         this.primaryLineColor = genColorFromIndex(0); // default auto-blue color in Hex code
         this.lineColorMap = new Map<LineKey, string>([[SpectralProfileWidgetStore.PRIMARY_LINE_KEY, this.primaryLineColor]]);
         this.linePlotPointSize = 1.5;

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -9,7 +9,7 @@ import {FindIntensityUnitType, GetCommonIntensityOptions, GetIntensityConversion
 import {TelemetryAction, TelemetryService} from "services";
 import {AppStore, ProfileFittingStore, ProfileSmoothingStore} from "stores";
 import {MultiProfileCategory, RegionId, RegionsType, RegionWidgetStore, SpectralLine, SpectralProfileSelectionStore} from "stores/Widgets";
-import {clamp, getColorForTheme, isAutoColor} from "utilities";
+import {clamp, genColorFromIndex, getColorForTheme, isAutoColor} from "utilities";
 
 export enum MomentSelectingMode {
     NONE = 1,
@@ -375,7 +375,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.meanRmsVisible = false;
         this.secondaryAxisCursorInfoVisible = false;
         this.markerTextVisible = false;
-        this.primaryLineColor = "auto-blue";
+        // this.primaryLineColor = "auto-blue";
+        this.primaryLineColor = genColorFromIndex(0); // default auto-blue color in Hex code
         this.lineColorMap = new Map<LineKey, string>([[SpectralProfileWidgetStore.PRIMARY_LINE_KEY, this.primaryLineColor]]);
         this.linePlotPointSize = 1.5;
         this.lineWidth = 1;


### PR DESCRIPTION
**Description**

This PR closes #2236. The colors of spectral profiles in multi-image mode are fixed, i.e., the color doesn't vary with activeFrame changes. Adding support for plotting the selected frames. The multi-region, statistic, and polarization profiles adopt the same color assigning method.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~