### PR TITLE
Fix incorrect pixel ratio and compass display size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed incorrect pixel aspect ratio, compass size, and the failure to switch to pixel coordinates when images contained incomplete ``CDELTi`` and ``PCi_j`` information or had non-uniform pixel sizes ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399), [#2602](https://github.com/CARTAvis/carta-frontend/issues/2602)).
-* Set the default pixel aspect ratio to unity when images lack valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).`
+* Fixed incorrect aspect ratio and compass size when images contained incomplete ``CDELTi`` and ``PCi_j`` information ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399)).
+* Fixed the failure to switch to pixel coordinates when images had non-square pixels ([#2602](https://github.com/CARTAvis/carta-frontend/issues/2602)).
+
+### Changed
+* Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Fixed issues where the compass did not display at the correct size and some images lacking a CDELT+PC matrix rendered with an incorrect aspect ratio ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed incorrect aspect ratio and compass size when images contained incomplete ``CDELTi`` and ``PCi_j`` information ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399)).
+* Fixed incorrect aspect ratio and compass size when images contained incomplete `CDELTi` and `PCi_j` information ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399)).
 * Fixed the failure to switch to pixel coordinates when images had non-square pixels ([#2602](https://github.com/CARTAvis/carta-frontend/issues/2602)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed issues where the compass did not display at the correct size and some images lacking a CDELT+PC matrix rendered with an incorrect aspect ratio ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399)).
+* Fixed issues where the compass did not display at the correct size, some images lacking a CDELT+PC matrix rendered with an incorrect aspect ratio and cannot switch to pixel coordinates, and images with no valid WCS do not display in the correct aspect ratio ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399), [#2602](https://github.com/CARTAvis/carta-frontend/issues/2602), [#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed issues where the compass did not display at the correct size, some images lacking a CDELT+PC matrix rendered with an incorrect aspect ratio and cannot switch to pixel coordinates, and images with no valid WCS do not display in the correct aspect ratio ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399), [#2602](https://github.com/CARTAvis/carta-frontend/issues/2602), [#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
+* Fixed incorrect pixel aspect ratio, compass size, and the failure to switch to pixel coordinates when images contained incomplete ``CDELTi`` and ``PCi_j`` information or had non-uniform pixel sizes ([#2382](https://github.com/CARTAvis/carta-frontend/issues/2382), [#2399](https://github.com/CARTAvis/carta-frontend/issues/2399), [#2602](https://github.com/CARTAvis/carta-frontend/issues/2602)).
+* Set the default pixel aspect ratio to unity when images lack valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).`
 
 ## [5.0.3]
 

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -82,7 +82,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 const newFrame = AST.frame(2, "Domain=PIXEL");
                 AST.addFrame(tempWcsInfo, 1, scaleMapping, newFrame);
                 AST.setI(tempWcsInfo, "Base", frame.isOffsetCoord ? 4 : 3);
-                AST.setI(tempWcsInfo, "Current", frame.isOffsetCoord && OverlaySettings.Instance.isImgCoordinates ? 3 : 2);
+                AST.setI(tempWcsInfo, "Current", OverlaySettings.Instance.isImgCoordinates ? 3 : 2);
             }
 
             if (frame.isOffsetCoord && OverlaySettings.Instance.isWcsCoordinates) {

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -112,7 +112,7 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
                 region.setControlPoint(0, positionImageSpace);
             } else if (anchor.id() === "northTip" || anchor.id() === "eastTip") {
                 if (!frame.validWcs) {
-                    region.setLength(distance * frame.zoomLevel);
+                    region.setLength((distance * frame.zoomLevel) / imageRatio);
                 } else {
                     region.setLength((distance * (frame.spatialReference?.zoomLevel || frame.zoomLevel)) / imageRatio);
                 }

--- a/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
+++ b/src/components/ImageView/RegionView/CompassAndRulerAnnotationComponent.tsx
@@ -111,7 +111,11 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
             if (anchor.id() === "origin") {
                 region.setControlPoint(0, positionImageSpace);
             } else if (anchor.id() === "northTip" || anchor.id() === "eastTip") {
-                region.setLength((distance * (frame.spatialReference?.zoomLevel || frame.zoomLevel)) / imageRatio);
+                if (!frame.validWcs) {
+                    region.setLength(distance * frame.zoomLevel);
+                } else {
+                    region.setLength((distance * (frame.spatialReference?.zoomLevel || frame.zoomLevel)) / imageRatio);
+                }
             }
         }
     };
