### PR TITLE
bug of dynamic layout request dir info

### DIFF
--- a/src/stores/FileBrowserStore/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore/FileBrowserStore.ts
@@ -660,7 +660,8 @@ export class FileBrowserStore {
         this.selectedFiles = selection;
 
         // for dynamic layout
-        if (PreferenceStore.Instance.dynamicLayoutEnable) {
+        const isFile = selection[0]?.isFile; // prevent first selection is a directory
+        if (PreferenceStore.Instance.dynamicLayoutEnable && isFile) {
             this.selectedFilesCtypes = yield this.selectedFilesCtypeInfo();
             if (this.selectedFiles.length > 0) {
                 AppStore.Instance.dynamicLayoutStore.matchLayoutMapping(this.selectedFilesCtypes);

--- a/src/stores/FileBrowserStore/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore/FileBrowserStore.ts
@@ -660,12 +660,9 @@ export class FileBrowserStore {
         this.selectedFiles = selection;
 
         // for dynamic layout
-        const isFile = selection[0]?.isFile; // prevent first selection is a directory
-        if (PreferenceStore.Instance.dynamicLayoutEnable && isFile) {
+        if (PreferenceStore.Instance.dynamicLayoutEnable && selection.length > 0 && selection.every(item => item.isFile)) {
             this.selectedFilesCtypes = yield this.selectedFilesCtypeInfo();
-            if (this.selectedFiles.length > 0) {
-                AppStore.Instance.dynamicLayoutStore.matchLayoutMapping(this.selectedFilesCtypes);
-            }
+            AppStore.Instance.dynamicLayoutStore.matchLayoutMapping(this.selectedFilesCtypes);
         }
     }
 


### PR DESCRIPTION
**Description**

Close #2557. Dynamic layout requests the directory information after the file list behavior has changed. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated` / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~