### PR TITLE
rename spectral string to frequency string in channel map setting

### DIFF
--- a/src/components/ChannelMapControl/ChannelMapControlComponent.tsx
+++ b/src/components/ChannelMapControl/ChannelMapControlComponent.tsx
@@ -91,7 +91,7 @@ export class ChannelMapControlComponent extends React.Component<WidgetProps> {
         const channelTickPre = numChannels - 1 - 4 * channelStep < channelStep / 2 ? [0, channelStep, 2 * channelStep, 3 * channelStep, numChannels - 1] : [0, channelStep, 2 * channelStep, 3 * channelStep, 4 * channelStep, numChannels - 1];
         const channelTick = numChannels > 10 ? channelTickPre : Array.from(Array(numChannels).keys());
 
-        const channelMapLabelVisible = channelMapSettings.showChannelString || channelMapSettings.showSpectralString || channelMapSettings.showVelocityString;
+        const channelMapLabelVisible = channelMapSettings.showChannelString || channelMapSettings.showFrequencyString || channelMapSettings.showVelocityString;
 
         const channelMapPanel = (
             <div className="channel-map-control-container">
@@ -146,13 +146,13 @@ export class ChannelMapControlComponent extends React.Component<WidgetProps> {
                         <Switch checked={channelMapSettings.showChannelString} onChange={ev => channelMapSettings.setShowChannelString(ev.currentTarget.checked)} disabled={!channelMapSettings.channelMapEnabled} />
                     </div>
                 </FormGroup>
-                <FormGroup className="channel-map-control-label" inline={true} label="Show spectral string" disabled={!channelMapSettings.channelMapEnabled}>
+                <FormGroup className="channel-map-control-label" inline={true} label="Show frequency string" disabled={!channelMapSettings.channelMapEnabled}>
                     <div style={{display: "flex", alignItems: "center"}}>
-                        <Switch checked={channelMapSettings.showSpectralString} onChange={ev => channelMapSettings.setShowSpectralString(ev.currentTarget.checked)} disabled={!channelMapSettings.channelMapEnabled} />
-                        {channelMapSettings.showSpectralString && (
+                        <Switch checked={channelMapSettings.showFrequencyString} onChange={ev => channelMapSettings.setShowFrequencyString(ev.currentTarget.checked)} disabled={!channelMapSettings.channelMapEnabled} />
+                        {channelMapSettings.showFrequencyString && (
                             <Checkbox
-                                checked={channelMapSettings.showSpectralStringUnit}
-                                onChange={(ev: React.ChangeEvent<HTMLInputElement>) => channelMapSettings.setShowSpectralStringUnit(ev.currentTarget.checked)}
+                                checked={channelMapSettings.showFrequencyStringUnit}
+                                onChange={(ev: React.ChangeEvent<HTMLInputElement>) => channelMapSettings.setShowFrequencyStringUnit(ev.currentTarget.checked)}
                                 label="Show unit"
                                 style={{marginLeft: "10px"}}
                                 disabled={!channelMapSettings.channelMapEnabled}

--- a/src/components/ImageView/ChannelMapView/ChannelMapLabelComponent.tsx
+++ b/src/components/ImageView/ChannelMapView/ChannelMapLabelComponent.tsx
@@ -32,13 +32,13 @@ export class ChannelMapLabelComponent extends React.Component<ChannelMapLabelCom
 
         let spectralString = "";
         let velocityString = "";
-        if (channelMapStore.showSpectralString || channelMapStore.showVelocityString) {
+        if (channelMapStore.showFrequencyString || channelMapStore.showVelocityString) {
             ({spectralString, velocityString} = frame.getFreqWithChannel(this.props.channel));
         }
 
-        if (channelMapStore.showSpectralString) {
+        if (channelMapStore.showFrequencyString) {
             spectralString = spectralString.replace(/^[^:]+:\s*/, "");
-            if (!channelMapStore.showSpectralStringUnit) {
+            if (!channelMapStore.showFrequencyStringUnit) {
                 spectralString = spectralString.replace(/\s+[^ ]*$/, "");
             }
         } else {

--- a/src/stores/ChannelMapStore/ChannelMapStore.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.ts
@@ -75,11 +75,11 @@ export class ChannelMapStore {
     /** Indicates whether to show the channel string. */
     @observable showChannelString: boolean = false;
     /** Indicates whether to show the spectral string. */
-    @observable showSpectralString: boolean = false;
+    @observable showFrequencyString: boolean = false;
     /** Indicates whether to show the velocity string. */
     @observable showVelocityString: boolean = false;
     /** Indicates whether to show the unit of the spectral string. */
-    @observable showSpectralStringUnit: boolean = true;
+    @observable showFrequencyStringUnit: boolean = true;
     /** Indicates whether to show the unit of the velocity string. */
     @observable showVelocityStringUnit: boolean = true;
     /** Font index used for rendering the channel map label. */
@@ -198,8 +198,8 @@ export class ChannelMapStore {
      * Show or hide the spectral string.
      * @param show - True to show, false to hide.
      */
-    @action setShowSpectralString = (show: boolean) => {
-        this.showSpectralString = show;
+    @action setShowFrequencyString = (show: boolean) => {
+        this.showFrequencyString = show;
     };
 
     /**
@@ -214,8 +214,8 @@ export class ChannelMapStore {
      * Show or hide the unit of the spectral string.
      * @param show - True to show, false to hide.
      */
-    @action setShowSpectralStringUnit = (show: boolean) => {
-        this.showSpectralStringUnit = show;
+    @action setShowFrequencyStringUnit = (show: boolean) => {
+        this.showFrequencyStringUnit = show;
     };
 
     /**

--- a/src/stores/ChannelMapStore/ChannelMapStore.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.ts
@@ -74,11 +74,11 @@ export class ChannelMapStore {
     @observable channelMapEnabled: boolean = false;
     /** Indicates whether to show the channel string. */
     @observable showChannelString: boolean = false;
-    /** Indicates whether to show the spectral string. */
+    /** Indicates whether to show the frequency string. */
     @observable showFrequencyString: boolean = false;
     /** Indicates whether to show the velocity string. */
     @observable showVelocityString: boolean = false;
-    /** Indicates whether to show the unit of the spectral string. */
+    /** Indicates whether to show the unit of the frequency string. */
     @observable showFrequencyStringUnit: boolean = true;
     /** Indicates whether to show the unit of the velocity string. */
     @observable showVelocityStringUnit: boolean = true;
@@ -195,7 +195,7 @@ export class ChannelMapStore {
     };
 
     /**
-     * Show or hide the spectral string.
+     * Show or hide the frequency string.
      * @param show - True to show, false to hide.
      */
     @action setShowFrequencyString = (show: boolean) => {
@@ -211,7 +211,7 @@ export class ChannelMapStore {
     };
 
     /**
-     * Show or hide the unit of the spectral string.
+     * Show or hide the unit of the frequency string.
      * @param show - True to show, false to hide.
      */
     @action setShowFrequencyStringUnit = (show: boolean) => {


### PR DESCRIPTION
**Description**

A quick modification for renaming the show spectral string to show frequency string. Additionally, modify the names of the related functions.