### PR TITLE
Fix keyboard shortcuts of next/previous images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed hotkeys for next/prev images ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
+* Fixed hotkeys for navigating to the next and previous images, resolved keyboard event conflicts between the image viewer and the dropdown menu, and automatically resized the hotkeys dialog ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575), [#758](https://github.com/CARTAvis/carta-frontend/issues/758)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Fixed hotkeys for next/prev images and "useHotkeys() was used outside of a <HotkeysProvider> context" problem ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
+* Fixed hotkeys for next/prev images and "useHotkeys() was used outside of a `<HotkeysProvider>` context" problem ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed hotkeys for next/prev images and "useHotkeys() was used outside of a <HotkeysProvider> context" problem ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
+
 ## [5.0.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Fixed hotkeys for next/prev images and "useHotkeys() was used outside of a `<HotkeysProvider>` context" problem ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
+* Fixed hotkeys for next/prev images and "useHotkeys() was used outside of a `HotkeysProvider` context" problem ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed hotkeys for navigating to the next and previous images, resolved keyboard event conflicts between the image viewer and the dropdown menu, and automatically resized the hotkeys dialog ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575), [#758](https://github.com/CARTAvis/carta-frontend/issues/758)).
+* Fixed hotkeys of the next and previous images for macOS, resolved keyboard event conflicts between the image viewer and the dropdown menu, and unified the hotkeys dialog and adjusted the layout ([#2575](https://github.com/CARTAvis/carta-frontend/issues/2575), [#758](https://github.com/CARTAvis/carta-frontend/issues/758)).
 
 ## [5.0.3]
 

--- a/public/index.html
+++ b/public/index.html
@@ -101,29 +101,6 @@
             }
         }
     </style>
-    <script>
-        // Suppress benign ResizeObserver errors
-        // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
-        // These are benign errors that occur when ResizeObserver can't deliver all observations
-        // within a single animation frame, which is common with modern UI libraries.
-        window.addEventListener('error', function(e) {
-            if (e.message === 'ResizeObserver loop limit exceeded' || 
-                e.message === 'ResizeObserver loop completed with undelivered notifications.') {
-                e.stopImmediatePropagation();
-                return false;
-            }
-        });
-        
-        // Also handle unhandled promise rejections for ResizeObserver
-        window.addEventListener('unhandledrejection', function(e) {
-            if (e.reason && e.reason.message && 
-                (e.reason.message.includes('ResizeObserver loop limit exceeded') ||
-                 e.reason.message.includes('ResizeObserver loop completed with undelivered notifications'))) {
-                e.preventDefault();
-                return false;
-            }
-        });
-    </script>
 </head>
 <body>
 <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -101,6 +101,29 @@
             }
         }
     </style>
+    <script>
+        // Suppress ResizeObserver errors in development
+        // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
+        // These are benign errors that occur when ResizeObserver can't deliver all observations
+        // within a single animation frame, which is common with modern UI libraries.
+        window.addEventListener('error', function(e) {
+            if (e.message === 'ResizeObserver loop limit exceeded' || 
+                e.message === 'ResizeObserver loop completed with undelivered notifications.') {
+                e.stopImmediatePropagation();
+                return false;
+            }
+        });
+        
+        // Also handle unhandled promise rejections for ResizeObserver
+        window.addEventListener('unhandledrejection', function(e) {
+            if (e.reason && e.reason.message && 
+                (e.reason.message.includes('ResizeObserver loop limit exceeded') ||
+                 e.reason.message.includes('ResizeObserver loop completed with undelivered notifications'))) {
+                e.preventDefault();
+                return false;
+            }
+        });
+    </script>
 </head>
 <body>
 <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -102,7 +102,7 @@
         }
     </style>
     <script>
-        // Suppress ResizeObserver errors in development
+        // Suppress benign ResizeObserver errors
         // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
         // These are benign errors that occur when ResizeObserver can't deliver all observations
         // within a single animation frame, which is common with modern UI libraries.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {ResizeDetector} from "components/Shared";
 import {ApiService} from "services";
 import {AlertStore, AlertType, AppStore} from "stores";
 
-import {HotkeyTargetContainer} from "./HotkeyWrapper";
+import {HotkeyService, HotkeysRegistrar} from "./HotkeyWrapper";
 
 import "./App.scss";
 import "./layout-base.scss";
@@ -103,7 +103,8 @@ export class App extends React.Component {
                 <ResizeDetector onResize={this.onContainerResize} throttleTime={200} targetRef={this.appContainerRef}>
                     <div className={glClassName} ref={this.setAppContainerRef} />
                 </ResizeDetector>
-                <HotkeyTargetContainer />
+                <HotkeysRegistrar />
+                <HotkeyService />
                 <FloatingWidgetManagerComponent />
             </div>
         );

--- a/src/HotkeyWrapper.scss
+++ b/src/HotkeyWrapper.scss
@@ -2,10 +2,11 @@
 $col-w: 360px; /* column width */
 $gap: 20px; /* column gap */
 $pad: 20px; /* Blueprint dialog body horizontal padding per side */
+$breakpoint-buffer: 100px; /* additional buffer for responsive breakpoint calculations */
 
 // Calculate breakpoint values
-$breakpoint-2col: $col-w * 2 + $gap + $pad * 2 + $pad * 5;
-$breakpoint-3col: $col-w * 3 + $gap * 2 + $pad * 2 + $pad * 5;
+$breakpoint-2col: $col-w * 2 + $gap + $pad * 2 + $breakpoint-buffer;
+$breakpoint-3col: $col-w * 3 + $gap * 2 + $pad * 2 + $breakpoint-buffer;
 
 .bp5-dialog.hotkeys-dialog {
     /* 1 col = 1×col-w + 0×gap + 2×pad */

--- a/src/HotkeyWrapper.scss
+++ b/src/HotkeyWrapper.scss
@@ -1,10 +1,45 @@
-.hotkeys-dialog {
+/* SCSS sizing variables */
+$col-w: 360px; /* column width */
+$gap: 20px; /* column gap */
+$pad: 20px; /* Blueprint dialog body horizontal padding per side */
+
+// Calculate breakpoint values
+$breakpoint-2col: $col-w * 2 + $gap + $pad * 2 + $pad * 5;
+$breakpoint-3col: $col-w * 3 + $gap * 2 + $pad * 2 + $pad * 5;
+
+.bp5-dialog.hotkeys-dialog {
+    /* 1 col = 1×col-w + 0×gap + 2×pad */
+    width: $col-w + $pad * 2;
     max-width: 95vw;
 }
 
-.hotkeys-grid {
-    display: grid;
-    gap: 20px;
-    align-items: start;
+@media (min-width: $breakpoint-2col) {
+    .bp5-dialog.hotkeys-dialog {
+        /* 2 cols = 2×col-w + 1×gap + 2×pad */
+        width: $col-w * 2 + $gap + $pad * 2;
+    }
 }
 
+@media (min-width: $breakpoint-3col) {
+    .bp5-dialog.hotkeys-dialog {
+        /* 3 cols = 3×col-w + 2×gap + 2×pad */
+        width: $col-w * 3 + $gap * 2 + $pad * 2;
+    }
+}
+
+.hotkeys-grid {
+    /* Multi-column layout: top-to-bottom, then next column */
+    column-width: $col-w;
+    column-gap: $gap;
+    width: 100%;
+}
+
+.hotkeys-item {
+    /* Keep group intact within a column */
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    display: block;
+    width: 100%;
+    margin-bottom: $gap; /* vertical spacing between groups */
+}

--- a/src/HotkeyWrapper.scss
+++ b/src/HotkeyWrapper.scss
@@ -1,3 +1,5 @@
+@import "~@blueprintjs/core/lib/scss/variables.scss";
+
 /* SCSS sizing variables */
 $col-w: 360px; /* column width */
 $gap: 20px; /* column gap */
@@ -8,21 +10,21 @@ $breakpoint-buffer: 100px; /* additional buffer for responsive breakpoint calcul
 $breakpoint-2col: $col-w * 2 + $gap + $pad * 2 + $breakpoint-buffer;
 $breakpoint-3col: $col-w * 3 + $gap * 2 + $pad * 2 + $breakpoint-buffer;
 
-.bp5-dialog.hotkeys-dialog {
+.#{$ns}-dialog.hotkeys-dialog {
     /* 1 col = 1×col-w + 0×gap + 2×pad */
     width: $col-w + $pad * 2;
     max-width: 95vw;
 }
 
 @media (min-width: $breakpoint-2col) {
-    .bp5-dialog.hotkeys-dialog {
+    .#{$ns}-dialog.hotkeys-dialog {
         /* 2 cols = 2×col-w + 1×gap + 2×pad */
         width: $col-w * 2 + $gap + $pad * 2;
     }
 }
 
 @media (min-width: $breakpoint-3col) {
-    .bp5-dialog.hotkeys-dialog {
+    .#{$ns}-dialog.hotkeys-dialog {
         /* 3 cols = 3×col-w + 2×gap + 2×pad */
         width: $col-w * 3 + $gap * 2 + $pad * 2;
     }

--- a/src/HotkeyWrapper.scss
+++ b/src/HotkeyWrapper.scss
@@ -1,7 +1,7 @@
 @import "~@blueprintjs/core/lib/scss/variables.scss";
 
 /* SCSS sizing variables */
-$col-w: 360px; /* column width */
+$col-w: 380px; /* column width */
 $gap: 20px; /* column gap */
 $pad: 20px; /* Blueprint dialog body horizontal padding per side */
 $breakpoint-buffer: 100px; /* additional buffer for responsive breakpoint calculations */
@@ -31,18 +31,15 @@ $breakpoint-3col: $col-w * 3 + $gap * 2 + $pad * 2 + $breakpoint-buffer;
 }
 
 .hotkeys-grid {
-    /* Multi-column layout: top-to-bottom, then next column */
-    column-width: $col-w;
-    column-gap: $gap;
+    /* Multi-row layout: left-to-right, then next row */
+    display: flex;
+    flex-wrap: wrap;
+    gap: $gap;
     width: 100%;
 }
 
 .hotkeys-item {
-    /* Keep group intact within a column */
-    break-inside: avoid;
-    -webkit-column-break-inside: avoid;
-    page-break-inside: avoid;
-    display: block;
-    width: 100%;
-    margin-bottom: $gap; /* vertical spacing between groups */
+    /* Keep group intact within a row */
+    flex: 0 0 $col-w;
+    box-sizing: border-box;
 }

--- a/src/HotkeyWrapper.scss
+++ b/src/HotkeyWrapper.scss
@@ -1,0 +1,10 @@
+.hotkeys-dialog {
+    max-width: 95vw;
+}
+
+.hotkeys-grid {
+    display: grid;
+    gap: 20px;
+    align-items: start;
+}
+

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -21,9 +21,13 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
             columnCount: this.calculateColumnCount()
         };
         this.resizeListener = () => {
-            const newColumnCount = this.calculateColumnCount();
-            if (newColumnCount !== this.state.columnCount) {
-                this.setState({columnCount: newColumnCount});
+            // Only update column count if the hotkeys dialog is open
+            const appStore = AppStore.Instance;
+            if (appStore.dialogStore.dialogVisible.get(DialogId.Hotkey)) {
+                const newColumnCount = this.calculateColumnCount();
+                if (newColumnCount !== this.state.columnCount) {
+                    this.setState({columnCount: newColumnCount});
+                }
             }
         };
     }

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -10,8 +10,64 @@ import {RegionMode} from "stores/Frame";
 // There are some issues with the Blueprint hotkey target decorator, so this rather hacky workaround is needed for now
 // Once the issues are fixed, the decorator can be used and the functions can be made non-static
 
+interface HotkeyContainerState {
+    columnCount: number;
+}
+
 @observer
-export class HotkeyContainer extends React.Component {
+export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
+    private resizeListener: () => void;
+
+    constructor(props: {}) {
+        super(props);
+        this.state = {
+            columnCount: this.calculateColumnCount()
+        };
+        this.resizeListener = () => {
+            const newColumnCount = this.calculateColumnCount();
+            if (newColumnCount !== this.state.columnCount) {
+                this.setState({columnCount: newColumnCount});
+            }
+        };
+    }
+
+    componentDidMount() {
+        window.addEventListener("resize", this.resizeListener);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("resize", this.resizeListener);
+    }
+
+    private calculateColumnCount(): number {
+        const screenWidth = window.innerWidth;
+        if (screenWidth < 840) {
+            return 1;
+        } else if (screenWidth < 1280) {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+
+    private getDialogWidth(): string {
+        const columnCount = this.state?.columnCount || this.calculateColumnCount();
+        switch (columnCount) {
+            case 1:
+                return "400px";
+            case 2:
+                return "800px";
+            case 3:
+            default:
+                return "1200px";
+        }
+    }
+
+    private getGridColumns(): string {
+        const columnCount = this.state?.columnCount || this.calculateColumnCount();
+        return Array(columnCount).fill("1fr").join(" ");
+    }
+
     public render() {
         const appStore = AppStore.Instance;
         const className = classNames(Classes.HOTKEY_DIALOG, {[Classes.DARK]: appStore.darkTheme});
@@ -24,8 +80,20 @@ export class HotkeyContainer extends React.Component {
                 canEscapeKeyClose={true}
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
+                style={{width: this.getDialogWidth(), maxWidth: "90vw"}}
             >
-                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys(false)}</div>
+                <div className={Classes.DIALOG_BODY}>
+                    <div
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: this.getGridColumns(),
+                            gap: "20px",
+                            alignItems: "start"
+                        }}
+                    >
+                        {HotkeyContainer.RenderHotkeysInColumns(false, this.state?.columnCount || this.calculateColumnCount())}
+                    </div>
+                </div>
             </Dialog>
         );
     }
@@ -108,7 +176,7 @@ export class HotkeyContainer extends React.Component {
         }
     };
 
