### PR TITLE
Fix preference schema bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [5.0.2]
-* Fixed invalid values in preferences.json causes all preferences to be reset ([#2561](https://github.com/CARTAvis/carta-frontend/issues/2561)).
+* Fixed invalid values in preferences.json cause all preferences to be reset ([#2561](https://github.com/CARTAvis/carta-frontend/issues/2561)).
 
 ## [5.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [5.0.2]
+
+### Fixed
 * Fixed invalid values in preferences.json cause all preferences to be reset ([#2561](https://github.com/CARTAvis/carta-frontend/issues/2561)).
 
 ## [5.0.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2]
+* Fixed invalid values in preferences.json causes all preferences to be reset ([#2561](https://github.com/CARTAvis/carta-frontend/issues/2561)).
+
 ## [5.0.1]
 
 ### Fixed

--- a/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourGeneratorPanel/ContourGeneratorPanelComponent.tsx
@@ -5,7 +5,7 @@ import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ClearableNumericInputComponent, SafeNumericInput, SCALING_POPOVER_PROPS, ScalingSelectComponent} from "components/Shared";
-import {ContourGeneratorType, FrameScaling, FrameStore} from "stores/Frame";
+import {ContourGeneratorType, FrameScaling, FrameStore, PreferenceStore} from "stores";
 import {getPercentiles, scaleValue} from "utilities";
 
 import "./ContourGeneratorPanelComponent.scss";
@@ -20,7 +20,7 @@ export class ContourGeneratorPanelComponent extends React.Component<{
 }> {
     @observable generator: ContourGeneratorType = this.props.generatorType ? this.props.generatorType : ContourGeneratorType.StartStepMultiplier;
 
-    @observable numLevels: number = 5;
+    @observable numLevels: number = PreferenceStore.Instance.contourNumLevels;
 
     // region min-max-scaling
     @observable enteredMinValue: number | undefined;

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -610,7 +610,14 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Region size" labelInfo="(px)">
-                    <SafeNumericInput placeholder="Region size" min={1} value={preference.regionSize} stepSize={1} onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_SIZE, Math.max(1, value))} />
+                    <SafeNumericInput
+                        placeholder="Region size"
+                        min={10}
+                        max={100}
+                        value={preference.regionSize}
+                        stepSize={1}
+                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.REGION_SIZE, Math.max(10, Math.min(100, value)))}
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Creation mode">
                     <RadioGroup selectedValue={preference.regionCreationMode} onChange={ev => preference.setPreference(PreferenceKeys.REGION_CREATION_MODE, ev.currentTarget.value)}>
@@ -668,9 +675,10 @@ export class PreferenceDialogComponent extends React.Component {
                     <SafeNumericInput
                         placeholder="Point size"
                         min={1}
+                        max={100}
                         value={preference.pointAnnotationWidth}
                         stepSize={1}
-                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.POINT_ANNOTATION_WIDTH, Math.max(1, value))}
+                        onValueChange={(value: number) => preference.setPreference(PreferenceKeys.POINT_ANNOTATION_WIDTH, Math.max(1, Math.min(100, value)))}
                     />
                 </FormGroup>
             </React.Fragment>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -55,13 +55,13 @@ export class PreferenceDialogComponent extends React.Component {
     };
 
     @computed get pvPreviewCubeSizeMaxValue(): number {
-        if (PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit === MemoryUnit.TB) {
+        if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.TB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e12;
-        } else if (PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit === MemoryUnit.GB) {
+        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e9;
-        } else if (PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit === MemoryUnit.MB) {
+        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.MB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e6;
-        } else if (PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit === MemoryUnit.kB) {
+        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.kB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e3;
         } else {
             return PV_PREVIEW_CUBE_SIZE_LIMIT;
@@ -822,12 +822,12 @@ export class PreferenceDialogComponent extends React.Component {
                             placeholder="PV preview cube size limit"
                             min={1e-12}
                             max={this.pvPreviewCubeSizeMaxValue}
-                            value={preference.pvPreivewCubeSizeLimit}
+                            value={preference.pvPreviewCubeSizeLimit}
                             majorStepSize={1}
                             stepSize={1}
                             onValueChange={value => preference.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, value)}
                         />
-                        <HTMLSelect value={preference.pvPreivewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
+                        <HTMLSelect value={preference.pvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
                             <option key={0} value={"MB"}>
                                 MB
                             </option>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -45,7 +45,7 @@ export enum MemoryUnit {
 
 const PercentileSelect = Select<string>;
 
-const PV_PREVIEW_CUBE_SIZE_LIMIT = 1000000000; //need to be removed and replaced by backend limit
+const PV_PREVIEW_CUBE_SIZE_LIMIT = 2000000000; //need to be removed and replaced by backend limit
 
 @observer
 export class PreferenceDialogComponent extends React.Component {
@@ -55,17 +55,22 @@ export class PreferenceDialogComponent extends React.Component {
     };
 
     @computed get pvPreviewCubeSizeMaxValue(): number {
-        if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.TB) {
+        if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.TB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e12;
-        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB) {
+        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e9;
-        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.MB) {
+        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.MB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e6;
-        } else if (PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit === MemoryUnit.kB) {
+        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.kB) {
             return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e3;
         } else {
             return PV_PREVIEW_CUBE_SIZE_LIMIT;
         }
+    }
+
+    @computed get showedPvPreviewCubeSizeLimit(): number {
+        const preference = PreferenceStore.Instance;
+        return this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? preference.pvPreviewCubeSizeLimit : preference.pvPreviewCubeSizeLimit * 1000;
     }
 
     constructor(props: any) {
@@ -99,8 +104,18 @@ export class PreferenceDialogComponent extends React.Component {
     }, 100);
 
     @action private handlePvPreviewCubeSizeUnitChange = _.throttle(unit => {
-        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT, unit);
+        this.showedPvPreviewCubeSizeLimitUnit = unit;
+        // always store value in GB
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT, MemoryUnit.GB);
     }, 100);
+
+    @action private handlePvPreviewCubeSizeChange = _.throttle((size, unit) => {
+        const storedSize = unit === MemoryUnit.GB ? size : size / 1000; // Convert to GB if necessary
+        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, storedSize);
+    }, 100);
+
+    // variable for showing preview cube size unit in the dialog
+    @observable private showedPvPreviewCubeSizeLimitUnit = PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit;
 
     private reset = () => {
         const preference = PreferenceStore.Instance;
@@ -822,12 +837,12 @@ export class PreferenceDialogComponent extends React.Component {
                             placeholder="PV preview cube size limit"
                             min={1e-12}
                             max={this.pvPreviewCubeSizeMaxValue}
-                            value={preference.pvPreviewCubeSizeLimit}
-                            majorStepSize={1}
-                            stepSize={preference.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 100}
-                            onValueChange={value => preference.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, value)}
+                            value={this.showedPvPreviewCubeSizeLimit}
+                            majorStepSize={2}
+                            stepSize={this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 100}
+                            onValueChange={value => this.handlePvPreviewCubeSizeChange(value, this.showedPvPreviewCubeSizeLimitUnit)}
                         />
-                        <HTMLSelect value={preference.pvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
+                        <HTMLSelect value={this.showedPvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
                             <option key={0} value={"MB"}>
                                 MB
                             </option>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -451,11 +451,11 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="WCS format">
-                    <HTMLSelect
-                        options={[WCSType.AUTOMATIC, WCSType.DEGREES, WCSType.SEXAGESIMAL]}
-                        value={preference.wcsType}
-                        onChange={(event: React.FormEvent<HTMLSelectElement>) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_WCS_TYPE, event.currentTarget.value)}
-                    />
+                    <HTMLSelect value={preference.wcsType} onChange={(event: React.FormEvent<HTMLSelectElement>) => preference.setPreference(PreferenceKeys.WCS_OVERLAY_WCS_TYPE, event.currentTarget.value)}>
+                        <option value={WCSType.AUTOMATIC}>Automatic</option>
+                        <option value={WCSType.DEGREES}>Degrees</option>
+                        <option value={WCSType.SEXAGESIMAL}>Sexagesimal</option>
+                    </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Colorbar visible">
                     <Switch checked={preference.colorbarVisible} onChange={ev => preference.setPreference(PreferenceKeys.WCS_OVERLAY_COLORBAR_VISIBLE, ev.currentTarget.checked)} />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -43,9 +43,17 @@ export enum MemoryUnit {
     B = "B"
 }
 
+export enum ConvertToGB {
+    TB = 1e3,
+    GB = 1,
+    MB = 1e-3,
+    kB = 1e-6,
+    B = 1e-9
+}
+
 const PercentileSelect = Select<string>;
 
-const PV_PREVIEW_CUBE_SIZE_LIMIT = 2000000000; //need to be removed and replaced by backend limit
+const PV_PREVIEW_CUBE_SIZE_LIMIT = 2; //in unit of GB
 
 @observer
 export class PreferenceDialogComponent extends React.Component {
@@ -55,22 +63,16 @@ export class PreferenceDialogComponent extends React.Component {
     };
 
     @computed get pvPreviewCubeSizeMaxValue(): number {
-        if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.TB) {
-            return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e12;
-        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB) {
-            return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e9;
-        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.MB) {
-            return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e6;
-        } else if (this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.kB) {
-            return PV_PREVIEW_CUBE_SIZE_LIMIT / 1e3;
-        } else {
-            return PV_PREVIEW_CUBE_SIZE_LIMIT;
-        }
+        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? PV_PREVIEW_CUBE_SIZE_LIMIT : PV_PREVIEW_CUBE_SIZE_LIMIT / ConvertToGB.MB;
+    }
+
+    @computed get pvPreviewCubeSizeMinValue(): number {
+        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 128;
     }
 
     @computed get showedPvPreviewCubeSizeLimit(): number {
         const preference = PreferenceStore.Instance;
-        return this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? preference.pvPreviewCubeSizeLimit : preference.pvPreviewCubeSizeLimit * 1000;
+        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? preference.pvPreviewCubeSizeLimit : preference.pvPreviewCubeSizeLimit / ConvertToGB.MB;
     }
 
     constructor(props: any) {
@@ -104,18 +106,16 @@ export class PreferenceDialogComponent extends React.Component {
     }, 100);
 
     @action private handlePvPreviewCubeSizeUnitChange = _.throttle(unit => {
-        this.showedPvPreviewCubeSizeLimitUnit = unit;
-        // always store value in GB
-        PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT, MemoryUnit.GB);
+        this.pvPreviewCubeSizeLimitUnit = unit;
     }, 100);
 
     @action private handlePvPreviewCubeSizeChange = _.throttle((size, unit) => {
-        const storedSize = unit === MemoryUnit.GB ? size : size / 1000; // Convert to GB if necessary
+        const storedSize = unit === MemoryUnit.GB ? size : size * ConvertToGB.MB; // Convert to GB if necessary
         PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, storedSize);
     }, 100);
 
     // variable for showing preview cube size unit in the dialog
-    @observable private showedPvPreviewCubeSizeLimitUnit = PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit;
+    @observable private pvPreviewCubeSizeLimitUnit = PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit;
 
     private reset = () => {
         const preference = PreferenceStore.Instance;
@@ -835,18 +835,18 @@ export class PreferenceDialogComponent extends React.Component {
                     <div className="pv-preview-cube-size-limit">
                         <SafeNumericInput
                             placeholder="PV preview cube size limit"
-                            min={1e-12}
+                            min={this.pvPreviewCubeSizeMinValue}
                             max={this.pvPreviewCubeSizeMaxValue}
                             value={this.showedPvPreviewCubeSizeLimit}
-                            majorStepSize={this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 2 : 2000}
-                            stepSize={this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 100}
-                            onValueChange={value => this.handlePvPreviewCubeSizeChange(value, this.showedPvPreviewCubeSizeLimitUnit)}
+                            majorStepSize={this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 2 : 2048}
+                            stepSize={this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 128}
+                            onValueChange={value => this.handlePvPreviewCubeSizeChange(value, this.pvPreviewCubeSizeLimitUnit)}
                         />
-                        <HTMLSelect value={this.showedPvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
-                            <option key={0} value={"MB"}>
+                        <HTMLSelect value={this.pvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
+                            <option key={0} value={MemoryUnit.MB}>
                                 MB
                             </option>
-                            <option key={1} value={"GB"}>
+                            <option key={1} value={MemoryUnit.GB}>
                                 GB
                             </option>
                         </HTMLSelect>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -824,7 +824,7 @@ export class PreferenceDialogComponent extends React.Component {
                             max={this.pvPreviewCubeSizeMaxValue}
                             value={preference.pvPreviewCubeSizeLimit}
                             majorStepSize={1}
-                            stepSize={1}
+                            stepSize={preference.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 100}
                             onValueChange={value => preference.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, value)}
                         />
                         <HTMLSelect value={preference.pvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -265,7 +265,13 @@ export class PreferenceDialogComponent extends React.Component {
                 </FormGroup>
                 {(preference.scaling === FrameScaling.LOG || preference.scaling === FrameScaling.POWER) && (
                     <FormGroup label={"Alpha"} inline={true}>
-                        <SafeNumericInput buttonPosition={"none"} value={preference.scalingAlpha} onValueChange={value => preference.setPreference(PreferenceKeys.RENDER_CONFIG_SCALING_ALPHA, value)} />
+                        <SafeNumericInput
+                            min={RenderConfigStore.ALPHA_MIN}
+                            max={RenderConfigStore.ALPHA_MAX}
+                            buttonPosition={"none"}
+                            value={preference.scalingAlpha}
+                            onValueChange={value => preference.setPreference(PreferenceKeys.RENDER_CONFIG_SCALING_ALPHA, value)}
+                        />
                     </FormGroup>
                 )}
                 {preference.scaling === FrameScaling.GAMMA && (

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -35,14 +35,6 @@ enum PreferenceDialogTabs {
     COMPATIBILITY
 }
 
-export enum MemoryUnit {
-    TB = "TB",
-    GB = "GB",
-    MB = "MB",
-    kB = "kB",
-    B = "B"
-}
-
 export enum ConvertToGB {
     TB = 1e3,
     GB = 1,
@@ -63,16 +55,15 @@ export class PreferenceDialogComponent extends React.Component {
     };
 
     @computed get pvPreviewCubeSizeMaxValue(): number {
-        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? PV_PREVIEW_CUBE_SIZE_LIMIT : PV_PREVIEW_CUBE_SIZE_LIMIT / ConvertToGB.MB;
+        return PV_PREVIEW_CUBE_SIZE_LIMIT / ConvertToGB[this.pvPreviewCubeSizeLimitUnit];
     }
 
     @computed get pvPreviewCubeSizeMinValue(): number {
-        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 128;
+        return 0.1 / ConvertToGB[this.pvPreviewCubeSizeLimitUnit];
     }
 
     @computed get showedPvPreviewCubeSizeLimit(): number {
-        const preference = PreferenceStore.Instance;
-        return this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? preference.pvPreviewCubeSizeLimit : preference.pvPreviewCubeSizeLimit / ConvertToGB.MB;
+        return PreferenceStore.Instance.pvPreviewCubeSizeLimit / ConvertToGB[this.pvPreviewCubeSizeLimitUnit];
     }
 
     constructor(props: any) {
@@ -110,12 +101,12 @@ export class PreferenceDialogComponent extends React.Component {
     }, 100);
 
     @action private handlePvPreviewCubeSizeChange = _.throttle((size, unit) => {
-        const storedSize = unit === MemoryUnit.GB ? size : size * ConvertToGB.MB; // Convert to GB if necessary
+        const storedSize = size * ConvertToGB[this.pvPreviewCubeSizeLimitUnit]; // Convert to GB if necessary
         PreferenceStore.Instance.setPreference(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT, storedSize);
     }, 100);
 
     // variable for showing preview cube size unit in the dialog
-    @observable private pvPreviewCubeSizeLimitUnit = PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit;
+    @observable private pvPreviewCubeSizeLimitUnit = "GB";
 
     private reset = () => {
         const preference = PreferenceStore.Instance;
@@ -838,15 +829,15 @@ export class PreferenceDialogComponent extends React.Component {
                             min={this.pvPreviewCubeSizeMinValue}
                             max={this.pvPreviewCubeSizeMaxValue}
                             value={this.showedPvPreviewCubeSizeLimit}
-                            majorStepSize={this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 2 : 2048}
-                            stepSize={this.pvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 128}
+                            majorStepSize={0.5 / ConvertToGB[this.pvPreviewCubeSizeLimitUnit]}
+                            stepSize={0.1 / ConvertToGB[this.pvPreviewCubeSizeLimitUnit]}
                             onValueChange={value => this.handlePvPreviewCubeSizeChange(value, this.pvPreviewCubeSizeLimitUnit)}
                         />
                         <HTMLSelect value={this.pvPreviewCubeSizeLimitUnit} onChange={ev => this.handlePvPreviewCubeSizeUnitChange(ev.target.value)}>
-                            <option key={0} value={MemoryUnit.MB}>
+                            <option key={0} value={"MB"}>
                                 MB
                             </option>
-                            <option key={1} value={MemoryUnit.GB}>
+                            <option key={1} value={"GB"}>
                                 GB
                             </option>
                         </HTMLSelect>

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -838,7 +838,7 @@ export class PreferenceDialogComponent extends React.Component {
                             min={1e-12}
                             max={this.pvPreviewCubeSizeMaxValue}
                             value={this.showedPvPreviewCubeSizeLimit}
-                            majorStepSize={2}
+                            majorStepSize={this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 2 : 2000}
                             stepSize={this.showedPvPreviewCubeSizeLimitUnit === MemoryUnit.GB ? 0.1 : 100}
                             onValueChange={value => this.handlePvPreviewCubeSizeChange(value, this.showedPvPreviewCubeSizeLimitUnit)}
                         />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -11,7 +11,7 @@ import tinycolor from "tinycolor2";
 
 import {DraggableDialogComponent, LayoutMappingComponent} from "components/Dialogs";
 import {AppToaster, AutoColorPickerComponent, ColormapComponent, ColorPickerComponent, PointShapeSelectComponent, SafeNumericInput, ScalingSelectComponent, ScrollShadow, SuccessToast} from "components/Shared";
-import {CompressionQuality, CursorInfoVisibility, CursorPosition, Event, FileFilterMode, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, ConvertToGB, CursorInfoVisibility, CursorPosition, Event, FileFilterMode, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
 import {TelemetryMode} from "services";
 import {AppStore, BeamType, DialogId, HelpType, PreferenceKeys, PreferenceStore} from "stores";
 import {ContourGeneratorType, FrameScaling, RegionStore, RenderConfigStore} from "stores/Frame";
@@ -33,14 +33,6 @@ enum PreferenceDialogTabs {
     CATALOG,
     TELEMETRY,
     COMPATIBILITY
-}
-
-export enum ConvertToGB {
-    TB = 1e3,
-    GB = 1,
-    MB = 1e-3,
-    kB = 1e-6,
-    B = 1e-9
 }
 
 const PercentileSelect = Select<string>;

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -157,7 +157,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
     }
 
     @computed get isCubeSizeBelowLimit(): boolean {
-        return this.estimatedCubeSize?.bitValue <= PvGeneratorComponent.getBitValueFromFormatted(PreferenceStore.Instance.pvPreivewCubeSizeLimit, PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit);
+        return this.estimatedCubeSize?.bitValue <= PvGeneratorComponent.getBitValueFromFormatted(PreferenceStore.Instance.pvPreviewCubeSizeLimit, PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit);
     }
 
     constructor(props: WidgetProps) {
@@ -302,7 +302,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                         <br />
                         1. Line region is selected.
                         <br />
-                        2. Preview cube size is less than the threshold ({`${PreferenceStore.Instance.pvPreivewCubeSizeLimit} ${PreferenceStore.Instance.pvPreivewCubeSizeLimitUnit}`}).
+                        2. Preview cube size is less than the threshold ({`${PreferenceStore.Instance.pvPreviewCubeSizeLimit} ${PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit}`}).
                     </small>
                 </i>
             </span>

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
-import {MemoryUnit, TaskProgressDialogComponent} from "components/Dialogs";
+import {TaskProgressDialogComponent} from "components/Dialogs";
 import {SafeNumericInput, ScrollShadow, SpectralSettingsComponent} from "components/Shared";
 import {Point2D, SpectralSystem} from "models";
 import {AppStore, DefaultWidgetConfig, HelpType, PreferenceStore, WidgetProps, WidgetsStore} from "stores";
@@ -31,25 +31,6 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
             helpType: HelpType.PV_GENERATOR
         };
     }
-
-    public static formatBitValue = (bitValue: number): {value: number; unit: string; bitValue: number} => {
-        let value: number;
-        let unit: string;
-        if (bitValue >= 1e9) {
-            value = parseFloat(toFixed(bitValue / 1e9, 2));
-            unit = MemoryUnit.GB;
-        } else if (bitValue >= 1e6) {
-            value = parseFloat(toFixed(bitValue / 1e6, 2));
-            unit = MemoryUnit.MB;
-        } else if (bitValue >= 1e3) {
-            value = parseFloat(toFixed(bitValue / 1e6, 3));
-            unit = MemoryUnit.MB;
-        } else {
-            value = parseFloat(toFixed(bitValue / 1e6, 4));
-            unit = MemoryUnit.MB;
-        }
-        return {value, unit, bitValue: bitValue};
-    };
 
     @computed get widgetStore(): PvGeneratorWidgetStore {
         const widgetsStore = WidgetsStore.Instance;
@@ -105,11 +86,11 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         return false;
     }
 
-    @computed get estimatedCubeSize(): {value: number; unit: string; bitValue: number} {
+    @computed get estimatedCubeSize(): number {
         const frame = this.widgetStore?.effectiveFrame;
 
         if (!frame) {
-            return {value: 0, unit: "", bitValue: 0};
+            return 0;
         }
 
         // Find percentage of selected channel range
@@ -139,11 +120,12 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
             return undefined;
         }
 
-        return PvGeneratorComponent.formatBitValue(estimatedSize);
+        // Return estimated size in GB to be consistent with PreferenceStore.Instance.pvPreviewCubeSizeLimit
+        return parseFloat(toFixed(estimatedSize / 1e9, 2));
     }
 
     @computed get isCubeSizeBelowLimit(): boolean {
-        return this.estimatedCubeSize?.bitValue <= PreferenceStore.Instance.pvPreviewCubeSizeLimit * 1e9; // Convert GB to bits
+        return this.estimatedCubeSize <= PreferenceStore.Instance.pvPreviewCubeSizeLimit;
     }
 
     constructor(props: WidgetProps) {
@@ -288,7 +270,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                         <br />
                         1. Line region is selected.
                         <br />
-                        2. Preview cube size is less than the threshold ({`${PreferenceStore.Instance.pvPreviewCubeSizeLimit} ${PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit}`}).
+                        2. Preview cube size is less than the threshold ({`${PreferenceStore.Instance.pvPreviewCubeSizeLimit} GB`}).
                     </small>
                 </i>
             </span>
@@ -388,8 +370,8 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
                     </div>
                 </FormGroup>
                 <div className="cube-size-button-group">
-                    <FormGroup className="cube-size-group" inline label="Preview cube size" labelInfo={this.estimatedCubeSize ? `(${this.estimatedCubeSize.unit})` : ""} disabled={!this.estimatedCubeSize}>
-                        <label className="cube-size" style={{color: this.isCubeSizeBelowLimit ? "" : "red"}}>{`${this.estimatedCubeSize?.value ?? ""}`}</label>
+                    <FormGroup className="cube-size-group" inline label="Preview cube size" labelInfo="(GB)" disabled={!this.estimatedCubeSize}>
+                        <label className="cube-size" style={{color: this.isCubeSizeBelowLimit ? "" : "red"}}>{`${this.estimatedCubeSize ?? ""}`}</label>
                     </FormGroup>
                 </div>
                 <div className="generate-button">

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -51,20 +51,6 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         return {value, unit, bitValue: bitValue};
     };
 
-    public static getBitValueFromFormatted = (value: number, unit: string): number => {
-        let bitValue = value;
-        if (unit === MemoryUnit.TB) {
-            bitValue = value * 1e12;
-        } else if (unit === MemoryUnit.GB) {
-            bitValue = value * 1e9;
-        } else if (unit === MemoryUnit.MB) {
-            bitValue = value * 1e6;
-        } else if (unit === MemoryUnit.kB) {
-            bitValue = value * 1e3;
-        }
-        return bitValue;
-    };
-
     @computed get widgetStore(): PvGeneratorWidgetStore {
         const widgetsStore = WidgetsStore.Instance;
         if (widgetsStore.pvGeneratorWidgets) {
@@ -157,7 +143,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
     }
 
     @computed get isCubeSizeBelowLimit(): boolean {
-        return this.estimatedCubeSize?.bitValue <= PvGeneratorComponent.getBitValueFromFormatted(PreferenceStore.Instance.pvPreviewCubeSizeLimit, PreferenceStore.Instance.pvPreviewCubeSizeLimitUnit);
+        return this.estimatedCubeSize?.bitValue <= PreferenceStore.Instance.pvPreviewCubeSizeLimit * 1e9; // Convert GB to bits
     }
 
     constructor(props: WidgetProps) {

--- a/src/models/DataSize/DataSize.ts
+++ b/src/models/DataSize/DataSize.ts
@@ -1,0 +1,7 @@
+export enum ConvertToGB {
+    TB = 1e3,
+    GB = 1,
+    MB = 1e-3,
+    kB = 1e-6,
+    B = 1e-9
+}

--- a/src/models/Wcs/WCSType.ts
+++ b/src/models/Wcs/WCSType.ts
@@ -1,7 +1,7 @@
 export class WCSType {
-    public static readonly AUTOMATIC = "Automatic";
-    public static readonly DEGREES = "Degrees";
-    public static readonly SEXAGESIMAL = "Sexagesimal";
+    public static readonly AUTOMATIC = "automatic";
+    public static readonly DEGREES = "degrees";
+    public static readonly SEXAGESIMAL = "sexagesimal";
 
     public static isValid = (wcsType: string): boolean => {
         return wcsType === WCSType.AUTOMATIC || wcsType === WCSType.DEGREES || wcsType === WCSType.SEXAGESIMAL;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ export * from "./ControlMap/ControlMap";
 export * from "./Ctype/CtypeDefinition";
 export * from "./Cursor/CursorInfo";
 export * from "./Cursor/CursorPosition";
+export * from "./DataSize/DataSize";
 export * from "./Event/Event";
 export * from "./FileFilterMode/FileFilterMode";
 export * from "./FrameView/FrameView";

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -5,6 +5,7 @@ import {action, computed, makeObservable, observable} from "mobx";
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
 import {AppStore, PreferenceKeys} from "stores";
+import {Pre} from "@blueprintjs/core";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
 const snippetSchema = require("carta-schemas/snippet_schema_1.json");
@@ -213,19 +214,36 @@ export class ApiService {
         if (preferences["version"] === 1) {
             // Convert preferences[PreferenceKeys.WCS_OVERLAY_AST_COLOR] from a number in version 1 to a string in version 2
             // default to "auto-blue" if the value is not in the AST_COLORS map
-            const astColors = ["auto-black", "auto-white", "auto-red", "auto-forest", "auto-blue", "auto-turquoise", "auto-violet", "auto-gold", "auto-gray"];
-            const astColorKey = PreferenceKeys.WCS_OVERLAY_AST_COLOR;
-            if (astColorKey in preferences || preferences[astColorKey] === 0) {
-                preferences[astColorKey] = astColors.includes(preferences[astColorKey]) ? astColors[preferences[astColorKey]] : "auto-blue";
+            enum ASTColors {
+                black,
+                white,
+                red,
+                forest,
+                blue,
+                turquoise,
+                violet,
+                gold,
+                gray
             }
-            preferences["version"] = 2;
-            this.setPreferences(preferences);
+            const astColorKey = PreferenceKeys.WCS_OVERLAY_AST_COLOR;
+            const color = preferences[astColorKey] in ASTColors ? ASTColors[preferences[astColorKey]] : "blue";
+            preferences[astColorKey] = `auto-${color}`;
+            this.setPreference(astColorKey, preferences[astColorKey]);
+
+            // preferences["version"] = 2;
+            this.setPreference("version", 2);
         }
 
         // Upgrade to schema version 2
-        const key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
-        if (/[A-Z]/.test(preferences[key])) {
+        let key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
+        if (preferences[key]) {
             preferences[key] = preferences[key].toLowerCase();
+            this.setPreference(key, preferences[key]);
+        }
+
+        key = PreferenceKeys.IMAGE_PANEL_MODE;
+        if (preferences[key] === "static") {
+            preferences[key] = "fixed";
             this.setPreference(key, preferences[key]);
         }
     };

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -4,10 +4,10 @@ import {action, computed, makeObservable, observable} from "mobx";
 
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
+import {AST_COLORS} from "utilities";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
 const snippetSchema = require("carta-schemas/snippet_schema_1.json");
-// const workspaceSchema = require("carta-schemas/workspace_schema_1.json");
 
 export interface RuntimeConfig {
     dashboardAddress?: string;
@@ -202,38 +202,10 @@ export class ApiService {
         // Upgrade to V2 if required
         if (preferences?.version && preferences.version === 1) {
             if (preferences.astColor || preferences.astColor === 0) {
-                switch (preferences.astColor) {
-                    case 0:
-                        preferences.astColor = "auto-black";
-                        break;
-                    case 1:
-                        preferences.astColor = "auto-white";
-                        break;
-                    case 2:
-                        preferences.astColor = "auto-red";
-                        break;
-                    case 3:
-                        preferences.astColor = "auto-forest";
-                        break;
-                    case 4:
-                        preferences.astColor = "auto-blue";
-                        break;
-                    case 5:
-                        preferences.astColor = "auto-turquoise";
-                        break;
-                    case 6:
-                        preferences.astColor = "auto-violet";
-                        break;
-                    case 7:
-                        preferences.astColor = "auto-gold";
-                        break;
-                    case 8:
-                        preferences.astColor = "auto-gray";
-                        break;
-                    default:
-                        preferences.astColor = "auto-blue";
-                        break;
-                }
+                // Convert preferences.astColor from a number in version 1 to a string in version 2
+                // default to "auto-blue" if the value is not in the AST_COLORS map
+                const astColorArray = Array.from(AST_COLORS.keys());
+                preferences.astColor = astColorArray.includes(preferences.astColor) ? AST_COLORS.get(preferences.astColor) : "auto-blue";
             }
             preferences.version = 2;
             this.setPreferences(preferences);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -176,7 +176,7 @@ export class ApiService {
                 }
             } catch (err) {
                 console.log(err);
-                AppStore.Instance.alertStore.showAlert(`Failed to load preferences: preferences.json might contain malformed values and are reset to defaults. Please check the backup file preferences.json.bak.`);
+                AppStore.Instance.alertStore.showAlert(`Failed to load preferences: preferences.json might be malformed and reset to default. Please check the backup file preferences.json.bak.`);
                 return undefined;
             }
         } else {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -217,10 +217,13 @@ export class ApiService {
         // Upgrade to schema version 2
         const schemaVersionRegex = /schema_(\d+)\.json/;
         const schemaKey = "$schema";
-        if (preferences[schemaKey] && preferences[schemaKey].match(schemaVersionRegex)[1] === "1") {
-            if (preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE]) {
-                preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE] = preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE].toLowerCase();
-                this.setPreferences(preferences);
+        if (preferences[schemaKey]) {
+            const matchResult = preferences[schemaKey].match(schemaVersionRegex);
+            if (matchResult && matchResult[1] === "1") {
+                if (preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE]) {
+                    preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE] = preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE].toLowerCase();
+                    this.setPreferences(preferences);
+                }
             }
         }
     };
@@ -236,7 +239,6 @@ export class ApiService {
             try {
                 const url = `${ApiService.RuntimeConfig.apiAddress}/database/preferences`;
                 const response = await this.axiosInstance.put(url, preferences);
-                console.log("qq2");
                 return response?.data?.success;
             } catch (err) {
                 console.log(err);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -203,7 +203,7 @@ export class ApiService {
 
                 if (deletedKeys.length > 0) {
                     // Show an alert to the user about the deleted preferences
-                    AppStore.Instance.alertStore.showAlert(`Deleted invalid preferences: ${deletedKeys.join(", ")}`);
+                    AppStore.Instance.alertStore.showAlert(`Invalid preferences reset to defaults: ${deletedKeys.join(", ")}`);
                 }
             }
         }
@@ -254,11 +254,11 @@ export class ApiService {
                 this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
             }
         } else if (cubeSizeUnitKey in preferences) {
-            delete preferences[cubeSizeUnitKey];
-            this.clearPreferences([cubeSizeUnitKey]);
             // set an invalid value to cubeSizeKey to be removed by the validator
             preferences[cubeSizeKey] = -1;
         }
+        delete preferences[cubeSizeUnitKey];
+        this.clearPreferences([cubeSizeUnitKey]);
     };
 
     public setPreference = async (key: string, value: any) => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -239,6 +239,17 @@ export class ApiService {
             preferences[key] = preferences[key].toLowerCase();
             this.setPreference(key, preferences[key]);
         }
+
+        // This is to ensure consistency in the unit used for the preview cube size limit
+        const cubeSizeUnitKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT;
+        const cubeSizeKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT;
+        if (preferences[cubeSizeUnitKey] === "MB") {
+            // Convert MB to GB for consistency
+            preferences[cubeSizeUnitKey] = "GB";
+            preferences[cubeSizeKey] = preferences[cubeSizeKey] / 1000;
+            this.setPreference(cubeSizeUnitKey, preferences[cubeSizeUnitKey]);
+            this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
+        }
     };
 
     public setPreference = async (key: string, value: any) => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -4,8 +4,7 @@ import {action, computed, makeObservable, observable} from "mobx";
 
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
-import {PreferenceKeys} from "stores";
-import {AST_COLORS} from "utilities";
+import {AppStore, PreferenceKeys} from "stores";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
 const snippetSchema = require("carta-schemas/snippet_schema_1.json");
@@ -46,8 +45,8 @@ export class ApiService {
         }
     }
 
-    private static PreferenceValidator = new Ajv({strictTypes: false}).compile(preferencesSchema);
-    private static SnippetValidator = new Ajv({strictTypes: false}).compile(snippetSchema);
+    private static PreferenceValidator = new Ajv({strictTypes: false, allErrors: true}).compile(preferencesSchema);
+    private static SnippetValidator = new Ajv({strictTypes: false, allErrors: true}).compile(snippetSchema);
 
     @observable private _accessToken: string | undefined;
     private _tokenLifetime: number;
@@ -186,14 +185,23 @@ export class ApiService {
         if (preferences) {
             this.upgradePreferences(preferences);
             const valid = ApiService.PreferenceValidator(preferences);
+            let deletedKeys: string[] = [];
             if (!valid) {
                 for (const error of ApiService.PreferenceValidator.errors ?? []) {
                     if (error.instancePath) {
                         console.log(`Removing invalid preference ${error.instancePath}`);
                         // Trim the leading "." from the path
                         delete preferences[error.instancePath.substring(1)];
+
                         this.clearPreferences([error.instancePath.substring(1)]);
+                        deletedKeys.push(error.instancePath.substring(1));
                     }
+                }
+
+                if (deletedKeys.length > 0) {
+                    // Show an alert to the user about the deleted preferences
+                    const appStore = AppStore.Instance;
+                    appStore.alertStore.showAlert(`Deleted invalid preferences: ${deletedKeys.join(", ")}`);
                 }
             }
         }
@@ -202,13 +210,13 @@ export class ApiService {
 
     private upgradePreferences = (preferences: any) => {
         // Upgrade to V2 if required
-        if (preferences["version"] && preferences["version"] === 1) {
+        if (preferences["version"] === 1) {
             // Convert preferences[PreferenceKeys.WCS_OVERLAY_AST_COLOR] from a number in version 1 to a string in version 2
             // default to "auto-blue" if the value is not in the AST_COLORS map
+            const astColors = ["auto-black", "auto-white", "auto-red", "auto-forest", "auto-blue", "auto-turquoise", "auto-violet", "auto-gold", "auto-gray"];
             const astColorKey = PreferenceKeys.WCS_OVERLAY_AST_COLOR;
-            if (preferences[astColorKey] || preferences[astColorKey] === 0) {
-                const astColorArrays = Array.from(AST_COLORS.keys());
-                preferences[astColorKey] = astColorArrays.includes(preferences[astColorKey]) ? AST_COLORS.get(preferences[astColorKey]) : "auto-blue";
+            if (astColorKey in preferences || preferences[astColorKey] === 0) {
+                preferences[astColorKey] = astColors.includes(preferences[astColorKey]) ? astColors[preferences[astColorKey]] : "auto-blue";
             }
             preferences["version"] = 2;
             this.setPreferences(preferences);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -2,6 +2,7 @@ import Ajv from "ajv";
 import axios, {AxiosInstance} from "axios";
 import {action, computed, makeObservable, observable} from "mobx";
 
+// import {ConvertToGB} from "components/Dialogs";
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
 import {AppStore, PreferenceKeys} from "stores";
@@ -214,18 +215,18 @@ export class ApiService {
             // Convert preferences[PreferenceKeys.WCS_OVERLAY_AST_COLOR] from a number in version 1 to a string in version 2
             // default to "auto-blue" if the value is not in the AST_COLORS map
             enum ASTColors {
-                black,
-                white,
-                red,
-                forest,
-                blue,
-                turquoise,
-                violet,
-                gold,
-                gray
+                black = 0,
+                white = 1,
+                red = 2,
+                forest = 3,
+                blue = 4,
+                turquoise = 5,
+                violet = 6,
+                gold = 7,
+                gray = 8
             }
             const astColorKey = PreferenceKeys.WCS_OVERLAY_AST_COLOR;
-            const color = preferences[astColorKey] in ASTColors ? ASTColors[preferences[astColorKey]] : "blue";
+            const color = typeof preferences[astColorKey] === "number" ? (ASTColors[preferences[astColorKey]] ?? "blue") : "blue";
             preferences[astColorKey] = `auto-${color}`;
             this.setPreference(astColorKey, preferences[astColorKey]);
 
@@ -243,12 +244,25 @@ export class ApiService {
         // This is to ensure consistency in the unit used for the preview cube size limit
         const cubeSizeUnitKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT;
         const cubeSizeKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT;
-        if (preferences[cubeSizeUnitKey] === "MB") {
-            // Convert MB to GB for consistency
-            preferences[cubeSizeKey] = preferences[cubeSizeKey] / 1000;
-            this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
-            this.clearPreferences([cubeSizeUnitKey]); // Remove the deprecated unit key from preferences.json
+
+        // const memoryUnits = ["TB", "GB", "MB", "kB", "B"];
+        enum ConvertToGB {
+            TB = 1e3,
+            GB = 1,
+            MB = 1e-3,
+            kB = 1e-6,
+            B = 1e-9
         }
+        if (ConvertToGB[preferences[cubeSizeUnitKey]] && typeof preferences[cubeSizeKey] === "number") {
+            let gbSize = preferences[cubeSizeKey] * ConvertToGB[preferences[cubeSizeUnitKey] as string];
+            if (gbSize !== preferences[cubeSizeKey]) {
+                preferences[cubeSizeKey] = gbSize;
+                this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
+            }
+        }
+
+        delete preferences[cubeSizeUnitKey];
+        this.clearPreferences([cubeSizeUnitKey]);
     };
 
     public setPreference = async (key: string, value: any) => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -201,8 +201,7 @@ export class ApiService {
 
                 if (deletedKeys.length > 0) {
                     // Show an alert to the user about the deleted preferences
-                    const appStore = AppStore.Instance;
-                    appStore.alertStore.showAlert(`Deleted invalid preferences: ${deletedKeys.join(", ")}`);
+                    AppStore.Instance.alertStore.showAlert(`Deleted invalid preferences: ${deletedKeys.join(", ")}`);
                 }
             }
         }
@@ -235,7 +234,7 @@ export class ApiService {
         }
 
         // Normalize case of wcsType value, which may have been saved incorrectly in existing preferences
-        let key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
+        const key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
         if (/[A-Z]/.test(preferences[key])) {
             preferences[key] = preferences[key].toLowerCase();
             this.setPreference(key, preferences[key]);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -245,10 +245,9 @@ export class ApiService {
         const cubeSizeKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT;
         if (preferences[cubeSizeUnitKey] === "MB") {
             // Convert MB to GB for consistency
-            preferences[cubeSizeUnitKey] = "GB";
             preferences[cubeSizeKey] = preferences[cubeSizeKey] / 1000;
-            this.setPreference(cubeSizeUnitKey, preferences[cubeSizeUnitKey]);
             this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
+            this.clearPreferences([cubeSizeUnitKey]); // Remove the deprecated unit key from preferences.json
         }
     };
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -2,7 +2,6 @@ import Ajv from "ajv";
 import axios, {AxiosInstance} from "axios";
 import {action, computed, makeObservable, observable} from "mobx";
 
-// import {ConvertToGB} from "components/Dialogs";
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
 import {AppStore, PreferenceKeys} from "stores";
@@ -245,7 +244,6 @@ export class ApiService {
         const cubeSizeUnitKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT;
         const cubeSizeKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT;
 
-        // const memoryUnits = ["TB", "GB", "MB", "kB", "B"];
         enum ConvertToGB {
             TB = 1e3,
             GB = 1,

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -234,7 +234,7 @@ export class ApiService {
             this.setPreference("version", 2);
         }
 
-        // Fix the inconsistent `wcsType` value between schema v1 and v2
+        // Normalize case of wcsType value, which may have been saved incorrectly in existing preferences
         let key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
         if (/[A-Z]/.test(preferences[key])) {
             preferences[key] = preferences[key].toLowerCase();

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -223,16 +223,10 @@ export class ApiService {
         }
 
         // Upgrade to schema version 2
-        const schemaVersionRegex = /schema_(\d+)\.json/;
-        const schemaKey = "$schema";
-        if (preferences[schemaKey]) {
-            const matchResult = preferences[schemaKey].match(schemaVersionRegex);
-            if (matchResult && matchResult[1] === "1") {
-                if (preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE]) {
-                    preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE] = preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE].toLowerCase();
-                    this.setPreferences(preferences);
-                }
-            }
+        const key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
+        if (/[A-Z]/.test(preferences[key])) {
+            preferences[key] = preferences[key].toLowerCase();
+            this.setPreference(key, preferences[key]);
         }
     };
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -4,6 +4,7 @@ import {action, computed, makeObservable, observable} from "mobx";
 
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
+import {PreferenceKeys} from "stores";
 import {AST_COLORS} from "utilities";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
@@ -191,6 +192,7 @@ export class ApiService {
                         console.log(`Removing invalid preference ${error.instancePath}`);
                         // Trim the leading "." from the path
                         delete preferences[error.instancePath.substring(1)];
+                        this.clearPreferences([error.instancePath.substring(1)]);
                     }
                 }
             }
@@ -200,15 +202,26 @@ export class ApiService {
 
     private upgradePreferences = (preferences: any) => {
         // Upgrade to V2 if required
-        if (preferences?.version && preferences.version === 1) {
-            if (preferences.astColor || preferences.astColor === 0) {
-                // Convert preferences.astColor from a number in version 1 to a string in version 2
-                // default to "auto-blue" if the value is not in the AST_COLORS map
-                const astColorArray = Array.from(AST_COLORS.keys());
-                preferences.astColor = astColorArray.includes(preferences.astColor) ? AST_COLORS.get(preferences.astColor) : "auto-blue";
+        if (preferences["version"] && preferences["version"] === 1) {
+            // Convert preferences[PreferenceKeys.WCS_OVERLAY_AST_COLOR] from a number in version 1 to a string in version 2
+            // default to "auto-blue" if the value is not in the AST_COLORS map
+            const astColorKey = PreferenceKeys.WCS_OVERLAY_AST_COLOR;
+            if (preferences[astColorKey] || preferences[astColorKey] === 0) {
+                const astColorArrays = Array.from(AST_COLORS.keys());
+                preferences[astColorKey] = astColorArrays.includes(preferences[astColorKey]) ? AST_COLORS.get(preferences[astColorKey]) : "auto-blue";
             }
-            preferences.version = 2;
+            preferences["version"] = 2;
             this.setPreferences(preferences);
+        }
+
+        // Upgrade to schema version 2
+        const schemaVersionRegex = /schema_(\d+)\.json/;
+        const schemaKey = "$schema";
+        if (preferences[schemaKey] && preferences[schemaKey].match(schemaVersionRegex)[1] === "1") {
+            if (preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE]) {
+                preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE] = preferences[PreferenceKeys.WCS_OVERLAY_WCS_TYPE].toLowerCase();
+                this.setPreferences(preferences);
+            }
         }
     };
 
@@ -223,6 +236,7 @@ export class ApiService {
             try {
                 const url = `${ApiService.RuntimeConfig.apiAddress}/database/preferences`;
                 const response = await this.axiosInstance.put(url, preferences);
+                console.log("qq2");
                 return response?.data?.success;
             } catch (err) {
                 console.log(err);

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -176,6 +176,7 @@ export class ApiService {
                 }
             } catch (err) {
                 console.log(err);
+                AppStore.Instance.alertStore.showAlert(`Failed to load preferences: preferences.json might contain malformed values and are reset to defaults. Please check the backup file preferences.json.bak.`);
                 return undefined;
             }
         } else {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -5,7 +5,6 @@ import {action, computed, makeObservable, observable} from "mobx";
 import {AppToaster} from "components/Shared";
 import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
 import {AppStore, PreferenceKeys} from "stores";
-import {Pre} from "@blueprintjs/core";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
 const snippetSchema = require("carta-schemas/snippet_schema_1.json");
@@ -192,10 +191,11 @@ export class ApiService {
                     if (error.instancePath) {
                         console.log(`Removing invalid preference ${error.instancePath}`);
                         // Trim the leading "." from the path
-                        delete preferences[error.instancePath.substring(1)];
-
-                        this.clearPreferences([error.instancePath.substring(1)]);
-                        deletedKeys.push(error.instancePath.substring(1));
+                        const errorKey = error.instancePath.substring(1);
+                        // Remove the invalid preference from the preferences object
+                        delete preferences[errorKey];
+                        this.clearPreferences([errorKey]);
+                        deletedKeys.push(errorKey);
                     }
                 }
 
@@ -230,20 +230,14 @@ export class ApiService {
             preferences[astColorKey] = `auto-${color}`;
             this.setPreference(astColorKey, preferences[astColorKey]);
 
-            // preferences["version"] = 2;
+            preferences["version"] = 2;
             this.setPreference("version", 2);
         }
 
-        // Upgrade to schema version 2
+        // Fix the inconsistent `wcsType` value between schema v1 and v2
         let key = PreferenceKeys.WCS_OVERLAY_WCS_TYPE;
-        if (preferences[key]) {
+        if (/[A-Z]/.test(preferences[key])) {
             preferences[key] = preferences[key].toLowerCase();
-            this.setPreference(key, preferences[key]);
-        }
-
-        key = PreferenceKeys.IMAGE_PANEL_MODE;
-        if (preferences[key] === "static") {
-            preferences[key] = "fixed";
             this.setPreference(key, preferences[key]);
         }
     };

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -3,7 +3,7 @@ import axios, {AxiosInstance} from "axios";
 import {action, computed, makeObservable, observable} from "mobx";
 
 import {AppToaster} from "components/Shared";
-import {LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
+import {ConvertToGB, LayoutConfig, Snippet, Workspace, WorkspaceListItem} from "models";
 import {AppStore, PreferenceKeys} from "stores";
 
 const preferencesSchema = require("carta-schemas/preferences_schema_2.json");
@@ -185,6 +185,7 @@ export class ApiService {
 
         if (preferences) {
             this.upgradePreferences(preferences);
+            console.log(preferences);
             const valid = ApiService.PreferenceValidator(preferences);
             let deletedKeys: string[] = [];
             if (!valid) {
@@ -245,23 +246,19 @@ export class ApiService {
         const cubeSizeUnitKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT;
         const cubeSizeKey = PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT;
 
-        enum ConvertToGB {
-            TB = 1e3,
-            GB = 1,
-            MB = 1e-3,
-            kB = 1e-6,
-            B = 1e-9
-        }
-        if (ConvertToGB[preferences[cubeSizeUnitKey]] && typeof preferences[cubeSizeKey] === "number") {
-            let gbSize = preferences[cubeSizeKey] * ConvertToGB[preferences[cubeSizeUnitKey] as string];
+        const conversionFactor = ConvertToGB[preferences[cubeSizeUnitKey]];
+        if (typeof conversionFactor === "number") {
+            let gbSize = preferences[cubeSizeKey] * conversionFactor;
             if (gbSize !== preferences[cubeSizeKey]) {
                 preferences[cubeSizeKey] = gbSize;
                 this.setPreference(cubeSizeKey, preferences[cubeSizeKey]);
             }
+        } else if (cubeSizeUnitKey in preferences) {
+            delete preferences[cubeSizeUnitKey];
+            this.clearPreferences([cubeSizeUnitKey]);
+            // set an invalid value to cubeSizeKey to be removed by the validator
+            preferences[cubeSizeKey] = -1;
         }
-
-        delete preferences[cubeSizeUnitKey];
-        this.clearPreferences([cubeSizeUnitKey]);
     };
 
     public setPreference = async (key: string, value: any) => {

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -629,11 +629,11 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_STOP_ANIMATION_PLAYBACK_MINUTES) ?? DEFAULTS.PERFORMANCE.stopAnimationPlaybackMinutes;
     }
 
-    @computed get pvPreivewCubeSizeLimit(): number {
+    @computed get pvPreviewCubeSizeLimit(): number {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT) ?? DEFAULTS.PERFORMANCE.pvPreviewCubeSizeLimit;
     }
 
-    @computed get pvPreivewCubeSizeLimitUnit(): string {
+    @computed get pvPreviewCubeSizeLimitUnit(): string {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT) ?? DEFAULTS.PERFORMANCE.pvPreviewCubeSizeLimitUnit;
     }
 

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -27,7 +27,6 @@ import {ApiService} from "services";
 import {TelemetryMode} from "services/TelemetryService";
 import {BeamType, FileFilteringType} from "stores";
 import {ContourGeneratorType, FrameScaling} from "stores/Frame";
-import {parseBoolean} from "utilities";
 
 export enum PreferenceKeys {
     SILENT_FILE_SORTING_STRING = "fileSortingString",
@@ -1020,8 +1019,6 @@ export class PreferenceStore {
      * Fetch the values of the preference keys
      */
     @flow.bound *fetchPreferences() {
-        yield this.upgradePreferences();
-
         const preferences = yield ApiService.Instance.getPreferences();
         if (preferences) {
             const keys = Object.keys(preferences);
@@ -1032,146 +1029,6 @@ export class PreferenceStore {
         }
         this.preferenceReady = true;
     }
-
-    /**
-     * Perform localStorage upgrade by iterating over the old CARTA version keys. This list consists of keys that were present when CARTA used a single localStorage entry per key
-     */
-    private upgradePreferences = async () => {
-        if (!localStorage.getItem("preferences")) {
-            const stringKeys = [
-                PreferenceKeys.GLOBAL_THEME,
-                PreferenceKeys.LAYOUT,
-                PreferenceKeys.GLOBAL_CURSOR_POSITION,
-                PreferenceKeys.GLOBAL_ZOOM_MODE,
-                PreferenceKeys.GLOBAL_ZOOM_POINT,
-                PreferenceKeys.GLOBAL_SPECTRAL_MATCHING_TYPE,
-                PreferenceKeys.RENDER_CONFIG_COLORMAP,
-                PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX,
-                PreferenceKeys.CONTOUR_CONFIG_GENERATOR_TYPE,
-                PreferenceKeys.CONTOUR_CONFIG_COLOR,
-                PreferenceKeys.CONTOUR_CONFIG_COLORMAP,
-                PreferenceKeys.WCS_OVERLAY_WCS_TYPE,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_POSITION,
-                PreferenceKeys.WCS_OVERLAY_BEAM_COLOR,
-                PreferenceKeys.WCS_OVERLAY_BEAM_TYPE,
-                PreferenceKeys.REGION_COLOR,
-                PreferenceKeys.REGION_CREATION_MODE,
-                PreferenceKeys.WCS_OVERLAY_AST_COLOR,
-                PreferenceKeys.CATALOG_TABLE_SEPARATOR_POSITION,
-                PreferenceKeys.PIXEL_GRID_COLOR
-            ];
-
-            const intKeys = [
-                PreferenceKeys.GLOBAL_AUTO_WCS_MATCHING,
-                PreferenceKeys.RENDER_CONFIG_SCALING,
-                PreferenceKeys.CONTOUR_CONFIG_SMOOTHING_MODE,
-                PreferenceKeys.CONTOUR_CONFIG_SMOOTHING_FACTOR,
-                PreferenceKeys.CONTOUR_CONFIG_NUM_LEVELS,
-                PreferenceKeys.REGION_DASH_LENGTH,
-                PreferenceKeys.REGION_TYPE,
-                PreferenceKeys.PERFORMANCE_IMAGE_COMPRESSION_QUALITY,
-                PreferenceKeys.PERFORMANCE_ANIMATION_COMPRESSION_QUALITY,
-                PreferenceKeys.PERFORMANCE_GPU_TILE_CACHE,
-                PreferenceKeys.PERFORMANCE_SYSTEM_TILE_CACHE,
-                PreferenceKeys.PERFORMANCE_CONTOUR_DECIMATION,
-                PreferenceKeys.PERFORMANCE_CONTOUR_COMPRESSION_LEVEL,
-                PreferenceKeys.PERFORMANCE_CONTOUR_CHUNK_SIZE,
-                PreferenceKeys.PERFORMANCE_CONTOUR_CONTROL_MAP_WIDTH,
-                PreferenceKeys.PERFORMANCE_STOP_ANIMATION_PLAYBACK_MINUTES,
-                PreferenceKeys.CATALOG_DISPLAYED_COLUMN_SIZE
-            ];
-
-            const numberKeys = [
-                PreferenceKeys.RENDER_CONFIG_PERCENTILE,
-                PreferenceKeys.RENDER_CONFIG_SCALING_ALPHA,
-                PreferenceKeys.RENDER_CONFIG_SCALING_GAMMA,
-                PreferenceKeys.RENDER_CONFIG_NAN_ALPHA,
-                PreferenceKeys.CONTOUR_CONFIG_THICKNESS,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_WIDTH,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_TICKS_DENSITY,
-                PreferenceKeys.WCS_OVERLAY_BEAM_WIDTH,
-                PreferenceKeys.REGION_LINE_WIDTH
-            ];
-
-            const booleanKeys = [
-                PreferenceKeys.GLOBAL_AUTOLAUNCH,
-                PreferenceKeys.GLOBAL_DRAG_PANNING,
-                PreferenceKeys.GLOBAL_TRANSPARENT_IMAGE_BACKGROUND,
-                PreferenceKeys.RENDER_CONFIG_USE_SMOOTHED_BIAS_CONTRAST,
-                PreferenceKeys.CONTOUR_CONFIG_COLORMAP_ENABLED,
-                PreferenceKeys.WCS_OVERLAY_AST_GRID_VISIBLE,
-                PreferenceKeys.WCS_OVERLAY_AST_LABELS_VISIBLE,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_VISIBLE,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_INTERACTIVE,
-                PreferenceKeys.WCS_OVERLAY_COLORBAR_LABEL_VISIBLE,
-                PreferenceKeys.WCS_OVERLAY_BEAM_VISIBLE,
-                PreferenceKeys.PERFORMANCE_STREAM_CONTOURS_WHILE_ZOOMING,
-                PreferenceKeys.PERFORMANCE_LOW_BAND_WIDTH_MODE,
-                PreferenceKeys.PIXEL_GRID_VISIBLE
-            ];
-
-            const preferenceObject = {};
-
-            for (const key of stringKeys) {
-                const entry = localStorage.getItem(key);
-                if (entry) {
-                    preferenceObject[key] = entry;
-                }
-            }
-
-            for (const key of intKeys) {
-                const entry = parseInt(localStorage.getItem(key));
-                if (isFinite(entry)) {
-                    preferenceObject[key] = entry;
-                }
-            }
-
-            for (const key of numberKeys) {
-                const entry = parseFloat(localStorage.getItem(key));
-                if (isFinite(entry)) {
-                    preferenceObject[key] = entry;
-                }
-            }
-
-            for (const key of booleanKeys) {
-                const entryString = localStorage.getItem(key);
-                if (entryString) {
-                    preferenceObject[key] = parseBoolean(localStorage.getItem(key), false);
-                }
-            }
-
-            const logEntryString = localStorage.getItem(PreferenceKeys.LOG_EVENT);
-            if (logEntryString) {
-                try {
-                    const logEntries = JSON.parse(logEntryString);
-                    if (logEntries && Array.isArray(logEntries)) {
-                        preferenceObject[PreferenceKeys.LOG_EVENT] = logEntries;
-                    }
-                } catch (e) {
-                    console.log("Problem parsing log events");
-                }
-            }
-
-            // Manual schema adjustments
-
-            // Beam -> beam and Solid -> solid
-            if (preferenceObject[PreferenceKeys.WCS_OVERLAY_BEAM_TYPE]) {
-                preferenceObject[PreferenceKeys.WCS_OVERLAY_BEAM_TYPE] = preferenceObject[PreferenceKeys.WCS_OVERLAY_BEAM_TYPE].toLowerCase();
-            }
-
-            // 1.0x to full
-            if (preferenceObject[PreferenceKeys.GLOBAL_ZOOM_MODE] === "1.0x") {
-                preferenceObject[PreferenceKeys.GLOBAL_ZOOM_MODE] = "full";
-            }
-
-            for (const key of Object.keys(preferenceObject)) {
-                this.preferences.set(key as PreferenceKeys, preferenceObject[key]);
-            }
-
-            preferenceObject["version"] = 1;
-            await ApiService.Instance.setPreferences(preferenceObject);
-        }
-    };
 
     private constructor() {
         makeObservable(this);

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -2,7 +2,6 @@ import {Colors} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import {action, computed, flow, makeObservable, observable} from "mobx";
 
-import {MemoryUnit} from "components/Dialogs";
 import {
     CARTA_INFO,
     CompressionQuality,
@@ -262,8 +261,7 @@ const DEFAULTS = {
         lowBandwidthMode: false,
         stopAnimationPlaybackMinutes: 5,
         limitOverlayRedraw: true,
-        pvPreviewCubeSizeLimit: 1,
-        pvPreviewCubeSizeLimitUnit: MemoryUnit.GB
+        pvPreviewCubeSizeLimit: 1
     },
     LOG_EVENT: {
         eventLoggingEnabled: []
@@ -631,10 +629,6 @@ export class PreferenceStore {
 
     @computed get pvPreviewCubeSizeLimit(): number {
         return this.preferences.get(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT) ?? DEFAULTS.PERFORMANCE.pvPreviewCubeSizeLimit;
-    }
-
-    @computed get pvPreviewCubeSizeLimitUnit(): string {
-        return this.preferences.get(PreferenceKeys.PERFORMANCE_PV_PREVIEW_CUBE_SIZE_LIMIT_UNIT) ?? DEFAULTS.PERFORMANCE.pvPreviewCubeSizeLimitUnit;
     }
 
     @computed get isPVAxesOrderReverse(): boolean {

--- a/src/utilities/color/color.ts
+++ b/src/utilities/color/color.ts
@@ -29,19 +29,6 @@ export const SWATCH_COLORS = [
 ];
 export const DEFAULT_COLOR = SWATCH_COLORS[0];
 
-// Colors for AST image overlay
-export const AST_COLORS = new Map<number, string>([
-    [0, "auto-black"],
-    [1, "auto-white"],
-    [2, "auto-red"],
-    [3, "auto-forest"],
-    [4, "auto-blue"],
-    [5, "auto-turquoise"],
-    [6, "auto-violet"],
-    [7, "auto-gold"],
-    [8, "auto-gray"]
-]);
-
 const SELECTABLE_COLORS = ["blue", "orange", "green", "red", "violet", "sepia", "indigo", "gray", "lime", "turquoise", "forest", "gold", "cerulean", "rose", "vermilion", "light_gray", "dark_gray"];
 export const AUTO_COLOR_OPTIONS = SELECTABLE_COLORS.map(color => {
     return `auto-${color}`;

--- a/src/utilities/color/color.ts
+++ b/src/utilities/color/color.ts
@@ -29,6 +29,19 @@ export const SWATCH_COLORS = [
 ];
 export const DEFAULT_COLOR = SWATCH_COLORS[0];
 
+// Colors for AST image overlay
+export const AST_COLORS = new Map<number, string>([
+    [0, "auto-black"],
+    [1, "auto-white"],
+    [2, "auto-red"],
+    [3, "auto-forest"],
+    [4, "auto-blue"],
+    [5, "auto-turquoise"],
+    [6, "auto-violet"],
+    [7, "auto-gold"],
+    [8, "auto-gray"]
+]);
+
 const SELECTABLE_COLORS = ["blue", "orange", "green", "red", "violet", "sepia", "indigo", "gray", "lime", "turquoise", "forest", "gold", "cerulean", "rose", "vermilion", "light_gray", "dark_gray"];
 export const AUTO_COLOR_OPTIONS = SELECTABLE_COLORS.map(color => {
     return `auto-${color}`;


### PR DESCRIPTION
**Description**

Close #2561. Fix the bug that invalid values in preferences.json cause all preferences to be reset. 

This PR needs backend: https://github.com/CARTAvis/carta-backend/pull/1486 and schemas: https://github.com/CARTAvis/schemas/pull/10.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~