### PR TITLE
Reduce distance offsets in the catalog queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Reduced offset between the coordinate from user input/center pixel and the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Reduced offset between the coordinate from user input/center pixel and the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
+* Increased the precision of the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 
 ## [5.0.3]
 

--- a/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
+++ b/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
@@ -249,7 +249,7 @@ export class CatalogQueryComponent extends React.Component {
         const configStore = CatalogOnlineQueryConfigStore.Instance;
         if (configStore.catalogDB === CatalogDatabase.SIMBAD) {
             // In Simbad, the coordinate system parameter is never interpreted. All coordinates MUST be expressed in the ICRS coordinate system
-            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS);
+            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, "10");
             const query = `SELECT Top ${configStore.maxObject} *, DISTANCE(POINT('ICRS', ${centerCoord.x},${centerCoord.y}), POINT('ICRS', ra, dec)) as dist FROM basic WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS',${centerCoord.x},${centerCoord.y},${configStore.radiusAsDeg}))=1 AND ra IS NOT NULL AND dec IS NOT NULL order by dist`;
             configStore.setQueryStatus(true);
             const dataSize = await CatalogApiService.Instance.appendSimbadCatalog(query);

--- a/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
+++ b/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
@@ -258,7 +258,7 @@ export class CatalogQueryComponent extends React.Component {
         } else if (configStore.catalogDB === CatalogDatabase.VIZIER) {
             configStore.setQueryStatus(true);
             configStore.resetVizier();
-            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5);
+            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, "10");
             const resources = await CatalogApiService.Instance.queryVizierTableName(centerCoord, configStore.searchRadius, configStore.radiusUnits, configStore.vizierKeyWords);
             configStore.setQueryStatus(false);
             configStore.setVizierQueryResult(resources);
@@ -269,7 +269,7 @@ export class CatalogQueryComponent extends React.Component {
     private loadVizierCatalogs = async () => {
         const configStore = CatalogOnlineQueryConfigStore.Instance;
         const sources = configStore.selectedVizierSource;
-        const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5);
+        const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, "10");
         configStore.setQueryStatus(true);
         const resources = await CatalogApiService.Instance.queryVizierSource(centerCoord, configStore.searchRadius, configStore.radiusUnits, configStore.maxObject, sources);
         CatalogApiService.Instance.appendVizierCatalog(resources);

--- a/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
+++ b/src/components/Dialogs/OnlineDataQueryDialog/CatalogOnlineQueryComponent.tsx
@@ -249,7 +249,7 @@ export class CatalogQueryComponent extends React.Component {
         const configStore = CatalogOnlineQueryConfigStore.Instance;
         if (configStore.catalogDB === CatalogDatabase.SIMBAD) {
             // In Simbad, the coordinate system parameter is never interpreted. All coordinates MUST be expressed in the ICRS coordinate system
-            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, "10");
+            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, CatalogOnlineQueryConfigStore.QUERY_DEG_PRECISION);
             const query = `SELECT Top ${configStore.maxObject} *, DISTANCE(POINT('ICRS', ${centerCoord.x},${centerCoord.y}), POINT('ICRS', ra, dec)) as dist FROM basic WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS',${centerCoord.x},${centerCoord.y},${configStore.radiusAsDeg}))=1 AND ra IS NOT NULL AND dec IS NOT NULL order by dist`;
             configStore.setQueryStatus(true);
             const dataSize = await CatalogApiService.Instance.appendSimbadCatalog(query);
@@ -258,7 +258,7 @@ export class CatalogQueryComponent extends React.Component {
         } else if (configStore.catalogDB === CatalogDatabase.VIZIER) {
             configStore.setQueryStatus(true);
             configStore.resetVizier();
-            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, "10");
+            const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, CatalogOnlineQueryConfigStore.QUERY_DEG_PRECISION);
             const resources = await CatalogApiService.Instance.queryVizierTableName(centerCoord, configStore.searchRadius, configStore.radiusUnits, configStore.vizierKeyWords);
             configStore.setQueryStatus(false);
             configStore.setVizierQueryResult(resources);
@@ -269,7 +269,7 @@ export class CatalogQueryComponent extends React.Component {
     private loadVizierCatalogs = async () => {
         const configStore = CatalogOnlineQueryConfigStore.Instance;
         const sources = configStore.selectedVizierSource;
-        const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, "10");
+        const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.FK5, CatalogOnlineQueryConfigStore.QUERY_DEG_PRECISION);
         configStore.setQueryStatus(true);
         const resources = await CatalogApiService.Instance.queryVizierSource(centerCoord, configStore.searchRadius, configStore.radiusUnits, configStore.maxObject, sources);
         CatalogApiService.Instance.appendVizierCatalog(resources);

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -244,7 +244,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
                 AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem},` + dirAxesSetting);
                 if (explicitSystem === SystemType.FK4) {
                     AST.set(frame.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
-                } else {
+                } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
                     AST.set(frame.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
                 }
             }

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -243,7 +243,7 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             const explicitSystem = this.props.overlaySettings.global.explicitSystem;
             if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined && OverlaySettings.Instance.isWcsCoordinates && frame.validWcs) {
                 AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY},` + dirAxesSetting);
-                setAstSystem(frame.wcsInfo, explicitSystem);
+                setAstSystem(frame.wcsInfo, explicitSystem, this.props.overlaySettings.global);
             }
         }
 

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -5,7 +5,8 @@ import * as _ from "lodash";
 import {observer} from "mobx-react";
 
 import {ImageItem, ImageType, SPECTRAL_TYPE_STRING} from "models";
-import {AppStore, OverlaySettings, OverlayStore, PreferenceStore, SystemType} from "stores";
+import {AppStore, OverlaySettings, OverlayStore, PreferenceStore} from "stores";
+import {setAstSystem} from "utilities";
 
 import "./OverlayComponent.scss";
 
@@ -241,12 +242,8 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             const formatStyingY = this.props.overlaySettings.numbers.formatStringY;
             const explicitSystem = this.props.overlaySettings.global.explicitSystem;
             if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined && OverlaySettings.Instance.isWcsCoordinates && frame.validWcs) {
-                AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem},` + dirAxesSetting);
-                if (explicitSystem === SystemType.FK4) {
-                    AST.set(frame.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
-                } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
-                    AST.set(frame.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
-                }
+                AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY},` + dirAxesSetting);
+                setAstSystem(frame.wcsInfo, explicitSystem);
             }
         }
 

--- a/src/components/ImageView/Overlay/OverlayComponent.tsx
+++ b/src/components/ImageView/Overlay/OverlayComponent.tsx
@@ -5,7 +5,7 @@ import * as _ from "lodash";
 import {observer} from "mobx-react";
 
 import {ImageItem, ImageType, SPECTRAL_TYPE_STRING} from "models";
-import {AppStore, OverlaySettings, OverlayStore, PreferenceStore} from "stores";
+import {AppStore, OverlaySettings, OverlayStore, PreferenceStore, SystemType} from "stores";
 
 import "./OverlayComponent.scss";
 
@@ -242,6 +242,11 @@ export class OverlayComponent extends React.Component<OverlayComponentProps> {
             const explicitSystem = this.props.overlaySettings.global.explicitSystem;
             if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined && OverlaySettings.Instance.isWcsCoordinates && frame.validWcs) {
                 AST.set(frame.wcsInfo, `Format(${frame.dirX})=${formatStringX}, Format(${frame.dirY})=${formatStyingY}, System=${explicitSystem},` + dirAxesSetting);
+                if (explicitSystem === SystemType.FK4) {
+                    AST.set(frame.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
+                } else {
+                    AST.set(frame.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
+                }
             }
         }
 

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -9,7 +9,7 @@ import {observer} from "mobx-react";
 
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, RegionSelectorComponent, ResizeDetector, SmoothingType, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {Point2D, POLARIZATIONS} from "models";
-import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, WidgetProps, WidgetsStore} from "stores";
+import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, SystemType, WidgetProps, WidgetsStore} from "stores";
 import {FrameStore} from "stores/Frame";
 import {RegionId, SpatialProfileWidgetStore} from "stores/Widgets";
 import {binarySearchByX, clamp, formattedExponential, getColorForTheme, toFixed, transformPoint} from "utilities";
@@ -384,7 +384,15 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
 
         let astString = new ASTSettingsString();
