### PR TITLE
Fix PV Generator Widget Closing Unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
-* Fixed issue where the PV generator widget and progress bar were removed after clicking the generate button when a PV image already exists ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
+* Fixed issue where the PV generator widget and progress bar were removed after clicking the generate button when a PV image already exists ([#2576](https://github.com/CARTAvis/carta-frontend/issues/2576)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
-* Fixed issue where the PV generator widget and progress bar were removed after clicking the generate button when a PV image already exists ([#2576](https://github.com/CARTAvis/carta-frontend/issues/2576)).
+* Fixed issue where the PV generator widget and progress bar were removed after clicking the generate button when a PV image already exists ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
 
 ## [5.0.3]
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -958,7 +958,6 @@ export class AppStore {
             }
 
             this.widgetsStore.pvGeneratorWidgets.get(pvGeneratorWidgetId)?.removePreviewFrame(parseInt(pvGeneratorWidgetId.split("-")[2]));
-            this.widgetsStore.removeFloatingWidget(pvGeneratorWidgetId);
             this.previewFrames.delete(fileId);
 
             // clear existing requirements for the frame


### PR DESCRIPTION
**Description**

Closes #2349
Fix PV Generator Widget Closing Unexpectedly

**Problem**
When generating a new PV image while an existing one is open:

1. `requestPV` closes the existing PV image (AppStore.ts L1467).
2. Inside `closeFile` (AppStore.ts L862), this.removeFrame(frame) is called (L884).
3. This triggers `this.widgetsStore.removeFloatingWidget(pvGeneratorWidgetId)` (L961), which closes the PV generator widget.
4. Since `TaskProgressDialogComponent` is part of the PV generator component, it also disappears, causing the progress dialog to vanish unexpectedly.

**Solution**
Ensure that closing an existing PV image does not also close the PV generator widget. This prevents the PV generator and its progress dialog from being unintentionally removed when generating a new PV image.

**Verification**
1. Follow the reproduction steps in #2349.
2. Move the region and click Generate again.
3. Verify that:
   - The PV generator widget remains open.
   - The progress dialog remains visible during PV generation.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)