### PR TITLE
fix extra (pixel) in the X label of pv

### DIFF
--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -111,6 +111,11 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 }
             }
 
+            if (frame.isPVImage && settings.labels.customText) {
+                // Disable the PV image labels when custom labels are set
+                AST.set(tempWcsInfo, `Unit(1)="", Unit(2)=""`);
+            }
+
             const plot = (styleString: string) => {
                 AST.plot(
                     tempWcsInfo,

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -111,7 +111,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 }
             }
 
-            if (frame.isPVImage && settings.labels.customText) {
+            if (settings.labels.customText) {
                 // Disable the PV image labels when custom labels are set
                 AST.set(tempWcsInfo, `Unit(1)="", Unit(2)=""`);
             }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1408,6 +1408,7 @@ export class FrameStore {
         } else {
             // init WCS
             const astFrameSet = this.initFrame();
+            overlaySettings.global.setValidWcs(false); // initialize validWcs to false
             if (astFrameSet) {
                 this.spectralFrame = AST.getSpectralFrame(astFrameSet);
                 if (frameInfo.fileInfoExtended.depth > 1) {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1380,6 +1380,7 @@ export class FrameStore {
                 const skySystem = entries.find(entry => entry.name.includes("RADESYS"))?.value;
                 if (Object.values(SystemType).includes(skySystem as SystemType)) {
                     AppStore.Instance.overlaySettings.global.setDefaultSystem(skySystem as SystemType);
+                    overlaySettings.global.setValidWcs(true);
                 }
 
                 this.spectralFrame = AST.getSpectralFrame(astFrameSet);

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -110,13 +110,21 @@ export class OverlayGlobalSettings {
             const symbolY = AST.getString(frame?.wcsInfo, "Symbol(2)");
             const labelX = AST.getString(frame?.wcsInfo, "Label(1)");
             const labelY = AST.getString(frame?.wcsInfo, "Label(2)");
+            const haveUnitX = AST.getString(frame?.wcsInfo, "Unit(1)") !== "";
+            const haveUnitY = AST.getString(frame?.wcsInfo, "Unit(2)") !== "";
 
-            const isSysPixel = typeof this.explicitSystem === "undefined" || this.explicitSystem === SystemType.Image;
-            const getSystemName = (symbolXY: string, isSysPixel: boolean, isPVImage: boolean, explicitSystem: SystemType) => {
-                return ((symbolXY === "RA" || symbolXY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || (isSysPixel && !isPVImage) ? (isSysPixel ? ` (pixel)` : ` (${explicitSystem})`) : ""; // a space between ` and ( is essential
+            const isSysPixel = (this.explicitSystem === undefined && !(frame?.isPVImage || frame?.isSwappedZ)) || this.explicitSystem === SystemType.Image;
+            const getSystemName = (symbolXY: string, isSysPixel: boolean, haveUnit: boolean, explicitSystem: SystemType) => {
+                if (isSysPixel) {
+                    return haveUnit ? "" : " (pixel)";
+                } else if ((symbolXY === "RA" || symbolXY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) {
+                    return ` (${explicitSystem})`;
+                } else {
+                    return "";
+                }
             };
-            const systemNameX = getSystemName(symbolX, isSysPixel, frame?.isPVImage, this?.explicitSystem);
-            const systemNameY = getSystemName(symbolY, isSysPixel, frame?.isPVImage, this?.explicitSystem);
+            const systemNameX = getSystemName(symbolX, isSysPixel, haveUnitX, this?.explicitSystem);
+            const systemNameY = getSystemName(symbolY, isSysPixel, haveUnitY, this?.explicitSystem);
             astString.add("Label(1)", `"${labelX.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameX}"`, labelX !== undefined);
             astString.add("Label(2)", `"${labelY.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameY}"`, labelY !== undefined);
         }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -113,10 +113,10 @@ export class OverlayGlobalSettings {
 
             const isSysPixel = typeof this.explicitSystem === "undefined" || this.explicitSystem === SystemType.Image;
             const getSystemName = (symbolXY: string, isSysPixel: boolean, isPVImage: boolean, explicitSystem: SystemType) => {
-                return ((symbolXY === "RA" || symbolXY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !isPVImage ? ` (pixel)` : ` (${explicitSystem})`) : ""; // a space between ` and ( is essential
+                return ((symbolXY === "RA" || symbolXY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || (isSysPixel && !isPVImage) ? (isSysPixel ? ` (pixel)` : ` (${explicitSystem})`) : ""; // a space between ` and ( is essential
             };
-            const systemNameX = getSystemName(symbolX, isSysPixel, frame?.isPVImage, this.explicitSystem);
-            const systemNameY = getSystemName(symbolY, isSysPixel, frame?.isPVImage, this.explicitSystem);
+            const systemNameX = getSystemName(symbolX, isSysPixel, frame?.isPVImage, this?.explicitSystem);
+            const systemNameY = getSystemName(symbolY, isSysPixel, frame?.isPVImage, this?.explicitSystem);
             astString.add("Label(1)", `"${labelX.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameX}"`, labelX !== undefined);
             astString.add("Label(2)", `"${labelY.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameY}"`, labelY !== undefined);
         }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -112,8 +112,8 @@ export class OverlayGlobalSettings {
             const labelY = AST.getString(frame?.wcsInfo, "Label(2)");
 
             const isSysPixel = typeof this.explicitSystem === "undefined" || this.explicitSystem === SystemType.Image;
-            const systemNameX = ((symbolX === "RA" || symbolX === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
-            const systemNameY = ((symbolY === "RA" || symbolY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
+            const systemNameX = ((symbolX === "RA" || symbolX === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !frame?.isPVImage ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
+            const systemNameY = ((symbolY === "RA" || symbolY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !frame?.isPVImage ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
             astString.add("Label(1)", `"${labelX.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameX}"`, labelX !== undefined);
             astString.add("Label(2)", `"${labelY.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameY}"`, labelY !== undefined);
         }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -112,8 +112,11 @@ export class OverlayGlobalSettings {
             const labelY = AST.getString(frame?.wcsInfo, "Label(2)");
 
             const isSysPixel = typeof this.explicitSystem === "undefined" || this.explicitSystem === SystemType.Image;
-            const systemNameX = ((symbolX === "RA" || symbolX === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !frame?.isPVImage ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
-            const systemNameY = ((symbolY === "RA" || symbolY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !frame?.isPVImage ? ` (pixel)` : ` (${this.explicitSystem})`) : ""; // a space between ` and ( is eccential
+            const getSystemName = (symbolXY: string, isSysPixel: boolean, isPVImage: boolean, explicitSystem: SystemType) => {
+                return ((symbolXY === "RA" || symbolXY === "Dec") && AppStore.Instance.overlaySettings.labels?.raDecReference) || isSysPixel ? (isSysPixel && !isPVImage ? ` (pixel)` : ` (${explicitSystem})`) : ""; // a space between ` and ( is essential
+            };
+            const systemNameX = getSystemName(symbolX, isSysPixel, frame?.isPVImage, this.explicitSystem);
+            const systemNameY = getSystemName(symbolY, isSysPixel, frame?.isPVImage, this.explicitSystem);
             astString.add("Label(1)", `"${labelX.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameX}"`, labelX !== undefined);
             astString.add("Label(2)", `"${labelY.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameY}"`, labelY !== undefined);
         }


### PR DESCRIPTION
**Description**

Close #2551. Fix the extra `(pixel)` in the X label of the PV image when using a polyline as a PV cut. 

**Checklist**

Check PV image X label 

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~