### PR TITLE
correct flux unit displayed in spectral profile for K-unit images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.3]
+
+### Fixed
+* Fixed flux density unit display in spectral profile for images with brightness temperature (K) units ([#2572](https://github.com/CARTAvis/carta-frontend/issues/2572)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.3]
 
 ### Fixed
-* Fixed flux density unit display in spectral profile for images with brightness temperature (K) units ([#2572](https://github.com/CARTAvis/carta-frontend/issues/2572)).
+* Fixed flux density unit display in spectral profile for images with brightness temperature (K) ([#2572](https://github.com/CARTAvis/carta-frontend/issues/2572)).
 
 ## [5.0.2]
 

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -5,11 +5,11 @@ import tinycolor from "tinycolor2";
 
 import {SpectralProfilerSettingsTabs} from "components";
 import {LineSettings, PlotType, SmoothingType, VERTICAL_RANGE_PADDING} from "components/Shared";
-import {FindIntensityUnitType, GetCommonIntensityOptions, GetIntensityConversion, GetIntensityOptions, IntensityConfig, IntensityUnitType, IsIntensitySupported, LineKey, Point2D, POLARIZATIONS, SpectralSystem} from "models";
+import {GetCommonIntensityOptions, GetIntensityConversion, GetIntensityOptions, IntensityConfig, IsIntensitySupported, LineKey, Point2D, POLARIZATIONS, SpectralSystem} from "models";
 import {TelemetryAction, TelemetryService} from "services";
 import {AppStore, ProfileFittingStore, ProfileSmoothingStore} from "stores";
 import {MultiProfileCategory, RegionId, RegionsType, RegionWidgetStore, SpectralLine, SpectralProfileSelectionStore} from "stores/Widgets";
-import {clamp, genColorFromIndex, getColorForTheme, isAutoColor} from "utilities";
+import {clamp, genColorFromIndex, getColorForTheme, isAutoColor, pixelToFluxDensityUnit} from "utilities";
 
 export enum MomentSelectingMode {
     NONE = 1,
@@ -731,7 +731,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                 if (this.profileSelectionStore.isStatsTypeFluxDensityOnly && this.profileSelectionStore.isCoordinatesPangleOnly) {
                     return "";
                 } else if (this.profileSelectionStore.isStatsTypeFluxDensityOnly && unitString) {
-                    return FindIntensityUnitType(unitString) === IntensityUnitType.Kelvin ? unitString : unitString.substring(0, unitString.indexOf("/"));
+                    return pixelToFluxDensityUnit(unitString);
                 } else if (this.profileSelectionStore.isStatsTypeSumSqOnly) {
                     return `(${unitString})^2`;
                 } else {


### PR DESCRIPTION
**Description**

Close #2572. Fix the incorrect flux unit display in the spectral profile for K-unit images.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~