-    static RenderHotkeys(isHiddenHotkeysIncluded: boolean = true) {
+    static GetHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
 
@@ -129,7 +197,7 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={0} group={regionGroupTitle} global={true} combo="c" label="Toggle region creation mode" onKeyDown={HotkeyContainer.ToggleCreateMode} />,
             <Hotkey key={1} group={regionGroupTitle} global={true} combo="l" label="Toggle current region lock" onKeyDown={HotkeyContainer.ToggleRegionLock} />,
             <Hotkey key={2} group={regionGroupTitle} global={true} combo="shift + l" label="Unlock all regions" onKeyDown={HotkeyContainer.UnlockAllRegions} />,
-            <Hotkey key={3} group={regionGroupTitle} global={true} combo="del" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion} />,
+            <Hotkey key={3} group={regionGroupTitle} global={true} combo="delete" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion} />,
             <Hotkey key={4} group={regionGroupTitle} global={true} combo="backspace" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion} />,
             <Hotkey key={5} group={regionGroupTitle} global={true} combo="esc" label="Deselect region/Cancel region creation" onKeyDown={HotkeyContainer.HandleRegionEsc} />,
             <Hotkey key={6} group={regionGroupTitle} global={true} combo="mod" label="Switch region creation mode" />,
@@ -148,6 +216,7 @@ export class HotkeyContainer extends React.Component {
 
         if (isHiddenHotkeysIncluded) {
             animatorHotkeys.push(
+                // ‘ and “ can be typed with option + ] and option + [ on macOS
                 <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
                 <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="Previous image" onKeyDown={appStore.prevImage} />
             );
@@ -168,33 +237,155 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={2} group={otherGroupTitle} global={true} combo="G" label="Mirror cursor on multipanel view" onKeyDown={appStore.toggleCursorMirror} />
         ];
 
+        return {
+            navigationHotKeys,
+            regionHotKeys,
+            animatorHotkeys,
+            fileHotkeys,
+            otherHotKeys
+        };
+    }
+
+    static RenderHotkeysInColumns(isHiddenHotkeysIncluded: boolean = true, columnCount: number = 3) {
+        const hotkeys = HotkeyContainer.GetHotkeyDefinitions(isHiddenHotkeysIncluded);
+
+        if (columnCount === 1) {
+            // Single column: all hotkeys together
+            return [
+                <div key="column1">
+                    <Hotkeys>
+                        {hotkeys.navigationHotKeys}
+                        {hotkeys.regionHotKeys}
+                        {hotkeys.animatorHotkeys}
+                        {hotkeys.fileHotkeys}
+                        {hotkeys.otherHotKeys}
+                    </Hotkeys>
+                </div>
+            ];
+        } else if (columnCount === 2) {
+            // Two columns: balanced distribution
+            const column1 = (
+                <div key="column1">
+                    <Hotkeys>
+                        {hotkeys.navigationHotKeys}
+                        {hotkeys.regionHotKeys}
+                    </Hotkeys>
+                </div>
+            );
+
+            const column2 = (
+                <div key="column2">
+                    <Hotkeys>
+                        {hotkeys.animatorHotkeys}
+                        {hotkeys.fileHotkeys}
+                        {hotkeys.otherHotKeys}
+                    </Hotkeys>
+                </div>
+            );
+
+            return [column1, column2];
+        } else {
+            // Three columns: original layout
+            const column1 = (
+                <div key="column1">
+                    <Hotkeys>
+                        {hotkeys.navigationHotKeys}
+                        {hotkeys.regionHotKeys}
+                    </Hotkeys>
+                </div>
+            );
+
+            const column2 = (
+                <div key="column2">
+                    <Hotkeys>
+                        {hotkeys.animatorHotkeys}
+                        {hotkeys.fileHotkeys}
+                    </Hotkeys>
+                </div>
+            );
+
+            const column3 = (
+                <div key="column3">
+                    <Hotkeys>{hotkeys.otherHotKeys}</Hotkeys>
+                </div>
+            );
+
+            return [column1, column2, column3];
+        }
+    }
+
+    static RenderHotkeys(isHiddenHotkeysIncluded: boolean = true) {
+        const hotkeys = HotkeyContainer.GetHotkeyDefinitions(isHiddenHotkeysIncluded);
+
         return (
             <Hotkeys>
-                {regionHotKeys}
-                {navigationHotKeys}
-                {animatorHotkeys}
-                {fileHotkeys}
-                {otherHotKeys}
+                {hotkeys.regionHotKeys}
+                {hotkeys.navigationHotKeys}
+                {hotkeys.animatorHotkeys}
+                {hotkeys.fileHotkeys}
+                {hotkeys.otherHotKeys}
             </Hotkeys>
         );
     }
 }
 
-function HotkeyWrapper() {} // tslint:disable-line
+function HotkeyWrapper(this: any, props: any) {
+    // Initialize state manually since we can't call ES6 class constructor with .call()
+    this.state = {
+        columnCount: this.calculateColumnCount()
+    };
+    this.resizeListener = () => {
+        const newColumnCount = this.calculateColumnCount();
+        if (newColumnCount !== this.state.columnCount) {
+            this.setState({columnCount: newColumnCount});
+        }
+    };
+}
 HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
+HotkeyWrapper.prototype.constructor = HotkeyWrapper;
 HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
 
 HotkeyWrapper.prototype.componentDidMount = function () {
+    // Call parent's componentDidMount to set up resize listener
+    if (HotkeyContainer.prototype.componentDidMount) {
+        HotkeyContainer.prototype.componentDidMount.call(this);
+    }
     // Use capture phase so we can intercept certain keys (e.g. Shift+?) before Blueprint's handlers
     document.addEventListener("keydown", this.handleGlobalKeydown, true);
 };
 
 HotkeyWrapper.prototype.componentWillUnmount = function () {
+    // Call parent's componentWillUnmount to clean up resize listener
+    if (HotkeyContainer.prototype.componentWillUnmount) {
+        HotkeyContainer.prototype.componentWillUnmount.call(this);
+    }
     document.removeEventListener("keydown", this.handleGlobalKeydown, true);
 };
 
 HotkeyWrapper.prototype.handleGlobalKeydown = function (event: KeyboardEvent) {
     const appStore = AppStore.Instance;
+
+    // Helper to detect if an element (or its ancestors) is an editable control
+    const isEditable = (el: Element | null): boolean => {
+        if (!el) return false;
+        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) return true;
+        const he = el as HTMLElement;
+        if (he && (he.isContentEditable || he.getAttribute("contenteditable") !== null)) return true;
+        // Common ARIA roles used by input components
+        const role = he?.getAttribute?.("role");
+        if (role && ["textbox", "searchbox", "combobox", "spinbutton"].includes(role)) return true;
+        // Check ancestors for editable containers
+        return !!el.closest(
+            'input, textarea, select, [contenteditable], [role="textbox"], [role="searchbox"], [role="combobox"], [role="spinbutton"]'
+        );
+    };
+
+    // Ignore when focus is inside editable elements (inputs, textareas, selects, or contenteditable)
+    const target = (event.target as Element) ?? null;
+    const activeEl = (document.activeElement as Element) ?? null;
+    if (isEditable(target) || isEditable(activeEl)) {
+        return;
+    }
 
     // Intercept Shift+? to open our custom Hotkeys dialog and block Blueprint's default dialog
     // This prevents React 18 warnings from Blueprint's legacy ReactDOM.render path.

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -177,7 +177,6 @@ function HotkeyWrapper() {} // tslint:disable-line
 HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
 HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
 
-// Add global event handler to debug phonetic input method keys
 HotkeyWrapper.prototype.componentDidMount = function () {
     document.addEventListener("keydown", this.handleGlobalKeydown);
 };

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -10,11 +10,11 @@ import {RegionMode} from "stores/Frame";
 import "./HotkeyWrapper.scss";
 
 enum HotkeyGroup {
-    Navigation = "1) Navigation",
-    Regions = "2) Regions",
-    FrameControls = "3) Frame controls",
-    FileControls = "4) File controls",
-    Other = "5) Other"
+    Navigation = "Navigation",
+    Regions = "Regions",
+    FrameControls = "Frame controls",
+    FileControls = "File controls",
+    Other = "Other"
 }
 
 @observer

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -6,69 +6,11 @@ import {observer} from "mobx-react";
 import {ImageViewLayer} from "components";
 import {AppStore, BrowserMode, DialogId} from "stores";
 import {RegionMode} from "stores/Frame";
+
 import "./HotkeyWrapper.scss";
 
-interface HotkeyServiceState {
-    columnCount: number;
-}
-
 @observer
-export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
-    private resizeListener: () => void;
-
-    constructor(props: {}) {
-        super(props);
-        this.state = {
-            columnCount: this.calculateColumnCount()
-        };
-        this.resizeListener = () => {
-            // Only update column count if the hotkeys dialog is open
-            const appStore = AppStore.Instance;
-            if (appStore.dialogStore.dialogVisible.get(DialogId.Hotkey)) {
-                const newColumnCount = this.calculateColumnCount();
-                if (newColumnCount !== this.state.columnCount) {
-                    this.setState({columnCount: newColumnCount});
-                }
-            }
-        };
-    }
-
-    componentDidMount() {
-        window.addEventListener("resize", this.resizeListener);
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener("resize", this.resizeListener);
-    }
-
-    private calculateColumnCount(): number {
-        const screenWidth = window.innerWidth;
-        if (screenWidth < 840) {
-            return 1;
-        } else if (screenWidth < 1280) {
-            return 2;
-        } else {
-            return 3;
-        }
-    }
-
-    private getDialogWidth(): string {
-        const columnCount = this.state?.columnCount || this.calculateColumnCount();
-        switch (columnCount) {
-            case 1:
-                return "400px";
-            case 2:
-                return "800px";
-            case 3:
-            default:
-                return "1200px";
-        }
-    }
-
-    private getGridColumns(): string {
-        const columnCount = this.state?.columnCount || this.calculateColumnCount();
-        return Array(columnCount).fill("1fr").join(" ");
-    }
+export class HotkeyService extends React.Component<{}> {
 
     public render() {
         const appStore = AppStore.Instance;
@@ -82,12 +24,9 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 canEscapeKeyClose={true}
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
-                style={{width: this.getDialogWidth()}}
             >
                 <div className={Classes.DIALOG_BODY}>
-                    <div className="hotkeys-grid" style={{gridTemplateColumns: this.getGridColumns()}}>
-                        {HotkeyService.RenderHotkeysInColumns(this.state?.columnCount || this.calculateColumnCount())}
-                    </div>
+                    <div className="hotkeys-grid">{HotkeyService.RenderHotkeyGroups()}</div>
                 </div>
             </Dialog>
         );
@@ -270,9 +209,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
 
     // For display in custom hotkeys dialog
     static GetHotkeyDefinitionsForDisplay() {
-        const toElements = (hotkeys: any[]) => hotkeys.map((hotkey, index) => (
-            <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />
-        ));
+        const toElements = (hotkeys: any[]) => hotkeys.map((hotkey, index) => <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />);
 
         // 1) Navigation
         const navigationHotKeys: React.ReactElement[] = toElements(HotkeyService.GetNavigationDisplayOnlyHotkeys());
@@ -300,25 +237,14 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
         };
     }
 
