### PR TITLE
Yuhsuan/2550 pv image axis conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed no wcs grid if filename contains comma characters ([#2386](https://github.com/CARTAvis/carta-frontend/issues/2386)).
 * Fixed incorrect status in the animator widget and incorrect title in the image view widget when PV previews are active ([#2523](https://github.com/CARTAvis/carta-frontend/issues/2523), [#2524](https://github.com/CARTAvis/carta-frontend/issues/2524)).
 * Fixed jumpy non-square images after widget resizing ([#2467](https://github.com/CARTAvis/carta-frontend/issues/2467)).
-* Colors of multi-spectral profiles do not vary with the image selection ([[#2236](https://github.com/CARTAvis/carta-frontend/issues/2236)]).
+* Colors of multi-spectral profiles do not vary with the image selection ([#2236](https://github.com/CARTAvis/carta-frontend/issues/2236)).
 * Fix reference axes in the scatter plot of Stokes analysis ([#2531](https://github.com/CARTAvis/carta-frontend/issues/2531) and [#2532](https://github.com/CARTAvis/carta-frontend/issues/2532)).
-* Fixed incorrect disabling of spectral axis convention for spatial-spectral images ([[#2550](https://github.com/CARTAvis/carta-frontend/issues/2550)]).
+* Fixed incorrect disabling of spectral axis convention for spatial-spectral images ([#2550](https://github.com/CARTAvis/carta-frontend/issues/2550)).
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492](https://github.com/CARTAvis/carta-frontend/issues/2492)).
 * Enable the copy function in the cursor info widget ([#2468](https://github.com/CARTAvis/carta-frontend/issues/2468)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed jumpy non-square images after widget resizing ([#2467](https://github.com/CARTAvis/carta-frontend/issues/2467)).
 * Colors of multi-spectral profiles do not vary with the image selection ([[#2236](https://github.com/CARTAvis/carta-frontend/issues/2236)]).
 * Fix reference axes in the scatter plot of Stokes analysis ([#2531](https://github.com/CARTAvis/carta-frontend/issues/2531) and [#2532](https://github.com/CARTAvis/carta-frontend/issues/2532)).
+* Fixed incorrect disabling of spectral axis convention for spatial-spectral images ([[#2550](https://github.com/CARTAvis/carta-frontend/issues/2550)]).
 ### Added
 * Enhanced support for modifying the render configuration and the active channel/polarization in channel map mode ([#2492](https://github.com/CARTAvis/carta-frontend/issues/2492)).
 * Enable the copy function in the cursor info widget ([#2468](https://github.com/CARTAvis/carta-frontend/issues/2468)).

--- a/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
@@ -170,7 +170,13 @@ export class ImageSaveComponent extends React.Component {
                             {numChannels > 1 && (
                                 <React.Fragment>
                                     <div className="coordinate-select">
-                                        <SpectralSettingsComponent frame={activeFrame} onSpectralCoordinateChange={this.updateSpectralCoordinate} onSpectralSystemChange={this.updateSpectralSystem} disable={false} customLabel="Range unit" />
+                                        <SpectralSettingsComponent
+                                            frame={activeFrame}
+                                            onSpectralCoordinateChange={this.updateSpectralCoordinate}
+                                            onSpectralSystemChange={this.updateSpectralSystem}
+                                            disable={!activeFrame?.isSpectralChannel}
+                                            customLabel="Range unit"
+                                        />
                                     </div>
                                     <div className="range-select">
                                         <FormGroup label={"Range from"} inline={true}>

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -774,7 +774,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                     <SafeNumericInput
                         placeholder="Position (X)"
                         min={0}
-                        max={AppStore.Instance.activeFrame.renderWidth}
+                        max={AppStore.Instance.activeFrame?.renderWidth}
                         value={beamSettings.shiftX}
                         stepSize={5}
                         minorStepSize={1}
@@ -786,7 +786,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                     <SafeNumericInput
                         placeholder="Position (Y)"
                         min={0}
-                        max={AppStore.Instance.activeFrame.renderHeight}
+                        max={AppStore.Instance.activeFrame?.renderHeight}
                         value={beamSettings.shiftY}
                         stepSize={5}
                         minorStepSize={1}

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -802,7 +802,13 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                 <p>For spatial-spectral image</p>
                 <Divider />
                 <p>Spectral axis</p>
-                <SpectralSettingsComponent frame={appStore.activeFrame} onSpectralCoordinateChange={frame.setSpectralCoordinate} onSpectralSystemChange={frame.setSpectralSystem} disable={!isPVImage} disableChannelOption={true} />
+                <SpectralSettingsComponent
+                    frame={appStore.activeFrame}
+                    onSpectralCoordinateChange={frame.setSpectralCoordinate}
+                    onSpectralSystemChange={frame.setSpectralSystem}
+                    disable={!isPVImage || !appStore.activeFrame?.isSpectralChannel}
+                    disableChannelOption={true}
+                />
             </div>
         ) : null;
 

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -802,13 +802,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
                 <p>For spatial-spectral image</p>
                 <Divider />
                 <p>Spectral axis</p>
-                <SpectralSettingsComponent
-                    frame={appStore.activeFrame}
-                    onSpectralCoordinateChange={frame.setSpectralCoordinate}
-                    onSpectralSystemChange={frame.setSpectralSystem}
-                    disable={!isPVImage || !appStore.activeFrame?.isSpectralChannel}
-                    disableChannelOption={true}
-                />
+                <SpectralSettingsComponent frame={appStore.activeFrame} onSpectralCoordinateChange={frame.setSpectralCoordinate} onSpectralSystemChange={frame.setSpectralSystem} disable={!isPVImage} disableChannelOption={true} />
             </div>
         ) : null;
 

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -347,7 +347,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                         this.setisValidSpectralRange(true);
                         this.widgetStore.setSpectralSystem(sys as SpectralSystem);
                     }}
-                    disable={frame?.isPVImage}
+                    disable={frame?.isPVImage || !frame?.isSpectralChannel}
                 />
                 {frame && frame.numChannels > 1 && (
                     <FormGroup label="Range" inline={true} labelInfo={`(${frame.spectralUnit})`}>

--- a/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
+++ b/src/components/Shared/SpectralSettings/SpectralSettingsComponent.tsx
@@ -33,8 +33,7 @@ export class SpectralSettingsComponent extends React.Component<{
                       return {value: system, label: system, key: system};
                   })
                 : [{value: frame?.spectralAxis?.specsys, label: frame?.spectralAxis?.specsys}];
-        const hasFrameCoordinateSetting = frame?.isSpectralChannel;
-        const disableCoordinateSetting = this.props.disable || !hasFrameCoordinateSetting;
+        const disableCoordinateSetting = this.props.disable;
         const disableSystemSetting = this.props.disable || !frame || !frame.isSpectralSystemConvertible;
 
         return (

--- a/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
+++ b/src/components/SpectralProfiler/MomentGeneratorComponent/MomentGeneratorComponent.tsx
@@ -177,7 +177,7 @@ export class MomentGeneratorComponent extends React.Component<{widgetStore: Spec
 
         const spectralPanel = (
             <React.Fragment>
-                <SpectralSettingsComponent frame={frame} onSpectralCoordinateChange={widgetStore.setSpectralCoordinate} onSpectralSystemChange={widgetStore.setSpectralSystem} disable={frame?.isPVImage} />
+                <SpectralSettingsComponent frame={frame} onSpectralCoordinateChange={widgetStore.setSpectralCoordinate} onSpectralSystemChange={widgetStore.setSpectralSystem} disable={frame?.isPVImage || !frame?.isSpectralChannel} />
                 {frame && frame.numChannels > 1 && (
                     <FormGroup label="Range" inline={true} labelInfo={frame?.spectralUnit ? `(${frame.spectralUnit})` : ""}>
                         <div className="range-select">

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -192,7 +192,7 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
                                         onSpectralCoordinateChangeSecondary={widgetStore.setSpectralCoordinateSecondary}
                                         onSpectralSystemChange={widgetStore.setSpectralSystem}
                                         secondaryAxisCursorInfoVisible={widgetStore.secondaryAxisCursorInfoVisible}
-                                        disable={widgetStore.effectiveFrame?.isPVImage}
+                                        disable={widgetStore.effectiveFrame?.isPVImage || !widgetStore.effectiveFrame?.isSpectralChannel}
                                     />
                                     <FormGroup label={"Intensity unit"} inline={true}>
                                         <HTMLSelect

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
@@ -135,7 +135,14 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
                         <Tab
                             id={StokesAnalysisSettingsTabs.CONVERSION}
                             title="Conversion"
-                            panel={<SpectralSettingsComponent frame={widgetStore.effectiveFrame} onSpectralCoordinateChange={widgetStore.setSpectralCoordinate} onSpectralSystemChange={widgetStore.setSpectralSystem} disable={!hasStokes} />}
+                            panel={
+                                <SpectralSettingsComponent
+                                    frame={widgetStore.effectiveFrame}
+                                    onSpectralCoordinateChange={widgetStore.setSpectralCoordinate}
+                                    onSpectralSystemChange={widgetStore.setSpectralSystem}
+                                    disable={!hasStokes || !widgetStore.effectiveFrame?.isSpectralChannel}
+                                />
+                            }
                         />
                         <Tab id={StokesAnalysisSettingsTabs.LINE_PLOT_STYLING} title="Line Plot Styling" panel={<LinePlotSettingsPanelComponent {...lineSettingsProps} />} />
                         <Tab id={StokesAnalysisSettingsTabs.SCATTER_PLOT_STYLING} title="Scatter Plot Styling" panel={<ScatterPlotSettingsPanelComponent {...scatterSettingsProps} />} />


### PR DESCRIPTION
**Description**

Closes #2550 incorrect disabling of spectral axis convention for spatial-spectral images.

The root cause is that the shared component `SpectralSettingsComponent` disables the settings when the third axis is not spectral. Fixed by moving the check out of the component and avoid checking it in the image view settings.

Also fixed crash when closing all images with the image view settings widget opened.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~