### PR TITLE
Replace the old VizieR base URL with the new one that supports CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed VizieR database URL ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
+
 ## [5.0.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Fixed VizieR database URL ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
+* Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 
 ## [5.0.3]
 

--- a/src/services/CatalogApiService.ts
+++ b/src/services/CatalogApiService.ts
@@ -20,7 +20,7 @@ export class CatalogApiService {
     private static staticInstance: CatalogApiService;
     private static readonly DBMap = new Map<CatalogDatabase, {baseURL: string}>([
         [CatalogDatabase.SIMBAD, {baseURL: "https://simbad.u-strasbg.fr/simbad/sim-tap/"}],
-        [CatalogDatabase.VIZIER, {baseURL: "https://vizier.u-strasbg.fr/viz-bin/"}]
+        [CatalogDatabase.VIZIER, {baseURL: "https://vizier.cds.unistra.fr/viz-bin/"}]
     ]);
     private axiosInstanceSimbad: AxiosInstance;
     private axiosInstanceVizier: AxiosInstance;


### PR DESCRIPTION
**Description**

Closes #2480. Replace the old VizieR base URL (https://vizier.u-strasbg.fr/viz-bin/) with the new one that supports CORS (https://vizier.cds.unistra.fr/viz-bin/).

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)