-    static RenderHotkeysInColumns(columnCount: number = 3) {
+    static RenderHotkeyGroups() {
         const hotkeys = HotkeyService.GetHotkeyDefinitionsForDisplay();
         const hotkeyGroups = [hotkeys.navigationHotKeys, hotkeys.regionHotKeys, hotkeys.animatorHotkeys, hotkeys.fileHotkeys, hotkeys.otherHotKeys];
 
-        // Define how to distribute groups across columns
-        const columnDistributions = {
-            1: [[0, 1, 2, 3, 4]], // All groups in one column
-            2: [
-                [0, 1],
-                [2, 3, 4]
-            ], // First two groups in column 1, rest in column 2
-            3: [[0, 1], [2, 3], [4]] // Distribute across three columns
-        };
-
-        const distribution = columnDistributions[columnCount] || columnDistributions[3];
-
-        return distribution.map((groupIndices: number[], columnIndex: number) => (
-            <div key={`column${columnIndex + 1}`}>
-                <Hotkeys>{groupIndices.map(index => hotkeyGroups[index])}</Hotkeys>
+        // Render each group; placement handled purely by CSS multi-column
+        return hotkeyGroups.map((group, idx) => (
+            <div className="hotkeys-item" key={`hotkeys-group-${idx}`}>
+                <Hotkeys>{group}</Hotkeys>
             </div>
         ));
     }
@@ -326,13 +252,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
 
 export function HotkeysRegistrar() {
     const hotkeys = React.useMemo(
-        () => [
-            ...HotkeyService.GetFrameControlHotkeys(),
-            ...HotkeyService.GetFrameControlHiddenHotkeys(),
-            ...HotkeyService.GetRegionHotkeys(),
-            ...HotkeyService.GetFileControlHotkeys(),
-            ...HotkeyService.GetOtherHotkeys()
-        ],
+        () => [...HotkeyService.GetFrameControlHotkeys(), ...HotkeyService.GetFrameControlHiddenHotkeys(), ...HotkeyService.GetRegionHotkeys(), ...HotkeyService.GetFileControlHotkeys(), ...HotkeyService.GetOtherHotkeys()],
         []
     );
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -11,7 +11,6 @@ import "./HotkeyWrapper.scss";
 
 @observer
 export class HotkeyService extends React.Component<{}> {
-
     public render() {
         const appStore = AppStore.Instance;
         const className = classNames(Classes.HOTKEY_DIALOG, {[Classes.DARK]: appStore.darkTheme});

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -148,8 +148,8 @@ export class HotkeyContainer extends React.Component {
 
         if (includeHidden) {
             animatorHotkeys.push(
-               <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="" onKeyDown={appStore.nextImage} />,
-               <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="" onKeyDown={appStore.prevImage} />
+                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="" onKeyDown={appStore.nextImage} />,
+                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="" onKeyDown={appStore.prevImage} />
             );
         }
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {Classes, Dialog, Hotkey, Hotkeys, HotkeysTarget} from "@blueprintjs/core";
+import {Classes, Dialog, Hotkey, Hotkeys, useHotkeys} from "@blueprintjs/core";
 import classNames from "classnames";
 import {observer} from "mobx-react";
 
@@ -7,15 +7,12 @@ import {ImageViewLayer} from "components";
 import {AppStore, BrowserMode, DialogId} from "stores";
 import {RegionMode} from "stores/Frame";
 
-// There are some issues with the Blueprint hotkey target decorator, so this rather hacky workaround is needed for now
-// Once the issues are fixed, the decorator can be used and the functions can be made non-static
-
-interface HotkeyContainerState {
+interface HotkeyServiceState {
     columnCount: number;
 }
 
 @observer
-export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
+export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
     private resizeListener: () => void;
 
     constructor(props: {}) {
@@ -91,7 +88,7 @@ export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
                             alignItems: "start"
                         }}
                     >
-                        {HotkeyContainer.RenderHotkeysInColumns(false, this.state?.columnCount || this.calculateColumnCount())}
+                        {HotkeyService.RenderHotkeysInColumns(this.state?.columnCount || this.calculateColumnCount())}
                     </div>
                 </div>
             </Dialog>
@@ -176,9 +173,225 @@ export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
         }
     };
 
-    static GetHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
+    // Unified hotkey definitions used by both display and registration systems
+    static GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
+
+        return [
+            // 3) Frame controls
+            {
+                combo: `${modString}]`,
+                group: "3) Frame controls",
+                label: "Next image",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: () => appStore.nextImage()
+            },
+            {
+                combo: `${modString}[`,
+                group: "3) Frame controls",
+                label: "Previous image",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: () => appStore.prevImage()
+            },
+            {
+                combo: `${modString}up`,
+                group: "3) Frame controls",
+                label: "Next channel",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: HotkeyService.NextChannel
+            },
+            {
+                combo: `${modString}down`,
+                group: "3) Frame controls",
+                label: "Previous channel",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: HotkeyService.PrevChannel
+            },
+            {
+                combo: `${modString}shift + up`,
+                group: "3) Frame controls",
+                label: "Next Stokes cube",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: HotkeyService.NextStokes
+            },
+            {
+                combo: `${modString}shift + down`,
+                group: "3) Frame controls",
+                label: "Previous Stokes cube",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: HotkeyService.PrevStokes
+            },
+
+            // Hidden hotkeys for input method compatibility (only included if requested)
+            ...(isHiddenHotkeysIncluded
+                ? [
+                      {
+                          combo: `${modString}‘`,
+                          group: "3) Frame controls",
+                          label: "Next image",
+                          global: true,
+                          allowInInput: false,
+                          preventDefault: true,
+                          onKeyDown: () => appStore.nextImage()
+                      },
+                      {
+                          combo: `${modString}“`,
+                          group: "3) Frame controls",
+                          label: "Previous image",
+                          global: true,
+                          allowInInput: false,
+                          preventDefault: true,
+                          onKeyDown: () => appStore.prevImage()
+                      }
+                  ]
+                : []),
+
+            // 2) Regions
+            {
+                combo: "c",
+                group: "2) Regions",
+                label: "Toggle region creation mode",
+                global: true,
+                allowInInput: false,
+                onKeyDown: HotkeyService.ToggleCreateMode
+            },
+            {
+                combo: "l",
+                group: "2) Regions",
+                label: "Toggle current region lock",
+                global: true,
+                allowInInput: false,
+                onKeyDown: HotkeyService.ToggleRegionLock
+            },
+            {
+                combo: "shift+l",
+                group: "2) Regions",
+                label: "Unlock all regions",
+                global: true,
+                allowInInput: false,
+                onKeyDown: HotkeyService.UnlockAllRegions
+            },
+            {
+                combo: "delete",
+                group: "2) Regions",
+                label: "Delete selected region",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: () => appStore.deleteSelectedRegion()
+            },
+            {
+                combo: "backspace",
+                group: "2) Regions",
+                label: "Delete selected region",
+                global: true,
+                allowInInput: false,
+                preventDefault: true,
+                onKeyDown: () => appStore.deleteSelectedRegion()
+            },
+            {
+                combo: "esc",
+                group: "2) Regions",
+                label: "Deselect/Cancel region creation",
+                global: true,
+                allowInInput: false,
+                onKeyDown: HotkeyService.HandleRegionEsc
+            },
+
+            // 4) File controls
+            {
+                combo: `${modString}O`,
+                group: "4) File controls",
+                label: "Open image",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)
+            },
+            {
+                combo: `${modString}L`,
+                group: "4) File controls",
+                label: "Append image",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)
+            },
+            {
+                combo: `${modString}W`,
+                group: "4) File controls",
+                label: "Close image",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.closeCurrentFile(true)
+            },
+            {
+                combo: `${modString}S`,
+                group: "4) File controls",
+                label: "Save image",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)
+            },
+            {
+                combo: `${modString}G`,
+                group: "4) File controls",
+                label: "Import catalog",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)
+            },
+            {
+                combo: `${modString}E`,
+                group: "4) File controls",
+                label: "Export image",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.exportImage(1)
+            },
+
+            // 5) Other
+            {
+                combo: "shift+d",
+                group: "5) Other",
+                label: "Toggle light/dark theme",
+                global: true,
+                allowInInput: false,
+                onKeyDown: HotkeyService.ToggleDarkTheme
+            },
+            {
+                combo: "f",
+                group: "5) Other",
+                label: "Freeze/unfreeze cursor position",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.toggleCursorFrozen()
+            },
+            {
+                combo: "g",
+                group: "5) Other",
+                label: "Mirror cursor on multipanel view",
+                global: true,
+                allowInInput: false,
+                onKeyDown: () => appStore.toggleCursorMirror()
+            }
+        ];
+    }
+
+    // For display in custom hotkeys dialog
+    static GetHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
+        const unifiedHotkeys = HotkeyService.GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded);
 
         const navigationGroupTitle = "1) Navigation";
         const regionGroupTitle = "2) Regions";
@@ -193,49 +406,32 @@ export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
             <Hotkey key={3} group={navigationGroupTitle} global={true} combo="mouse-wheel" label="Zoom image" />
         ];
 
-        const regionHotKeys = [
-            <Hotkey key={0} group={regionGroupTitle} global={true} combo="c" label="Toggle region creation mode" onKeyDown={HotkeyContainer.ToggleCreateMode} />,
-            <Hotkey key={1} group={regionGroupTitle} global={true} combo="l" label="Toggle current region lock" onKeyDown={HotkeyContainer.ToggleRegionLock} />,
-            <Hotkey key={2} group={regionGroupTitle} global={true} combo="shift + l" label="Unlock all regions" onKeyDown={HotkeyContainer.UnlockAllRegions} />,
-            <Hotkey key={3} group={regionGroupTitle} global={true} combo="delete" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion} />,
-            <Hotkey key={4} group={regionGroupTitle} global={true} combo="backspace" label="Delete selected region" onKeyDown={appStore.deleteSelectedRegion} />,
-            <Hotkey key={5} group={regionGroupTitle} global={true} combo="esc" label="Deselect region/Cancel region creation" onKeyDown={HotkeyContainer.HandleRegionEsc} />,
-            <Hotkey key={6} group={regionGroupTitle} global={true} combo="mod" label="Switch region creation mode" />,
-            <Hotkey key={7} group={regionGroupTitle} global={true} combo={"shift"} label="Symmetric region creation" />,
-            <Hotkey key={8} group={regionGroupTitle} global={true} combo="double-click" label="Region properties" />
+        const regionDisplayOnlyHotkeys = [
+            <Hotkey key={100} group={regionGroupTitle} global={true} combo="mod" label="Switch region creation mode" />,
+            <Hotkey key={101} group={regionGroupTitle} global={true} combo="shift" label="Symmetric region creation" />,
+            <Hotkey key={102} group={regionGroupTitle} global={true} combo="double-click" label="Region properties" />
         ];
 
-        const animatorHotkeys = [
-            <Hotkey key={0} group={animatorGroupTitle} global={true} combo={`${modString}]`} label="Next image" onKeyDown={appStore.nextImage} />,
-            <Hotkey key={1} group={animatorGroupTitle} global={true} combo={`${modString}[`} label="Previous image" onKeyDown={appStore.prevImage} />,
-            <Hotkey key={2} group={animatorGroupTitle} global={true} combo={`${modString}up`} label="Next channel" onKeyDown={HotkeyContainer.NextChannel} />,
-            <Hotkey key={3} group={animatorGroupTitle} global={true} combo={`${modString}down`} label="Previous channel" onKeyDown={HotkeyContainer.PrevChannel} />,
-            <Hotkey key={4} group={animatorGroupTitle} global={true} combo={`${modString}shift + up`} label="Next Stokes cube" onKeyDown={HotkeyContainer.NextStokes} />,
-            <Hotkey key={5} group={animatorGroupTitle} global={true} combo={`${modString}shift + down`} label="Previous Stokes cube" onKeyDown={HotkeyContainer.PrevStokes} />
-        ];
+        const regionHotKeys: React.ReactElement[] = [];
+        const animatorHotkeys: React.ReactElement[] = [];
+        const fileHotkeys: React.ReactElement[] = [];
+        const otherHotKeys: React.ReactElement[] = [];
 
