### PR TITLE
Yuhsuan/2467 jumpy non square images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the crash when loading fits files without CTYPE keywords in their header ([#2481](https://github.com/CARTAvis/carta-frontend/issues/2481)).
 * Fixed no WCS overaly after opening a file with a non-standard header ([#2395](https://github.com/CARTAvis/carta-frontend/issues/2395)).
 * Fixed no wcs grid if filename contains comma characters ([#2386](https://github.com/CARTAvis/carta-frontend/issues/2386)).
+* Fixed jumpy non-square images after widget resizing ([#2467](https://github.com/CARTAvis/carta-frontend/issues/2467)).
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492](https://github.com/CARTAvis/carta-frontend/issues/2492)).
 ### Changed

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -109,10 +109,15 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         if (prevProps.width !== this.props.width || prevProps.height !== this.props.height) {
             const stage = this.stageRef.current;
             if (stage) {
-                const offset = {x: (this.props.width - prevProps.width) / 2, y: (this.props.height - prevProps.height) / 2};
+                const offset = {x: ((this.props.width - prevProps.width) / 2) * this.props.frame.aspectRatio, y: (this.props.height - prevProps.height) / 2};
                 const zoom = stage.scaleX();
                 const mutatedOffset = scale2D(offset, (1 - zoom) / zoom);
                 this.stageResizeOffset = add2D(this.stageResizeOffset, mutatedOffset);
+
+                const frame = this.props.frame?.spatialReference ?? this.props.frame;
+                if (frame) {
+                    this.syncStage(frame.centerMovement, frame.zoomLevel);
+                }
             }
         }
     }


### PR DESCRIPTION
**Description**

Fixed #2467 by considering the aspect ratio when calculating `RegionViewComponent.stageResizeOffset` after resizing widgets, and making sure the stage position is updated after the `RegionViewComponent.stageResizeOffset` calculation.

Details of the root cause: when dragging an image, we trigger the following steps.

1. Konva `<Stage>` is dragged (i.e. the `<Stage>` position is updated).
2. `FrameStore.center` is updated according to the `<Stage>` position.
3. The `<Stage>` position of all matched images (including the dragged `<Stage>`) are updated according to `FrameStore.center` and `RegionViewComponent.stageResizeOffset`.

If `RegionViewComponent.stageResizeOffset` is incorrect, we get incorrect stage position in step 3. Sometimes step 3 occurs after step 1 of the next drag event (i.e. the stage position is updated with our incorrect calculation after the update of the drag event. The two values should be close when the calculation is correct.), and we get incorrect frame center in step 2 and see an additional jump of the raster image.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~