### PR TITLE
`npm audit fix` updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,12 +1783,13 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.20.13",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.6.tgz",
+            "integrity": "sha512-vDVrlmRAY8z9Ul/HxT+8ceAru95LQgkSKiXkSYZvqtbkPSfhZJgpRp45Cldbh1GJ1kxzQkI70AqyrTI58KpaWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "core-js-pure": "^3.25.1",
-                "regenerator-runtime": "^0.13.11"
+                "core-js-pure": "^3.30.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3223,17 +3224,17 @@
             }
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-            "version": "0.5.10",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.16.tgz",
+            "integrity": "sha512-kLQc9xz6QIqd2oIYyXRUiAp79kGpFBm3fEM9ahfG1HI0WI5gdZ2OVHWdmZYnwODt7ISck+QuQ6sBPrtvUBML7Q==",
             "license": "MIT",
             "dependencies": {
-                "ansi-html-community": "^0.0.8",
-                "common-path-prefix": "^3.0.0",
+                "ansi-html": "^0.0.9",
                 "core-js-pure": "^3.23.3",
                 "error-stack-parser": "^2.0.6",
-                "find-up": "^5.0.0",
                 "html-entities": "^2.1.0",
                 "loader-utils": "^2.0.4",
-                "schema-utils": "^3.0.0",
+                "schema-utils": "^4.2.0",
                 "source-map": "^0.7.3"
             },
             "engines": {
@@ -3243,9 +3244,9 @@
                 "@types/webpack": "4.x || 5.x",
                 "react-refresh": ">=0.10.0 <1.0.0",
                 "sockjs-client": "^1.4.0",
-                "type-fest": ">=0.17.0 <4.0.0",
+                "type-fest": ">=0.17.0 <5.0.0",
                 "webpack": ">=4.43.0 <6.0.0",
-                "webpack-dev-server": "3.x || 4.x",
+                "webpack-dev-server": "3.x || 4.x || 5.x",
                 "webpack-hot-middleware": "2.x",
                 "webpack-plugin-serve": "0.x || 1.x"
             },
@@ -3268,6 +3269,37 @@
                 "webpack-plugin-serve": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
@@ -4359,7 +4391,9 @@
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/ws": {
-            "version": "8.5.4",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -4662,9 +4696,10 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -5109,6 +5144,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-html": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+            "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+            "engines": [
+                "node >= 0.8.0"
+            ],
+            "license": "Apache-2.0",
+            "bin": {
+                "ansi-html": "bin/ansi-html"
             }
         },
         "node_modules/ansi-html-community": {
@@ -5866,7 +5913,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6534,10 +6583,6 @@
             "version": "2.20.3",
             "license": "MIT"
         },
-        "node_modules/common-path-prefix": {
-            "version": "3.0.0",
-            "license": "ISC"
-        },
         "node_modules/common-tags": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -6705,7 +6750,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.27.2",
+            "version": "3.43.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.43.0.tgz",
+            "integrity": "sha512-i/AgxU2+A+BbJdMxh3v7/vxi2SbFqxiFmg6VsDwYB4jkucrd1BZNA9a9gphC0fYMG5IBSgQcbQnk865VCLe7xA==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -9253,9 +9300,10 @@
             }
         },
         "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -12528,6 +12576,16 @@
                 "language-subtag-registry": "~0.3.2"
             }
         },
+        "node_modules/launch-editor": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
+            "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "shell-quote": "^1.8.1"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "license": "MIT",
@@ -15616,7 +15674,9 @@
             }
         },
         "node_modules/protobufjs-cli/node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17498,8 +17558,13 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.0",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -19478,7 +19543,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.11.1",
+            "version": "4.15.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "license": "MIT",
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
@@ -19487,7 +19554,7 @@
                 "@types/serve-index": "^1.9.1",
                 "@types/serve-static": "^1.13.10",
                 "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.1",
+                "@types/ws": "^8.5.5",
                 "ansi-html-community": "^0.0.8",
                 "bonjour-service": "^1.0.11",
                 "chokidar": "^3.5.3",
@@ -19500,6 +19567,7 @@
                 "html-entities": "^2.3.2",
                 "http-proxy-middleware": "^2.0.3",
                 "ipaddr.js": "^2.0.1",
+                "launch-editor": "^2.6.0",
                 "open": "^8.0.9",
                 "p-retry": "^4.5.0",
                 "rimraf": "^3.0.2",
@@ -19508,8 +19576,8 @@
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.1",
-                "ws": "^8.4.2"
+                "webpack-dev-middleware": "^5.3.4",
+                "ws": "^8.13.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
@@ -19525,6 +19593,9 @@
                 "webpack": "^4.37.0 || ^5.0.0"
             },
             "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                },
                 "webpack-cli": {
                     "optional": true
                 }


### PR DESCRIPTION
Noticed that when running an `npm audit` check on the `dev` branch of the controller that it was reporting one security issue via the frontend it's pulling in.

This pull request is just the result of running `npm audit fix` on the frontend codebase, which had another thing issue it'd also reported.

Output from `npm audit` prior to this:
```
# npm audit report

@babel/runtime-corejs3  <7.26.10
Severity: moderate
Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/runtime-corejs3

brace-expansion  1.0.0 - 1.1.11 || 2.0.0 - 2.0.1
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix`
node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion
node_modules/brace-expansion
node_modules/filelist/node_modules/brace-expansion
node_modules/protobufjs-cli/node_modules/brace-expansion
...```