-        if (isHiddenHotkeysIncluded) {
-            animatorHotkeys.push(
-                // ‘ and “ can be typed with option + ] and option + [ on macOS
-                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
-                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="Previous image" onKeyDown={appStore.prevImage} />
-            );
-        }
+        unifiedHotkeys.forEach((hotkey, index) => {
+            const hotkeyElement = <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />;
 
-        const fileHotkeys = [
-            <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)} />,
-            <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />,
-            <Hotkey key={2} group={fileGroupTitle} global={true} combo={`${modString}W`} label="Close image" onKeyDown={() => appStore.closeCurrentFile(true)} />,
-            <Hotkey key={3} group={fileGroupTitle} global={true} combo={`${modString}S`} label="Save image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)} />,
-            <Hotkey key={4} group={fileGroupTitle} global={true} combo={`${modString}G`} label="Import catalog" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)} />,
-            <Hotkey key={5} group={fileGroupTitle} global={true} combo={`${modString}E`} label="Export image" onKeyDown={() => appStore.exportImage(1)} />
-        ];
+            if (hotkey.group === regionGroupTitle) {
+                regionHotKeys.push(hotkeyElement);
+            } else if (hotkey.group === animatorGroupTitle) {
+                animatorHotkeys.push(hotkeyElement);
+            } else if (hotkey.group === fileGroupTitle) {
+                fileHotkeys.push(hotkeyElement);
+            } else if (hotkey.group === otherGroupTitle) {
+                otherHotKeys.push(hotkeyElement);
+            }
+        });
 
-        const otherHotKeys = [
-            <Hotkey key={0} group={otherGroupTitle} global={true} combo="shift + D" label="Toggle light/dark theme" onKeyDown={HotkeyContainer.ToggleDarkTheme} />,
-            <Hotkey key={1} group={otherGroupTitle} global={true} combo="F" label="Freeze/unfreeze cursor position" onKeyDown={appStore.toggleCursorFrozen} />,
-            <Hotkey key={2} group={otherGroupTitle} global={true} combo="G" label="Mirror cursor on multipanel view" onKeyDown={appStore.toggleCursorMirror} />
-        ];
+        regionHotKeys.push(...regionDisplayOnlyHotkeys);
 
         return {
             navigationHotKeys,
@@ -246,161 +442,57 @@ export class HotkeyContainer extends React.Component<{}, HotkeyContainerState> {
         };
     }
 
-    static RenderHotkeysInColumns(isHiddenHotkeysIncluded: boolean = true, columnCount: number = 3) {
-        const hotkeys = HotkeyContainer.GetHotkeyDefinitions(isHiddenHotkeysIncluded);
+    static RenderHotkeysInColumns(columnCount: number = 3) {
+        const hotkeys = HotkeyService.GetHotkeyDefinitions(false);
+        const hotkeyGroups = [hotkeys.navigationHotKeys, hotkeys.regionHotKeys, hotkeys.animatorHotkeys, hotkeys.fileHotkeys, hotkeys.otherHotKeys];
 
-        if (columnCount === 1) {
-            // Single column: all hotkeys together
-            return [
-                <div key="column1">
-                    <Hotkeys>
-                        {hotkeys.navigationHotKeys}
-                        {hotkeys.regionHotKeys}
-                        {hotkeys.animatorHotkeys}
-                        {hotkeys.fileHotkeys}
-                        {hotkeys.otherHotKeys}
-                    </Hotkeys>
-                </div>
-            ];
-        } else if (columnCount === 2) {
-            // Two columns: balanced distribution
-            const column1 = (
-                <div key="column1">
-                    <Hotkeys>
-                        {hotkeys.navigationHotKeys}
-                        {hotkeys.regionHotKeys}
-                    </Hotkeys>
-                </div>
-            );
+        // Define how to distribute groups across columns
+        const columnDistributions = {
+            1: [[0, 1, 2, 3, 4]], // All groups in one column
+            2: [
+                [0, 1],
+                [2, 3, 4]
+            ], // First two groups in column 1, rest in column 2
+            3: [[0, 1], [2, 3], [4]] // Distribute across three columns
+        };
 
-            const column2 = (
-                <div key="column2">
-                    <Hotkeys>
-                        {hotkeys.animatorHotkeys}
-                        {hotkeys.fileHotkeys}
-                        {hotkeys.otherHotKeys}
-                    </Hotkeys>
-                </div>
-            );
+        const distribution = columnDistributions[columnCount] || columnDistributions[3];
 
-            return [column1, column2];
-        } else {
-            // Three columns: original layout
-            const column1 = (
-                <div key="column1">
-                    <Hotkeys>
-                        {hotkeys.navigationHotKeys}
-                        {hotkeys.regionHotKeys}
-                    </Hotkeys>
-                </div>
-            );
-
-            const column2 = (
-                <div key="column2">
-                    <Hotkeys>
-                        {hotkeys.animatorHotkeys}
-                        {hotkeys.fileHotkeys}
-                    </Hotkeys>
-                </div>
-            );
-
-            const column3 = (
-                <div key="column3">
-                    <Hotkeys>{hotkeys.otherHotKeys}</Hotkeys>
-                </div>
-            );
-
-            return [column1, column2, column3];
-        }
-    }
-
-    static RenderHotkeys(isHiddenHotkeysIncluded: boolean = true) {
-        const hotkeys = HotkeyContainer.GetHotkeyDefinitions(isHiddenHotkeysIncluded);
-
-        return (
-            <Hotkeys>
-                {hotkeys.regionHotKeys}
-                {hotkeys.navigationHotKeys}
-                {hotkeys.animatorHotkeys}
-                {hotkeys.fileHotkeys}
-                {hotkeys.otherHotKeys}
-            </Hotkeys>
-        );
+        return distribution.map((groupIndices: number[], columnIndex: number) => (
+            <div key={`column${columnIndex + 1}`}>
+                <Hotkeys>{groupIndices.map(index => hotkeyGroups[index])}</Hotkeys>
+            </div>
+        ));
     }
 }
 
-function HotkeyWrapper(this: any, props: any) {
-    // Initialize state manually since we can't call ES6 class constructor with .call()
-    this.state = {
-        columnCount: this.calculateColumnCount()
-    };
-    this.resizeListener = () => {
-        const newColumnCount = this.calculateColumnCount();
-        if (newColumnCount !== this.state.columnCount) {
-            this.setState({columnCount: newColumnCount});
-        }
-    };
+export function HotkeysRegistrar() {
+    const hotkeys = React.useMemo(() => HotkeyService.GetUnifiedHotkeyDefinitions(true), []);
+
+    useHotkeys(hotkeys);
+
+    // Directly handle Shift+? to open custom hotkeys dialog
+    React.useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            // Only handle if not in an editable element
+            const target = event.target as Element;
+            if (target && (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target.closest("input, textarea, [contenteditable]"))) {
+                return;
+            }
+
+            if (event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey && (event.key === "?" || event.key === "/")) {
+                event.preventDefault();
+                event.stopPropagation();
+                const currentAppStore = AppStore.Instance;
+                if (!currentAppStore.dialogStore.dialogVisible.get(DialogId.Hotkey)) {
+                    currentAppStore.dialogStore.showDialog(DialogId.Hotkey);
+                }
+            }
+        };
+
+        document.addEventListener("keydown", onKeyDown, true);
+        return () => document.removeEventListener("keydown", onKeyDown, true);
+    }, []);
+
+    return null;
 }
-HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
-HotkeyWrapper.prototype.constructor = HotkeyWrapper;
-HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
-
-HotkeyWrapper.prototype.componentDidMount = function () {
-    // Call parent's componentDidMount to set up resize listener
-    if (HotkeyContainer.prototype.componentDidMount) {
-        HotkeyContainer.prototype.componentDidMount.call(this);
-    }
-    // Use capture phase so we can intercept certain keys (e.g. Shift+?) before Blueprint's handlers
-    document.addEventListener("keydown", this.handleGlobalKeydown, true);
-};
-
-HotkeyWrapper.prototype.componentWillUnmount = function () {
-    // Call parent's componentWillUnmount to clean up resize listener
-    if (HotkeyContainer.prototype.componentWillUnmount) {
-        HotkeyContainer.prototype.componentWillUnmount.call(this);
-    }
-    document.removeEventListener("keydown", this.handleGlobalKeydown, true);
-};
-
-HotkeyWrapper.prototype.handleGlobalKeydown = function (event: KeyboardEvent) {
-    const appStore = AppStore.Instance;
-
-    // Helper to detect if an element (or its ancestors) is an editable control
-    const isEditable = (el: Element | null): boolean => {
-        if (!el) return false;
-        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) return true;
-        const he = el as HTMLElement;
-        if (he && (he.isContentEditable || he.getAttribute("contenteditable") !== null)) return true;
-        // Common ARIA roles used by input components
-        const role = he?.getAttribute?.("role");
-        if (role && ["textbox", "searchbox", "combobox", "spinbutton"].includes(role)) return true;
-        // Check ancestors for editable containers
-        return !!el.closest(
-            'input, textarea, select, [contenteditable], [role="textbox"], [role="searchbox"], [role="combobox"], [role="spinbutton"]'
-        );
-    };
-
-    // Ignore when focus is inside editable elements (inputs, textareas, selects, or contenteditable)
-    const target = (event.target as Element) ?? null;
-    const activeEl = (document.activeElement as Element) ?? null;
-    if (isEditable(target) || isEditable(activeEl)) {
-        return;
-    }
-
-    // Intercept Shift+? to open our custom Hotkeys dialog and block Blueprint's default dialog
-    // This prevents React 18 warnings from Blueprint's legacy ReactDOM.render path.
-    if (event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey && (event.key === "?" || event.key === "/")) {
-        event.preventDefault();
-        event.stopPropagation();
-        if (typeof event.stopImmediatePropagation === "function") {
-            event.stopImmediatePropagation();
-        }
-        // Ensure only one instance of our dialog is shown
-        if (!appStore.dialogStore.dialogVisible.get(DialogId.Hotkey)) {
-            appStore.dialogStore.showDialog(DialogId.Hotkey);
-        }
-        return;
-    }
-};
-
-export const HotkeyTargetContainer = HotkeysTarget(HotkeyWrapper as any);

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {Classes, Dialog, Hotkey, Hotkeys, HotkeysTarget} from "@blueprintjs/core";
 import classNames from "classnames";
-import {action} from "mobx";
 import {observer} from "mobx-react";
 
 import {ImageViewLayer} from "components";
@@ -195,12 +194,12 @@ HotkeyWrapper.prototype.handleGlobalKeydown = function (event: KeyboardEvent) {
         if (event.key === "\u201C") {
             // Option+[ in English input method produces '“' (U+201C)
             event.preventDefault();
-            action(() => appStore?.prevImage())();
+            appStore.prevImage();
             return;
         } else if (event.key === "\u2018") {
             // Option+] in English input method produces '‘' (U+2018)
             event.preventDefault();
-            action(() => appStore?.nextImage())();
+            appStore.nextImage();
             return;
         }
     }

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -173,6 +173,36 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
         }
     };
 
+    // Check if any BlueprintJS menu/popover is currently open and visible
+    static IsMenuOpen = (): boolean => {
+        try {
+            // Check for visible popover with menu content
+            const popovers = document.querySelectorAll('.bp5-popover-content, .bp4-popover-content, .bp3-popover-content');
+            for (const popover of popovers) {
+                const style = window.getComputedStyle(popover);
+                // Only consider it open if it's actually visible and has substantial opacity
+                if (style.display !== 'none' && 
+                    style.visibility !== 'hidden' && 
+                    parseFloat(style.opacity) > 0.8) {
+                    
+                    // Check if it contains a menu (not just any popover content)
+                    const menu = popover.querySelector('.bp5-menu, .bp4-menu, .bp3-menu');
+                    if (menu) {
+                        const menuStyle = window.getComputedStyle(menu);
+                        if (menuStyle.display !== 'none' && menuStyle.visibility !== 'hidden') {
+                            return true;
+                        }
+                    }
+                }
+            }
+            
+            return false;
+        } catch (error) {
+            // If there's any error, assume no menu is open to allow hotkeys to work
+            return false;
+        }
+    };
+
     // Unified hotkey definitions used by both display and registration systems
     static GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
         const appStore = AppStore.Instance;

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -9,6 +9,14 @@ import {RegionMode} from "stores/Frame";
 
 import "./HotkeyWrapper.scss";
 