@@ -131,22 +135,31 @@ export const CompassAnnotation = observer((props: CompassRulerAnnotationProps) =
     const controlPoint = frame.spatialReference ? transformPoint(frame.spatialTransformAST, region.controlPoints[0], false) : region.controlPoints[0];
     const originPoints = transformedImageToCanvasPos(controlPoint, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
 
-    for (let i = 0; i < northApproxPoints.length; i += 2) {
-        const point = transformedImageToCanvasPos({x: northApproxPoints[i], y: northApproxPoints[i + 1]}, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
-        if (pointDistance(point, originPoints) >= (region.length * imageRatio) / zoomLevel) {
-            break;
-        }
-        northPointArray[i] = point.x - mousePoint.current.x;
-        northPointArray[i + 1] = point.y - mousePoint.current.y;
-    }
+    if (!frame.validWcs) {
+        const originX = originPoints.x - mousePoint.current.x;
+        const originY = originPoints.y - mousePoint.current.y;
+        const compassStageLength = (region.length * imageRatio) / zoomLevel;
 
-    for (let i = 0; i < eastApproxPoints.length; i += 2) {
-        const point = transformedImageToCanvasPos({x: eastApproxPoints[i], y: eastApproxPoints[i + 1]}, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
-        if (pointDistance(point, originPoints) >= (region.length * imageRatio) / zoomLevel) {
-            break;
+        northPointArray.push(originX, originY, originX, originY - compassStageLength);
+        eastPointArray.push(originX, originY, originX - compassStageLength, originY);
+    } else {
+        for (let i = 0; i < northApproxPoints.length; i += 2) {
+            const point = transformedImageToCanvasPos({x: northApproxPoints[i], y: northApproxPoints[i + 1]}, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
+            if (pointDistance(point, originPoints) >= (region.length * imageRatio) / zoomLevel) {
+                break;
+            }
+            northPointArray[i] = point.x - mousePoint.current.x;
+            northPointArray[i + 1] = point.y - mousePoint.current.y;
         }
-        eastPointArray[i] = point.x - mousePoint.current.x;
-        eastPointArray[i + 1] = point.y - mousePoint.current.y;
+
+        for (let i = 0; i < eastApproxPoints.length; i += 2) {
+            const point = transformedImageToCanvasPos({x: eastApproxPoints[i], y: eastApproxPoints[i + 1]}, frame, props.layerWidth, props.layerHeight, props.stageRef.current);
+            if (pointDistance(point, originPoints) >= (region.length * imageRatio) / zoomLevel) {
+                break;
+            }
+            eastPointArray[i] = point.x - mousePoint.current.x;
+            eastPointArray[i + 1] = point.y - mousePoint.current.y;
+        }
     }
 
     // Dummy variables for triggering re-render

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -339,6 +339,7 @@ export class CompassAnnotationStore extends RegionStore {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
         const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
+        const renderedAxesNumbers = this.activeFrame.renderedAxesNumbers;
         const frameView = this.activeFrame.requiredFrameViewForRegionRender;
         const top = frameView.yMax;
         const bottom = frameView.yMin;
@@ -349,8 +350,8 @@ export class CompassAnnotationStore extends RegionStore {
 
         const xAxis = 1;
         const yAxis = 2;
-        const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis) * Math.PI) / 180;
-        const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis) * Math.PI) / 180;
+        const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis, renderedAxesNumbers) * Math.PI) / 180;
+        const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis, renderedAxesNumbers) * Math.PI) / 180;
 
         const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
         const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -24,7 +24,6 @@ export enum Font {
 }
 
 const NUMBER_OF_POINT_TRANSFORMED = 201;
-const DEFAULT_COMPASS_ANGULAR_SIZE_RAD = 6.18; // Fallback angular size in radians for compass rendering
 
 export class PointAnnotationStore extends RegionStore {
     @observable pointShape: CARTA.PointAnnotationShape;
@@ -338,45 +337,41 @@ export class CompassAnnotationStore extends RegionStore {
     public getCompassApproximation(wcsInfo: AST.FrameSet, spatiallyMatched?: boolean, spatialTransform?: AST.Mapping): {northApproximatePoints: number[]; eastApproximatePoints: number[]} {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
 
-        const frameView = this.activeFrame.requiredFrameViewForRegionRender;
-        const top = frameView.yMax;
-        const bottom = frameView.yMin;
-        const left = frameView.xMin;
-        const right = frameView.xMax;
-        const width = right - left;
-        const height = top - bottom;
+        if (wcsInfo && this.activeFrame.validWcs) {
+            const frameView = this.activeFrame.requiredFrameViewForRegionRender;
+            const top = frameView.yMax;
+            const bottom = frameView.yMin;
+            const left = frameView.xMin;
+            const right = frameView.xMax;
+            const width = right - left;
+            const height = top - bottom;
 
-        if (!wcsInfo || !this.activeFrame.validWcs) {
+            const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
+
+            const pixelSize = getPixelSizes(this.activeFrame);
+            const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
+            const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
+            const angularWidth = Math.abs(xPixelSizeRad * width);
+            const angularHeight = Math.abs(yPixelSizeRad * height);
+
+            const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirX, transformed.x, transformed.y, angularWidth);
+            const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirY, transformed.x, transformed.y, angularHeight);
+            return {northApproximatePoints, eastApproximatePoints};
+        } else {
+            // fallback to pixel coordinate
             const compassSize = this.length;
             const centerX = originPoint.x;
             const centerY = originPoint.y;
-
             const northApproximatePoints: number[] = [];
             const eastApproximatePoints: number[] = [];
 
             for (let i = 0; i < NUMBER_OF_POINT_TRANSFORMED; i++) {
                 const t = i / (NUMBER_OF_POINT_TRANSFORMED - 1);
-                
                 northApproximatePoints.push(centerX, centerY + t * compassSize);
                 eastApproximatePoints.push(centerX - t * compassSize, centerY);
             }
-
             return {northApproximatePoints, eastApproximatePoints};
         }
-
-        const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
-
-        const pixelSize = getPixelSizes(this.activeFrame);
-        const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
-        const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
-
-        const angularWidth = isFinite(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
-        const angularHeight = isFinite(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
-
-        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirX, transformed.x, transformed.y, angularWidth);
-        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirY, transformed.x, transformed.y, angularHeight);
-
-        return {northApproximatePoints, eastApproximatePoints};
     }
 
     public getAnnotationStyles = () => {

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -353,8 +353,8 @@ export class CompassAnnotationStore extends RegionStore {
         const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
         const pixelSizeArcsec = getPixelSizes(this.activeFrame);
-        const xPixelSizeRad = (pixelSizeArcsec.x / 3600 * Math.PI) / 180;
-        const yPixelSizeRad = (pixelSizeArcsec.y / 3600 * Math.PI) / 180;
+        const xPixelSizeRad = ((pixelSizeArcsec.x / 3600) * Math.PI) / 180;
+        const yPixelSizeRad = ((pixelSizeArcsec.y / 3600) * Math.PI) / 180;
         const angularWidth = Math.abs(xPixelSizeRad * width);
         const angularHeight = Math.abs(yPixelSizeRad * height);
 

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -6,7 +6,7 @@ import {action, makeObservable, observable} from "mobx";
 import {Point2D} from "models";
 import {BackendService} from "services";
 import {FrameStore} from "stores/Frame";
-import {getPixelSize, transformPoint} from "utilities";
+import {getPixelSizes, transformPoint} from "utilities";
 
 import {RegionStore} from "./Region/RegionStore";
 
@@ -348,7 +348,7 @@ export class CompassAnnotationStore extends RegionStore {
         const width = right - left;
         const height = top - bottom;
 
-        const pixelSize = getPixelSize(this.activeFrame, renderedAxesNumbers);
+        const pixelSize = getPixelSizes(this.activeFrame, renderedAxesNumbers);
         const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
         const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
 

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -352,9 +352,9 @@ export class CompassAnnotationStore extends RegionStore {
 
         const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
-        const pixelSize = getPixelSizes(this.activeFrame);
-        const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
-        const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
+        const pixelSizeArcsec = getPixelSizes(this.activeFrame);
+        const xPixelSizeRad = (pixelSizeArcsec.x / 3600 * Math.PI) / 180;
+        const yPixelSizeRad = (pixelSizeArcsec.y / 3600 * Math.PI) / 180;
         const angularWidth = Math.abs(xPixelSizeRad * width);
         const angularHeight = Math.abs(yPixelSizeRad * height);
 

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -344,7 +344,7 @@ export class CompassAnnotationStore extends RegionStore {
         const left = frameView.xMin;
         const right = frameView.xMax;
         const width = right - left;
-        const height = top - bottom
+        const height = top - bottom;
 
         const xPixelSizeRad = (getPixelSize(this.activeFrame, 1) * Math.PI) / 180;
         const yPixelSizeRad = (getPixelSize(this.activeFrame, 2) * Math.PI) / 180;

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -6,7 +6,7 @@ import {action, makeObservable, observable} from "mobx";
 import {Point2D} from "models";
 import {BackendService} from "services";
 import {FrameStore} from "stores/Frame";
-import {transformPoint} from "utilities";
+import {getPixelSize, transformPoint} from "utilities";
 
 import {RegionStore} from "./Region/RegionStore";
 
@@ -338,20 +338,21 @@ export class CompassAnnotationStore extends RegionStore {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
         const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
-        const delta1 = this.activeFrame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.includes("CDELT1"));
-        const delta2 = this.activeFrame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.includes("CDELT2"));
         const frameView = this.activeFrame.requiredFrameViewForRegionRender;
         const top = frameView.yMax;
         const bottom = frameView.yMin;
         const left = frameView.xMin;
         const right = frameView.xMax;
         const width = right - left;
-        const height = top - bottom;
-        const angularWidth = delta1 ? Math.abs((delta1?.numericValue * Math.PI * width) / 180) : 6.18;
-        const angularHeight = delta2 ? Math.abs((delta2?.numericValue * Math.PI * height) / 180) : 6.18;
+        const height = top - bottom
 
-        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 2, transformed.x, transformed.y, delta1 ? angularWidth : 6.18);
-        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 1, transformed.x, transformed.y, delta2 ? angularHeight : 6.18);
+        const xPixelSizeRad = (getPixelSize(this.activeFrame, 1) * Math.PI) / 180;
+        const yPixelSizeRad = (getPixelSize(this.activeFrame, 2) * Math.PI) / 180;
+        const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : 6.18;
+        const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : 6.18;
+
+        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 2, transformed.x, transformed.y, angularHeight);
+        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 1, transformed.x, transformed.y, angularWidth);
 
         return {northApproximatePoints, eastApproximatePoints};
     }

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -350,8 +350,10 @@ export class CompassAnnotationStore extends RegionStore {
         const yAxis = 2;
         const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis) * Math.PI) / 180;
         const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis) * Math.PI) / 180;
