### PR TITLE
Disable text selection in file list cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Disable text selection in file list cells ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
+* Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Disable text selection in file list cells ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
+
 ## [5.0.3]
 
 ### Fixed

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
@@ -3,7 +3,7 @@
 .file-browser-dialog {
     min-width: 60%;
     height: 100%;
-    user-select: none;
+    user-select: auto;
 
     .file-path {
         margin-top: 20px;

--- a/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileBrowserDialogComponent.scss
@@ -3,7 +3,7 @@
 .file-browser-dialog {
     min-width: 60%;
     height: 100%;
-    user-select: auto;
+    user-select: none !important;
 
     .file-path {
         margin-top: 20px;

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
@@ -67,8 +67,6 @@
             inset -1px 0 0 rgba($black, 0.05) !important;
         line-height: 22px;
         height: 22px;
-        user-select: none;
-        -webkit-user-select: none;
 
         &.folder-cell {
             cursor: pointer !important;

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.scss
@@ -67,7 +67,8 @@
             inset -1px 0 0 rgba($black, 0.05) !important;
         line-height: 22px;
         height: 22px;
-        user-select: text;
+        user-select: none;
+        -webkit-user-select: none;
 
         &.folder-cell {
             cursor: pointer !important;


### PR DESCRIPTION
**Description**

Closes #2574.

Disable text selection in file browser. Only texts in file information and header can be selected.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)