### PR TITLE
Documentation: corrected beta and rc versions in release checklist examples

### DIFF
--- a/docs_website/docs/contributing/release-guidelines.md
+++ b/docs_website/docs/contributing/release-guidelines.md
@@ -10,29 +10,29 @@ In this document, 123 is a placeholder for the current release number, and 124 f
 
 ### Beta release
 
-1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
+1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Create a `release/123.0` branch using the `dev` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-beta.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-beta.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. Create packages from the release branch.
 
 ### After beta release
 
 1. `dev` branch: update `CHANGELOG.md`. Create a new `Unreleased` section.
-2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.1`.
+2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.0`.
 
 ### Additional beta release
 
 This process should be followed if changes have to be made after the beta packages have already been published (or even provided to a limited number of users). If there are significant changes in `dev` that should _not_ be included in the beta release, follow the point release procedure instead (but adjust the version strings as required).
 
 1. Make the required fixes in `dev`.
-2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.2`.
+2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
 3. `dev` branch: update the user manual URL if necessary.
 4. Merge the `dev` branch into the `release/123.0` branch.
-5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.2`. Run `npm install` to update `package-lock.json`.
-6. Create a `v123.0.0-beta.2` tag using the release branch.
+5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
+6. Create a `v123.0.0-beta.1` tag using the release branch.
 7. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 8. Create packages from the release branch.
 
@@ -43,8 +43,8 @@ This process should be followed if changes have to be made after the beta packag
 1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Merge the `dev` branch into the `release/123.0` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-rc.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-rc.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. `release/123.0` branch: update the `package.json` version string to `123.0.0`. Run `npm install` to update `package-lock.json`.
 8. Create a `v123.0.0` tag using the release branch.

--- a/docs_website/versioned_docs/version-4.1.0/contributing/release-guidelines.md
+++ b/docs_website/versioned_docs/version-4.1.0/contributing/release-guidelines.md
@@ -10,29 +10,29 @@ In this document, 123 is a placeholder for the current release number, and 124 f
 
 ### Beta release
 
-1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
+1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Create a `release/123.0` branch using the `dev` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-beta.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-beta.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. Create packages from the release branch.
 
 ### After beta release
 
 1. `dev` branch: update `CHANGELOG.md`. Create a new `Unreleased` section.
-2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.1`.
+2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.0`.
 
 ### Additional beta release
 
 This process should be followed if changes have to be made after the beta packages have already been published (or even provided to a limited number of users). If there are significant changes in `dev` that should _not_ be included in the beta release, follow the point release procedure instead (but adjust the version strings as required).
 
 1. Make the required fixes in `dev`.
-2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.2`.
+2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
 3. `dev` branch: update the user manual URL if necessary.
 4. Merge the `dev` branch into the `release/123.0` branch.
-5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.2`. Run `npm install` to update `package-lock.json`.
-6. Create a `v123.0.0-beta.2` tag using the release branch.
+5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
+6. Create a `v123.0.0-beta.1` tag using the release branch.
 7. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 8. Create packages from the release branch.
 
@@ -43,8 +43,8 @@ This process should be followed if changes have to be made after the beta packag
 1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Merge the `dev` branch into the `release/123.0` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-rc.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-rc.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. `release/123.0` branch: update the `package.json` version string to `123.0.0`. Run `npm install` to update `package-lock.json`.
 8. Create a `v123.0.0` tag using the release branch.

--- a/docs_website/versioned_docs/version-5.0.0-beta.1c/contributing/release-guidelines.md
+++ b/docs_website/versioned_docs/version-5.0.0-beta.1c/contributing/release-guidelines.md
@@ -10,29 +10,29 @@ In this document, 123 is a placeholder for the current release number, and 124 f
 
 ### Beta release
 
-1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
+1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Create a `release/123.0` branch using the `dev` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-beta.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-beta.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. Create packages from the release branch.
 
 ### After beta release
 
 1. `dev` branch: update `CHANGELOG.md`. Create a new `Unreleased` section.
-2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.1`.
+2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#Versioning)). Create a new version `123.0.0-beta.0`.
 
 ### Additional beta release
 
 This process should be followed if changes have to be made after the beta packages have already been published (or even provided to a limited number of users). If there are significant changes in `dev` that should _not_ be included in the beta release, follow the point release procedure instead (but adjust the version strings as required).
 
 1. Make the required fixes in `dev`.
-2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.2`.
+2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
 3. `dev` branch: update the user manual URL if necessary.
 4. Merge the `dev` branch into the `release/123.0` branch.
-5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.2`. Run `npm install` to update `package-lock.json`.
-6. Create a `v123.0.0-beta.2` tag using the release branch.
+5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
+6. Create a `v123.0.0-beta.1` tag using the release branch.
 7. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 8. Create packages from the release branch.
 
@@ -43,8 +43,8 @@ This process should be followed if changes have to be made after the beta packag
 1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Merge the `dev` branch into the `release/123.0` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.1`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-rc.1` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-rc.0`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-rc.0` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. `release/123.0` branch: update the `package.json` version string to `123.0.0`. Run `npm install` to update `package-lock.json`.
 8. Create a `v123.0.0` tag using the release branch.


### PR DESCRIPTION
**Description**

`beta` and `rc` versions start from 0, same as [the backend ](https://github.com/CARTAvis/carta-backend/pull/1479).
To avoid confusion, the docs for 4.1 and 5.0-beta are modified as well.