-        const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : 6.18;
-        const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : 6.18;
+
+        const DEFAULT_COMPASS_ANGULAR_SIZE_RAD = 6.18; // Fallback angular size in radians for compass rendering
+        const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
+        const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
 
         const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, xAxis, transformed.x, transformed.y, angularWidth);
         const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, yAxis, transformed.x, transformed.y, angularHeight);

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -355,8 +355,8 @@ export class CompassAnnotationStore extends RegionStore {
         const angularWidth = isFinite(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
         const angularHeight = isFinite(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
 
-        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[0], transformed.x, transformed.y, angularWidth);
-        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[1], transformed.x, transformed.y, angularHeight);
+        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirX, transformed.x, transformed.y, angularWidth);
+        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirY, transformed.x, transformed.y, angularHeight);
 
         return {northApproximatePoints, eastApproximatePoints};
     }

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -24,6 +24,7 @@ export enum Font {
 }
 
 const NUMBER_OF_POINT_TRANSFORMED = 201;
+const DEFAULT_COMPASS_ANGULAR_SIZE_RAD = 6.18; // Fallback angular size in radians for compass rendering
 
 export class PointAnnotationStore extends RegionStore {
     @observable pointShape: CARTA.PointAnnotationShape;
@@ -351,7 +352,6 @@ export class CompassAnnotationStore extends RegionStore {
         const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis) * Math.PI) / 180;
         const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis) * Math.PI) / 180;
 
-        const DEFAULT_COMPASS_ANGULAR_SIZE_RAD = 6.18; // Fallback angular size in radians for compass rendering
         const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
         const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
 

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -339,7 +339,6 @@ export class CompassAnnotationStore extends RegionStore {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
         const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
-        const renderedAxesNumbers = this.activeFrame.renderedAxesNumbers;
         const frameView = this.activeFrame.requiredFrameViewForRegionRender;
         const top = frameView.yMax;
         const bottom = frameView.yMin;
@@ -348,7 +347,7 @@ export class CompassAnnotationStore extends RegionStore {
         const width = right - left;
         const height = top - bottom;
 
-        const pixelSize = getPixelSizes(this.activeFrame, renderedAxesNumbers);
+        const pixelSize = getPixelSizes(this.activeFrame);
         const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
         const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
 

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -351,8 +351,8 @@ export class CompassAnnotationStore extends RegionStore {
         const xPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[0], renderedAxesNumbers) * Math.PI) / 180;
         const yPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[1], renderedAxesNumbers) * Math.PI) / 180;
 
-        const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
-        const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
+        const angularWidth = isFinite(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
+        const angularHeight = isFinite(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
 
         const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[0], transformed.x, transformed.y, angularWidth);
         const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[1], transformed.x, transformed.y, angularHeight);

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -348,8 +348,9 @@ export class CompassAnnotationStore extends RegionStore {
         const width = right - left;
         const height = top - bottom;
 
-        const xPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[0], renderedAxesNumbers) * Math.PI) / 180;
-        const yPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[1], renderedAxesNumbers) * Math.PI) / 180;
+        const pixelSize = getPixelSize(this.activeFrame, renderedAxesNumbers);
+        const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
+        const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
 
         const angularWidth = isFinite(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
         const angularHeight = isFinite(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -337,7 +337,6 @@ export class CompassAnnotationStore extends RegionStore {
 
     public getCompassApproximation(wcsInfo: AST.FrameSet, spatiallyMatched?: boolean, spatialTransform?: AST.Mapping): {northApproximatePoints: number[]; eastApproximatePoints: number[]} {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
-        const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
         const frameView = this.activeFrame.requiredFrameViewForRegionRender;
         const top = frameView.yMax;
@@ -346,6 +345,26 @@ export class CompassAnnotationStore extends RegionStore {
         const right = frameView.xMax;
         const width = right - left;
         const height = top - bottom;
+
+        if (!wcsInfo || !this.activeFrame.validWcs) {
+            const compassSize = this.length;
+            const centerX = originPoint.x;
+            const centerY = originPoint.y;
+
+            const northApproximatePoints: number[] = [];
+            const eastApproximatePoints: number[] = [];
+
+            for (let i = 0; i < NUMBER_OF_POINT_TRANSFORMED; i++) {
+                const t = i / (NUMBER_OF_POINT_TRANSFORMED - 1);
+                
+                northApproximatePoints.push(centerX, centerY + t * compassSize);
+                eastApproximatePoints.push(centerX - t * compassSize, centerY);
+            }
+
+            return {northApproximatePoints, eastApproximatePoints};
+        }
+
+        const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
 
         const pixelSize = getPixelSizes(this.activeFrame);
         const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -348,16 +348,14 @@ export class CompassAnnotationStore extends RegionStore {
         const width = right - left;
         const height = top - bottom;
 
-        const xAxis = 1;
-        const yAxis = 2;
-        const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis, renderedAxesNumbers) * Math.PI) / 180;
-        const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis, renderedAxesNumbers) * Math.PI) / 180;
+        const xPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[0], renderedAxesNumbers) * Math.PI) / 180;
+        const yPixelSizeRad = (getPixelSize(this.activeFrame, renderedAxesNumbers[1], renderedAxesNumbers) * Math.PI) / 180;
 
         const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
         const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : DEFAULT_COMPASS_ANGULAR_SIZE_RAD;
 