-        astString.add("System", AppStore.Instance.overlaySettings.global.explicitSystem);
+        const explicitSystem = AppStore.Instance.overlaySettings.global.explicitSystem;
+        astString.add("System", explicitSystem);
+        if (explicitSystem === SystemType.FK4) {
+            astString.add("Equinox", "B1950.0");
+            astString.add("Epoch", "B1950.0");
+        } else {
+            astString.add("Equinox", "J2000.0");
+            astString.add("Epoch", "J2000.0");
+        }
 
         if (this.widgetStore.isXProfile) {
             for (let i = 0; i < ticks.length; i++) {

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -384,7 +384,8 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
 
         let astString = new ASTSettingsString();
-        setAstStringSystem(astString, AppStore.Instance.overlaySettings.global.explicitSystem);
+        const global = AppStore.Instance.overlaySettings.global;
+        setAstStringSystem(astString, global.explicitSystem, global);
 
         if (this.widgetStore.isXProfile) {
             for (let i = 0; i < ticks.length; i++) {

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -389,7 +389,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         if (explicitSystem === SystemType.FK4) {
             astString.add("Equinox", "B1950.0");
             astString.add("Epoch", "B1950.0");
-        } else {
+        } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
             astString.add("Equinox", "J2000.0");
             astString.add("Epoch", "J2000.0");
         }

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -9,10 +9,10 @@ import {observer} from "mobx-react";
 
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, RegionSelectorComponent, ResizeDetector, SmoothingType, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {Point2D, POLARIZATIONS} from "models";
-import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, SystemType, WidgetProps, WidgetsStore} from "stores";
+import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, WidgetProps, WidgetsStore} from "stores";
 import {FrameStore} from "stores/Frame";
 import {RegionId, SpatialProfileWidgetStore} from "stores/Widgets";
-import {binarySearchByX, clamp, formattedExponential, getColorForTheme, toFixed, transformPoint} from "utilities";
+import {binarySearchByX, clamp, formattedExponential, getColorForTheme, setAstStringSystem,toFixed, transformPoint} from "utilities";
 
 import {MultiPlotProps, TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 
@@ -385,14 +385,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
 
         let astString = new ASTSettingsString();
         const explicitSystem = AppStore.Instance.overlaySettings.global.explicitSystem;
-        astString.add("System", explicitSystem);
-        if (explicitSystem === SystemType.FK4) {
-            astString.add("Equinox", "B1950.0");
-            astString.add("Epoch", "B1950.0");
-        } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
-            astString.add("Equinox", "J2000.0");
-            astString.add("Epoch", "J2000.0");
-        }
+        setAstStringSystem(astString, explicitSystem);
 
         if (this.widgetStore.isXProfile) {
             for (let i = 0; i < ticks.length; i++) {

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -9,10 +9,10 @@ import {observer} from "mobx-react";
 
 import {LinePlotComponent, LinePlotComponentProps, PlotType, ProfilerInfoComponent, RegionSelectorComponent, ResizeDetector, SmoothingType, VERTICAL_RANGE_PADDING} from "components/Shared";
 import {Point2D, POLARIZATIONS} from "models";
-import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, WidgetProps, WidgetsStore} from "stores";
+import {AppStore, DefaultWidgetConfig, HelpType, SpatialProfileStore, WidgetProps, WidgetsStore} from "stores";
 import {FrameStore} from "stores/Frame";
 import {RegionId, SpatialProfileWidgetStore} from "stores/Widgets";
-import {binarySearchByX, clamp, formattedExponential, getColorForTheme, setAstStringSystem, toFixed, transformPoint} from "utilities";
+import {ASTSettingsString, binarySearchByX, clamp, formattedExponential, getColorForTheme, setAstStringSystem, toFixed, transformPoint} from "utilities";
 
 import {MultiPlotProps, TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -12,7 +12,7 @@ import {Point2D, POLARIZATIONS} from "models";
 import {AppStore, ASTSettingsString, DefaultWidgetConfig, HelpType, SpatialProfileStore, WidgetProps, WidgetsStore} from "stores";
 import {FrameStore} from "stores/Frame";
 import {RegionId, SpatialProfileWidgetStore} from "stores/Widgets";
-import {binarySearchByX, clamp, formattedExponential, getColorForTheme, setAstStringSystem,toFixed, transformPoint} from "utilities";
+import {binarySearchByX, clamp, formattedExponential, getColorForTheme, setAstStringSystem, toFixed, transformPoint} from "utilities";
 
 import {MultiPlotProps, TickType} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
 

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -384,8 +384,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
 
         let astString = new ASTSettingsString();
-        const explicitSystem = AppStore.Instance.overlaySettings.global.explicitSystem;
-        setAstStringSystem(astString, explicitSystem);
+        setAstStringSystem(astString, AppStore.Instance.overlaySettings.global.explicitSystem);
 
         if (this.widgetStore.isXProfile) {
             for (let i = 0; i < ticks.length; i++) {

--- a/src/services/CatalogApiService.ts
+++ b/src/services/CatalogApiService.ts
@@ -187,7 +187,7 @@ export class CatalogApiService {
                 const headers = CatalogApiProcessing.ProcessSimbadMetaData(response.data?.metadata);
                 const columnData = CatalogApiProcessing.ProcessSimbadData(response.data?.data, headers);
                 const coosys: CARTA.ICoosys = {system: configStore.coordsType};
-                const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, "10");
+                const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, CatalogOnlineQueryConfigStore.QUERY_DEG_PRECISION);
                 const fileName = `${configStore.catalogDB}_${configStore.coordsType}_${centerCoord.x}_${centerCoord.y}_${configStore.searchRadius}${configStore.radiusUnits}`;
                 const catalogFileInfo: CARTA.ICatalogFileInfo = {
                     name: fileName,

--- a/src/services/CatalogApiService.ts
+++ b/src/services/CatalogApiService.ts
@@ -187,7 +187,7 @@ export class CatalogApiService {
                 const headers = CatalogApiProcessing.ProcessSimbadMetaData(response.data?.metadata);
                 const columnData = CatalogApiProcessing.ProcessSimbadData(response.data?.data, headers);
                 const coosys: CARTA.ICoosys = {system: configStore.coordsType};
-                const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS);
+                const centerCoord = configStore.convertToDeg(configStore.centerPixelCoordAsPoint2D, SystemType.ICRS, "10");
                 const fileName = `${configStore.catalogDB}_${configStore.coordsType}_${centerCoord.x}_${centerCoord.y}_${configStore.searchRadius}${configStore.radiusUnits}`;
                 const catalogFileInfo: CARTA.ICatalogFileInfo = {
                     name: fileName,

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -330,13 +330,9 @@ export class CatalogStore {
             let system = "System=" + catalogFrame;
             AST.set(wcsCopy, system);
             if (catalogFrame === CatalogSystemType.FK4) {
-                AST.set(wcsCopy, "Epoch=B1950");
-                AST.set(wcsCopy, "Equinox=1950");
-            }
-
-            if (catalogFrame === CatalogSystemType.FK5) {
-                AST.set(wcsCopy, "Epoch=J2000");
-                AST.set(wcsCopy, "Equinox=2000");
+                AST.set(wcsCopy, "Equinox=B1950.0, Epoch=B1950.0");
+            } else {
+                AST.set(wcsCopy, "Equinox=J2000.0, Epoch=J2000.0");
             }
 
             const xWCSValues = new Float64Array(N);

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -318,17 +318,18 @@ export class CatalogStore {
 
     private static TransformCatalogData(xWcsData: Array<number>, yWcsData: Array<number>, wcsInfo: AST.FrameSet, xUnit: string, yUnit: string, catalogFrame: CatalogSystemType): {xImageCoords: Float64Array; yImageCoords: Float64Array} {
         if (xWcsData?.length === yWcsData?.length && xWcsData?.length > 0) {
+            const overlay = AppStore.Instance.overlaySettings;
             const N = xWcsData.length;
 
             let xFraction = CatalogStore.GetFractionFromUnit(xUnit.toLocaleLowerCase());
             let yFraction = CatalogStore.GetFractionFromUnit(yUnit.toLocaleLowerCase());
 
             let wcsCopy = AST.copy(wcsInfo);
-            if (wcsCopy !== 0 && AppStore.Instance.overlaySettings.isImgCoordinates) {
+            if (wcsCopy !== 0 && overlay.isImgCoordinates) {
                 AST.setI(wcsCopy, "Current", 2);
             }
 
-            setAstSystem(wcsCopy, catalogFrame as any);
+            setAstSystem(wcsCopy, catalogFrame, overlay.global);
 
             const xWCSValues = new Float64Array(N);
             const yWCSValues = new Float64Array(N);

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -6,7 +6,7 @@ import {CatalogWebGLService} from "services";
 import {AppStore, CatalogOnlineQueryProfileStore, CatalogProfileStore, WidgetsStore} from "stores";
 import {FrameStore} from "stores/Frame";
 import {CatalogWidgetStore} from "stores/Widgets";
-import {minMaxArray} from "utilities";
+import {minMaxArray, setAstSystem} from "utilities";
 
 type CatalogOverlayCoords = {
     x: Float32Array;
@@ -327,13 +327,8 @@ export class CatalogStore {
             if (wcsCopy !== 0 && AppStore.Instance.overlaySettings.isImgCoordinates) {
                 AST.setI(wcsCopy, "Current", 2);
             }
-            let system = "System=" + catalogFrame;
-            AST.set(wcsCopy, system);
-            if (catalogFrame === CatalogSystemType.FK4) {
-                AST.set(wcsCopy, "Equinox=B1950.0, Epoch=B1950.0");
-            } else if (catalogFrame === CatalogSystemType.FK5 || catalogFrame === CatalogSystemType.Ecliptic || catalogFrame === CatalogSystemType.Galactic) {
-                AST.set(wcsCopy, "Equinox=J2000.0, Epoch=J2000.0");
-            }
+
+            setAstSystem(wcsCopy, catalogFrame as any);
 
             const xWCSValues = new Float64Array(N);
             const yWCSValues = new Float64Array(N);

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -331,7 +331,7 @@ export class CatalogStore {
             AST.set(wcsCopy, system);
             if (catalogFrame === CatalogSystemType.FK4) {
                 AST.set(wcsCopy, "Equinox=B1950.0, Epoch=B1950.0");
-            } else {
+            } else if (catalogFrame === CatalogSystemType.FK5 || catalogFrame === CatalogSystemType.Ecliptic || catalogFrame === CatalogSystemType.Galactic) {
                 AST.set(wcsCopy, "Equinox=J2000.0, Epoch=J2000.0");
             }
 

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -310,13 +310,13 @@ export class CatalogOnlineQueryConfigStore {
         return tables;
     }
 
-    convertToDeg(pixelCoords: Point2D, system?: SystemType): {x: string | undefined; y: string | undefined} {
+    convertToDeg(pixelCoords: Point2D, system?: SystemType, precision?: string): {x: string | undefined; y: string | undefined} {
         const frame = this.activeFrame;
         const overlay = AppStore.Instance.overlaySettings;
         let p: {x: string | undefined; y: string | undefined} = {x: undefined, y: undefined};
         if (frame && overlay) {
-            const precision = overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
-            const format = `${NumberFormatType.Degrees}.${precision}`;
+            const effectivePrecision = precision ? precision : overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
+            const format = `${NumberFormatType.Degrees}.${effectivePrecision}`;
             const wcsCopy = AST.copy(frame.wcsInfo);
             let astString = new ASTSettingsString();
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;
@@ -333,13 +333,13 @@ export class CatalogOnlineQueryConfigStore {
         return p;
     }
 
-    convertToPixel(coords: Point2D): {x: number | undefined; y: number | undefined} | null {
+    convertToPixel(coords: Point2D, precision?: string): {x: number | undefined; y: number | undefined} | null {
         const frame = this.activeFrame;
         const overlay = AppStore.Instance.overlaySettings;
         let p: {x: number | undefined; y: number | undefined} | null = {x: undefined, y: undefined};
         if (frame && overlay) {
-            const precision = overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
-            const format = `${NumberFormatType.Degrees}.${precision}`;
+            const effectivePrecision = precision ? precision : overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
+            const format = `${NumberFormatType.Degrees}.${effectivePrecision}`;
             const wcsCopy = AST.copy(frame.wcsInfo);
             if (frame.isXY || frame.isYX) {
                 AST.set(wcsCopy, `System=${SystemType.ICRS}`);

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -333,7 +333,11 @@ export class CatalogOnlineQueryConfigStore {
             let astString = new ASTSettingsString();
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;
             if (frame.isXY || frame.isYX) {
-                AST.set(wcsCopy, `System=${sys}`);
+                if (sys === SystemType.FK4) {
+                    AST.set(wcsCopy, `System=${sys} Equinox=B1950.0, Epoch=B1950.0`);
+                } else {
+                    AST.set(wcsCopy, `System=${sys} Equinox=J2000.0, Epoch=J2000.0`);
+                };
                 astString.add(`Format(${frame.dirX})`, format);
                 astString.add(`Format(${frame.dirY})`, format);
             }

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -334,9 +334,11 @@ export class CatalogOnlineQueryConfigStore {
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;
             if (frame.isXY || frame.isYX) {
                 if (sys === SystemType.FK4) {
-                    AST.set(wcsCopy, `System=${sys} Equinox=B1950.0, Epoch=B1950.0`);
+                    AST.set(wcsCopy, `System=${sys}, Equinox=B1950.0, Epoch=B1950.0`);
+                } else if (sys === SystemType.FK5 || sys === SystemType.Ecliptic || sys === SystemType.Galactic) {
+                    AST.set(wcsCopy, `System=${sys}, Equinox=J2000.0, Epoch=J2000.0`);
                 } else {
-                    AST.set(wcsCopy, `System=${sys} Equinox=J2000.0, Epoch=J2000.0`);
+                    AST.set(wcsCopy, `System=${sys}`);
                 }
                 astString.add(`Format(${frame.dirX})`, format);
                 astString.add(`Format(${frame.dirY})`, format);

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -19,6 +19,7 @@ export class CatalogOnlineQueryConfigStore {
     public static readonly MIN_OBJECTS = 1;
     public static readonly MAX_OBJECTS = 10000000;
     public static readonly OBJECT_SIZE = 1000;
+    public static readonly QUERY_DEG_PRECISION = "10";
 
     @observable isQuerying: boolean;
     @observable catalogDB: CatalogDatabase;

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -337,7 +337,7 @@ export class CatalogOnlineQueryConfigStore {
                     AST.set(wcsCopy, `System=${sys} Equinox=B1950.0, Epoch=B1950.0`);
                 } else {
                     AST.set(wcsCopy, `System=${sys} Equinox=J2000.0, Epoch=J2000.0`);
-                };
+                }
                 astString.add(`Format(${frame.dirX})`, format);
                 astString.add(`Format(${frame.dirY})`, format);
             }

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -317,7 +317,7 @@ export class CatalogOnlineQueryConfigStore {
 
     private getEffectivePrecision(precision?: string): string {
         if (precision && !this.isValidPrecisionString(precision)) {
-            console.warn(`Invalid precision string: ${precision}. Using default precision *.`);
+            console.warn(`Invalid precision string: ${precision}. Expected '*' or a non-negative integer. Using default precision *.`);
         }
         const overlay = AppStore.Instance.overlaySettings;
         const effectivePrecision = precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -320,8 +320,7 @@ export class CatalogOnlineQueryConfigStore {
             console.warn(`Invalid precision string: ${precision}. Expected '*' or a non-negative integer. Using default precision *.`);
         }
         const overlay = AppStore.Instance.overlaySettings;
-        const effectivePrecision = precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");
-        return this.isValidPrecisionString(effectivePrecision) ? effectivePrecision : "*";
+        return precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");
     }
 
     convertToDeg(pixelCoords: Point2D, system?: SystemType, precision?: string): {x: string | undefined; y: string | undefined} {

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -310,12 +310,17 @@ export class CatalogOnlineQueryConfigStore {
         return tables;
     }
 
+    private getEffectivePrecision(precision?: string): string {
+        const overlay = AppStore.Instance.overlaySettings;
+        return precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");
+    }
+
     convertToDeg(pixelCoords: Point2D, system?: SystemType, precision?: string): {x: string | undefined; y: string | undefined} {
         const frame = this.activeFrame;
         const overlay = AppStore.Instance.overlaySettings;
         let p: {x: string | undefined; y: string | undefined} = {x: undefined, y: undefined};
         if (frame && overlay) {
-            const effectivePrecision = precision ? precision : overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
+            const effectivePrecision = this.getEffectivePrecision(precision);
             const format = `${NumberFormatType.Degrees}.${effectivePrecision}`;
             const wcsCopy = AST.copy(frame.wcsInfo);
             let astString = new ASTSettingsString();
@@ -338,7 +343,7 @@ export class CatalogOnlineQueryConfigStore {
         const overlay = AppStore.Instance.overlaySettings;
         let p: {x: number | undefined; y: number | undefined} | null = {x: undefined, y: undefined};
         if (frame && overlay) {
-            const effectivePrecision = precision ? precision : overlay.numbers.customPrecision ? overlay.numbers.precision : "*";
+            const effectivePrecision = this.getEffectivePrecision(precision);
             const format = `${NumberFormatType.Degrees}.${effectivePrecision}`;
             const wcsCopy = AST.copy(frame.wcsInfo);
             if (frame.isXY || frame.isYX) {

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -4,7 +4,7 @@ import {action, computed, makeObservable, observable, reaction} from "mobx";
 import {CatalogSystemType, Point2D} from "models";
 import {CatalogDatabase} from "services";
 import {AppStore, ASTSettingsString, NumberFormatType, SystemType} from "stores";
-import {clamp, getPixelValueFromWCS, transformPoint, VizierResource} from "utilities";
+import {clamp, getPixelValueFromWCS, setAstSystem, transformPoint, VizierResource} from "utilities";
 
 export enum RadiusUnits {
     DEGREES = "deg",
@@ -333,13 +333,7 @@ export class CatalogOnlineQueryConfigStore {
             let astString = new ASTSettingsString();
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;
             if (frame.isXY || frame.isYX) {
-                if (sys === SystemType.FK4) {
-                    AST.set(wcsCopy, `System=${sys}, Equinox=B1950.0, Epoch=B1950.0`);
-                } else if (sys === SystemType.FK5 || sys === SystemType.Ecliptic || sys === SystemType.Galactic) {
-                    AST.set(wcsCopy, `System=${sys}, Equinox=J2000.0, Epoch=J2000.0`);
-                } else {
-                    AST.set(wcsCopy, `System=${sys}`);
-                }
+                setAstSystem(wcsCopy, sys);
                 astString.add(`Format(${frame.dirX})`, format);
                 astString.add(`Format(${frame.dirY})`, format);
             }

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -333,7 +333,7 @@ export class CatalogOnlineQueryConfigStore {
             let astString = new ASTSettingsString();
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;
             if (frame.isXY || frame.isYX) {
-                setAstSystem(wcsCopy, sys);
+                setAstSystem(wcsCopy, sys, overlay.global);
                 astString.add(`Format(${frame.dirX})`, format);
                 astString.add(`Format(${frame.dirY})`, format);
             }

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -311,9 +311,17 @@ export class CatalogOnlineQueryConfigStore {
         return tables;
     }
 
+    private isValidPrecisionString(precision: string): boolean {
+        return precision === "*" || /^[0-9]+$/.test(precision);
+    }
+
     private getEffectivePrecision(precision?: string): string {
+        if (precision && !this.isValidPrecisionString(precision)) {
+            console.warn(`Invalid precision string: ${precision}. Using default precision *.`);
+        }
         const overlay = AppStore.Instance.overlaySettings;
-        return precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");
+        const effectivePrecision = precision ?? (overlay.numbers.customPrecision ? overlay.numbers.precision.toString() : "*");
+        return this.isValidPrecisionString(effectivePrecision) ? effectivePrecision : "*";
     }
 
     convertToDeg(pixelCoords: Point2D, system?: SystemType, precision?: string): {x: string | undefined; y: string | undefined} {
@@ -321,8 +329,7 @@ export class CatalogOnlineQueryConfigStore {
         const overlay = AppStore.Instance.overlaySettings;
         let p: {x: string | undefined; y: string | undefined} = {x: undefined, y: undefined};
         if (frame && overlay) {
-            const effectivePrecision = this.getEffectivePrecision(precision);
-            const format = `${NumberFormatType.Degrees}.${effectivePrecision}`;
+            const format = `${NumberFormatType.Degrees}.${this.getEffectivePrecision(precision)}`;
             const wcsCopy = AST.copy(frame.wcsInfo);
             let astString = new ASTSettingsString();
             const sys = system ? system : overlay.global.explicitSystem ? overlay.global.explicitSystem : SystemType.ICRS;

--- a/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
+++ b/src/stores/CatalogOnlineQuery/CatalogOnlineQueryConfigStore.ts
@@ -3,8 +3,8 @@ import {action, computed, makeObservable, observable, reaction} from "mobx";
 
 import {CatalogSystemType, Point2D} from "models";
 import {CatalogDatabase} from "services";
-import {AppStore, ASTSettingsString, NumberFormatType, SystemType} from "stores";
-import {clamp, getPixelValueFromWCS, setAstSystem, transformPoint, VizierResource} from "utilities";
+import {AppStore, NumberFormatType, SystemType} from "stores";
+import {ASTSettingsString, clamp, getPixelValueFromWCS, setAstSystem, transformPoint, VizierResource} from "utilities";
 
 export enum RadiusUnits {
     DEGREES = "deg",

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1605,7 +1605,7 @@ export class FrameStore {
                     AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
                     if (explicitSystem === SystemType.FK4) {
                         AST.set(this.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
-                    } else {
+                    } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
                         AST.set(this.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
                     }
 
@@ -1614,7 +1614,7 @@ export class FrameStore {
                         AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
                         if (explicitSystem === SystemType.FK4) {
                             AST.set(this.wcsInfoShifted, "Equinox=B1950.0, Epoch=B1950.0");
-                        } else {
+                        } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
                             AST.set(this.wcsInfoShifted, "Equinox=J2000.0, Epoch=J2000.0");
                         }
                     }
@@ -2056,7 +2056,7 @@ export class FrameStore {
                 if (system === SystemType.FK4) {
                     astString.add("Equinox", "B1950.0");
                     astString.add("Epoch", "B1950.0");
-                } else {
+                } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
                     astString.add("Equinox", "J2000.0");
                     astString.add("Epoch", "J2000.0");
                 }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -37,20 +37,7 @@ import {
     ZoomPoint
 } from "models";
 import {BackendService, CatalogWebGLService, ContourWebGLService, TILE_SIZE, TileService} from "services";
-import {
-    AnimatorStore,
-    AppStore,
-    ASTSettingsString,
-    ChannelMapInnerOverlayStore,
-    ChannelMapOuterOverlayStore,
-    ImageViewOverlayStore,
-    INITIAL_LAYOUT_ITEM,
-    LogStore,
-    OverlayStore,
-    PreferenceStore,
-    PvPreviewOverlayStore,
-    SystemType
-} from "stores";
+import {AnimatorStore, AppStore, ChannelMapInnerOverlayStore, ChannelMapOuterOverlayStore, ImageViewOverlayStore, INITIAL_LAYOUT_ITEM, LogStore, OverlayStore, PreferenceStore, PvPreviewOverlayStore, SystemType} from "stores";
 import {
     CENTER_POINT_INDEX,
     ColorbarStore,
@@ -67,6 +54,7 @@ import {
 } from "stores/Frame";
 import {PvGeneratorWidgetStore, RegionId} from "stores/Widgets";
 import {
+    ASTSettingsString,
     clamp,
     formattedArcsec,
     formattedFrequency,

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -87,6 +87,8 @@ import {
     ProtobufProcessing,
     rotate2D,
     round2D,
+    setAstStringSystem,
+    setAstSystem,
     subtract2D,
     toFixed,
     transformPoint,
@@ -1602,21 +1604,13 @@ export class FrameStore {
                     }
                 } else {
                     AST.setI(this.wcsInfo, "Current", 2);
-                    AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
-                    if (explicitSystem === SystemType.FK4) {
-                        AST.set(this.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
-                    } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
-                        AST.set(this.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
-                    }
+                    AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}`);
+                    setAstSystem(this.wcsInfo, explicitSystem);
 
                     if (this.wcsInfoShifted) {
                         AST.setI(this.wcsInfoShifted, "Current", 2);
-                        AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
-                        if (explicitSystem === SystemType.FK4) {
-                            AST.set(this.wcsInfoShifted, "Equinox=B1950.0, Epoch=B1950.0");
-                        } else if (explicitSystem === SystemType.FK5 || explicitSystem === SystemType.Ecliptic || explicitSystem === SystemType.Galactic) {
-                            AST.set(this.wcsInfoShifted, "Equinox=J2000.0, Epoch=J2000.0");
-                        }
+                        AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}`);
+                        setAstSystem(this.wcsInfoShifted, explicitSystem);
                     }
                 }
             }
@@ -2049,17 +2043,10 @@ export class FrameStore {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
                 const explicitSystem = overlaySettings.global.explicitSystem;
-                const system = this.isPVImage || this.isUVImage || this.isSwappedZ ? "cartesian" : explicitSystem;
+                const system = this.isPVImage || this.isUVImage || this.isSwappedZ ? SystemType.Image : explicitSystem;
                 astString.add(`Format(${this.dirX})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringX(precisionX));
                 astString.add(`Format(${this.dirY})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringY(precisionY));
-                astString.add("System", system);
-                if (system === SystemType.FK4) {
-                    astString.add("Equinox", "B1950.0");
-                    astString.add("Epoch", "B1950.0");
-                } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
-                    astString.add("Equinox", "J2000.0");
-                    astString.add("Epoch", "J2000.0");
-                }
+                setAstStringSystem(astString, system);
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map(pos => AST.getFormattedCoordinates(this.wcsInfo, pos.x, pos.y, astString.toString(), true));
                 let [p, n1, n2] = formattedNeighbourhood;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1603,9 +1603,20 @@ export class FrameStore {
                 } else {
                     AST.setI(this.wcsInfo, "Current", 2);
                     AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
+                    if (explicitSystem === SystemType.FK4) {
+                        AST.set(this.wcsInfo, "Equinox=B1950.0, Epoch=B1950.0");
+                    } else {
+                        AST.set(this.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
+                    }
+                    
                     if (this.wcsInfoShifted) {
                         AST.setI(this.wcsInfoShifted, "Current", 2);
                         AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);
+                        if (explicitSystem === SystemType.FK4) {
+                            AST.set(this.wcsInfoShifted, "Equinox=B1950.0, Epoch=B1950.0");
+                        } else {
+                            AST.set(this.wcsInfoShifted, "Equinox=J2000.0, Epoch=J2000.0");
+                        }
                     }
                 }
             }
@@ -2037,9 +2048,18 @@ export class FrameStore {
             while (precisionX < FrameStore.CursorInfoMaxPrecision && precisionY < FrameStore.CursorInfoMaxPrecision) {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
+                const explicitSystem = overlaySettings.global.explicitSystem;
+                const system = this.isPVImage || this.isUVImage || this.isSwappedZ ? "cartesian" : explicitSystem;
                 astString.add(`Format(${this.dirX})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringX(precisionX));
                 astString.add(`Format(${this.dirY})`, this.isPVImage || this.isUVImage || this.isSwappedZ ? undefined : overlaySettings.numbers.cursorFormatStringY(precisionY));
-                astString.add("System", this.isPVImage || this.isUVImage || this.isSwappedZ ? "cartesian" : overlaySettings.global.explicitSystem);
+                astString.add("System", system);
+                if (system === SystemType.FK4) {
+                    astString.add("Equinox", "B1950.0");
+                    astString.add("Epoch", "B1950.0");
+                } else {
+                    astString.add("Equinox", "J2000.0");
+                    astString.add("Epoch", "J2000.0");
+                }
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map(pos => AST.getFormattedCoordinates(this.wcsInfo, pos.x, pos.y, astString.toString(), true));
                 let [p, n1, n2] = formattedNeighbourhood;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2031,10 +2031,9 @@ export class FrameStore {
             while (precisionX < FrameStore.CursorInfoMaxPrecision && precisionY < FrameStore.CursorInfoMaxPrecision) {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
-                const system = this.isNormalImage ? overlaySettings.global.explicitSystem : SystemType.Image;
                 astString.add(`Format(${this.dirX})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringX(precisionX) : undefined);
                 astString.add(`Format(${this.dirY})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringY(precisionY) : undefined);
-                setAstStringSystem(astString, system);
+                setAstStringSystem(astString, this.isNormalImage ? overlaySettings.global.explicitSystem : SystemType.Image);
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map(pos => AST.getFormattedCoordinates(this.wcsInfo, pos.x, pos.y, astString.toString(), true));
                 let [p, n1, n2] = formattedNeighbourhood;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1715,7 +1715,7 @@ export class FrameStore {
 
             const entryString = `${name}=  ${value}`;
 
-            const nameKey = name.trim().toUpperCase();
+            const nameKey = name?.trim().toUpperCase() ?? "";
             const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
             if (nameKey === "RADESYS" && valueKey === "FK4") {
                 system = SystemType.FK4;
@@ -1784,7 +1784,7 @@ export class FrameStore {
 
             const entryString = `${name}=  ${value}`;
 
-            const nameKey = name.trim().toUpperCase();
+            const nameKey = name?.trim().toUpperCase() ?? "";
             const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
             if (nameKey === "RADESYS" && valueKey === "FK4") {
                 system = SystemType.FK4;
@@ -1860,7 +1860,7 @@ export class FrameStore {
 
             const entryString = `${name}=  ${value}`;
 
-            const nameKey = name.trim().toUpperCase();
+            const nameKey = name?.trim().toUpperCase() ?? "";
             const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
             if (nameKey === "RADESYS" && valueKey === "FK4") {
                 system = SystemType.FK4;
@@ -1929,7 +1929,7 @@ export class FrameStore {
 
             const entryString = `${name}=  ${value}`;
 
-            const nameKey = name.trim().toUpperCase();
+            const nameKey = name?.trim().toUpperCase() ?? "";
             const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
             if (nameKey === "RADESYS" && valueKey === "FK4") {
                 system = SystemType.FK4;
@@ -2047,7 +2047,7 @@ export class FrameStore {
             while (precisionX < FrameStore.CursorInfoMaxPrecision && precisionY < FrameStore.CursorInfoMaxPrecision) {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
-                const system = this.isNormalImage ? overlaySettings.global.explicitSystem : SystemType.Image;
+                const system = this.isNormalImage ? (overlaySettings.global.explicitSystem ?? SystemType.Image) : SystemType.Image;
                 astString.add(`Format(${this.dirX})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringX(precisionX) : undefined);
                 astString.add(`Format(${this.dirY})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringY(precisionY) : undefined);
                 setAstStringSystem(astString, system, overlaySettings.global);
@@ -2177,7 +2177,7 @@ export class FrameStore {
             } else {
                 if ((this.spectralAxis && !this.spectralAxis.valid) || this.isSpectralPropsEqual) {
                     return this.channelInfo.getChannelIndexWCS(x);
-                } else {
+                } else if (this.spectralFrame && this.spectralType && this.spectralUnit && this.spectralSystem) {
                     // invert x in selected widget wcs to frame's default wcs
                     const tx = AST.transformSpectralPoint(this.spectralFrame, this.spectralType, this.spectralUnit, this.spectralSystem, x, false);
                     return this.channelInfo.getChannelIndexWCS(tx);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1608,7 +1608,7 @@ export class FrameStore {
                     } else {
                         AST.set(this.wcsInfo, "Equinox=J2000.0, Epoch=J2000.0");
                     }
-                    
+
                     if (this.wcsInfoShifted) {
                         AST.setI(this.wcsInfoShifted, "Current", 2);
                         AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}, System=${explicitSystem}`);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -136,6 +136,8 @@ export class FrameStore {
     public readonly wcsInfo3D: AST.FrameSet;
     public readonly validWcs: boolean;
     public readonly defaultWcsSystem: SystemType;
+    public readonly defaultWcsEquinox: string;
+    public readonly defaultWcsEpoch: string;
     @observable public frameInfo: FrameInfo;
     public readonly overlayStore: OverlayStore;
     public readonly channelMapOuterOverlayStore: ChannelMapOuterOverlayStore;
@@ -1377,7 +1379,11 @@ export class FrameStore {
                 const entries = this.frameInfo.fileInfoExtended.headerEntries;
                 const skySystem = entries.find(entry => entry.name.includes("RADESYS"))?.value;
                 if (Object.values(SystemType).includes(skySystem as SystemType)) {
-                    AppStore.Instance.overlaySettings.global.setDefaultSystem(skySystem as SystemType);
+                    const equinox = AST.getString(this.wcsInfo, "Equinox");
+                    const epoch = AST.getString(this.wcsInfo, "Epoch");
+                    overlaySettings.global.setDefaultSystem(skySystem as SystemType);
+                    overlaySettings.global.setDefaultEquinox(equinox);
+                    overlaySettings.global.setDefaultEpoch(epoch);
                     overlaySettings.global.setValidWcs(true);
                 }
 
@@ -1431,6 +1437,8 @@ export class FrameStore {
                     AST.set(this.wcsInfoForTransformation, `Format(${this.dirY})=${overlaySettings.numbers.formatTypeY}.${WCS_PRECISION}`);
                     this.validWcs = true;
                     this.defaultWcsSystem = AST.getString(this.wcsInfo, "System") as SystemType;
+                    this.defaultWcsEquinox = AST.getString(this.wcsInfo, "Equinox");
+                    this.defaultWcsEpoch = AST.getString(this.wcsInfo, "Epoch");
                     overlaySettings.setDefaultsFromFrame(this);
                 }
             }
@@ -1598,14 +1606,15 @@ export class FrameStore {
                         AST.setI(this.wcsInfoShifted, "Current", 3);
                     }
                 } else {
+                    const global = AppStore.Instance.overlaySettings.global;
                     AST.setI(this.wcsInfo, "Current", 2);
                     AST.set(this.wcsInfo, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}`);
-                    setAstSystem(this.wcsInfo, explicitSystem);
+                    setAstSystem(this.wcsInfo, explicitSystem, global);
 
                     if (this.wcsInfoShifted) {
                         AST.setI(this.wcsInfoShifted, "Current", 2);
                         AST.set(this.wcsInfoShifted, `Format(${this.dirX})=${formatStringX}, Format(${this.dirY})=${formatStyingY}`);
-                        setAstSystem(this.wcsInfoShifted, explicitSystem);
+                        setAstSystem(this.wcsInfoShifted, explicitSystem, global);
                     }
                 }
             }
@@ -1715,6 +1724,10 @@ export class FrameStore {
         const regStokesNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.stokesNumber}`);
 
         const fitsChan = AST.emptyFitsChan();
+
+        let system = "";
+        let epoch = "";
+
         for (let entry of this.frameInfo.fileInfoExtended.headerEntries) {
             let name = entry.name;
             if (name.match(regOtherAxes) || name.match(regStokesNumber) || name === "HISTORY") {
@@ -1744,7 +1757,24 @@ export class FrameStore {
             }
 
             const entryString = `${name}=  ${value}`;
+
+            const nameKey = name.trim().toUpperCase();
+            const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
+            if (nameKey === "RADESYS" && valueKey === "FK4") {
+                system = SystemType.FK4;
+            }
+            if (nameKey === "DATE-OBS") {
+                epoch = entryString;
+                continue;
+            }
+
             AST.putFits(fitsChan, entryString);
+        }
+
+        if (system === SystemType.FK4 && epoch) {
+            // Only add epoch if the native system is FK4.
+            // Otherwise, coordinate conversion will be incorrect.
+            AST.putFits(fitsChan, epoch);
         }
         return AST.getFrameFromFitsChan(fitsChan, false);
     };
@@ -1763,6 +1793,10 @@ export class FrameStore {
         const regStokesNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.stokesNumber}`);
 
         const fitsChan = AST.emptyFitsChan();
+
+        let system = "";
+        let epoch = "";
+
         for (let entry of this.frameInfo.fileInfoExtended.headerEntries) {
             let name = entry.name;
 
@@ -1792,7 +1826,24 @@ export class FrameStore {
             }
 
             const entryString = `${name}=  ${value}`;
+
+            const nameKey = name.trim().toUpperCase();
+            const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
+            if (nameKey === "RADESYS" && valueKey === "FK4") {
+                system = SystemType.FK4;
+            }
+            if (nameKey === "DATE-OBS") {
+                epoch = entryString;
+                continue;
+            }
+
             AST.putFits(fitsChan, entryString);
+        }
+
+        if (system === SystemType.FK4 && epoch) {
+            // Only add epoch if the native system is FK4.
+            // Otherwise, coordinate conversion will be incorrect.
+            AST.putFits(fitsChan, epoch);
         }
         return AST.getFrameFromFitsChan(fitsChan, false);
     };
@@ -1811,6 +1862,9 @@ export class FrameStore {
         const regDirYNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.dirYNumber}`);
         const regSpectralNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.spectralNumber}`);
         const regStokesNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.stokesNumber}`);
+
+        let system = "";
+        let epoch = "";
 
         for (let entry of this.frameInfo.fileInfoExtended.headerEntries) {
             let name = entry.name;
@@ -1848,7 +1902,24 @@ export class FrameStore {
             }
 
             const entryString = `${name}=  ${value}`;
+
+            const nameKey = name.trim().toUpperCase();
+            const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
+            if (nameKey === "RADESYS" && valueKey === "FK4") {
+                system = SystemType.FK4;
+            }
+            if (nameKey === "DATE-OBS") {
+                epoch = entryString;
+                continue;
+            }
+
             AST.putFits(fitsChan, entryString);
+        }
+
+        if (system === SystemType.FK4 && epoch) {
+            // Only add epoch if the native system is FK4.
+            // Otherwise, coordinate conversion will be incorrect.
+            AST.putFits(fitsChan, epoch);
         }
         return AST.getFrameFromFitsChan(fitsChan, checkSkyDomain);
     };
@@ -1860,6 +1931,9 @@ export class FrameStore {
         const regDirYNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.dirYNumber}`);
         const regSpectralNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.spectralNumber}`);
         const regStokesNumber = new RegExp(`(CTYPE|CDELT|CRPIX|CRVAL|CUNIT|NAXIS|CROTA)${this.stokesNumber}`);
+
+        let system = "";
+        let epoch = "";
 
         for (let entry of this.frameInfo.fileInfoExtended.headerEntries) {
             let name = entry.name;
@@ -1897,7 +1971,24 @@ export class FrameStore {
             }
 
             const entryString = `${name}=  ${value}`;
+
+            const nameKey = name.trim().toUpperCase();
+            const valueKey = value.replace(/^'+|'+$/g, "").toUpperCase();
+            if (nameKey === "RADESYS" && valueKey === "FK4") {
+                system = SystemType.FK4;
+            }
+            if (nameKey === "DATE-OBS") {
+                epoch = entryString;
+                continue;
+            }
+
             AST.putFits(fitsChan, entryString);
+        }
+
+        if (system === SystemType.FK4 && epoch) {
+            // Only add epoch if the native system is FK4.
+            // Otherwise, coordinate conversion will be incorrect.
+            AST.putFits(fitsChan, epoch);
         }
         return AST.getFrameFromFitsChan(fitsChan, false);
     };
@@ -2019,9 +2110,10 @@ export class FrameStore {
             while (precisionX < FrameStore.CursorInfoMaxPrecision && precisionY < FrameStore.CursorInfoMaxPrecision) {
                 let astString = new ASTSettingsString();
                 const overlaySettings = AppStore.Instance.overlaySettings;
+                const system = this.isNormalImage ? overlaySettings.global.explicitSystem : SystemType.Image;
                 astString.add(`Format(${this.dirX})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringX(precisionX) : undefined);
                 astString.add(`Format(${this.dirY})`, this.isNormalImage ? overlaySettings.numbers.cursorFormatStringY(precisionY) : undefined);
-                setAstStringSystem(astString, this.isNormalImage ? overlaySettings.global.explicitSystem : SystemType.Image);
+                setAstStringSystem(astString, system, overlaySettings.global);
 
                 let formattedNeighbourhood = normalizedNeighbourhood.map(pos => AST.getFormattedCoordinates(this.wcsInfo, pos.x, pos.y, astString.toString(), true));
                 let [p, n1, n2] = formattedNeighbourhood;

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -106,7 +106,7 @@ export class OverlayGlobalSettings {
             if (this.explicitSystem === SystemType.FK4) {
                 astString.add("Equinox", "B1950.0");
                 astString.add("Epoch", "B1950.0");
-            } else {
+            } else if (this.explicitSystem === SystemType.FK5 || this.explicitSystem === SystemType.Ecliptic || this.explicitSystem === SystemType.Galactic) {
                 astString.add("Equinox", "J2000.0");
                 astString.add("Epoch", "J2000.0");
             }
@@ -140,7 +140,7 @@ export class OverlayGlobalSettings {
             if (this.system === SystemType.FK4) {
                 astString.add("Equinox", "B1950.0");
                 astString.add("Epoch", "B1950.0");
-            } else {
+            } else if (this.system === SystemType.FK5 || this.system === SystemType.Ecliptic || this.system === SystemType.Galactic) {
                 astString.add("Equinox", "J2000.0");
                 astString.add("Epoch", "J2000.0");
             }
@@ -1066,7 +1066,7 @@ export class OverlaySettings {
                     AST.set(frame.wcsInfoForTransformation, `System=${this.global.explicitSystem}`);
                     if (this.global.explicitSystem === SystemType.FK4) {
                         AST.set(frame.wcsInfoForTransformation, "Equinox=B1950.0, Epoch=B1950.0");
-                    } else {
+                    } else if (this.global.explicitSystem === SystemType.FK5 || this.global.explicitSystem === SystemType.Ecliptic || this.global.explicitSystem === SystemType.Galactic) {
                         AST.set(frame.wcsInfoForTransformation, "Equinox=J2000.0, Epoch=J2000.0");
                     }
                 }

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -4,7 +4,7 @@ import {action, autorun, computed, makeObservable, observable} from "mobx";
 import {WCSType} from "models";
 import {AlertStore, AppStore, PreferenceStore, PvGeneratorWidgetStore} from "stores";
 import {FrameStore, OverlayBeamStore, WCS_PRECISION} from "stores/Frame";
-import {clamp, getColorForTheme, setAstStringSystem, setAstSystem, toFixed} from "utilities";
+import {ASTSettingsString, clamp, getColorForTheme, setAstStringSystem, setAstSystem, toFixed} from "utilities";
 
 const AST_DEFAULT_COLOR = "auto-blue";
 
@@ -57,31 +57,6 @@ export class Padding {
     right: number;
     top: number;
     bottom: number;
-}
-
-export class ASTSettingsString {
-    stringList: Array<string>;
-
-    constructor() {
-        this.stringList = [];
-    }
-
-    add(name: string, value: any, storeIf: boolean = true) {
-        if (value !== undefined && storeIf) {
-            let storedValue = typeof value === "boolean" ? (value ? 1 : 0) : value;
-            this.stringList.push(`${name}=${storedValue}`);
-        }
-    }
-
-    addSection(section: string) {
-        if (section !== undefined) {
-            this.stringList.push(section);
-        }
-    }
-
-    toString() {
-        return this.stringList.filter(str => str.length > 0).join(", ");
-    }
 }
 
 export class OverlayGlobalSettings {

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -4,7 +4,7 @@ import {action, autorun, computed, makeObservable, observable} from "mobx";
 import {WCSType} from "models";
 import {AlertStore, AppStore, PreferenceStore, PvGeneratorWidgetStore} from "stores";
 import {FrameStore, OverlayBeamStore, WCS_PRECISION} from "stores/Frame";
-import {clamp, getColorForTheme, toFixed} from "utilities";
+import {clamp, getColorForTheme, setAstStringSystem, setAstSystem, toFixed} from "utilities";
 
 const AST_DEFAULT_COLOR = "auto-blue";
 
@@ -102,14 +102,7 @@ export class OverlayGlobalSettings {
 
         const isWcsFrameAndSystem = typeof this.explicitSystem !== "undefined" && this.explicitSystem !== SystemType.Image && frame.validWcs;
         if (isWcsFrameAndSystem) {
-            astString.add("System", this.explicitSystem);
-            if (this.explicitSystem === SystemType.FK4) {
-                astString.add("Equinox", "B1950.0");
-                astString.add("Epoch", "B1950.0");
-            } else if (this.explicitSystem === SystemType.FK5 || this.explicitSystem === SystemType.Ecliptic || this.explicitSystem === SystemType.Galactic) {
-                astString.add("Equinox", "J2000.0");
-                astString.add("Epoch", "J2000.0");
-            }
+            setAstStringSystem(astString, this.explicitSystem);
         }
 
         if (!AppStore.Instance.overlaySettings.labels?.customText) {
@@ -137,13 +130,7 @@ export class OverlayGlobalSettings {
         }
 
         if ((frame?.isXY || frame?.isYX) && !frame?.isPVImage && isWcsFrameAndSystem) {
-            if (this.system === SystemType.FK4) {
-                astString.add("Equinox", "B1950.0");
-                astString.add("Epoch", "B1950.0");
-            } else if (this.system === SystemType.FK5 || this.system === SystemType.Ecliptic || this.system === SystemType.Galactic) {
-                astString.add("Equinox", "J2000.0");
-                astString.add("Epoch", "J2000.0");
-            }
+            setAstStringSystem(astString, this.explicitSystem, true);
         }
 
         return astString.toString();
@@ -1063,12 +1050,7 @@ export class OverlaySettings {
             this.setFormatsFromSystem();
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem && this.global.explicitSystem !== SystemType.Image) {
-                    AST.set(frame.wcsInfoForTransformation, `System=${this.global.explicitSystem}`);
-                    if (this.global.explicitSystem === SystemType.FK4) {
-                        AST.set(frame.wcsInfoForTransformation, "Equinox=B1950.0, Epoch=B1950.0");
-                    } else if (this.global.explicitSystem === SystemType.FK5 || this.global.explicitSystem === SystemType.Ecliptic || this.global.explicitSystem === SystemType.Galactic) {
-                        AST.set(frame.wcsInfoForTransformation, "Equinox=J2000.0, Epoch=J2000.0");
-                    }
+                    setAstSystem(frame.wcsInfoForTransformation, this.global.explicitSystem);
                 }
             });
         });

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -100,7 +100,7 @@ export class OverlayGlobalSettings {
         astString.add("Color", AstColorsIndex.GLOBAL);
         astString.add("Tol", toFixed(this.tolerance / 100, 2), this.tolerance >= 0.001); // convert to fraction
 
-        const isWcsFrameAndSystem = typeof this.explicitSystem !== "undefined" && this.explicitSystem !== SystemType.Image && frame.validWcs;
+        const isWcsFrameAndSystem = typeof this.explicitSystem !== "undefined" && this.explicitSystem !== SystemType.Image && frame?.validWcs;
         if (isWcsFrameAndSystem) {
             setAstStringSystem(astString, this.explicitSystem);
         }
@@ -127,10 +127,6 @@ export class OverlayGlobalSettings {
             const systemNameY = getSystemName(symbolY, isSysPixel, haveUnitY, this?.explicitSystem);
             astString.add("Label(1)", `"${labelX.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameX}"`, labelX !== undefined);
             astString.add("Label(2)", `"${labelY.replace(/%/g, "%%%%").replace(/"/g, "”")}${systemNameY}"`, labelY !== undefined);
-        }
-
-        if ((frame?.isXY || frame?.isYX) && !frame?.isPVImage && isWcsFrameAndSystem) {
-            setAstStringSystem(astString, this.explicitSystem, true);
         }
 
         return astString.toString();

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -67,6 +67,8 @@ export class OverlayGlobalSettings {
 
     // We need this so that we know what to do if it's set to native
     @observable defaultSystem: SystemType;
+    @observable defaultEquinox: string;
+    @observable defaultEpoch: string;
     @observable validWcs: boolean;
 
     public styleString(frame?: FrameStore) {
@@ -77,7 +79,7 @@ export class OverlayGlobalSettings {
 
         const isWcsFrameAndSystem = typeof this.explicitSystem !== "undefined" && this.explicitSystem !== SystemType.Image && frame?.validWcs;
         if (isWcsFrameAndSystem) {
-            setAstStringSystem(astString, this.explicitSystem);
+            setAstStringSystem(astString, this.explicitSystem, this);
         }
 
         if (!AppStore.Instance.overlaySettings.labels?.customText) {
@@ -159,6 +161,14 @@ export class OverlayGlobalSettings {
 
     @action setDefaultSystem(system: SystemType) {
         this.defaultSystem = system;
+    }
+
+    @action setDefaultEquinox(equinox: string) {
+        this.defaultEquinox = equinox;
+    }
+
+    @action setDefaultEpoch(epoch: string) {
+        this.defaultEpoch = epoch;
     }
 
     @action setValidWcs(validWcs: boolean) {
@@ -1021,7 +1031,7 @@ export class OverlaySettings {
             this.setFormatsFromSystem();
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem && this.global.explicitSystem !== SystemType.Image) {
-                    setAstSystem(frame.wcsInfoForTransformation, this.global.explicitSystem);
+                    setAstSystem(frame.wcsInfoForTransformation, this.global.explicitSystem, this.global);
                 }
             });
         });
@@ -1092,6 +1102,9 @@ export class OverlaySettings {
         this.numbers.setValidWcs(frame.validWcs);
 
         this.global.setDefaultSystem(frame.defaultWcsSystem);
+        this.global.setDefaultEquinox(frame.defaultWcsEquinox);
+        this.global.setDefaultEpoch(frame.defaultWcsEpoch);
+
         this.setFormatsFromSystem();
 
         if (this.global.system === SystemType.Auto) {

--- a/src/stores/OverlayStore/OverlayStore.ts
+++ b/src/stores/OverlayStore/OverlayStore.ts
@@ -103,6 +103,13 @@ export class OverlayGlobalSettings {
         const isWcsFrameAndSystem = typeof this.explicitSystem !== "undefined" && this.explicitSystem !== SystemType.Image && frame.validWcs;
         if (isWcsFrameAndSystem) {
             astString.add("System", this.explicitSystem);
+            if (this.explicitSystem === SystemType.FK4) {
+                astString.add("Equinox", "B1950.0");
+                astString.add("Epoch", "B1950.0");
+            } else {
+                astString.add("Equinox", "J2000.0");
+                astString.add("Epoch", "J2000.0");
+            }
         }
 
         if (!AppStore.Instance.overlaySettings.labels?.customText) {
@@ -131,9 +138,11 @@ export class OverlayGlobalSettings {
 
         if ((frame?.isXY || frame?.isYX) && !frame?.isPVImage && isWcsFrameAndSystem) {
             if (this.system === SystemType.FK4) {
-                astString.add("Equinox", "1950");
+                astString.add("Equinox", "B1950.0");
+                astString.add("Epoch", "B1950.0");
             } else {
-                astString.add("Equinox", "2000");
+                astString.add("Equinox", "J2000.0");
+                astString.add("Epoch", "J2000.0");
             }
         }
 
@@ -1055,6 +1064,11 @@ export class OverlaySettings {
             AppStore.Instance.frames.forEach(frame => {
                 if (frame?.validWcs && frame?.wcsInfoForTransformation && this.global.explicitSystem && this.global.explicitSystem !== SystemType.Image) {
                     AST.set(frame.wcsInfoForTransformation, `System=${this.global.explicitSystem}`);
+                    if (this.global.explicitSystem === SystemType.FK4) {
+                        AST.set(frame.wcsInfoForTransformation, "Equinox=B1950.0, Epoch=B1950.0");
+                    } else {
+                        AST.set(frame.wcsInfoForTransformation, "Equinox=J2000.0, Epoch=J2000.0");
+                    }
                 }
             });
         });

--- a/src/utilities/ast/ast.test.ts
+++ b/src/utilities/ast/ast.test.ts
@@ -1,8 +1,25 @@
 import * as AST from "ast_wrapper";
 
+import {CatalogSystemType} from "../../models";
 import {SystemType} from "../../stores";
 
 import {ASTSettingsString, setAstStringSystem, setAstSystem} from "./ast";
+
+const gs = (defaultSystem: SystemType, defaultEquinox: string, defaultEpoch: string) => ({
+    defaultSystem,
+    defaultEquinox,
+    defaultEpoch
+} as any);
+
+const astOut = (system: SystemType | CatalogSystemType, global: any, skipSystem: boolean = false) => {
+    const s = new ASTSettingsString();
+    setAstStringSystem(s, system, global, skipSystem);
+    return s.toString();
+};
+
+const defaultFK4 = gs(SystemType.FK4, "B1950.0", "B1953.2");
+const defaultFK5 = gs(SystemType.FK5, "J2012.0", "J2000.0");
+const defaultICRS = gs(SystemType.ICRS, "J2000.0", "J2000.0");
 
 jest.mock("ast_wrapper", () => ({
     __esModule: true,
@@ -10,6 +27,33 @@ jest.mock("ast_wrapper", () => ({
     setColor: jest.fn(),
     getString: jest.fn().mockReturnValue(""),
     fonts: []
+}));
+
+// Mock heavy modules to avoid initializing MobX decorators and React trees in tests.
+jest.mock("../../stores", () => ({
+    __esModule: true,
+    SystemType: {
+        Auto: "AUTO",
+        Ecliptic: "ECLIPTIC",
+        FK4: "FK4",
+        FK5: "FK5",
+        Galactic: "GALACTIC",
+        ICRS: "ICRS",
+        Image: "CARTESIAN"
+    }
+}));
+
+jest.mock("../../models", () => ({
+    __esModule: true,
+    CatalogSystemType: {
+        Ecliptic: "ECLIPTIC",
+        FK4: "FK4",
+        FK5: "FK5",
+        Galactic: "GALACTIC",
+        ICRS: "ICRS",
+        Pixel0: "Pixel0",
+        Pixel1: "Pixel1"
+    }
 }));
 
 describe("ASTSettingsString", () => {
@@ -43,28 +87,134 @@ describe("ASTSettingsString", () => {
 
         expect(astString.toString()).toBe("DrawTitle=1, Font(Title)=title_font, TextLab=1, Font(TextLab)=textlab_font");
     });
+
+    test("addSection(undefined) does nothing and toString remains unchanged", () => {
+        const astString = new ASTSettingsString();
+        astString.add("Size(NumLab)", 5);
+        astString.addSection(undefined as any);
+        expect(astString.toString()).toBe("Size(NumLab)=5");
+    });
+
+    test('addSection("") is omitted by toString filter', () => {
+        const astString = new ASTSettingsString();
+        astString.add("Size(NumLab)", 5);
+        astString.addSection("");
+        expect(astString.toString()).toBe("Size(NumLab)=5");
+    });
 });
 
 describe("setAstStringSystem", () => {
-    test("appends system with FK4 equinox and epoch", () => {
-        const astString = new ASTSettingsString();
-        setAstStringSystem(astString, SystemType.FK4);
+    test.each([
+        ["FK4 equinox and epoch", SystemType.FK4, "System=FK4, Equinox=B1950.0, Epoch=B1953.2"],
+        ["FK5 equinox and epoch", SystemType.FK5, "System=FK5, Equinox=J2000.0, Epoch=J2000.0"],
+        ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
+    ] as Array<[string, SystemType, string]>)
+    ("applies FK4 overlay defaults for %s", (_description, system, expected) => {
+        expect(astOut(system, defaultFK4)).toBe(expected);
+    });
 
-        expect(astString.toString()).toBe("System=FK4, Equinox=B1950.0, Epoch=B1950.0");
+    test.each([
+        ["FK4 equinox and epoch", SystemType.FK4, "System=FK4, Equinox=B1950.0, Epoch=B1950.0"],
+        ["FK5 equinox and epoch", SystemType.FK5, "System=FK5, Equinox=J2012.0, Epoch=J2000.0"],
+        ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
+    ] as Array<[string, SystemType, string]>)
+    ("applies FK5 overlay defaults for %s", (_description, system, expected) => {
+        expect(astOut(system, defaultFK5)).toBe(expected);
+    });
+
+    test.each([
+        ["FK4 equinox and epoch", SystemType.FK4, "System=FK4, Equinox=B1950.0, Epoch=B1950.0"],
+        ["FK5 equinox and epoch", SystemType.FK5, "System=FK5, Equinox=J2000.0, Epoch=J2000.0"],
+        ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
+    ] as Array<[string, SystemType, string]>)
+    ("applies ICRS overlay defaults and fallback for %s", (_description, system, expected) => {
+        expect(astOut(system, defaultICRS)).toBe(expected);
+    });
+
+    test.each([
+        [SystemType.FK4, "B1975.0", "B1975.0", "System=FK4, Equinox=B1975.0, Epoch=B1975.0"],
+        [SystemType.FK5, "J2015.5", "J2000.0", "System=FK5, Equinox=J2015.5, Epoch=J2000.0"],
+        [SystemType.ICRS, "J2000.0", "J2000.0", "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        [SystemType.Galactic, "J2000.0", "J2000.0", "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        [SystemType.Ecliptic, "J2020.0", "J2000.0", "System=ECLIPTIC, Equinox=J2020.0, Epoch=J2000.0"]
+    ] as Array<[SystemType, string, string, string]>)
+    ("uses overlay defaults when defaultSystem=%s and system matches default", (defaultSystem, defaultEquinox, defaultEpoch, expected) => {
+        const customGlobalSettings = gs(defaultSystem, defaultEquinox, defaultEpoch);
+        expect(astOut(defaultSystem, customGlobalSettings)).toBe(expected);
     });
 
     test("appends equinox and epoch without system when skipped", () => {
-        const astString = new ASTSettingsString();
-        setAstStringSystem(astString, SystemType.FK5, true);
-
-        expect(astString.toString()).toBe("Equinox=J2000.0, Epoch=J2000.0");
+        expect(astOut(SystemType.FK5, defaultFK5, true)).toBe("Equinox=J2012.0, Epoch=J2000.0");
     });
 
-    test("only adds system when no equinox or epoch applies", () => {
-        const astString = new ASTSettingsString();
-        setAstStringSystem(astString, SystemType.ICRS);
+    test("skips system but adds FK4 equinox/epoch when skipSystem is true", () => {
+        expect(astOut(SystemType.FK4, defaultFK5, true)).toBe("Equinox=B1950.0, Epoch=B1950.0");
+    });
 
-        expect(astString.toString()).toBe("System=ICRS");
+    test("uses overlay defaults when defaultSystem matches non-FK5 system", () => {
+        const customGlobalSettings = gs(SystemType.Galactic, "J2000.0", "J2000.0");
+        expect(astOut(SystemType.Galactic, customGlobalSettings)).toBe("System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("falls back to J2000 when defaultSystem is FK4 and system is non-FK4", () => {
+        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
+        expect(astOut(SystemType.ICRS, customGlobalSettings)).toBe("System=ICRS, Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("uses overlay defaults when defaultSystem is FK4 and system is FK4", () => {
+        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
+        expect(astOut(SystemType.FK4, customGlobalSettings)).toBe("System=FK4, Equinox=B1975.0, Epoch=B1975.0");
+    });
+
+    test("skipSystem=true uses overlay defaults for non-FK4 when defaultSystem is FK5", () => {
+        expect(astOut(SystemType.ICRS, defaultFK5, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("skipSystem=true uses overlay defaults when defaultSystem is FK5 and system is FK5", () => {
+        const customGlobalSettings = gs(SystemType.FK5, "J2015.5", "J2000.0");
+        expect(astOut(SystemType.FK5, customGlobalSettings, true)).toBe("Equinox=J2015.5, Epoch=J2000.0");
+    });
+
+    test("skipSystem=true uses overlay defaults when defaultSystem is Ecliptic and system is Ecliptic", () => {
+        const customGlobalSettings = gs(SystemType.Ecliptic, "J2020.0", "J2000.0");
+        expect(astOut(SystemType.Ecliptic, customGlobalSettings, true)).toBe("Equinox=J2020.0, Epoch=J2000.0");
+    });
+
+    test("skipSystem=true uses J2000/J2000 when defaultSystem is Galactic and system is Galactic", () => {
+        const customGlobalSettings = gs(SystemType.Galactic, "J2000.0", "J2000.0");
+        expect(astOut(SystemType.Galactic, customGlobalSettings, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("skipSystem=true uses J2000/J2000 when defaultSystem is ICRS and system is ICRS", () => {
+        const customGlobalSettings = gs(SystemType.ICRS, "J2000.0", "J2000.0");
+        expect(astOut(SystemType.ICRS, customGlobalSettings, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("skipSystem=true uses overlay defaults when defaultSystem is FK4 and system is FK4", () => {
+        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
+        expect(astOut(SystemType.FK4, customGlobalSettings, true)).toBe("Equinox=B1975.0, Epoch=B1975.0");
+    });
+
+    test("Image system adds only System and no equinox/epoch", () => {
+        expect(astOut(SystemType.Image, defaultFK5)).toBe("System=CARTESIAN");
+    });
+
+    test("Image system with skipSystem=true produces empty string", () => {
+        expect(astOut(SystemType.Image, defaultFK5, true)).toBe("");
+    });
+
+    test("Catalog Pixel0 adds only System and no equinox/epoch", () => {
+        expect(astOut(CatalogSystemType.Pixel0, defaultFK5)).toBe("System=Pixel0");
+    });
+
+    test("Catalog Pixel1 with skipSystem=true produces empty string", () => {
+        expect(astOut(CatalogSystemType.Pixel1, defaultFK5, true)).toBe("");
     });
 });
 
@@ -76,27 +226,40 @@ describe("setAstSystem", () => {
     });
 
     test("sets system and equinox/epoch on FrameSet", () => {
-        setAstSystem(frameSet, SystemType.Galactic);
-
-        const mockSet = AST.set as jest.Mock;
-        expect(mockSet).toHaveBeenCalledTimes(2);
-        expect(mockSet).toHaveBeenNthCalledWith(1, frameSet, "System=GALACTIC");
-        expect(mockSet).toHaveBeenNthCalledWith(2, frameSet, "Equinox=J2000.0, Epoch=J2000.0");
-    });
-
-    test("skips setting system when requested", () => {
-        setAstSystem(frameSet, SystemType.Ecliptic, true);
+        setAstSystem(frameSet, SystemType.Galactic, defaultFK5);
 
         const mockSet = AST.set as jest.Mock;
         expect(mockSet).toHaveBeenCalledTimes(1);
-        expect(mockSet).toHaveBeenCalledWith(frameSet, "Equinox=J2000.0, Epoch=J2000.0");
+        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(SystemType.Galactic, defaultFK5));
     });
 
-    test("does not add equinox or epoch when unavailable", () => {
-        setAstSystem(frameSet, SystemType.ICRS);
+    test("does not add equinox or epoch for Image", () => {
+        setAstSystem(frameSet, SystemType.Image, defaultFK5);
 
         const mockSet = AST.set as jest.Mock;
         expect(mockSet).toHaveBeenCalledTimes(1);
-        expect(mockSet).toHaveBeenCalledWith(frameSet, "System=ICRS");
+        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(SystemType.Image, defaultFK5));
+    });
+
+    test("skips setting FrameSet when Image skipSystem is true", () => {
+        setAstSystem(frameSet, SystemType.Image, defaultFK5, true);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).not.toHaveBeenCalled();
+    });
+
+    test("sets catalog pixel system without equinox or epoch", () => {
+        setAstSystem(frameSet, CatalogSystemType.Pixel0, defaultFK5);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).toHaveBeenCalledTimes(1);
+        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(CatalogSystemType.Pixel0, defaultFK5));
+    });
+
+    test("skips setting FrameSet when catalog pixel skipSystem is true", () => {
+        setAstSystem(frameSet, CatalogSystemType.Pixel1, defaultFK5, true);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).not.toHaveBeenCalled();
     });
 });

--- a/src/utilities/ast/ast.test.ts
+++ b/src/utilities/ast/ast.test.ts
@@ -1,0 +1,102 @@
+jest.mock("ast_wrapper", () => ({
+    __esModule: true,
+    set: jest.fn(),
+    setColor: jest.fn(),
+    getString: jest.fn().mockReturnValue(""),
+    fonts: []
+}));
+
+import * as AST from "ast_wrapper";
+
+import {SystemType} from "../../stores";
+
+import {ASTSettingsString, setAstStringSystem, setAstSystem} from "./ast";
+
+describe("ASTSettingsString", () => {
+    test("adds values and converts booleans to numeric flags", () => {
+        const astString = new ASTSettingsString();
+        astString.add("DrawTitle", true);
+        astString.add("NumLab", false);
+        astString.add("Size(NumLab)", 5);
+
+        expect(astString.toString()).toBe("DrawTitle=1, NumLab=0, Size(NumLab)=5");
+    });
+
+    test("skips undefined values and optional entries", () => {
+        const astString = new ASTSettingsString();
+        astString.add("ShouldSkip", undefined);
+        astString.add("DrawTitle", "title", false);
+        astString.add("TextGapType", "plot");
+
+        expect(astString.toString()).toBe("TextGapType=plot");
+    });
+
+    test("adds section entries and omits empty segments", () => {
+        const astSection = new ASTSettingsString();
+        astSection.add("DrawTitle", true);
+        astSection.add("Font(Title)", "title_font");
+
+        const astString = new ASTSettingsString();
+        astString.addSection(astSection.toString());
+        astString.add("TextLab", true);
+        astString.add("Font(TextLab)", "textlab_font");
+
+        expect(astString.toString()).toBe("DrawTitle=1, Font(Title)=title_font, TextLab=1, Font(TextLab)=textlab_font");
+    });
+});
+
+describe("setAstStringSystem", () => {
+    test("appends system with FK4 equinox and epoch", () => {
+        const astString = new ASTSettingsString();
+        setAstStringSystem(astString, SystemType.FK4);
+
+        expect(astString.toString()).toBe("System=FK4, Equinox=B1950.0, Epoch=B1950.0");
+    });
+
+    test("appends equinox and epoch without system when skipped", () => {
+        const astString = new ASTSettingsString();
+        setAstStringSystem(astString, SystemType.FK5, true);
+
+        expect(astString.toString()).toBe("Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("only adds system when no equinox or epoch applies", () => {
+        const astString = new ASTSettingsString();
+        setAstStringSystem(astString, SystemType.ICRS);
+
+        expect(astString.toString()).toBe("System=ICRS");
+    });
+});
+
+describe("setAstSystem", () => {
+    const frameSet = {} as AST.FrameSet;
+
+    beforeEach(() => {
+        (AST.set as jest.Mock).mockClear();
+    });
+
+    test("sets system and equinox/epoch on FrameSet", () => {
+        setAstSystem(frameSet, SystemType.Galactic);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).toHaveBeenCalledTimes(2);
+        expect(mockSet).toHaveBeenNthCalledWith(1, frameSet, "System=GALACTIC");
+        expect(mockSet).toHaveBeenNthCalledWith(2, frameSet, "Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("skips setting system when requested", () => {
+        setAstSystem(frameSet, SystemType.Ecliptic, true);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).toHaveBeenCalledTimes(1);
+        expect(mockSet).toHaveBeenCalledWith(frameSet, "Equinox=J2000.0, Epoch=J2000.0");
+    });
+
+    test("does not add equinox or epoch when unavailable", () => {
+        setAstSystem(frameSet, SystemType.ICRS);
+
+        const mockSet = AST.set as jest.Mock;
+        expect(mockSet).toHaveBeenCalledTimes(1);
+        expect(mockSet).toHaveBeenCalledWith(frameSet, "System=ICRS");
+    });
+});

--- a/src/utilities/ast/ast.test.ts
+++ b/src/utilities/ast/ast.test.ts
@@ -1,3 +1,9 @@
+import * as AST from "ast_wrapper";
+
+import {SystemType} from "../../stores";
+
+import {ASTSettingsString, setAstStringSystem, setAstSystem} from "./ast";
+
 jest.mock("ast_wrapper", () => ({
     __esModule: true,
     set: jest.fn(),
@@ -5,12 +11,6 @@ jest.mock("ast_wrapper", () => ({
     getString: jest.fn().mockReturnValue(""),
     fonts: []
 }));
-
-import * as AST from "ast_wrapper";
-
-import {SystemType} from "../../stores";
-
-import {ASTSettingsString, setAstStringSystem, setAstSystem} from "./ast";
 
 describe("ASTSettingsString", () => {
     test("adds values and converts booleans to numeric flags", () => {

--- a/src/utilities/ast/ast.test.ts
+++ b/src/utilities/ast/ast.test.ts
@@ -5,11 +5,12 @@ import {SystemType} from "../../stores";
 
 import {ASTSettingsString, setAstStringSystem, setAstSystem} from "./ast";
 
-const gs = (defaultSystem: SystemType, defaultEquinox: string, defaultEpoch: string) => ({
-    defaultSystem,
-    defaultEquinox,
-    defaultEpoch
-} as any);
+const gs = (defaultSystem: SystemType, defaultEquinox: string, defaultEpoch: string) =>
+    ({
+        defaultSystem,
+        defaultEquinox,
+        defaultEpoch
+    }) as any;
 
 const astOut = (system: SystemType | CatalogSystemType, global: any, skipSystem: boolean = false) => {
     const s = new ASTSettingsString();
@@ -110,8 +111,7 @@ describe("setAstStringSystem", () => {
         ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
         ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
         ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
-    ] as Array<[string, SystemType, string]>)
-    ("applies FK4 overlay defaults for %s", (_description, system, expected) => {
+    ] as Array<[string, SystemType, string]>)("applies FK4 overlay defaults for %s", (_description, system, expected) => {
         expect(astOut(system, defaultFK4)).toBe(expected);
     });
 
@@ -121,8 +121,7 @@ describe("setAstStringSystem", () => {
         ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
         ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
         ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
-    ] as Array<[string, SystemType, string]>)
-    ("applies FK5 overlay defaults for %s", (_description, system, expected) => {
+    ] as Array<[string, SystemType, string]>)("applies FK5 overlay defaults for %s", (_description, system, expected) => {
         expect(astOut(system, defaultFK5)).toBe(expected);
     });
 
@@ -132,8 +131,7 @@ describe("setAstStringSystem", () => {
         ["ICRS equinox and epoch", SystemType.ICRS, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
         ["Galactic equinox and epoch", SystemType.Galactic, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
         ["Ecliptic equinox and epoch", SystemType.Ecliptic, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
-    ] as Array<[string, SystemType, string]>)
-    ("applies ICRS overlay defaults and fallback for %s", (_description, system, expected) => {
+    ] as Array<[string, SystemType, string]>)("applies ICRS overlay defaults and fallback for %s", (_description, system, expected) => {
         expect(astOut(system, defaultICRS)).toBe(expected);
     });
 
@@ -143,8 +141,7 @@ describe("setAstStringSystem", () => {
         [SystemType.ICRS, "J2000.0", "J2000.0", "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
         [SystemType.Galactic, "J2000.0", "J2000.0", "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
         [SystemType.Ecliptic, "J2020.0", "J2000.0", "System=ECLIPTIC, Equinox=J2020.0, Epoch=J2000.0"]
-    ] as Array<[SystemType, string, string, string]>)
-    ("uses overlay defaults when defaultSystem=%s and system matches default", (defaultSystem, defaultEquinox, defaultEpoch, expected) => {
+    ] as Array<[SystemType, string, string, string]>)("uses overlay defaults when defaultSystem=%s and system matches default", (defaultSystem, defaultEquinox, defaultEpoch, expected) => {
         const customGlobalSettings = gs(defaultSystem, defaultEquinox, defaultEpoch);
         expect(astOut(defaultSystem, customGlobalSettings)).toBe(expected);
     });

--- a/src/utilities/ast/ast.test.ts
+++ b/src/utilities/ast/ast.test.ts
@@ -12,9 +12,9 @@ const gs = (defaultSystem: SystemType, defaultEquinox: string, defaultEpoch: str
         defaultEpoch
     }) as any;
 
-const astOut = (system: SystemType | CatalogSystemType, global: any, skipSystem: boolean = false) => {
+const astOut = (system: SystemType | CatalogSystemType, global: any) => {
     const s = new ASTSettingsString();
-    setAstStringSystem(s, system, global, skipSystem);
+    setAstStringSystem(s, system, global);
     return s.toString();
 };
 
@@ -146,72 +146,47 @@ describe("setAstStringSystem", () => {
         expect(astOut(defaultSystem, customGlobalSettings)).toBe(expected);
     });
 
-    test("appends equinox and epoch without system when skipped", () => {
-        expect(astOut(SystemType.FK5, defaultFK5, true)).toBe("Equinox=J2012.0, Epoch=J2000.0");
+    test.each([
+        ["Galactic matches defaultSystem", SystemType.Galactic, SystemType.Galactic, "J2000.0", "J2000.0", "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["ICRS with FK4 defaultSystem (fallback)", SystemType.ICRS, SystemType.FK4, "B1975.0", "B1975.0", "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        ["FK4 matches defaultSystem with custom values", SystemType.FK4, SystemType.FK4, "B1975.0", "B1975.0", "System=FK4, Equinox=B1975.0, Epoch=B1975.0"]
+    ] as Array<[string, SystemType, SystemType, string, string, string]>)("%s", (_desc, system, defaultSys, equinox, epoch, expected) => {
+        const customGlobalSettings = gs(defaultSys, equinox, epoch);
+        expect(astOut(system, customGlobalSettings)).toBe(expected);
     });
 
-    test("skips system but adds FK4 equinox/epoch when skipSystem is true", () => {
-        expect(astOut(SystemType.FK4, defaultFK5, true)).toBe("Equinox=B1950.0, Epoch=B1950.0");
+    test.each([
+        ["Image", SystemType.Image, "System=CARTESIAN"],
+        ["Catalog Pixel0", CatalogSystemType.Pixel0, "System=Pixel0"],
+        ["Catalog Pixel1", CatalogSystemType.Pixel1, "System=Pixel1"]
+    ] as Array<[string, SystemType | CatalogSystemType, string]>)("%s system adds only System and no equinox/epoch", (_desc, system, expected) => {
+        expect(astOut(system, defaultFK5)).toBe(expected);
     });
 
-    test("uses overlay defaults when defaultSystem matches non-FK5 system", () => {
-        const customGlobalSettings = gs(SystemType.Galactic, "J2000.0", "J2000.0");
-        expect(astOut(SystemType.Galactic, customGlobalSettings)).toBe("System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0");
+    test.each([
+        ["FK4", CatalogSystemType.FK4, defaultFK5, "System=FK4, Equinox=B1950.0, Epoch=B1950.0"],
+        ["FK5", CatalogSystemType.FK5, defaultFK4, "System=FK5, Equinox=J2000.0, Epoch=J2000.0"],
+        ["ICRS", CatalogSystemType.ICRS, defaultFK4, "System=ICRS, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Galactic", CatalogSystemType.Galactic, defaultFK5, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Ecliptic", CatalogSystemType.Ecliptic, defaultFK4, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"]
+    ] as Array<[string, CatalogSystemType, any, string]>)("Catalog %s system uses standard equinox and epoch", (_desc, system, globalSettings, expected) => {
+        expect(astOut(system, globalSettings)).toBe(expected);
     });
 
-    test("falls back to J2000 when defaultSystem is FK4 and system is non-FK4", () => {
-        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
-        expect(astOut(SystemType.ICRS, customGlobalSettings)).toBe("System=ICRS, Equinox=J2000.0, Epoch=J2000.0");
+    test.each([
+        ["Ecliptic", SystemType.Ecliptic, "J2025.0", "System=ECLIPTIC, Equinox=J2025.0, Epoch=J2000.0"],
+        ["FK5", SystemType.FK5, "J2030.0", "System=FK5, Equinox=J2030.0, Epoch=J2000.0"]
+    ] as Array<[string, SystemType, string, string]>)("%s uses custom equinox and standard epoch when it is the default system", (_desc, system, customEquinox, expected) => {
+        const customSettings = gs(system, customEquinox, "J2000.0");
+        expect(astOut(system, customSettings)).toBe(expected);
     });
 
-    test("uses overlay defaults when defaultSystem is FK4 and system is FK4", () => {
-        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
-        expect(astOut(SystemType.FK4, customGlobalSettings)).toBe("System=FK4, Equinox=B1975.0, Epoch=B1975.0");
-    });
-
-    test("skipSystem=true uses overlay defaults for non-FK4 when defaultSystem is FK5", () => {
-        expect(astOut(SystemType.ICRS, defaultFK5, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
-    });
-
-    test("skipSystem=true uses overlay defaults when defaultSystem is FK5 and system is FK5", () => {
-        const customGlobalSettings = gs(SystemType.FK5, "J2015.5", "J2000.0");
-        expect(astOut(SystemType.FK5, customGlobalSettings, true)).toBe("Equinox=J2015.5, Epoch=J2000.0");
-    });
-
-    test("skipSystem=true uses overlay defaults when defaultSystem is Ecliptic and system is Ecliptic", () => {
-        const customGlobalSettings = gs(SystemType.Ecliptic, "J2020.0", "J2000.0");
-        expect(astOut(SystemType.Ecliptic, customGlobalSettings, true)).toBe("Equinox=J2020.0, Epoch=J2000.0");
-    });
-
-    test("skipSystem=true uses J2000/J2000 when defaultSystem is Galactic and system is Galactic", () => {
-        const customGlobalSettings = gs(SystemType.Galactic, "J2000.0", "J2000.0");
-        expect(astOut(SystemType.Galactic, customGlobalSettings, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
-    });
-
-    test("skipSystem=true uses J2000/J2000 when defaultSystem is ICRS and system is ICRS", () => {
-        const customGlobalSettings = gs(SystemType.ICRS, "J2000.0", "J2000.0");
-        expect(astOut(SystemType.ICRS, customGlobalSettings, true)).toBe("Equinox=J2000.0, Epoch=J2000.0");
-    });
-
-    test("skipSystem=true uses overlay defaults when defaultSystem is FK4 and system is FK4", () => {
-        const customGlobalSettings = gs(SystemType.FK4, "B1975.0", "B1975.0");
-        expect(astOut(SystemType.FK4, customGlobalSettings, true)).toBe("Equinox=B1975.0, Epoch=B1975.0");
-    });
-
-    test("Image system adds only System and no equinox/epoch", () => {
-        expect(astOut(SystemType.Image, defaultFK5)).toBe("System=CARTESIAN");
-    });
-
-    test("Image system with skipSystem=true produces empty string", () => {
-        expect(astOut(SystemType.Image, defaultFK5, true)).toBe("");
-    });
-
-    test("Catalog Pixel0 adds only System and no equinox/epoch", () => {
-        expect(astOut(CatalogSystemType.Pixel0, defaultFK5)).toBe("System=Pixel0");
-    });
-
-    test("Catalog Pixel1 with skipSystem=true produces empty string", () => {
-        expect(astOut(CatalogSystemType.Pixel1, defaultFK5, true)).toBe("");
+    test.each([
+        ["Ecliptic", SystemType.Ecliptic, defaultFK4, "System=ECLIPTIC, Equinox=J2000.0, Epoch=J2000.0"],
+        ["FK5", SystemType.FK5, defaultFK4, "System=FK5, Equinox=J2000.0, Epoch=J2000.0"],
+        ["Galactic", SystemType.Galactic, defaultFK5, "System=GALACTIC, Equinox=J2000.0, Epoch=J2000.0"]
+    ] as Array<[string, SystemType, any, string]>)("%s system uses standard values when defaultSystem is different", (_desc, system, globalSettings, expected) => {
+        expect(astOut(system, globalSettings)).toBe(expected);
     });
 });
 
@@ -222,7 +197,7 @@ describe("setAstSystem", () => {
         (AST.set as jest.Mock).mockClear();
     });
 
-    test("sets system and equinox/epoch on FrameSet", () => {
+    test("calls AST.set with correct settings string for a standard system", () => {
         setAstSystem(frameSet, SystemType.Galactic, defaultFK5);
 
         const mockSet = AST.set as jest.Mock;
@@ -230,33 +205,19 @@ describe("setAstSystem", () => {
         expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(SystemType.Galactic, defaultFK5));
     });
 
-    test("does not add equinox or epoch for Image", () => {
+    test("calls AST.set for Image system", () => {
         setAstSystem(frameSet, SystemType.Image, defaultFK5);
 
         const mockSet = AST.set as jest.Mock;
         expect(mockSet).toHaveBeenCalledTimes(1);
-        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(SystemType.Image, defaultFK5));
+        expect(mockSet).toHaveBeenCalledWith(frameSet, "System=CARTESIAN");
     });
 
-    test("skips setting FrameSet when Image skipSystem is true", () => {
-        setAstSystem(frameSet, SystemType.Image, defaultFK5, true);
-
-        const mockSet = AST.set as jest.Mock;
-        expect(mockSet).not.toHaveBeenCalled();
-    });
-
-    test("sets catalog pixel system without equinox or epoch", () => {
-        setAstSystem(frameSet, CatalogSystemType.Pixel0, defaultFK5);
+    test("calls AST.set for catalog systems", () => {
+        setAstSystem(frameSet, CatalogSystemType.ICRS, defaultFK5);
 
         const mockSet = AST.set as jest.Mock;
         expect(mockSet).toHaveBeenCalledTimes(1);
-        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(CatalogSystemType.Pixel0, defaultFK5));
-    });
-
-    test("skips setting FrameSet when catalog pixel skipSystem is true", () => {
-        setAstSystem(frameSet, CatalogSystemType.Pixel1, defaultFK5, true);
-
-        const mockSet = AST.set as jest.Mock;
-        expect(mockSet).not.toHaveBeenCalled();
+        expect(mockSet).toHaveBeenCalledWith(frameSet, astOut(CatalogSystemType.ICRS, defaultFK5));
     });
 });

--- a/src/utilities/ast/ast.ts
+++ b/src/utilities/ast/ast.ts
@@ -1,0 +1,75 @@
+import * as AST from "ast_wrapper";
+
+import {SystemType} from "stores";
+
+export class ASTSettingsString {
+    stringList: Array<string>;
+
+    constructor() {
+        this.stringList = [];
+    }
+
+    add(name: string, value: any, storeIf: boolean = true) {
+        if (value !== undefined && storeIf) {
+            let storedValue = typeof value === "boolean" ? (value ? 1 : 0) : value;
+            this.stringList.push(`${name}=${storedValue}`);
+        }
+    }
+
+    addSection(section: string) {
+        if (section !== undefined) {
+            this.stringList.push(section);
+        }
+    }
+
+    toString() {
+        return this.stringList.filter(str => str.length > 0).join(", ");
+    }
+}
+
+/**
+ * Get the Equinox and Epoch values for a given coordinate system
+ * @param system - The coordinate system type
+ * @returns An object with equinox and epoch strings, or null if not applicable
+ */
+function getEquinoxEpochForSystem(system: SystemType): {equinox: string; epoch: string} | null {
+    if (system === SystemType.FK4) {
+        return {equinox: "B1950.0", epoch: "B1950.0"};
+    } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
+        return {equinox: "J2000.0", epoch: "J2000.0"};
+    }
+    return null;
+}
+
+/**
+ * Set the System on an AST settings string and add Equinox/Epoch for that system when applicable.
+ * @param astString - The AST settings string to update
+ * @param system - The coordinate system to set and to use for Equinox/Epoch values
+ * @param skipSystem - Whether to only add Equinox/Epoch values, skip adding the System to the AST settings string
+ */
+export function setAstStringSystem(astString: ASTSettingsString, system: SystemType, skipSystem: boolean = false): void {
+    if (!skipSystem) {
+        astString.add("System", system);
+    }
+    const values = getEquinoxEpochForSystem(system);
+    if (values) {
+        astString.add("Equinox", values.equinox);
+        astString.add("Epoch", values.epoch);
+    }
+}
+
+/**
+ * Set the System on an AST FrameSet and apply Equinox/Epoch for that system when applicable.
+ * @param astTransform - The AST FrameSet to configure
+ * @param system - The coordinate system to set and to use for Equinox/Epoch values
+ * @param skipSystem - Whether to only apply Equinox/Epoch values, skip setting the System
+ */
+export function setAstSystem(astTransform: AST.FrameSet, system: SystemType, skipSystem: boolean = false): void {
+    if (!skipSystem) {
+        AST.set(astTransform, `System=${system}`);
+    }
+    const values = getEquinoxEpochForSystem(system);
+    if (values) {
+        AST.set(astTransform, `Equinox=${values.equinox}, Epoch=${values.epoch}`);
+    }
+}

--- a/src/utilities/ast/ast.ts
+++ b/src/utilities/ast/ast.ts
@@ -52,8 +52,8 @@ function getEquinoxEpochForSystem(system: SystemType | CatalogSystemType): {equi
  * Set the `System` on an AST settings string and add `Equinox`/`Epoch` for that system when applicable.
  *
  * Behavior:
- * - For image/pixel systems (`Image`, `Pixel0`, `Pixel1`): only `System` may be added (unless `skipSystem`), and no `Equinox`/`Epoch` are appended.
- * - For other systems: `System` is added (unless `skipSystem`), and `Equinox`/`Epoch` are determined by the system and defaults.
+ * - For image/pixel systems (`Image`, `Pixel0`, `Pixel1`): only `System` is added, and no `Equinox`/`Epoch` are appended.
+ * - For other systems: `System` is added, and `Equinox`/`Epoch` are determined by the system and defaults.
  * - If `system` equals the `defaultSystem` in `overlayGlobalSettings`:
  *   - `FK4`: use `defaultEquinox` and `defaultEpoch` from `overlayGlobalSettings`.
  *   - `FK5`/`Ecliptic`: use `defaultEquinox` and the epoch from the standard values for the system.
@@ -63,22 +63,16 @@ function getEquinoxEpochForSystem(system: SystemType | CatalogSystemType): {equi
  * @param astString - The AST settings string to update
  * @param system - The coordinate system to set and to use for Equinox/Epoch values
  * @param overlayGlobalSettings - The overlay global settings containing defaults
- * @param skipSystem - Whether to only add Equinox/Epoch values and skip adding `System`
  */
-export function setAstStringSystem(astString: ASTSettingsString, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings, skipSystem: boolean = false): void {
+export function setAstStringSystem(astString: ASTSettingsString, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings): void {
     const global = overlayGlobalSettings;
     const defaultSystem = global.defaultSystem;
 
+    astString.add("System", system);
+
     // For Image (pixel) coordinates, do not add Equinox or Epoch
     if (system === SystemType.Image || system === CatalogSystemType.Pixel0 || system === CatalogSystemType.Pixel1) {
-        if (!skipSystem) {
-            astString.add("System", system);
-        }
         return;
-    }
-
-    if (!skipSystem) {
-        astString.add("System", system);
     }
 
     const values = getEquinoxEpochForSystem(system);
@@ -109,11 +103,10 @@ export function setAstStringSystem(astString: ASTSettingsString, system: SystemT
  * @param astTransform - The AST `FrameSet` to configure
  * @param system - The coordinate system to set and to use for Equinox/Epoch values
  * @param overlayGlobalSettings - The overlay global settings containing defaults
- * @param skipSystem - Whether to only apply Equinox/Epoch values and skip setting `System`
  */
-export function setAstSystem(astTransform: AST.FrameSet, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings, skipSystem: boolean = false): void {
+export function setAstSystem(astTransform: AST.FrameSet, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings): void {
     const astString = new ASTSettingsString();
-    setAstStringSystem(astString, system, overlayGlobalSettings, skipSystem);
+    setAstStringSystem(astString, system, overlayGlobalSettings);
     if (astString.toString().length > 0) {
         AST.set(astTransform, astString.toString());
     }

--- a/src/utilities/ast/ast.ts
+++ b/src/utilities/ast/ast.ts
@@ -1,6 +1,8 @@
 import * as AST from "ast_wrapper";
 
+import {CatalogSystemType} from "models";
 import {SystemType} from "stores";
+import {OverlayGlobalSettings} from "stores/OverlayStore/OverlayStore";
 
 export class ASTSettingsString {
     stringList: Array<string>;
@@ -28,48 +30,91 @@ export class ASTSettingsString {
 }
 
 /**
- * Get the Equinox and Epoch values for a given coordinate system
+ * Get the Equinox and Epoch values for a given coordinate system.
+ *
+ * - Returns `{equinox: "B1950.0", epoch: "B1950.0"}` for `FK4`.
+ * - Returns `{equinox: "J2000.0", epoch: "J2000.0"}` for non-image/pixel systems other than `FK4`.
+ * - Returns `null` for image/pixel systems (`Image`, `Pixel0`, `Pixel1`).
+ *
  * @param system - The coordinate system type
- * @returns An object with equinox and epoch strings, or null if not applicable
+ * @returns An object with equinox and epoch strings, or `null` when not applicable
  */
-function getEquinoxEpochForSystem(system: SystemType): {equinox: string; epoch: string} | null {
+function getEquinoxEpochForSystem(system: SystemType | CatalogSystemType): {equinox: string; epoch: string} | null {
     if (system === SystemType.FK4) {
         return {equinox: "B1950.0", epoch: "B1950.0"};
-    } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
+    } else if (system !== SystemType.Image && system !== CatalogSystemType.Pixel0 && system !== CatalogSystemType.Pixel1) {
         return {equinox: "J2000.0", epoch: "J2000.0"};
     }
     return null;
 }
 
 /**
- * Set the System on an AST settings string and add Equinox/Epoch for that system when applicable.
+ * Set the `System` on an AST settings string and add `Equinox`/`Epoch` for that system when applicable.
+ *
+ * Behavior:
+ * - For image/pixel systems (`Image`, `Pixel0`, `Pixel1`): only `System` may be added (unless `skipSystem`), and no `Equinox`/`Epoch` are appended.
+ * - For other systems: `System` is added (unless `skipSystem`), and `Equinox`/`Epoch` are determined by the system and defaults.
+ * - If `system` equals the `defaultSystem` in `overlayGlobalSettings`:
+ *   - `FK4`: use `defaultEquinox` and `defaultEpoch` from `overlayGlobalSettings`.
+ *   - `FK5`/`Ecliptic`: use `defaultEquinox` and the epoch from the standard values for the system.
+ *   - Others: use the standard values returned by `getEquinoxEpochForSystem`.
+ * - If `system` differs from `defaultSystem`: always use the standard values returned by `getEquinoxEpochForSystem`.
+ *
  * @param astString - The AST settings string to update
  * @param system - The coordinate system to set and to use for Equinox/Epoch values
- * @param skipSystem - Whether to only add Equinox/Epoch values, skip adding the System to the AST settings string
+ * @param overlayGlobalSettings - The overlay global settings containing defaults
+ * @param skipSystem - Whether to only add Equinox/Epoch values and skip adding `System`
  */
-export function setAstStringSystem(astString: ASTSettingsString, system: SystemType, skipSystem: boolean = false): void {
+export function setAstStringSystem(astString: ASTSettingsString, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings, skipSystem: boolean = false): void {
+    const global = overlayGlobalSettings;
+    const defaultSystem = global.defaultSystem;
+
+    // For Image (pixel) coordinates, do not add Equinox or Epoch
+    if (system === SystemType.Image || system === CatalogSystemType.Pixel0 || system === CatalogSystemType.Pixel1) {
+        if (!skipSystem) {
+            astString.add("System", system);
+        }
+        return;
+    }
+
     if (!skipSystem) {
         astString.add("System", system);
     }
+
     const values = getEquinoxEpochForSystem(system);
-    if (values) {
-        astString.add("Equinox", values.equinox);
-        astString.add("Epoch", values.epoch);
+
+    if (system === defaultSystem) {
+        if (system === SystemType.FK4) {
+            astString.add("Equinox", global.defaultEquinox);
+            astString.add("Epoch", global.defaultEpoch);
+        } else if (system === SystemType.FK5 || system === SystemType.Ecliptic) {
+            astString.add("Equinox", global.defaultEquinox);
+            astString.add("Epoch", values?.epoch);
+        } else {
+            astString.add("Equinox", values?.equinox);
+            astString.add("Epoch", values?.epoch);
+        }
+    } else {
+        astString.add("Equinox", values?.equinox);
+        astString.add("Epoch", values?.epoch);
     }
 }
 
 /**
- * Set the System on an AST FrameSet and apply Equinox/Epoch for that system when applicable.
- * @param astTransform - The AST FrameSet to configure
+ * Set the `System` on an AST `FrameSet` and apply `Equinox`/`Epoch` for that system when applicable.
+ *
+ * Builds an internal settings string via `setAstStringSystem` and calls `AST.set` on
+ * the provided `FrameSet` only if the settings string is non-empty.
+ *
+ * @param astTransform - The AST `FrameSet` to configure
  * @param system - The coordinate system to set and to use for Equinox/Epoch values
- * @param skipSystem - Whether to only apply Equinox/Epoch values, skip setting the System
+ * @param overlayGlobalSettings - The overlay global settings containing defaults
+ * @param skipSystem - Whether to only apply Equinox/Epoch values and skip setting `System`
  */
-export function setAstSystem(astTransform: AST.FrameSet, system: SystemType, skipSystem: boolean = false): void {
-    if (!skipSystem) {
-        AST.set(astTransform, `System=${system}`);
-    }
-    const values = getEquinoxEpochForSystem(system);
-    if (values) {
-        AST.set(astTransform, `Equinox=${values.equinox}, Epoch=${values.epoch}`);
+export function setAstSystem(astTransform: AST.FrameSet, system: SystemType | CatalogSystemType, overlayGlobalSettings: OverlayGlobalSettings, skipSystem: boolean = false): void {
+    const astString = new ASTSettingsString();
+    setAstStringSystem(astString, system, overlayGlobalSettings, skipSystem);
+    if (astString.toString().length > 0) {
+        AST.set(astTransform, astString.toString());
     }
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,5 @@
 export * from "./array/array";
+export * from "./ast/ast";
 export * from "./CatalogApiProcessed/CatalogApiProcessed";
 export * from "./color/color";
 export * from "./export/export";

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -98,7 +98,7 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
         }
 
         const currentSystem = AST.getString(astTransform, "System");
-        setAstSystem(astTransform, currentSystem as SystemType, true);
+        setAstSystem(astTransform, currentSystem as SystemType, OverlaySettings.Instance.global, true);
 
         const pointWCS = transformPoint(astTransform, pixelCoords);
         const normVals = AST.normalizeCoordinates(astTransform, pointWCS.x, pointWCS.y);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -86,7 +86,7 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
         const currentSystem = AST.getString(astTransform, "System");
         if (currentSystem === SystemType.FK4) {
             AST.set(astTransform, "Equinox=B1950.0, Epoch=B1950.0");
-        } else {
+        } else if (currentSystem === SystemType.FK5 || currentSystem === SystemType.Ecliptic || currentSystem === SystemType.Galactic) {
             AST.set(astTransform, "Equinox=J2000.0, Epoch=J2000.0");
         }
 

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -1,7 +1,7 @@
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
-import {Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
+import {CatalogSystemType, Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
 import {NumberFormatType, OverlaySettings, SystemType} from "stores";
 import {FrameStore} from "stores/Frame";
 import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, setAstSystem, subtract2D, trimFitsComment} from "utilities";
@@ -98,7 +98,12 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
         }
 
         const currentSystem = AST.getString(astTransform, "System");
-        setAstSystem(astTransform, currentSystem as SystemType, OverlaySettings.Instance.global, true);
+        const validSystemTypes = [...Object.values(SystemType), ...Object.values(CatalogSystemType)];
+        if (validSystemTypes.includes(currentSystem as SystemType | CatalogSystemType)) {
+            setAstSystem(astTransform, currentSystem as SystemType | CatalogSystemType, OverlaySettings.Instance.global, true);
+        } else {
+            console.warn(`Unknown system type from AST: ${currentSystem}, skipping system configuration`);
+        }
 
         const pointWCS = transformPoint(astTransform, pixelCoords);
         const normVals = AST.normalizeCoordinates(astTransform, pointWCS.x, pointWCS.y);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -2,56 +2,9 @@ import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
 import {Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
-import {ASTSettingsString, NumberFormatType, OverlaySettings, SystemType} from "stores";
+import {NumberFormatType, OverlaySettings, SystemType} from "stores";
 import {FrameStore} from "stores/Frame";
-import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, subtract2D, trimFitsComment} from "utilities";
-
-/**
- * Get the Equinox and Epoch values for a given coordinate system
- * @param system - The coordinate system type
- * @returns An object with equinox and epoch strings, or null if not applicable
- */
-export function getEquinoxEpochForSystem(system: SystemType): {equinox: string; epoch: string} | null {
-    if (system === SystemType.FK4) {
-        return {equinox: "B1950.0", epoch: "B1950.0"};
-    } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
-        return {equinox: "J2000.0", epoch: "J2000.0"};
-    }
-    return null;
-}
-
-/**
- * Set the System on an AST settings string and add Equinox/Epoch for that system when applicable.
- * @param astString - The AST settings string to update
- * @param system - The coordinate system to set and to use for Equinox/Epoch values
- * @param skipSystem - Whether to only add Equinox/Epoch values, skip adding the System to the AST settings string
- */
-export function setAstStringSystem(astString: ASTSettingsString, system: SystemType, skipSystem: boolean = false): void {
-    if (!skipSystem) {
-        astString.add("System", system);
-    }
-    const values = getEquinoxEpochForSystem(system);
-    if (values) {
-        astString.add("Equinox", values.equinox);
-        astString.add("Epoch", values.epoch);
-    }
-}
-
-/**
- * Set the System on an AST FrameSet and apply Equinox/Epoch for that system when applicable.
- * @param astTransform - The AST FrameSet to configure
- * @param system - The coordinate system to set and to use for Equinox/Epoch values
- * @param skipSystem - Whether to only apply Equinox/Epoch values, skip setting the System
- */
-export function setAstSystem(astTransform: AST.FrameSet, system: SystemType, skipSystem: boolean = false): void {
-    if (!skipSystem) {
-        AST.set(astTransform, `System=${system}`);
-    }
-    const values = getEquinoxEpochForSystem(system);
-    if (values) {
-        AST.set(astTransform, `Equinox=${values.equinox}, Epoch=${values.epoch}`);
-    }
-}
+import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, setAstSystem, subtract2D, trimFitsComment} from "utilities";
 
 export function isWCSStringFormatValid(wcsString: string, format: NumberFormatType | undefined): boolean {
     if (!wcsString || !format) {

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -2,9 +2,56 @@ import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
 import {Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
-import {NumberFormatType, OverlaySettings, SystemType} from "stores";
+import {ASTSettingsString, NumberFormatType, OverlaySettings, SystemType} from "stores";
 import {FrameStore} from "stores/Frame";
 import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, subtract2D, trimFitsComment} from "utilities";
+
+/**
+ * Get the Equinox and Epoch values for a given coordinate system
+ * @param system - The coordinate system type
+ * @returns An object with equinox and epoch strings, or null if not applicable
+ */
+export function getEquinoxEpochForSystem(system: SystemType): {equinox: string; epoch: string} | null {
+    if (system === SystemType.FK4) {
+        return {equinox: "B1950.0", epoch: "B1950.0"};
+    } else if (system === SystemType.FK5 || system === SystemType.Ecliptic || system === SystemType.Galactic) {
+        return {equinox: "J2000.0", epoch: "J2000.0"};
+    }
+    return null;
+}
+
+/**
+ * Set the System on an AST settings string and add Equinox/Epoch for that system when applicable.
+ * @param astString - The AST settings string to update
+ * @param system - The coordinate system to set and to use for Equinox/Epoch values
+ * @param skipSystem - Whether to only add Equinox/Epoch values, skip adding the System to the AST settings string
+ */
+export function setAstStringSystem(astString: ASTSettingsString, system: SystemType, skipSystem: boolean = false): void {
+    if (!skipSystem) {
+        astString.add("System", system);
+    }
+    const values = getEquinoxEpochForSystem(system);
+    if (values) {
+        astString.add("Equinox", values.equinox);
+        astString.add("Epoch", values.epoch);
+    }
+}
+
+/**
+ * Set the System on an AST FrameSet and apply Equinox/Epoch for that system when applicable.
+ * @param astTransform - The AST FrameSet to configure
+ * @param system - The coordinate system to set and to use for Equinox/Epoch values
+ * @param skipSystem - Whether to only apply Equinox/Epoch values, skip setting the System
+ */
+export function setAstSystem(astTransform: AST.FrameSet, system: SystemType, skipSystem: boolean = false): void {
+    if (!skipSystem) {
+        AST.set(astTransform, `System=${system}`);
+    }
+    const values = getEquinoxEpochForSystem(system);
+    if (values) {
+        AST.set(astTransform, `Equinox=${values.equinox}, Epoch=${values.epoch}`);
+    }
+}
 
 export function isWCSStringFormatValid(wcsString: string, format: NumberFormatType | undefined): boolean {
     if (!wcsString || !format) {
@@ -84,11 +131,7 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
 
         // Handle epoch and equinox setting based on coordinate system
         const currentSystem = AST.getString(astTransform, "System");
-        if (currentSystem === SystemType.FK4) {
-            AST.set(astTransform, "Equinox=B1950.0, Epoch=B1950.0");
-        } else if (currentSystem === SystemType.FK5 || currentSystem === SystemType.Ecliptic || currentSystem === SystemType.Galactic) {
-            AST.set(astTransform, "Equinox=J2000.0, Epoch=J2000.0");
-        }
+        setAstSystem(astTransform, currentSystem as SystemType, true);
 
         const pointWCS = transformPoint(astTransform, pixelCoords);
         const normVals = AST.normalizeCoordinates(astTransform, pointWCS.x, pointWCS.y);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -1,10 +1,10 @@
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
-import {CatalogSystemType, Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
-import {NumberFormatType, OverlaySettings, SystemType} from "stores";
+import {Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
+import {NumberFormatType, OverlaySettings} from "stores";
 import {FrameStore} from "stores/Frame";
-import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, setAstSystem, subtract2D, trimFitsComment} from "utilities";
+import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, subtract2D, trimFitsComment} from "utilities";
 
 export function isWCSStringFormatValid(wcsString: string, format: NumberFormatType | undefined): boolean {
     if (!wcsString || !format) {
@@ -95,15 +95,6 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
         if (OverlaySettings.Instance.isImgCoordinates) {
             // need second frame(WCS frame) in the frame to get WCS point
             AST.setI(astTransform, "Current", 2);
-        }
-
-        const currentSystem = AST.getString(astTransform, "System") as SystemType | CatalogSystemType;
-        const validSystemTypes = [...Object.values(SystemType), ...Object.values(CatalogSystemType)];
-        if (validSystemTypes.includes(currentSystem)) {
-            setAstSystem(astTransform, currentSystem, OverlaySettings.Instance.global, true);
-        } else {
-            console.warn(`Unknown system type from AST: ${currentSystem}, skipping system configuration`);
-            return null;
         }
 
         const pointWCS = transformPoint(astTransform, pixelCoords);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -97,12 +97,13 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
             AST.setI(astTransform, "Current", 2);
         }
 
-        const currentSystem = AST.getString(astTransform, "System");
+        const currentSystem = AST.getString(astTransform, "System") as SystemType | CatalogSystemType;
         const validSystemTypes = [...Object.values(SystemType), ...Object.values(CatalogSystemType)];
-        if (validSystemTypes.includes(currentSystem as SystemType | CatalogSystemType)) {
-            setAstSystem(astTransform, currentSystem as SystemType | CatalogSystemType, OverlaySettings.Instance.global, true);
+        if (validSystemTypes.includes(currentSystem)) {
+            setAstSystem(astTransform, currentSystem, OverlaySettings.Instance.global, true);
         } else {
             console.warn(`Unknown system type from AST: ${currentSystem}, skipping system configuration`);
+            return null;
         }
 
         const pointWCS = transformPoint(astTransform, pixelCoords);

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -144,7 +144,6 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
             AST.setI(astTransform, "Current", 2);
         }
 
-        // Handle epoch and equinox setting based on coordinate system
         const currentSystem = AST.getString(astTransform, "System");
         setAstSystem(astTransform, currentSystem as SystemType, true);
 

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -2,7 +2,7 @@ import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
 import {Point2D, SPECTRAL_DEFAULT_UNIT, SpectralType, WCSPoint2D} from "models";
-import {NumberFormatType, OverlaySettings} from "stores";
+import {NumberFormatType, OverlaySettings, SystemType} from "stores";
 import {FrameStore} from "stores/Frame";
 import {add2D, magDir2D, polygonPerimeter, rotate2D, scale2D, subtract2D, trimFitsComment} from "utilities";
 
@@ -82,8 +82,14 @@ export function getUnformattedWCSPoint(astTransform: AST.FrameSet, pixelCoords: 
             AST.setI(astTransform, "Current", 2);
         }
 
-        const equinox = AST.getString(astTransform, "System") === "FK4" ? "1950.0" : "2000.0";
-        AST.set(astTransform, `Equinox=${equinox}`);
+        // Handle epoch and equinox setting based on coordinate system
+        const currentSystem = AST.getString(astTransform, "System");
+        if (currentSystem === SystemType.FK4) {
+            AST.set(astTransform, "Equinox=B1950.0, Epoch=B1950.0");
+        } else {
+            AST.set(astTransform, "Equinox=J2000.0, Epoch=J2000.0");
+        }
+
         const pointWCS = transformPoint(astTransform, pixelCoords);
         const normVals = AST.normalizeCoordinates(astTransform, pointWCS.x, pointWCS.y);
 


### PR DESCRIPTION
**Description**

Closes #1669.

This PR fixes:

1. **Offset between user input and query** – The coordinates used in the query are now converted from center coordinates (x, y) with a precision of `10` instead of `*`. The previous `*` format (four decimal places in the testing case) caused noticeable offsets. This change reduces the positional offset to within 0.0001 mas.
2. **Incorrect coordinate system conversion** – The native coordinate system now correctly uses epoch (for FK4 only) and equinox (for FK4, FK5, and ecliptic) values from the header, while the target coordinate systems use their default settings (B1950 for FK4 and J2000 for others). These adjustments improve the conversion accuracy between FK5 and ICRS from a few to tens of mas down to 0.00001–0.0001 mas.

**Additional tests**

1. Verify coordinate precision in query
    Ensure that the query uses 10 decimal places for both RA and Dec.

    <img width="716" height="68" alt="image" src="https://github.com/user-attachments/assets/72e6348b-b0da-4780-858b-10127f6580df" />

2. Verify coordinate conversion accuracy
    Confirm that the conversion accuracy between FK5 and ICRS is within 0.0001 mas (equivalent to 0.0000001 arcsec, seven decimal places) compared to Astropy results.
    The Python script for coordinate conversion is attached below.
  
    
    [print_coords.py](https://github.com/user-attachments/files/23162273/print_coords.py)
    Usage: `python print_coords.py your_file.fits`
    Additional parameters can be appended:
    * --hdu 1 (default: 0)
    * --x 1000.0 (default: crpix1 - 1)
    * --y 1000.0 (default: crpix2 - 1)
  
    
    <img width="636" height="52" alt="image" src="https://github.com/user-attachments/assets/c66c386c-dafb-429d-ba9d-8a15cbc3093d" />

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~