+enum HotkeyGroup {
+    Navigation = "1) Navigation",
+    Regions = "2) Regions",
+    FrameControls = "3) Frame controls",
+    FileControls = "4) File controls",
+    Other = "5) Other"
+}
+
 @observer
 export class HotkeyService extends React.Component<{}> {
     public render() {
@@ -111,7 +119,7 @@ export class HotkeyService extends React.Component<{}> {
 
     // For display in custom hotkeys dialog
     static NavigationDisplayHotkeys() {
-        const group = "1) Navigation";
+        const group = HotkeyGroup.Navigation;
         const base = {group, global: true};
         const items = [
             {combo: "click", label: "Pan image"},
@@ -124,7 +132,7 @@ export class HotkeyService extends React.Component<{}> {
 
     // For display in custom hotkeys dialog
     static RegionDisplayHotkeys() {
-        const group = "2) Regions";
+        const group = HotkeyGroup.Regions;
         const base = {group, global: true};
         const items = [
             {combo: "mod", label: "Switch region creation mode"},
@@ -136,7 +144,7 @@ export class HotkeyService extends React.Component<{}> {
 
     static RegionHotkeys() {
         const appStore = AppStore.Instance;
-        const group = "2) Regions";
+        const group = HotkeyGroup.Regions;
         const base = {group, global: true, allowInInput: false, preventDefault: true};
         const items = [
             {combo: "c", label: "Toggle region creation mode", onKeyDown: HotkeyService.ToggleCreateMode},
@@ -152,7 +160,7 @@ export class HotkeyService extends React.Component<{}> {
     static FrameControlHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
-        const group = "3) Frame controls";
+        const group = HotkeyGroup.FrameControls;
         const base = {group, global: true, allowInInput: false, preventDefault: true};
         const items = [
             {combo: `${modString}]`, label: "Next image", onKeyDown: appStore.nextImage},
@@ -169,7 +177,7 @@ export class HotkeyService extends React.Component<{}> {
     static FrameControlHiddenHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
-        const group = "3) Frame controls";
+        const group = HotkeyGroup.FrameControls;
         const base = {group, global: true, allowInInput: false, preventDefault: true};
         const items = [
             {combo: `${modString}‘`, label: "Next image", onKeyDown: appStore.nextImage},
@@ -181,7 +189,7 @@ export class HotkeyService extends React.Component<{}> {
     static FileControlHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
-        const group = "4) File controls";
+        const group = HotkeyGroup.FileControls;
         const base = {group, global: true, allowInInput: false, preventDefault: true};
         const items = [
             {combo: `${modString}O`, label: "Open image", onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)},
@@ -196,7 +204,7 @@ export class HotkeyService extends React.Component<{}> {
 
     static OtherHotkeys() {
         const appStore = AppStore.Instance;
-        const group = "5) Other";
+        const group = HotkeyGroup.Other;
         const base = {group, global: true, allowInInput: false, preventDefault: true};
         const items = [
             {combo: "shift + d", label: "Toggle light/dark theme", onKeyDown: HotkeyService.ToggleDarkTheme},

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -110,7 +110,7 @@ export class HotkeyService extends React.Component<{}> {
     };
 
     // For display in custom hotkeys dialog
-    static GetNavigationDisplayOnlyHotkeys() {
+    static NavigationDisplayHotkeys() {
         const group = "1) Navigation";
         const base = {group, global: true};
         const items = [
@@ -123,7 +123,7 @@ export class HotkeyService extends React.Component<{}> {
     }
 
     // For display in custom hotkeys dialog
-    static GetRegionDisplayOnlyHotkeys() {
+    static RegionDisplayHotkeys() {
         const group = "2) Regions";
         const base = {group, global: true};
         const items = [
@@ -134,7 +134,7 @@ export class HotkeyService extends React.Component<{}> {
         return items.map(item => ({...base, ...item}));
     }
 
-    static GetRegionHotkeys() {
+    static RegionHotkeys() {
         const appStore = AppStore.Instance;
         const group = "2) Regions";
         const base = {group, global: true, allowInInput: false, preventDefault: true};
@@ -149,7 +149,7 @@ export class HotkeyService extends React.Component<{}> {
         return items.map(item => ({...base, ...item}));
     }
 
-    static GetFrameControlHotkeys() {
+    static FrameControlHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
         const group = "3) Frame controls";
@@ -166,7 +166,7 @@ export class HotkeyService extends React.Component<{}> {
     }
 
     // Hidden hotkeys for input method compatibility
-    static GetFrameControlHiddenHotkeys() {
+    static FrameControlHiddenHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
         const group = "3) Frame controls";
@@ -178,7 +178,7 @@ export class HotkeyService extends React.Component<{}> {
         return items.map(item => ({...base, ...item}));
     }
 
-    static GetFileControlHotkeys() {
+    static FileControlHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
         const group = "4) File controls";
@@ -194,7 +194,7 @@ export class HotkeyService extends React.Component<{}> {
         return items.map(item => ({...base, ...item}));
     }
 
-    static GetOtherHotkeys() {
+    static OtherHotkeys() {
         const appStore = AppStore.Instance;
         const group = "5) Other";
         const base = {group, global: true, allowInInput: false, preventDefault: true};
@@ -208,24 +208,27 @@ export class HotkeyService extends React.Component<{}> {
 
     // For display in custom hotkeys dialog
     static GetHotkeyDefinitionsForDisplay() {
-        const toElements = (hotkeys: any[]) => hotkeys.map((hotkey, index) => <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />);
+        const toElements = (hotkeys: any[]) =>
+            hotkeys.map((hotkey, index) => {
+                return <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />;
+            });
 
         // 1) Navigation
-        const navigationHotKeys: React.ReactElement[] = toElements(HotkeyService.GetNavigationDisplayOnlyHotkeys());
+        const navigationHotKeys: React.ReactElement[] = toElements(HotkeyService.NavigationDisplayHotkeys());
 
         // 2) Regions
-        const regionHotKeys: React.ReactElement[] = toElements(HotkeyService.GetRegionHotkeys());
-        const regionDisplayOnlyHotkeys: React.ReactElement[] = toElements(HotkeyService.GetRegionDisplayOnlyHotkeys());
+        const regionHotKeys: React.ReactElement[] = toElements(HotkeyService.RegionHotkeys());
+        const regionDisplayOnlyHotkeys: React.ReactElement[] = toElements(HotkeyService.RegionDisplayHotkeys());
         regionHotKeys.push(...regionDisplayOnlyHotkeys);
 
         // 3) Frame controls
-        const animatorHotkeys: React.ReactElement[] = toElements(HotkeyService.GetFrameControlHotkeys());
+        const animatorHotkeys: React.ReactElement[] = toElements(HotkeyService.FrameControlHotkeys());
 
         // 4) File controls
-        const fileHotkeys: React.ReactElement[] = toElements(HotkeyService.GetFileControlHotkeys());
+        const fileHotkeys: React.ReactElement[] = toElements(HotkeyService.FileControlHotkeys());
 
         // 5) Other
-        const otherHotKeys: React.ReactElement[] = toElements(HotkeyService.GetOtherHotkeys());
+        const otherHotKeys: React.ReactElement[] = toElements(HotkeyService.OtherHotkeys());
 
         return {
             navigationHotKeys,
@@ -250,10 +253,7 @@ export class HotkeyService extends React.Component<{}> {
 }
 
 export function HotkeysRegistrar() {
-    const hotkeys = React.useMemo(
-        () => [...HotkeyService.GetFrameControlHotkeys(), ...HotkeyService.GetFrameControlHiddenHotkeys(), ...HotkeyService.GetRegionHotkeys(), ...HotkeyService.GetFileControlHotkeys(), ...HotkeyService.GetOtherHotkeys()],
-        []
-    );
+    const hotkeys = React.useMemo(() => [...HotkeyService.FrameControlHotkeys(), ...HotkeyService.FrameControlHiddenHotkeys(), ...HotkeyService.RegionHotkeys(), ...HotkeyService.FileControlHotkeys(), ...HotkeyService.OtherHotkeys()], []);
 
     useHotkeys(hotkeys);
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -146,10 +146,12 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={5} group={animatorGroupTitle} global={true} combo={`${modString}shift + down`} label="Previous Stokes cube" onKeyDown={HotkeyContainer.PrevStokes} />
         ];
 
+        // The two hotkeys are for macOS to support option + ] and option + [ to navigate between images
+        // and are not visible in the hotkey dialog
         if (includeHidden) {
             animatorHotkeys.push(
-                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="" onKeyDown={appStore.nextImage} />,
-                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="" onKeyDown={appStore.prevImage} />
+                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
+                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="Previous image" onKeyDown={appStore.prevImage} />
             );
         }
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -81,7 +81,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 canEscapeKeyClose={true}
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
-                style={{width: this.getDialogWidth(), maxWidth: "90vw"}}
+                style={{width: this.getDialogWidth(), maxWidth: "95vw"}}
             >
                 <div className={Classes.DIALOG_BODY}>
                     <div

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {Classes, Dialog, Hotkey, Hotkeys, HotkeysTarget} from "@blueprintjs/core";
 import classNames from "classnames";
+import {action} from "mobx";
 import {observer} from "mobx-react";
 
 import {ImageViewLayer} from "components";
@@ -25,7 +26,7 @@ export class HotkeyContainer extends React.Component {
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
             >
-                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys(false)}</div>
+                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys()}</div>
             </Dialog>
         );
     }
@@ -108,7 +109,7 @@ export class HotkeyContainer extends React.Component {
         }
     };
 
-    static RenderHotkeys(includeHidden: boolean = true) {
+    static RenderHotkeys() {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
 
@@ -146,15 +147,6 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={5} group={animatorGroupTitle} global={true} combo={`${modString}shift + down`} label="Previous Stokes cube" onKeyDown={HotkeyContainer.PrevStokes} />
         ];
 
-        // The two hotkeys are for macOS to support option + ] and option + [ to navigate between images
-        // They should only be registered when includeHidden is true to avoid showing in the help dialog
-        if (includeHidden) {
-            animatorHotkeys.push(
-                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
-                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="Previous image" onKeyDown={appStore.prevImage} />
-            );
-        }
-
         const fileHotkeys = [
             <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)} />,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />,
@@ -184,5 +176,34 @@ export class HotkeyContainer extends React.Component {
 
 function HotkeyWrapper() {} // tslint:disable-line
 HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
-HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys(false);
+HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
+
+// Add global event handler to debug phonetic input method keys
+HotkeyWrapper.prototype.componentDidMount = function() {
+    document.addEventListener('keydown', this.handleGlobalKeydown);
+};
+
+HotkeyWrapper.prototype.componentWillUnmount = function() {
+    document.removeEventListener('keydown', this.handleGlobalKeydown);
+};
+
+HotkeyWrapper.prototype.handleGlobalKeydown = function(event: KeyboardEvent) {
+    const appStore = AppStore.Instance;
+    
+    // Handle Option+[ and Option+] for English input method
+    if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
+        if (event.key === '\u201C') {
+            // Option+[ in English input method produces '“' (U+201C)
+            event.preventDefault();
+            action(() => appStore?.prevImage())();
+            return;
+        } else if (event.key === '\u2018') {
+            // Option+] in English input method produces '‘' (U+2018)
+            event.preventDefault();
+            action(() => appStore?.nextImage())();
+            return;
+        }
+    }
+};
+
 export const HotkeyTargetContainer = HotkeysTarget(HotkeyWrapper as any);

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -6,6 +6,7 @@ import {observer} from "mobx-react";
 import {ImageViewLayer} from "components";
 import {AppStore, BrowserMode, DialogId} from "stores";
 import {RegionMode} from "stores/Frame";
+import "./HotkeyWrapper.scss";
 
 interface HotkeyServiceState {
     columnCount: number;
@@ -77,21 +78,14 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
             <Dialog
                 portalClassName="dialog-portal"
                 isOpen={appStore.dialogStore.dialogVisible.get(DialogId.Hotkey)}
-                className={className}
+                className={classNames(className, "hotkeys-dialog")}
                 canEscapeKeyClose={true}
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
-                style={{width: this.getDialogWidth(), maxWidth: "95vw"}}
+                style={{width: this.getDialogWidth()}}
             >
                 <div className={Classes.DIALOG_BODY}>
-                    <div
-                        style={{
-                            display: "grid",
-                            gridTemplateColumns: this.getGridColumns(),
-                            gap: "20px",
-                            alignItems: "start"
-                        }}
-                    >
+                    <div className="hotkeys-grid" style={{gridTemplateColumns: this.getGridColumns()}}>
                         {HotkeyService.RenderHotkeysInColumns(this.state?.columnCount || this.calculateColumnCount())}
                     </div>
                 </div>

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -171,278 +171,125 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
         }
     };
 
-    // Unified hotkey definitions used by both display and registration systems
-    static GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
-        const appStore = AppStore.Instance;
-        const modString = appStore.modifierString;
-
-        return [
-            // 3) Frame controls
-            {
-                combo: `${modString}]`,
-                group: "3) Frame controls",
-                label: "Next image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.nextImage
-            },
-            {
-                combo: `${modString}[`,
-                group: "3) Frame controls",
-                label: "Previous image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.prevImage
-            },
-            {
-                combo: `${modString}up`,
-                group: "3) Frame controls",
-                label: "Next channel",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.NextChannel
-            },
-            {
-                combo: `${modString}down`,
-                group: "3) Frame controls",
-                label: "Previous channel",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.PrevChannel
-            },
-            {
-                combo: `${modString}shift + up`,
-                group: "3) Frame controls",
-                label: "Next Stokes cube",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.NextStokes
-            },
-            {
-                combo: `${modString}shift + down`,
-                group: "3) Frame controls",
-                label: "Previous Stokes cube",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.PrevStokes
-            },
-
-            // Hidden hotkeys for input method compatibility (only included if requested)
-            ...(isHiddenHotkeysIncluded
-                ? [
-                      {
-                          combo: `${modString}‘`,
-                          group: "3) Frame controls",
-                          label: "Next image",
-                          global: true,
-                          allowInInput: false,
-                          preventDefault: true,
-                          onKeyDown: appStore.nextImage
-                      },
-                      {
-                          combo: `${modString}“`,
-                          group: "3) Frame controls",
-                          label: "Previous image",
-                          global: true,
-                          allowInInput: false,
-                          preventDefault: true,
-                          onKeyDown: appStore.prevImage
-                      }
-                  ]
-                : []),
-
-            // 2) Regions
-            {
-                combo: "c",
-                group: "2) Regions",
-                label: "Toggle region creation mode",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.ToggleCreateMode
-            },
-            {
-                combo: "l",
-                group: "2) Regions",
-                label: "Toggle current region lock",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.ToggleRegionLock
-            },
-            {
-                combo: "shift+l",
-                group: "2) Regions",
-                label: "Unlock all regions",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.UnlockAllRegions
-            },
-            {
-                combo: "delete",
-                group: "2) Regions",
-                label: "Delete selected region",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.deleteSelectedRegion
-            },
-            {
-                combo: "backspace",
-                group: "2) Regions",
-                label: "Delete selected region",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.deleteSelectedRegion
-            },
-            {
-                combo: "esc",
-                group: "2) Regions",
-                label: "Deselect/Cancel region creation",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.HandleRegionEsc
-            },
-
-            // 4) File controls
-            {
-                combo: `${modString}O`,
-                group: "4) File controls",
-                label: "Open image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)
-            },
-            {
-                combo: `${modString}L`,
-                group: "4) File controls",
-                label: "Append image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)
-            },
-            {
-                combo: `${modString}W`,
-                group: "4) File controls",
-                label: "Close image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.closeCurrentFile(true)
-            },
-            {
-                combo: `${modString}S`,
-                group: "4) File controls",
-                label: "Save image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)
-            },
-            {
-                combo: `${modString}G`,
-                group: "4) File controls",
-                label: "Import catalog",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)
-            },
-            {
-                combo: `${modString}E`,
-                group: "4) File controls",
-                label: "Export image",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: () => appStore.exportImage(1)
-            },
-
-            // 5) Other
-            {
-                combo: "shift+d",
-                group: "5) Other",
-                label: "Toggle light/dark theme",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: HotkeyService.ToggleDarkTheme
-            },
-            {
-                combo: "f",
-                group: "5) Other",
-                label: "Freeze/unfreeze cursor position",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.toggleCursorFrozen
-            },
-            {
-                combo: "g",
-                group: "5) Other",
-                label: "Mirror cursor on multipanel view",
-                global: true,
-                allowInInput: false,
-                preventDefault: true,
-                onKeyDown: appStore.toggleCursorMirror
-            }
+    // For display in custom hotkeys dialog
+    static GetNavigationDisplayOnlyHotkeys() {
+        const group = "1) Navigation";
+        const base = {group, global: true};
+        const items = [
+            {combo: "click", label: "Pan image"},
+            {combo: "middle-click", label: "Pan image (inside region)"},
+            {combo: "mod + click", label: "Pan image (inside region)"},
+            {combo: "mouse-wheel", label: "Zoom image"}
         ];
+        return items.map(item => ({...base, ...item}));
     }
 
     // For display in custom hotkeys dialog
-    static GetHotkeyDefinitionsForDisplay(isHiddenHotkeysIncluded: boolean = true) {
-        const unifiedHotkeys = HotkeyService.GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded);
-
-        const navigationGroupTitle = "1) Navigation";
-        const regionGroupTitle = "2) Regions";
-        const animatorGroupTitle = "3) Frame controls";
-        const fileGroupTitle = "4) File controls";
-        const otherGroupTitle = "5) Other";
-
-        const navigationHotKeys = [
-            <Hotkey key={0} group={navigationGroupTitle} global={true} combo="click" label="Pan image" />,
-            <Hotkey key={1} group={navigationGroupTitle} global={true} combo="middle-click" label="Pan image (inside region)" />,
-            <Hotkey key={2} group={navigationGroupTitle} global={true} combo="mod+click" label="Pan image (inside region)" />,
-            <Hotkey key={3} group={navigationGroupTitle} global={true} combo="mouse-wheel" label="Zoom image" />
+    static GetRegionDisplayOnlyHotkeys() {
+        const group = "2) Regions";
+        const base = {group, global: true};
+        const items = [
+            {combo: "mod", label: "Switch region creation mode"},
+            {combo: "shift", label: "Symmetric region creation"},
+            {combo: "double-click", label: "Region properties"}
         ];
+        return items.map(item => ({...base, ...item}));
+    }
 
-        const regionDisplayOnlyHotkeys = [
-            <Hotkey key={100} group={regionGroupTitle} global={true} combo="mod" label="Switch region creation mode" />,
-            <Hotkey key={101} group={regionGroupTitle} global={true} combo="shift" label="Symmetric region creation" />,
-            <Hotkey key={102} group={regionGroupTitle} global={true} combo="double-click" label="Region properties" />
+    static GetRegionHotkeys() {
+        const appStore = AppStore.Instance;
+        const group = "2) Regions";
+        const base = {group, global: true, allowInInput: false, preventDefault: true};
+        const items = [
+            {combo: "c", label: "Toggle region creation mode", onKeyDown: HotkeyService.ToggleCreateMode},
+            {combo: "l", label: "Toggle current region lock", onKeyDown: HotkeyService.ToggleRegionLock},
+            {combo: "shift + l", label: "Unlock all regions", onKeyDown: HotkeyService.UnlockAllRegions},
+            {combo: "delete", label: "Delete selected region", onKeyDown: appStore.deleteSelectedRegion},
+            {combo: "backspace", label: "Delete selected region", onKeyDown: appStore.deleteSelectedRegion},
+            {combo: "esc", label: "Deselect/Cancel region creation", onKeyDown: HotkeyService.HandleRegionEsc}
         ];
+        return items.map(item => ({...base, ...item}));
+    }
 
-        const regionHotKeys: React.ReactElement[] = [];
-        const animatorHotkeys: React.ReactElement[] = [];
-        const fileHotkeys: React.ReactElement[] = [];
-        const otherHotKeys: React.ReactElement[] = [];
+    static GetFrameControlHotkeys() {
+        const appStore = AppStore.Instance;
+        const modString = appStore.modifierString;
+        const group = "3) Frame controls";
+        const base = {group, global: true, allowInInput: false, preventDefault: true};
+        const items = [
+            {combo: `${modString}]`, label: "Next image", onKeyDown: appStore.nextImage},
+            {combo: `${modString}[`, label: "Previous image", onKeyDown: appStore.prevImage},
+            {combo: `${modString}up`, label: "Next channel", onKeyDown: HotkeyService.NextChannel},
+            {combo: `${modString}down`, label: "Previous channel", onKeyDown: HotkeyService.PrevChannel},
+            {combo: `${modString}shift + up`, label: "Next Stokes cube", onKeyDown: HotkeyService.NextStokes},
+            {combo: `${modString}shift + down`, label: "Previous Stokes cube", onKeyDown: HotkeyService.PrevStokes}
+        ];
+        return items.map(item => ({...base, ...item}));
+    }
 
-        unifiedHotkeys.forEach((hotkey, index) => {
-            const hotkeyElement = <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />;
+    // Hidden hotkeys for input method compatibility
+    static GetFrameControlHiddenHotkeys() {
+        const appStore = AppStore.Instance;
+        const modString = appStore.modifierString;
+        const group = "3) Frame controls";
+        const base = {group, global: true, allowInInput: false, preventDefault: true};
+        const items = [
+            {combo: `${modString}‘`, label: "Next image", onKeyDown: appStore.nextImage},
+            {combo: `${modString}“`, label: "Previous image", onKeyDown: appStore.prevImage}
+        ];
+        return items.map(item => ({...base, ...item}));
+    }
 
-            if (hotkey.group === regionGroupTitle) {
-                regionHotKeys.push(hotkeyElement);
-            } else if (hotkey.group === animatorGroupTitle) {
-                animatorHotkeys.push(hotkeyElement);
-            } else if (hotkey.group === fileGroupTitle) {
-                fileHotkeys.push(hotkeyElement);
-            } else if (hotkey.group === otherGroupTitle) {
-                otherHotKeys.push(hotkeyElement);
-            }
-        });
+    static GetFileControlHotkeys() {
+        const appStore = AppStore.Instance;
+        const modString = appStore.modifierString;
+        const group = "4) File controls";
+        const base = {group, global: true, allowInInput: false, preventDefault: true};
+        const items = [
+            {combo: `${modString}O`, label: "Open image", onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)},
+            {combo: `${modString}L`, label: "Append image", onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)},
+            {combo: `${modString}W`, label: "Close image", onKeyDown: () => appStore.closeCurrentFile(true)},
+            {combo: `${modString}S`, label: "Save image", onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)},
+            {combo: `${modString}G`, label: "Import catalog", onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)},
+            {combo: `${modString}E`, label: "Export image", onKeyDown: () => appStore.exportImage(1)}
+        ];
+        return items.map(item => ({...base, ...item}));
+    }
 
+    static GetOtherHotkeys() {
+        const appStore = AppStore.Instance;
+        const group = "5) Other";
+        const base = {group, global: true, allowInInput: false, preventDefault: true};
+        const items = [
+            {combo: "shift + d", label: "Toggle light/dark theme", onKeyDown: HotkeyService.ToggleDarkTheme},
+            {combo: "f", label: "Freeze/unfreeze cursor position", onKeyDown: appStore.toggleCursorFrozen},
+            {combo: "g", label: "Mirror cursor on multipanel view", onKeyDown: appStore.toggleCursorMirror}
+        ];
+        return items.map(item => ({...base, ...item}));
+    }
+
+    // For display in custom hotkeys dialog
+    static GetHotkeyDefinitionsForDisplay() {
+        const toElements = (hotkeys: any[]) => hotkeys.map((hotkey, index) => (
+            <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />
+        ));
+
+        // 1) Navigation
+        const navigationHotKeys: React.ReactElement[] = toElements(HotkeyService.GetNavigationDisplayOnlyHotkeys());
+
+        // 2) Regions
+        const regionHotKeys: React.ReactElement[] = toElements(HotkeyService.GetRegionHotkeys());
+        const regionDisplayOnlyHotkeys: React.ReactElement[] = toElements(HotkeyService.GetRegionDisplayOnlyHotkeys());
         regionHotKeys.push(...regionDisplayOnlyHotkeys);
+
+        // 3) Frame controls
+        const animatorHotkeys: React.ReactElement[] = toElements(HotkeyService.GetFrameControlHotkeys());
+
+        // 4) File controls
+        const fileHotkeys: React.ReactElement[] = toElements(HotkeyService.GetFileControlHotkeys());
+
+        // 5) Other
+        const otherHotKeys: React.ReactElement[] = toElements(HotkeyService.GetOtherHotkeys());
 
         return {
             navigationHotKeys,
@@ -454,7 +301,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
     }
 
     static RenderHotkeysInColumns(columnCount: number = 3) {
-        const hotkeys = HotkeyService.GetHotkeyDefinitionsForDisplay(false);
+        const hotkeys = HotkeyService.GetHotkeyDefinitionsForDisplay();
         const hotkeyGroups = [hotkeys.navigationHotKeys, hotkeys.regionHotKeys, hotkeys.animatorHotkeys, hotkeys.fileHotkeys, hotkeys.otherHotKeys];
 
         // Define how to distribute groups across columns
@@ -478,7 +325,16 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
 }
 
 export function HotkeysRegistrar() {
-    const hotkeys = React.useMemo(() => HotkeyService.GetUnifiedHotkeyDefinitions(true), []);
+    const hotkeys = React.useMemo(
+        () => [
+            ...HotkeyService.GetFrameControlHotkeys(),
+            ...HotkeyService.GetFrameControlHiddenHotkeys(),
+            ...HotkeyService.GetRegionHotkeys(),
+            ...HotkeyService.GetFileControlHotkeys(),
+            ...HotkeyService.GetOtherHotkeys()
+        ],
+        []
+    );
 
     useHotkeys(hotkeys);
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -25,7 +25,7 @@ export class HotkeyContainer extends React.Component {
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
             >
-                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys()}</div>
+                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys(false)}</div>
             </Dialog>
         );
     }
@@ -108,7 +108,7 @@ export class HotkeyContainer extends React.Component {
         }
     };
 
-    static RenderHotkeys() {
+    static RenderHotkeys(includeHidden: boolean = true) {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
 
@@ -145,6 +145,13 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={4} group={animatorGroupTitle} global={true} combo={`${modString}shift + up`} label="Next Stokes cube" onKeyDown={HotkeyContainer.NextStokes} />,
             <Hotkey key={5} group={animatorGroupTitle} global={true} combo={`${modString}shift + down`} label="Previous Stokes cube" onKeyDown={HotkeyContainer.PrevStokes} />
         ];
+
+        if (includeHidden) {
+            animatorHotkeys.push(
+               <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="" onKeyDown={appStore.nextImage} />,
+               <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="" onKeyDown={appStore.prevImage} />
+            );
+        }
 
         const fileHotkeys = [
             <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)} />,

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -173,36 +173,6 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
         }
     };
 
-    // Check if any BlueprintJS menu/popover is currently open and visible
-    static IsMenuOpen = (): boolean => {
-        try {
-            // Check for visible popover with menu content
-            const popovers = document.querySelectorAll('.bp5-popover-content, .bp4-popover-content, .bp3-popover-content');
-            for (const popover of popovers) {
-                const style = window.getComputedStyle(popover);
-                // Only consider it open if it's actually visible and has substantial opacity
-                if (style.display !== 'none' && 
-                    style.visibility !== 'hidden' && 
-                    parseFloat(style.opacity) > 0.8) {
-                    
-                    // Check if it contains a menu (not just any popover content)
-                    const menu = popover.querySelector('.bp5-menu, .bp4-menu, .bp3-menu');
-                    if (menu) {
-                        const menuStyle = window.getComputedStyle(menu);
-                        if (menuStyle.display !== 'none' && menuStyle.visibility !== 'hidden') {
-                            return true;
-                        }
-                    }
-                }
-            }
-            
-            return false;
-        } catch (error) {
-            // If there's any error, assume no menu is open to allow hotkeys to work
-            return false;
-        }
-    };
-
     // Unified hotkey definitions used by both display and registration systems
     static GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
         const appStore = AppStore.Instance;
@@ -217,7 +187,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 global: true,
                 allowInInput: false,
                 preventDefault: true,
-                onKeyDown: () => appStore.nextImage()
+                onKeyDown: appStore.nextImage
             },
             {
                 combo: `${modString}[`,
@@ -226,7 +196,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 global: true,
                 allowInInput: false,
                 preventDefault: true,
-                onKeyDown: () => appStore.prevImage()
+                onKeyDown: appStore.prevImage
             },
             {
                 combo: `${modString}up`,
@@ -275,7 +245,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                           global: true,
                           allowInInput: false,
                           preventDefault: true,
-                          onKeyDown: () => appStore.nextImage()
+                          onKeyDown: appStore.nextImage
                       },
                       {
                           combo: `${modString}“`,
@@ -284,7 +254,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                           global: true,
                           allowInInput: false,
                           preventDefault: true,
-                          onKeyDown: () => appStore.prevImage()
+                          onKeyDown: appStore.prevImage
                       }
                   ]
                 : []),
@@ -296,6 +266,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Toggle region creation mode",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: HotkeyService.ToggleCreateMode
             },
             {
@@ -304,6 +275,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Toggle current region lock",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: HotkeyService.ToggleRegionLock
             },
             {
@@ -312,6 +284,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Unlock all regions",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: HotkeyService.UnlockAllRegions
             },
             {
@@ -321,7 +294,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 global: true,
                 allowInInput: false,
                 preventDefault: true,
-                onKeyDown: () => appStore.deleteSelectedRegion()
+                onKeyDown: appStore.deleteSelectedRegion
             },
             {
                 combo: "backspace",
@@ -330,7 +303,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 global: true,
                 allowInInput: false,
                 preventDefault: true,
-                onKeyDown: () => appStore.deleteSelectedRegion()
+                onKeyDown: appStore.deleteSelectedRegion
             },
             {
                 combo: "esc",
@@ -338,6 +311,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Deselect/Cancel region creation",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: HotkeyService.HandleRegionEsc
             },
 
@@ -348,6 +322,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Open image",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)
             },
             {
@@ -356,6 +331,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Append image",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)
             },
             {
@@ -364,6 +340,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Close image",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.closeCurrentFile(true)
             },
             {
@@ -372,6 +349,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Save image",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.SaveFile, false)
             },
             {
@@ -380,6 +358,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Import catalog",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.fileBrowserStore.showFileBrowser(BrowserMode.Catalog, false)
             },
             {
@@ -388,6 +367,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Export image",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: () => appStore.exportImage(1)
             },
 
@@ -398,6 +378,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Toggle light/dark theme",
                 global: true,
                 allowInInput: false,
+                preventDefault: true,
                 onKeyDown: HotkeyService.ToggleDarkTheme
             },
             {
@@ -406,7 +387,8 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Freeze/unfreeze cursor position",
                 global: true,
                 allowInInput: false,
-                onKeyDown: () => appStore.toggleCursorFrozen()
+                preventDefault: true,
+                onKeyDown: appStore.toggleCursorFrozen
             },
             {
                 combo: "g",
@@ -414,7 +396,8 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
                 label: "Mirror cursor on multipanel view",
                 global: true,
                 allowInInput: false,
-                onKeyDown: () => appStore.toggleCursorMirror()
+                preventDefault: true,
+                onKeyDown: appStore.toggleCursorMirror
             }
         ];
     }

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -179,25 +179,25 @@ HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
 HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
 
 // Add global event handler to debug phonetic input method keys
-HotkeyWrapper.prototype.componentDidMount = function() {
-    document.addEventListener('keydown', this.handleGlobalKeydown);
+HotkeyWrapper.prototype.componentDidMount = function () {
+    document.addEventListener("keydown", this.handleGlobalKeydown);
 };
 
-HotkeyWrapper.prototype.componentWillUnmount = function() {
-    document.removeEventListener('keydown', this.handleGlobalKeydown);
+HotkeyWrapper.prototype.componentWillUnmount = function () {
+    document.removeEventListener("keydown", this.handleGlobalKeydown);
 };
 
-HotkeyWrapper.prototype.handleGlobalKeydown = function(event: KeyboardEvent) {
+HotkeyWrapper.prototype.handleGlobalKeydown = function (event: KeyboardEvent) {
     const appStore = AppStore.Instance;
-    
+
     // Handle Option+[ and Option+] for English input method
     if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
-        if (event.key === '\u201C') {
+        if (event.key === "\u201C") {
             // Option+[ in English input method produces '“' (U+201C)
             event.preventDefault();
             action(() => appStore?.prevImage())();
             return;
-        } else if (event.key === '\u2018') {
+        } else if (event.key === "\u2018") {
             // Option+] in English input method produces '‘' (U+2018)
             event.preventDefault();
             action(() => appStore?.nextImage())();

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -25,7 +25,7 @@ export class HotkeyContainer extends React.Component {
                 canOutsideClickClose={true}
                 onClose={() => appStore.dialogStore.hideDialog(DialogId.Hotkey)}
             >
-                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys()}</div>
+                <div className={Classes.DIALOG_BODY}>{HotkeyContainer.RenderHotkeys(false)}</div>
             </Dialog>
         );
     }
@@ -108,7 +108,7 @@ export class HotkeyContainer extends React.Component {
         }
     };
 
-    static RenderHotkeys() {
+    static RenderHotkeys(isHiddenHotkeysIncluded: boolean = true) {
         const appStore = AppStore.Instance;
         const modString = appStore.modifierString;
 
@@ -146,6 +146,13 @@ export class HotkeyContainer extends React.Component {
             <Hotkey key={5} group={animatorGroupTitle} global={true} combo={`${modString}shift + down`} label="Previous Stokes cube" onKeyDown={HotkeyContainer.PrevStokes} />
         ];
 
+        if (isHiddenHotkeysIncluded) {
+            animatorHotkeys.push(
+                <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
+                <Hotkey key={7} group={animatorGroupTitle} global={true} combo={`${modString}“`} label="Previous image" onKeyDown={appStore.prevImage} />
+            );
+        }
+
         const fileHotkeys = [
             <Hotkey key={0} group={fileGroupTitle} global={true} combo={`${modString}O`} label="Open image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File)} />,
             <Hotkey key={1} group={fileGroupTitle} global={true} combo={`${modString}L`} label="Append image" onKeyDown={() => appStore.fileBrowserStore.showFileBrowser(BrowserMode.File, true)} />,
@@ -178,29 +185,30 @@ HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
 HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys();
 
 HotkeyWrapper.prototype.componentDidMount = function () {
-    document.addEventListener("keydown", this.handleGlobalKeydown);
+    // Use capture phase so we can intercept certain keys (e.g. Shift+?) before Blueprint's handlers
+    document.addEventListener("keydown", this.handleGlobalKeydown, true);
 };
 
 HotkeyWrapper.prototype.componentWillUnmount = function () {
-    document.removeEventListener("keydown", this.handleGlobalKeydown);
+    document.removeEventListener("keydown", this.handleGlobalKeydown, true);
 };
 
 HotkeyWrapper.prototype.handleGlobalKeydown = function (event: KeyboardEvent) {
     const appStore = AppStore.Instance;
 
-    // Handle Option+[ and Option+] for English input method
-    if (event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
-        if (event.key === "\u201C") {
-            // Option+[ in English input method produces '“' (U+201C)
-            event.preventDefault();
-            appStore.prevImage();
-            return;
-        } else if (event.key === "\u2018") {
-            // Option+] in English input method produces '‘' (U+2018)
-            event.preventDefault();
-            appStore.nextImage();
-            return;
+    // Intercept Shift+? to open our custom Hotkeys dialog and block Blueprint's default dialog
+    // This prevents React 18 warnings from Blueprint's legacy ReactDOM.render path.
+    if (event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey && (event.key === "?" || event.key === "/")) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === "function") {
+            event.stopImmediatePropagation();
         }
+        // Ensure only one instance of our dialog is shown
+        if (!appStore.dialogStore.dialogVisible.get(DialogId.Hotkey)) {
+            appStore.dialogStore.showDialog(DialogId.Hotkey);
+        }
+        return;
     }
 };
 

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -147,7 +147,7 @@ export class HotkeyContainer extends React.Component {
         ];
 
         // The two hotkeys are for macOS to support option + ] and option + [ to navigate between images
-        // and are not visible in the hotkey dialog
+        // They should only be registered when includeHidden is true to avoid showing in the help dialog
         if (includeHidden) {
             animatorHotkeys.push(
                 <Hotkey key={6} group={animatorGroupTitle} global={true} combo={`${modString}‘`} label="Next image" onKeyDown={appStore.nextImage} />,
@@ -184,5 +184,5 @@ export class HotkeyContainer extends React.Component {
 
 function HotkeyWrapper() {} // tslint:disable-line
 HotkeyWrapper.prototype = Object.create(HotkeyContainer.prototype);
-HotkeyWrapper.prototype.renderHotkeys = HotkeyContainer.RenderHotkeys;
+HotkeyWrapper.prototype.renderHotkeys = () => HotkeyContainer.RenderHotkeys(false);
 export const HotkeyTargetContainer = HotkeysTarget(HotkeyWrapper as any);

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -221,21 +221,21 @@ export class HotkeyService extends React.Component<{}> {
                 return <Hotkey key={index} group={hotkey.group} global={hotkey.global} combo={hotkey.combo} label={hotkey.label} onKeyDown={hotkey.onKeyDown} />;
             });
 
-        // 1) Navigation
+        // Navigation
         const navigationHotKeys: React.ReactElement[] = toElements(HotkeyService.NavigationDisplayHotkeys());
 
-        // 2) Regions
+        // Regions
         const regionHotKeys: React.ReactElement[] = toElements(HotkeyService.RegionHotkeys());
         const regionDisplayOnlyHotkeys: React.ReactElement[] = toElements(HotkeyService.RegionDisplayHotkeys());
         regionHotKeys.push(...regionDisplayOnlyHotkeys);
 
-        // 3) Frame controls
+        // Frame controls
         const animatorHotkeys: React.ReactElement[] = toElements(HotkeyService.FrameControlHotkeys());
 
-        // 4) File controls
+        // File controls
         const fileHotkeys: React.ReactElement[] = toElements(HotkeyService.FileControlHotkeys());
 
-        // 5) Other
+        // Other
         const otherHotKeys: React.ReactElement[] = toElements(HotkeyService.OtherHotkeys());
 
         return {

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -390,7 +390,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
     }
 
     // For display in custom hotkeys dialog
-    static GetHotkeyDefinitions(isHiddenHotkeysIncluded: boolean = true) {
+    static GetHotkeyDefinitionsForDisplay(isHiddenHotkeysIncluded: boolean = true) {
         const unifiedHotkeys = HotkeyService.GetUnifiedHotkeyDefinitions(isHiddenHotkeysIncluded);
 
         const navigationGroupTitle = "1) Navigation";
@@ -443,7 +443,7 @@ export class HotkeyService extends React.Component<{}, HotkeyServiceState> {
     }
 
     static RenderHotkeysInColumns(columnCount: number = 3) {
-        const hotkeys = HotkeyService.GetHotkeyDefinitions(false);
+        const hotkeys = HotkeyService.GetHotkeyDefinitionsForDisplay(false);
         const hotkeyGroups = [hotkeys.navigationHotKeys, hotkeys.regionHotKeys, hotkeys.animatorHotkeys, hotkeys.fileHotkeys, hotkeys.otherHotKeys];
 
         // Define how to distribute groups across columns

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ window["createRoot"] = (origCreateRoot => {
             );
         return root;
     };
-})(createRoot as any) as any; // tslint:disable-line
+})(createRoot);
 
 async function fetchConfig() {
     const baseUrl = window.location.href.replace(window.location.search, "").replace("index.html", "");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ async function fetchConfig() {
     const container = document.getElementById("root") as HTMLElement;
     const root = createRoot(container);
     root.render(
-        <HotkeysProvider renderDialog={() => <></>}>
+        <HotkeysProvider>
             <OverlaysProvider>
                 <App />
             </OverlaysProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ FocusStyleManager.onlyShowFocusOnTabs();
 // GoldenLayout requires these in the global namespace
 window["React"] = React; // tslint:disable-line
 // Ensure any roots created by GoldenLayout are wrapped with providers
-window["createRoot"] = ((origCreateRoot => {
+window["createRoot"] = (origCreateRoot => {
     return (container: Element | DocumentFragment) => {
         const root = origCreateRoot(container);
         const origRender = root.render.bind(root);
@@ -39,7 +39,7 @@ window["createRoot"] = ((origCreateRoot => {
             );
         return root;
     };
-})(createRoot as any)) as any; // tslint:disable-line
+})(createRoot as any) as any; // tslint:disable-line
 
 async function fetchConfig() {
     const baseUrl = window.location.href.replace(window.location.search, "").replace("index.html", "");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {createRoot} from "react-dom/client";
-import {FocusStyleManager, HotkeysProvider, OverlaysProvider} from "@blueprintjs/core";
+import {FocusStyleManager, OverlaysProvider} from "@blueprintjs/core";
 import axios from "axios";
 
 import {ApiService} from "services";
@@ -27,19 +27,7 @@ FocusStyleManager.onlyShowFocusOnTabs();
 // GoldenLayout requires these in the global namespace
 window["React"] = React; // tslint:disable-line
 // Ensure any roots created by GoldenLayout are wrapped with providers
-window["createRoot"] = (origCreateRoot => {
-    return (container: Element | DocumentFragment) => {
-        const root = origCreateRoot(container);
-        const origRender = root.render.bind(root);
-        root.render = (el: React.ReactNode) =>
-            origRender(
-                <HotkeysProvider>
-                    <OverlaysProvider>{el}</OverlaysProvider>
-                </HotkeysProvider>
-            );
-        return root;
-    };
-})(createRoot);
+window["createRoot"] = createRoot; // tslint:disable-line
 
 async function fetchConfig() {
     const baseUrl = window.location.href.replace(window.location.search, "").replace("index.html", "");
@@ -55,11 +43,9 @@ async function fetchConfig() {
     const container = document.getElementById("root") as HTMLElement;
     const root = createRoot(container);
     root.render(
-        <HotkeysProvider>
-            <OverlaysProvider>
-                <App />
-            </OverlaysProvider>
-        </HotkeysProvider>
+        <OverlaysProvider>
+            <App />
+        </OverlaysProvider>
     );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,15 @@ FocusStyleManager.onlyShowFocusOnTabs();
 // GoldenLayout requires these in the global namespace
 window["React"] = React; // tslint:disable-line
 // Ensure any roots created by GoldenLayout are wrapped with providers
-window["createRoot"] = createRoot; // tslint:disable-line
+window["createRoot"] = (container: Element | DocumentFragment) => {
+    const root = createRoot(container);
+    const originalRender = root.render.bind(root);
+    root.render = (children: React.ReactNode) => {
+        const wrappedChildren = React.createElement(HotkeysProvider, {renderDialog: () => React.createElement(React.Fragment)}, React.createElement(OverlaysProvider, null, children));
+        originalRender(wrappedChildren);
+    };
+    return root;
+}; // tslint:disable-line
 
 async function fetchConfig() {
     const baseUrl = window.location.href.replace(window.location.search, "").replace("index.html", "");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {createRoot} from "react-dom/client";
-import {FocusStyleManager, OverlaysProvider} from "@blueprintjs/core";
+import {FocusStyleManager, HotkeysProvider, OverlaysProvider} from "@blueprintjs/core";
 import axios from "axios";
 
 import {ApiService} from "services";
@@ -43,9 +43,11 @@ async function fetchConfig() {
     const container = document.getElementById("root") as HTMLElement;
     const root = createRoot(container);
     root.render(
-        <OverlaysProvider>
-            <App />
-        </OverlaysProvider>
+        <HotkeysProvider>
+            <OverlaysProvider>
+                <App />
+            </OverlaysProvider>
+        </HotkeysProvider>
     );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {createRoot} from "react-dom/client";
-import {FocusStyleManager, OverlaysProvider} from "@blueprintjs/core";
+import {FocusStyleManager, HotkeysProvider, OverlaysProvider} from "@blueprintjs/core";
 import axios from "axios";
 
 import {ApiService} from "services";
@@ -26,7 +26,20 @@ FocusStyleManager.onlyShowFocusOnTabs();
 
 // GoldenLayout requires these in the global namespace
 window["React"] = React; // tslint:disable-line
-window["createRoot"] = createRoot; // tslint:disable-line
+// Ensure any roots created by GoldenLayout are wrapped with providers
+window["createRoot"] = ((origCreateRoot => {
+    return (container: Element | DocumentFragment) => {
+        const root = origCreateRoot(container);
+        const origRender = root.render.bind(root);
+        root.render = (el: React.ReactNode) =>
+            origRender(
+                <HotkeysProvider>
+                    <OverlaysProvider>{el}</OverlaysProvider>
+                </HotkeysProvider>
+            );
+        return root;
+    };
+})(createRoot as any)) as any; // tslint:disable-line
 
 async function fetchConfig() {
     const baseUrl = window.location.href.replace(window.location.search, "").replace("index.html", "");
@@ -42,9 +55,11 @@ async function fetchConfig() {
     const container = document.getElementById("root") as HTMLElement;
     const root = createRoot(container);
     root.render(
-        <OverlaysProvider>
-            <App />
-        </OverlaysProvider>
+        <HotkeysProvider>
+            <OverlaysProvider>
+                <App />
+            </OverlaysProvider>
+        </HotkeysProvider>
     );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ async function fetchConfig() {
     const container = document.getElementById("root") as HTMLElement;
     const root = createRoot(container);
     root.render(
-        <HotkeysProvider>
+        <HotkeysProvider renderDialog={() => <></>}>
             <OverlaysProvider>
                 <App />
             </OverlaysProvider>

--- a/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
@@ -138,7 +138,9 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
 
         autorun(() => {
             if (this.effectiveFrame) {
-                this.selectedStokes = DEFAULT_STOKES;
+                action(() => {
+                    this.selectedStokes = DEFAULT_STOKES;
+                })();
             }
         });
     }


### PR DESCRIPTION
**Description**

Closes #2575 and closes #758.

Fixed:

1. Fix keyboard shortcuts of next/previous images
2. Migrate from Blueprint `HotkeysTarget` to hook-based `useHotkeys` with a new registrar component.
3. Introduce `HotkeyService` (custom dialog UI + responsive layout) and `HotkeysRegistrar` (global registration + Shift+? handler).
4. Ensure all React roots (including GoldenLayout-created) are wrapped with `HotkeysProvider` to fix “useHotkeys() was used outside of a HotkeysProvider context”.
5. Minor MobX fix: perform selectedStokes reset within an action in Spatial Profile store.
6. Avoid conflicts between keyboard events in the image viewer and the dropdown menu.
7. Add global error suppression for ResizeObserver errors according to [https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145](https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145).
- How to reproduce:
  - Comment out Line 104-126 (added by this PR) of `public/index.html`
  - Open DevTools (F12)
  - Resize the viewport width to 622px (or try other numbers if the error does not show)
  - Move the cursor to the Histogram Widget button in the upper right corner
  - See errors: ResizeObserver loop completed with undelivered notifications.
- This occurs in this PR only if error suppression is not applied.
<img height="500" alt="image" src="https://github.com/user-attachments/assets/2a0f9c05-9ef3-4cfd-adf5-621d04af5e41" />


8. Use custom hotkeys dialog for shift+?, which previously rendered the one generated by BlueprintJS.
- Before (from BlueprintJS):

<img height="500" alt="image" src="https://github.com/user-attachments/assets/ef7d7b98-0975-4d90-b194-01a9ad6bb76d" />


- After (custom hotkeys dialog):

<img height="500" alt="image" src="https://github.com/user-attachments/assets/89c98954-ed3d-4177-a1a8-5343bceeebfc" />

9. Automatically resize hotkeys dialog when viewport width changes (min 1 column, max 3 columns).
- Before:

<img width="1440" height="828" alt="image" src="https://github.com/user-attachments/assets/89c98954-ed3d-4177-a1a8-5343bceeebfc" />

- After:

<img height="500" alt="image" src="https://github.com/user-attachments/assets/b0664b25-b6a6-4f51-a4d2-26d741b50d08" />
<img height="500" alt="image" src="https://github.com/user-attachments/assets/f10a26fe-b02c-42fe-9778-a1ca9b42bca6" />
<img height="500" alt="image" src="https://github.com/user-attachments/assets/7353e920-fcaa-4829-b306-32b7b7badef9" />


### Testing Notes
- Verify global shortcuts (e.g., Next/Previous image, channel/stokes navigation, region actions, file actions) work outside inputs and are ignored inside editable fields.
- Confirm Shift+? opens the custom dialog and no BlueprintJS dialog appears.
- Resize window to validate 1/2/3 column layouts and width adjustments for hotkeys dialog.
- Verify #758 does not happen.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)