-        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, xAxis, transformed.x, transformed.y, angularWidth);
-        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, yAxis, transformed.x, transformed.y, angularHeight);
+        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[0], transformed.x, transformed.y, angularWidth);
+        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, renderedAxesNumbers[1], transformed.x, transformed.y, angularHeight);
 
         return {northApproximatePoints, eastApproximatePoints};
     }

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -337,41 +337,30 @@ export class CompassAnnotationStore extends RegionStore {
     public getCompassApproximation(wcsInfo: AST.FrameSet, spatiallyMatched?: boolean, spatialTransform?: AST.Mapping): {northApproximatePoints: number[]; eastApproximatePoints: number[]} {
         const originPoint = spatiallyMatched ? transformPoint(spatialTransform, this.controlPoints[0], false) : this.controlPoints[0];
 
-        if (wcsInfo && this.activeFrame.validWcs) {
-            const frameView = this.activeFrame.requiredFrameViewForRegionRender;
-            const top = frameView.yMax;
-            const bottom = frameView.yMin;
-            const left = frameView.xMin;
-            const right = frameView.xMax;
-            const width = right - left;
-            const height = top - bottom;
-
-            const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
-
-            const pixelSize = getPixelSizes(this.activeFrame);
-            const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
-            const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
-            const angularWidth = Math.abs(xPixelSizeRad * width);
-            const angularHeight = Math.abs(yPixelSizeRad * height);
-
-            const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirX, transformed.x, transformed.y, angularWidth);
-            const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirY, transformed.x, transformed.y, angularHeight);
-            return {northApproximatePoints, eastApproximatePoints};
-        } else {
-            // fallback to pixel coordinate
-            const compassSize = this.length;
-            const centerX = originPoint.x;
-            const centerY = originPoint.y;
-            const northApproximatePoints: number[] = [];
-            const eastApproximatePoints: number[] = [];
-
-            for (let i = 0; i < NUMBER_OF_POINT_TRANSFORMED; i++) {
-                const t = i / (NUMBER_OF_POINT_TRANSFORMED - 1);
-                northApproximatePoints.push(centerX, centerY + t * compassSize);
-                eastApproximatePoints.push(centerX - t * compassSize, centerY);
-            }
-            return {northApproximatePoints, eastApproximatePoints};
+        // Early return for invalid WCS - rendering component handles this case separately
+        if (!wcsInfo || !this.activeFrame.validWcs) {
+            return {northApproximatePoints: [], eastApproximatePoints: []};
         }
+
+        const frameView = this.activeFrame.requiredFrameViewForRegionRender;
+        const top = frameView.yMax;
+        const bottom = frameView.yMin;
+        const left = frameView.xMin;
+        const right = frameView.xMax;
+        const width = right - left;
+        const height = top - bottom;
+
+        const transformed = AST.transformPoint(wcsInfo, originPoint.x, originPoint.y);
+
+        const pixelSize = getPixelSizes(this.activeFrame);
+        const xPixelSizeRad = (pixelSize.x * Math.PI) / 180;
+        const yPixelSizeRad = (pixelSize.y * Math.PI) / 180;
+        const angularWidth = Math.abs(xPixelSizeRad * width);
+        const angularHeight = Math.abs(yPixelSizeRad * height);
+
+        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirX, transformed.x, transformed.y, angularWidth);
+        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, this.activeFrame.dirY, transformed.x, transformed.y, angularHeight);
+        return {northApproximatePoints, eastApproximatePoints};
     }
 
     public getAnnotationStyles = () => {

--- a/src/stores/Frame/AnnotationStore.ts
+++ b/src/stores/Frame/AnnotationStore.ts
@@ -346,13 +346,15 @@ export class CompassAnnotationStore extends RegionStore {
         const width = right - left;
         const height = top - bottom;
 
-        const xPixelSizeRad = (getPixelSize(this.activeFrame, 1) * Math.PI) / 180;
-        const yPixelSizeRad = (getPixelSize(this.activeFrame, 2) * Math.PI) / 180;
+        const xAxis = 1;
+        const yAxis = 2;
+        const xPixelSizeRad = (getPixelSize(this.activeFrame, xAxis) * Math.PI) / 180;
+        const yPixelSizeRad = (getPixelSize(this.activeFrame, yAxis) * Math.PI) / 180;
         const angularWidth = !Number.isNaN(xPixelSizeRad) ? Math.abs(xPixelSizeRad * width) : 6.18;
         const angularHeight = !Number.isNaN(yPixelSizeRad) ? Math.abs(yPixelSizeRad * height) : 6.18;
 
-        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 2, transformed.x, transformed.y, angularHeight);
-        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, 1, transformed.x, transformed.y, angularWidth);
+        const eastApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, xAxis, transformed.x, transformed.y, angularWidth);
+        const northApproximatePoints = AST.getAxisPointArray(wcsInfo, NUMBER_OF_POINT_TRANSFORMED, yAxis, transformed.x, transformed.y, angularHeight);
 
         return {northApproximatePoints, eastApproximatePoints};
     }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1951,11 +1951,11 @@ export class FrameStore {
         if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
             return null;
         }
