### PR TITLE
error handling for hypercube dynamic layout

### DIFF
--- a/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
+++ b/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
@@ -211,7 +211,9 @@ export class StokesDialogComponent extends React.Component {
         if (PreferenceStore.Instance.dynamicLayoutEnable) {
             const hyperCubeCtype = HyperCubeCtypeTransform(fileBrowserStore.selectedFilesCtypes);
             dynamicLayoutStore.matchLayoutMapping(hyperCubeCtype);
-            layoutStore.applyLayout(dynamicLayoutStore.dynamicLayoutName);
+            if (dynamicLayoutStore.dynamicLayoutName && layoutStore.layoutExists(dynamicLayoutStore.dynamicLayoutName)) {
+                layoutStore.applyLayout(dynamicLayoutStore.dynamicLayoutName);
+            }
         }
 
         await this.loadFile(stokeFiles)


### PR DESCRIPTION
**Description**

Close #2528. This is a quick fix for adding error handling for hypercube dynamic layout to prevent the pop up warning message. If there is no exist dynamic layout for hypercube (3D+Stokes), the warning message will show up when loading files as a hypercube.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~