### PR TITLE
Avoid ResizeObserver errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Suppressed benign ResizeObserver errors happening under development mode ([#2597](https://github.com/CARTAvis/carta-frontend/issues/2597)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Suppressed benign ResizeObserver errors happening under development mode ([#2597](https://github.com/CARTAvis/carta-frontend/issues/2597)).
+* Avoid ResizeObserver errors ([#2597](https://github.com/CARTAvis/carta-frontend/issues/2597)).
 
 ## [5.0.3]
 

--- a/public/index.html
+++ b/public/index.html
@@ -101,7 +101,6 @@
             }
         }
     </style>
-    
 </head>
 <body>
 <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -101,31 +101,7 @@
             }
         }
     </style>
-    <script>
-        // Suppress benign ResizeObserver errors
-        // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
-        // These are benign errors that occur when ResizeObserver can't deliver all observations
-        // within a single animation frame, which is common with modern UI libraries.
-        function isResizeObserverError(message) {
-            return message && (
-                message.includes('ResizeObserver loop limit exceeded') ||
-                message.includes('ResizeObserver loop completed with undelivered notifications.')
-            );
-        }
-
-        window.addEventListener('error', function(e) {
-            if (isResizeObserverError(e.message)) {
-                e.stopImmediatePropagation();
-            }
-        });
-        
-        // Also handle unhandled promise rejections for ResizeObserver
-        window.addEventListener('unhandledrejection', function(e) {
-            if (e.reason && isResizeObserverError(e.reason.message)) {
-                e.preventDefault();
-            }
-        });
-    </script>
+    
 </head>
 <body>
 <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -101,6 +101,29 @@
             }
         }
     </style>
+    <script>
+        // Suppress benign ResizeObserver errors
+        // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
+        // These are benign errors that occur when ResizeObserver can't deliver all observations
+        // within a single animation frame, which is common with modern UI libraries.
+        window.addEventListener('error', function(e) {
+            if (e.message === 'ResizeObserver loop limit exceeded' || 
+                e.message === 'ResizeObserver loop completed with undelivered notifications.') {
+                e.stopImmediatePropagation();
+                return false;
+            }
+        });
+        
+        // Also handle unhandled promise rejections for ResizeObserver
+        window.addEventListener('unhandledrejection', function(e) {
+            if (e.reason && e.reason.message && 
+                (e.reason.message.includes('ResizeObserver loop limit exceeded') ||
+                    e.reason.message.includes('ResizeObserver loop completed with undelivered notifications'))) {
+                e.preventDefault();
+                return false;
+            }
+        });
+    </script>
 </head>
 <body>
 <noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -106,21 +106,23 @@
         // Source: https://github.com/radix-ui/primitives/issues/2313#issuecomment-1986338145
         // These are benign errors that occur when ResizeObserver can't deliver all observations
         // within a single animation frame, which is common with modern UI libraries.
+        function isResizeObserverError(message) {
+            return message && (
+                message.includes('ResizeObserver loop limit exceeded') ||
+                message.includes('ResizeObserver loop completed with undelivered notifications.')
+            );
+        }
+
         window.addEventListener('error', function(e) {
-            if (e.message === 'ResizeObserver loop limit exceeded' || 
-                e.message === 'ResizeObserver loop completed with undelivered notifications.') {
+            if (isResizeObserverError(e.message)) {
                 e.stopImmediatePropagation();
-                return false;
             }
         });
         
         // Also handle unhandled promise rejections for ResizeObserver
         window.addEventListener('unhandledrejection', function(e) {
-            if (e.reason && e.reason.message && 
-                (e.reason.message.includes('ResizeObserver loop limit exceeded') ||
-                    e.reason.message.includes('ResizeObserver loop completed with undelivered notifications'))) {
+            if (e.reason && isResizeObserverError(e.reason.message)) {
                 e.preventDefault();
-                return false;
             }
         });
     </script>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,28 @@ import {App} from "./App";
 
 import "./index.scss";
 
+// Stop error resizeObserver
+// From https://github.com/ReactTooltip/react-tooltip/issues/1104#issuecomment-2142860676
+const debounce = (callback: (...args: any[]) => void, delay: number) => {
+    let tid: any;
+    return function (...args: any[]) {
+        // eslint-disable-next-line no-restricted-globals
+        const ctx = self;
+        tid && clearTimeout(tid);
+        tid = setTimeout(() => {
+            callback.apply(ctx, args);
+        }, delay);
+    };
+};
+
+const _ = (window as any).ResizeObserver;
+(window as any).ResizeObserver = class ResizeObserver extends _ {
+    constructor(callback: (...args: any[]) => void) {
+        callback = debounce(callback, 20);
+        super(callback);
+    }
+};
+
 for (const val of [allMaps, linearPng, logPng, sqrtPng, squaredPng, gammaPng, powerPng]) {
     new Image().src = val;
 }


### PR DESCRIPTION
**Description**

Closes  #2597
Avoid ResizeObserver errors by applying a 20ms debounce to all ResizeObserver callbacks to prevent rapid firing.

Reference: https://github.com/ReactTooltip/react-tooltip/issues/1104#issuecomment-2142860676

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] protobuf version bumped / no protobuf version bumped needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)