-        const xPixelSize = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
-        const yPixelSize = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
-        if (isFinite(xPixelSize) && isFinite(yPixelSize)) {
-            const xUnitSize = Math.round(xPixelSize * 1e6) / 1e6;
-            const yUnitSize = Math.round(yPixelSize * 1e6) / 1e6;
+        const xPixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
+        const yPixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
+        if (isFinite(xPixelSizeDeg) && isFinite(yPixelSizeDeg)) {
+            const xUnitSize = Math.round(xPixelSizeDeg * 3600 * 1e6) / 1e6;
+            const yUnitSize = Math.round(yPixelSizeDeg * 3600 * 1e6) / 1e6;
             return {x: xUnitSize, y: yUnitSize};
         }
         return null;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1454,7 +1454,7 @@ export class FrameStore {
         if (hasUnits && !sameUnits) {
             this.framePixelRatio = NaN;
         } else {
-            const pixelSize = getPixelSizes(this, this.renderedAxesNumbers);
+            const pixelSize = getPixelSizes(this);
             this.framePixelRatio = Math.abs(pixelSize.x / pixelSize.y);
             // Correct for numerical errors in CDELT values if they're within 0.1% of each other
             if (Math.abs(this.framePixelRatio - 1.0) < 0.001) {
@@ -1949,7 +1949,7 @@ export class FrameStore {
         if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
             return null;
         }
-        const pixelSizeDeg = getPixelSizes(this, this.renderedAxesNumbers);
+        const pixelSizeDeg = getPixelSizes(this);
         if (isFinite(pixelSizeDeg.x) && isFinite(pixelSizeDeg.y)) {
             const xUnitSize = Math.round(pixelSizeDeg.x * 3600 * 1e6) / 1e6;
             const yUnitSize = Math.round(pixelSizeDeg.y * 3600 * 1e6) / 1e6;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -271,7 +271,7 @@ export class FrameStore {
             return this.framePixelRatio;
         }
 
-        if (!this.validWcs && this.isNormalImage) {
+        if (this.isNormalImage && !this.validWcs) {
             return 1.0;
         }
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1455,9 +1455,8 @@ export class FrameStore {
             this.framePixelRatio = NaN;
         } else {
             // Assumes non-rotated pixels
-            const cDelt1 = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
-            const cDelt2 = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
-            this.framePixelRatio = Math.abs(cDelt1 / cDelt2);
+            const pixelSize = getPixelSize(this, this.renderedAxesNumbers);
+            this.framePixelRatio = Math.abs(pixelSize.x / pixelSize.y);
             // Correct for numerical errors in CDELT values if they're within 0.1% of each other
             if (Math.abs(this.framePixelRatio - 1.0) < 0.001) {
                 this.framePixelRatio = 1.0;
@@ -1951,11 +1950,10 @@ export class FrameStore {
         if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
             return null;
         }
-        const xPixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
-        const yPixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
-        if (isFinite(xPixelSizeDeg) && isFinite(yPixelSizeDeg)) {
-            const xUnitSize = Math.round(xPixelSizeDeg * 3600 * 1e6) / 1e6;
-            const yUnitSize = Math.round(yPixelSizeDeg * 3600 * 1e6) / 1e6;
+        const pixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers);
+        if (isFinite(pixelSizeDeg.x) && isFinite(pixelSizeDeg.y)) {
+            const xUnitSize = Math.round(pixelSizeDeg.x * 3600 * 1e6) / 1e6;
+            const yUnitSize = Math.round(pixelSizeDeg.y * 3600 * 1e6) / 1e6;
             return {x: xUnitSize, y: yUnitSize};
         }
         return null;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -74,7 +74,7 @@ import {
     getAngleInRad,
     getFormattedWCSPoint,
     getHeaderNumericValue,
-    getPixelSize,
+    getPixelSizes,
     getPixelValueFromWCS,
     GetRequiredTiles,
     getTransformedChannel,
@@ -1455,7 +1455,7 @@ export class FrameStore {
             this.framePixelRatio = NaN;
         } else {
             // Assumes non-rotated pixels
-            const pixelSize = getPixelSize(this, this.renderedAxesNumbers);
+            const pixelSize = getPixelSizes(this, this.renderedAxesNumbers);
             this.framePixelRatio = Math.abs(pixelSize.x / pixelSize.y);
             // Correct for numerical errors in CDELT values if they're within 0.1% of each other
             if (Math.abs(this.framePixelRatio - 1.0) < 0.001) {
@@ -1950,7 +1950,7 @@ export class FrameStore {
         if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
             return null;
         }
-        const pixelSizeDeg = getPixelSize(this, this.renderedAxesNumbers);
+        const pixelSizeDeg = getPixelSizes(this, this.renderedAxesNumbers);
         if (isFinite(pixelSizeDeg.x) && isFinite(pixelSizeDeg.y)) {
             const xUnitSize = Math.round(pixelSizeDeg.x * 3600 * 1e6) / 1e6;
             const yUnitSize = Math.round(pixelSizeDeg.y * 3600 * 1e6) / 1e6;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -271,6 +271,10 @@ export class FrameStore {
             return this.framePixelRatio;
         }
 
+        if (!this.validWcs) {
+            return 1.0;
+        }
+
         return this.renderWidth / this.frameInfo.fileInfoExtended.width / (this.renderHeight / this.frameInfo.fileInfoExtended.height);
     }
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -271,7 +271,7 @@ export class FrameStore {
             return this.framePixelRatio;
         }
 
-        if (!this.validWcs) {
+        if (!this.validWcs && this.isNormalImage) {
             return 1.0;
         }
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1454,7 +1454,6 @@ export class FrameStore {
         if (hasUnits && !sameUnits) {
             this.framePixelRatio = NaN;
         } else {
-            // Assumes non-rotated pixels
             const pixelSize = getPixelSizes(this, this.renderedAxesNumbers);
             this.framePixelRatio = Math.abs(pixelSize.x / pixelSize.y);
             // Correct for numerical errors in CDELT values if they're within 0.1% of each other

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -274,6 +274,10 @@ export class FrameStore {
         return this.renderWidth / this.frameInfo.fileInfoExtended.width / (this.renderHeight / this.frameInfo.fileInfoExtended.height);
     }
 
+    @computed get isNormalImage(): boolean {
+        return !this.isPVImage && !this.isUVImage && !this.isSwappedZ;
+    }
+
     get hasSquarePixels(): boolean {
         if (isFinite(this.framePixelRatio)) {
             return this.framePixelRatio === 1.0;
@@ -1467,7 +1471,8 @@ export class FrameStore {
         this.initSupportedSpectralConversion();
         this.initCenter();
         this.zoomLevel = preferenceStore.isZoomRAWMode ? 1.0 : this.zoomLevelForFit;
-        this.pixelUnitSizeArcsec = this.getPixelUnitSize();
+        const pixelSizesArcsec = getPixelSizes(this, 6);
+        this.pixelUnitSizeArcsec = this.isNormalImage && isFinite(pixelSizesArcsec.x) && isFinite(pixelSizesArcsec.y) ? pixelSizesArcsec : null;
 
         // init spectral settings
         if (this.spectralAxis && IsSpectralTypeSupported(this.spectralAxis.type.code as string) && IsSpectralUnitSupported(this.spectralAxis.type.unit as string)) {
@@ -1945,19 +1950,6 @@ export class FrameStore {
         this.zooming = false;
     };
 
-    private getPixelUnitSize = () => {
-        if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
-            return null;
-        }
-        const pixelSizeDeg = getPixelSizes(this);
-        if (isFinite(pixelSizeDeg.x) && isFinite(pixelSizeDeg.y)) {
-            const xUnitSize = Math.round(pixelSizeDeg.x * 3600 * 1e6) / 1e6;
-            const yUnitSize = Math.round(pixelSizeDeg.y * 3600 * 1e6) / 1e6;
-            return {x: xUnitSize, y: yUnitSize};
-        }
-        return null;
-    };
-
     /**
      * Converts positions from WCS coordinates to image coordinates.
      *
@@ -2011,7 +2003,7 @@ export class FrameStore {
         let cursorPosWCS, cursorPosFormatted;
         let precisionX = 0;
         let precisionY = 0;
-        if (((this.validWcs || this.isYX) && AppStore.Instance.overlaySettings.isWcsCoordinates) || this.isPVImage || this.isUVImage || this.isSwappedZ) {
+        if (((this.validWcs || this.isYX) && AppStore.Instance.overlaySettings.isWcsCoordinates) || !this.isNormalImage) {
             // We need to compare X and Y coordinates in both directions
             // to avoid a confusing drop in precision at rounding threshold
             const offsetBlock = [
@@ -2030,9 +2022,9 @@ export class FrameStore {
             while (precisionX < FrameStore.CursorInfoMaxPrecision && precisionY < FrameStore.CursorInfoMaxPrecision) {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
-                astString.add(`Format(${this.dirX})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringX(precisionX));
-                astString.add(`Format(${this.dirY})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringY(precisionY));
-                astString.add("System", this.isPVImage || this.isUVImage || this.isSwappedZ ? "cartesian" : overlaySettings.global.explicitSystem);
+                astString.add(`Format(${this.dirX})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringX(precisionX) : undefined);
+                astString.add(`Format(${this.dirY})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringY(precisionY) : undefined);
+                astString.add("System", this.isNormalImage ? overlaySettings.global.explicitSystem : "cartesian");
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map(pos => AST.getFormattedCoordinates(this.wcsInfo, pos.x, pos.y, astString.toString(), true));
                 let [p, n1, n2] = formattedNeighbourhood;
@@ -2296,7 +2288,7 @@ export class FrameStore {
     };
 
     @action updateOffsetCenter = () => {
-        if (!this.isPVImage && !this.isPreview && !this.isSwappedZ && !this.isUVImage) {
+        if (this.isNormalImage && !this.isPreview) {
             this.setOffsetCenter(this.center.x, this.center.y);
         }
     };

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1455,8 +1455,8 @@ export class FrameStore {
             this.framePixelRatio = NaN;
         } else {
             // Assumes non-rotated pixels
-            const cDelt1 = getPixelSize(this, this.renderedAxesNumbers[0]);
-            const cDelt2 = getPixelSize(this, this.renderedAxesNumbers[1]);
+            const cDelt1 = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
+            const cDelt2 = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
             this.framePixelRatio = Math.abs(cDelt1 / cDelt2);
             // Correct for numerical errors in CDELT values if they're within 0.1% of each other
             if (Math.abs(this.framePixelRatio - 1.0) < 0.001) {
@@ -1951,16 +1951,12 @@ export class FrameStore {
         if (this.isPVImage || this.isUVImage || this.isSwappedZ) {
             return null;
         }
-        const crpix1 = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${this.renderedAxesNumbers[0]}`) !== -1);
-        const crpix2 = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${this.renderedAxesNumbers[1]}`) !== -1);
-        if (crpix1 && crpix2) {
-            const crpix1Val = getHeaderNumericValue(crpix1);
-            const crpix2Val = getHeaderNumericValue(crpix2);
-            const xUnitSize = Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val + 1, crpix2Val) * 1e6) / 1e6;
-            const yUnitSize = Math.round(AST.geodesicDistance(this.wcsInfo, crpix1Val, crpix2Val, crpix1Val, crpix2Val + 1) * 1e6) / 1e6;
-            if (isFinite(xUnitSize) && isFinite(yUnitSize)) {
-                return {x: xUnitSize, y: yUnitSize};
-            }
+        const xPixelSize = getPixelSize(this, this.renderedAxesNumbers[0], this.renderedAxesNumbers);
+        const yPixelSize = getPixelSize(this, this.renderedAxesNumbers[1], this.renderedAxesNumbers);
+        if (isFinite(xPixelSize) && isFinite(yPixelSize)) {
+            const xUnitSize = Math.round(xPixelSize * 1e6) / 1e6;
+            const yUnitSize = Math.round(yPixelSize * 1e6) / 1e6;
+            return {x: xUnitSize, y: yUnitSize};
         }
         return null;
     };

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -66,7 +66,7 @@ export function getPixelSize(frame: FrameStore, axis: number): number {
 
     // Get CDELT value - coordinate increment at reference point (degrees/pixel)
     // CDELT represents the nominal coordinate increment per pixel
-    const cdelt = getHeaderNumericValue(find(entry => (entry.name ?? "").includes(`CDELT${axis}`)));
+    const cdelt = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CDELT${axis}`));
 
     // Get PC matrix elements - rotation/scaling transformation matrix
     // PC1_1, PC1_2, PC2_1, PC2_2 define rotation and scaling between pixel and world coordinates

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -44,53 +44,28 @@ export function getReferencePixel(frame: FrameStore): Point2D {
 }
 
 /**
- * Calculates the pixel size in degrees for a specific axis of an astronomical image
- * using WCS (World Coordinate System) header information.
+ * Calculates the pixel size in degrees along a given rendered axis by
+ * measuring geodesic distance in WCS at the reference pixel position.
  *
- * This function follows FITS WCS conventions to determine pixel scale by examining
- * CD matrix elements or CDELT/PC matrix combinations in the FITS header.
- *
- * @param frame - The FrameStore containing the astronomical image data and headers
- * @param axis - The axis number (1 or 2) for which to calculate pixel size
- * @returns The pixel size in degrees, or NaN if calculation fails
+ * @param frame - The `FrameStore` providing WCS info (`frame.wcsInfo`) and headers
+ * @param axis - Rendered world axis number for which to calculate pixel size
+ * @param renderedAxesNumbers - Tuple of rendered axes (e.g. `[xAxis, yAxis]`)
+ * @returns Pixel size in degrees, or `NaN` if it cannot be determined
  */
-export function getPixelSize(frame: FrameStore, axis: number): number {
-    // Extract header entries from the frame's file information
-    const headerEntries = frame?.frameInfo?.fileInfoExtended?.headerEntries;
-    if (!headerEntries) {
-        return NaN;
+export function getPixelSize(frame: FrameStore, axis: number, renderedAxesNumbers: [number, number]): number {
+    const crpix1 = frame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
+    const crpix2 = frame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
+
+    if (crpix1 && crpix2) {
+        const crpix1Val = getHeaderNumericValue(crpix1);
+        const crpix2Val = getHeaderNumericValue(crpix2);
+        if (axis === renderedAxesNumbers[0]) {
+            return AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val);
+        } else if (axis === renderedAxesNumbers[1]) {
+            return AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5);
+        }
     }
-
-    // Helper function to find header entries matching a predicate
-    const find = (pred: (entry: CARTA.IHeaderEntry) => boolean) => headerEntries.find(pred);
-
-    // Get CDELT value - coordinate increment at reference point (degrees/pixel)
-    // CDELT represents the nominal coordinate increment per pixel
-    const cdelt = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CDELT${axis}`));
-
-    // Get PC matrix elements - rotation/scaling transformation matrix
-    // PC1_1, PC1_2, PC2_1, PC2_2 define rotation and scaling between pixel and world coordinates
-    const pc1 = getHeaderNumericValue(find(entry => (entry.name ?? "") === `PC1_${axis}`));
-    const pc2 = getHeaderNumericValue(find(entry => (entry.name ?? "") === `PC2_${axis}`));
-
-    // Get CD matrix elements - coordinate transformation matrix (degrees/pixel)
-    // CD matrix combines coordinate increment and rotation/scaling in one step
-    // CD1_1, CD1_2, CD2_1, CD2_2 directly give coordinate derivatives
-    const cd1Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD1_${axis}`));
-    const cd2Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD2_${axis}`));
-
-    // Calculate effective CD matrix elements
-    // Prefer direct CD values if available, otherwise compute from CDELT * PC
-    // This handles both CD matrix and CDELT+PC matrix representations
-    const cd1 = isFinite(cd1Header) ? cd1Header : isFinite(cdelt) && isFinite(pc1) ? cdelt * pc1 : NaN;
-    const cd2 = isFinite(cd2Header) ? cd2Header : isFinite(cdelt) && isFinite(pc2) ? cdelt * pc2 : NaN;
-
-    // Calculate pixel size as the magnitude of the CD vector
-    // This gives the actual pixel scale accounting for rotation and skew
-    // sqrt(cd1**2 + cd2**2) represents the length of the coordinate transformation vector
-    const pixelSizeDeg = Math.sqrt(cd1 ** 2 + cd2 ** 2);
-
-    return pixelSizeDeg;
+    return NaN;
 }
 
 export function getFormattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: Point2D) {

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -55,7 +55,7 @@ export function getReferencePixel(frame: FrameStore): Point2D {
 export function getPixelSize(frame: FrameStore, axis: number, renderedAxesNumbers: [number, number]): number {
     const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
     const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
-    
+
     if (crpix1 && crpix2) {
         const crpix1Val = getHeaderNumericValue(crpix1);
         const crpix2Val = getHeaderNumericValue(crpix2);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -51,15 +51,14 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
  */
 export function getPixelSizes(frame: FrameStore): {x: number; y: number} {
-    const renderedAxesNumbers = frame.renderedAxesNumbers;
-    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${renderedAxesNumbers[0]}`);
-    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${renderedAxesNumbers[1]}`);
+    const crpixX = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${frame.dirXNumber}`);
+    const crpixY = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${frame.dirYNumber}`);
 
-    if (crpix1 && crpix2) {
-        const crpix1Val = getHeaderNumericValue(crpix1);
-        const crpix2Val = getHeaderNumericValue(crpix2);
-        const xPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val) / 3600;
-        const yPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5) / 3600;
+    if (crpixX && crpixY) {
+        const crpixXVal = getHeaderNumericValue(crpixX);
+        const crpixYVal = getHeaderNumericValue(crpixY);
+        const xPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpixXVal - 0.5, crpixYVal, crpixXVal + 0.5, crpixYVal) / 3600;
+        const yPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpixXVal, crpixYVal - 0.5, crpixXVal, crpixYVal + 0.5) / 3600;
         return {x: xPixelSizeDeg, y: yPixelSizeDeg};
     }
     return {x: NaN, y: NaN};

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -53,16 +53,16 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  * @returns Pixel size in degrees, or `NaN` if it cannot be determined
  */
 export function getPixelSize(frame: FrameStore, axis: number, renderedAxesNumbers: [number, number]): number {
-    const crpix1 = frame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
-    const crpix2 = frame.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
-
+    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
+    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
+    
     if (crpix1 && crpix2) {
         const crpix1Val = getHeaderNumericValue(crpix1);
         const crpix2Val = getHeaderNumericValue(crpix2);
         if (axis === renderedAxesNumbers[0]) {
-            return AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val);
+            return AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val) / 3600;
         } else if (axis === renderedAxesNumbers[1]) {
-            return AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5);
+            return AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5) / 3600;
         }
     }
     return NaN;

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -52,8 +52,8 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  */
 export function getPixelSizes(frame: FrameStore): {x: number; y: number} {
     const renderedAxesNumbers = frame.renderedAxesNumbers;
-    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
-    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
+    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${renderedAxesNumbers[0]}`);
+    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${renderedAxesNumbers[1]}`);
 
     if (crpix1 && crpix2) {
         const crpix1Val = getHeaderNumericValue(crpix1);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -44,22 +44,36 @@ export function getReferencePixel(frame: FrameStore): Point2D {
 }
 
 /**
- * Calculates the pixel sizes (in degrees per pixel) along the rendered X and Y axes by
+ * Calculates the pixel sizes (in arcseconds per pixel) along the rendered X and Y axes by
  * measuring WCS geodesic distances around the reference pixel (CRPIX).
  *
  * @param frame - The `FrameStore` providing WCS transform (`frame.wcsInfo`) and FITS headers
- * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
+ * @param rounding - Optional number of decimal places to round the pixel size in arcseconds.
+ *                   If omitted, raw (unrounded) arcsecond values are returned.
+ * @returns An object with `{ x, y }` pixel sizes in arcseconds; `NaN` values if they cannot be determined
  */
-export function getPixelSizes(frame: FrameStore): {x: number; y: number} {
+export function getPixelSizes(frame: FrameStore, rounding?: number): {x: number; y: number} {
     const crpixX = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${frame.dirXNumber}`);
     const crpixY = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name === `CRPIX${frame.dirYNumber}`);
 
     if (crpixX && crpixY) {
         const crpixXVal = getHeaderNumericValue(crpixX);
         const crpixYVal = getHeaderNumericValue(crpixY);
-        const xPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpixXVal - 0.5, crpixYVal, crpixXVal + 0.5, crpixYVal) / 3600;
-        const yPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpixXVal, crpixYVal - 0.5, crpixXVal, crpixYVal + 0.5) / 3600;
-        return {x: xPixelSizeDeg, y: yPixelSizeDeg};
+        const xPixelSizeArcsec = AST.geodesicDistance(frame.wcsInfo, crpixXVal - 0.5, crpixYVal, crpixXVal + 0.5, crpixYVal);
+        const yPixelSizeArcsec = AST.geodesicDistance(frame.wcsInfo, crpixXVal, crpixYVal - 0.5, crpixXVal, crpixYVal + 0.5);
+
+        if (!isFinite(xPixelSizeArcsec) || !isFinite(yPixelSizeArcsec)) {
+            return {x: NaN, y: NaN};
+        }
+
+        if (isFinite(rounding as number)) {
+            const factor = Math.pow(10, rounding as number);
+            return {
+                x: Math.round(xPixelSizeArcsec * factor) / factor,
+                y: Math.round(yPixelSizeArcsec * factor) / factor
+            };
+        }
+        return {x: xPixelSizeArcsec, y: yPixelSizeArcsec};
     }
     return {x: NaN, y: NaN};
 }

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -52,8 +52,8 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
  */
 export function getPixelSizes(frame: FrameStore, renderedAxesNumbers: [number, number]): {x: number; y: number} {
-    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
-    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
+    const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
+    const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
 
     if (crpix1 && crpix2) {
         const crpix1Val = getHeaderNumericValue(crpix1);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -51,7 +51,7 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  * @param renderedAxesNumbers - Tuple of rendered axes (e.g., `[xAxis, yAxis]`) indicating which CRPIX values to use
  * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
  */
-export function getPixelSize(frame: FrameStore, renderedAxesNumbers: [number, number]): {x: number; y: number} {
+export function getPixelSizes(frame: FrameStore, renderedAxesNumbers: [number, number]): {x: number; y: number} {
     const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
     const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
 

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -44,28 +44,25 @@ export function getReferencePixel(frame: FrameStore): Point2D {
 }
 
 /**
- * Calculates the pixel size in degrees along a given rendered axis by
- * measuring geodesic distance in WCS at the reference pixel position.
+ * Calculates the pixel sizes (in degrees per pixel) along the rendered X and Y axes by
+ * measuring WCS geodesic distances around the reference pixel (CRPIX).
  *
- * @param frame - The `FrameStore` providing WCS info (`frame.wcsInfo`) and headers
- * @param axis - Rendered world axis number for which to calculate pixel size
- * @param renderedAxesNumbers - Tuple of rendered axes (e.g. `[xAxis, yAxis]`)
- * @returns Pixel size in degrees, or `NaN` if it cannot be determined
+ * @param frame - The `FrameStore` providing WCS transform (`frame.wcsInfo`) and FITS headers
+ * @param renderedAxesNumbers - Tuple of rendered axes (e.g., `[xAxis, yAxis]`) indicating which CRPIX values to use
+ * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
  */
-export function getPixelSize(frame: FrameStore, axis: number, renderedAxesNumbers: [number, number]): number {
+export function getPixelSize(frame: FrameStore, renderedAxesNumbers: [number, number]): {x: number; y: number} {
     const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
     const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
 
     if (crpix1 && crpix2) {
         const crpix1Val = getHeaderNumericValue(crpix1);
         const crpix2Val = getHeaderNumericValue(crpix2);
-        if (axis === renderedAxesNumbers[0]) {
-            return AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val) / 3600;
-        } else if (axis === renderedAxesNumbers[1]) {
-            return AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5) / 3600;
-        }
+        const xPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpix1Val - 0.5, crpix2Val, crpix1Val + 0.5, crpix2Val) / 3600;
+        const yPixelSizeDeg = AST.geodesicDistance(frame.wcsInfo, crpix1Val, crpix2Val - 0.5, crpix1Val, crpix2Val + 0.5) / 3600;
+        return {x: xPixelSizeDeg, y: yPixelSizeDeg};
     }
-    return NaN;
+    return {x: NaN, y: NaN};
 }
 
 export function getFormattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: Point2D) {

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -46,10 +46,10 @@ export function getReferencePixel(frame: FrameStore): Point2D {
 /**
  * Calculates the pixel size in degrees for a specific axis of an astronomical image
  * using WCS (World Coordinate System) header information.
- * 
+ *
  * This function follows FITS WCS conventions to determine pixel scale by examining
  * CD matrix elements or CDELT/PC matrix combinations in the FITS header.
- * 
+ *
  * @param frame - The FrameStore containing the astronomical image data and headers
  * @param axis - The axis number (1 or 2) for which to calculate pixel size
  * @returns The pixel size in degrees, or NaN if calculation fails
@@ -78,7 +78,7 @@ export function getPixelSize(frame: FrameStore, axis: number): number {
     // CD1_1, CD1_2, CD2_1, CD2_2 directly give coordinate derivatives
     const cd1Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD1_${axis}`));
     const cd2Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD2_${axis}`));
-    
+
     // Calculate effective CD matrix elements
     // Prefer direct CD values if available, otherwise compute from CDELT * PC
     // This handles both CD matrix and CDELT+PC matrix representations

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -48,10 +48,10 @@ export function getReferencePixel(frame: FrameStore): Point2D {
  * measuring WCS geodesic distances around the reference pixel (CRPIX).
  *
  * @param frame - The `FrameStore` providing WCS transform (`frame.wcsInfo`) and FITS headers
- * @param renderedAxesNumbers - Tuple of rendered axes (e.g., `[xAxis, yAxis]`) indicating which CRPIX values to use
  * @returns An object with `{ x, y }` pixel sizes in degrees; `NaN` values if they cannot be determined
  */
-export function getPixelSizes(frame: FrameStore, renderedAxesNumbers: [number, number]): {x: number; y: number} {
+export function getPixelSizes(frame: FrameStore): {x: number; y: number} {
+    const renderedAxesNumbers = frame.renderedAxesNumbers;
     const crpix1 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[0]}`) !== -1);
     const crpix2 = frame?.frameInfo?.fileInfoExtended?.headerEntries.find(entry => entry.name?.indexOf(`CRPIX${renderedAxesNumbers[1]}`) !== -1);
 

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -43,24 +43,54 @@ export function getReferencePixel(frame: FrameStore): Point2D {
     return {x, y};
 }
 
+/**
+ * Calculates the pixel size in degrees for a specific axis of an astronomical image
+ * using WCS (World Coordinate System) header information.
+ * 
+ * This function follows FITS WCS conventions to determine pixel scale by examining
+ * CD matrix elements or CDELT/PC matrix combinations in the FITS header.
+ * 
+ * @param frame - The FrameStore containing the astronomical image data and headers
+ * @param axis - The axis number (1 or 2) for which to calculate pixel size
+ * @returns The pixel size in degrees, or NaN if calculation fails
+ */
 export function getPixelSize(frame: FrameStore, axis: number): number {
+    // Extract header entries from the frame's file information
     const headerEntries = frame?.frameInfo?.fileInfoExtended?.headerEntries;
     if (!headerEntries) {
         return NaN;
     }
 
-    // First try the usual CDELT value
-    let header = headerEntries.find(entry => entry.name === `CDELT${axis}`);
-    if (!header) {
-        // Otherwise revert to PC matrix
-        header = headerEntries.find(entry => entry.name === `PC${axis}_${axis}`);
-        if (!header) {
-            // Finally, try the deprecated CD matrix
-            header = headerEntries.find(entry => entry.name === `CD${axis}_${axis}`);
-        }
-    }
+    // Helper function to find header entries matching a predicate
+    const find = (pred: (entry: CARTA.IHeaderEntry) => boolean) => headerEntries.find(pred);
 
-    return getHeaderNumericValue(header);
+    // Get CDELT value - coordinate increment at reference point (degrees/pixel)
+    // CDELT represents the nominal coordinate increment per pixel
+    const cdelt = getHeaderNumericValue(find(entry => (entry.name ?? "").includes(`CDELT${axis}`)));
+
+    // Get PC matrix elements - rotation/scaling transformation matrix
+    // PC1_1, PC1_2, PC2_1, PC2_2 define rotation and scaling between pixel and world coordinates
+    const pc1 = getHeaderNumericValue(find(entry => (entry.name ?? "") === `PC1_${axis}`));
+    const pc2 = getHeaderNumericValue(find(entry => (entry.name ?? "") === `PC2_${axis}`));
+
+    // Get CD matrix elements - coordinate transformation matrix (degrees/pixel)
+    // CD matrix combines coordinate increment and rotation/scaling in one step
+    // CD1_1, CD1_2, CD2_1, CD2_2 directly give coordinate derivatives
+    const cd1Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD1_${axis}`));
+    const cd2Header = getHeaderNumericValue(find(entry => (entry.name ?? "") === `CD2_${axis}`));
+    
+    // Calculate effective CD matrix elements
+    // Prefer direct CD values if available, otherwise compute from CDELT * PC
+    // This handles both CD matrix and CDELT+PC matrix representations
+    const cd1 = isFinite(cd1Header) ? cd1Header : isFinite(cdelt) && isFinite(pc1) ? cdelt * pc1 : NaN;
+    const cd2 = isFinite(cd2Header) ? cd2Header : isFinite(cdelt) && isFinite(pc2) ? cdelt * pc2 : NaN;
+
+    // Calculate pixel size as the magnitude of the CD vector
+    // This gives the actual pixel scale accounting for rotation and skew
+    // sqrt(cd1**2 + cd2**2) represents the length of the coordinate transformation vector
+    const pixelSizeDeg = Math.sqrt(cd1 ** 2 + cd2 ** 2);
+
+    return pixelSizeDeg;
 }
 
 export function getFormattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: Point2D) {


### PR DESCRIPTION
### Description

Closes #2382, #2399, #2602, and #2604.

This PR fixed problems caused by incorrect pixel ratio calculations and handling.

### Problem
- Compass annotations were displayed at incorrect sizes.
    -  This issue occurs if the WCS does not have `CDELT` (#2382) or if there is no valid WCS (e.g., pixel coordinates only).
-  Images that lack a `CDELT` + `PC` matrix combination are rendered with incorrect aspect ratios (#2399).
-  The existing `getPixelSize` function only handled simple `CDELT` values and did not account for coordinate transformation matrices.
-  If the pixel ratio is not 1, pixel coordinates cannot be switched to (#2602).
-  If no valid WCS, the aspect ratio should be 1, not following that of the window.

### Solution
-  Unified pixel size calculations using `AST.geodesicDistance` now incorporate Yu-Hsuan's implementation of `getPixelUnitSize` in `FrameStore.ts`. This change eliminates the need to manage `CDELT`, `PC`, or `CD` matrices.
-  A fallback for compass annotation has been added in case of an invalid WCS.
    - Currently using up as north and left as east. (or do we need to disable compass when no valid WCS?)
-  A bug has been fixed that occurred when switching coordinates from world to image if the pixel ratio is not 1.
-  Set aspectRatio to 1 if it is normal image with no valid WCS. 

### Verification
1. Follow the reproduction steps in #2382:
   - Add a compass and ensure it is not as small as shown in the screenshot.
2. Follow the reproduction steps in #2399:
   - Load the image and confirm that the aspect ratio matches what DS9 displays.
3. Follow the reproduction steps in #2602:
   - Load the image, switch to pixel coordinates, and verify that the coordinates have been correctly adjusted.
4. Follow the reproduction steps in #2604:
   - Load the image and check the aspect ratio should be 1 and not change when resizing window.

### Checklist

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)