### PR TITLE
Yuhsuan/1600 z profiler overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([[#2492
 ](https://github.com/CARTAvis/carta-frontend/issues/2492)]).
+### Changed
+* The dropdown options in the z profile widget becomes scrollable with small widget width ([#1600](https://github.com/CARTAvis/carta-frontend/issues/1600)).
 
 ## [5.0.0-beta.1c]
 

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.scss
@@ -22,10 +22,6 @@
         flex: 3 3 auto;
         min-width: 0;
 
-        .profile-toolbar {
-            height: 42px;
-        }
-
         .body-split-pane {
             height: calc(100% - 42px) !important;
             position: inherit !important;

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.scss
@@ -21,11 +21,13 @@
     .profile-container {
         flex: 3 3 auto;
         min-width: 0;
+        display: flex;
+        flex-direction: column;
 
         .body-split-pane {
-            height: calc(100% - 42px) !important;
+            height: auto !important;
             position: inherit !important;
-            min-height: calc(100% - 42px) !important;
+            min-height: auto !important;
 
             .Resizer {
                 background: rgba(0, 0, 0, 0);

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -27,7 +27,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return {
             id: "spectral-profiler",
             type: "spectral-profiler",
-            minWidth: 880,
+            minWidth: 300,
             minHeight: 300,
             defaultWidth: 870,
             defaultHeight: 300,

--- a/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
+++ b/src/components/SpectralProfiler/SpectralProfilerToolbarComponent/SpectralProfilerToolbarComponent.scss
@@ -1,7 +1,7 @@
 @import "~@blueprintjs/core/lib/scss/variables.scss";
 
 .spectral-profiler-toolbar {
-    overflow: hidden;
+    overflow-x: auto;
     display: flex;
     user-select: none;
 
@@ -15,7 +15,7 @@
         .category-set {
             display: flex;
             align-items: center;
-            margin-right: 15px;
+            margin-right: 12px;
 
             .category-checkbox {
                 margin: 0 5px 0 0;


### PR DESCRIPTION
**Description**

Closes #1600 by making the dropdown options in the z profile widget scrollable.

Code changes

* Adjusted `overflow` in CSS.
* Adjusted the gaps to avoid the scrollbar appearing with the default width.
* Allowed a smaller minimum widget width when the widget is undocked.

Tested that the z profile widget

* shows the scrollbar according to the widget width and the OS settings (optionally/always showing scrollbars).
* does not show the scrollbar with the default width.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / ~new e2e test created~
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~