### PR TITLE
Reset window lock state when resuming a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Fixed an issue that caused the screen to freeze when resuming from disconnection ([#2082](https://github.com/CARTAvis/carta-frontend/issues/2082)).
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
-* Fixed an issue that caused the screen to freeze when resuming from disconnection ([#2082](https://github.com/CARTAvis/carta-frontend/issues/2082)).
+* Fixed a screen freeze issue that occurred when resuming a disconnected session with unfinished tasks showing a progress bar ([#2082](https://github.com/CARTAvis/carta-frontend/issues/2082)).
 
 ## [5.0.3]
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -165,10 +165,6 @@ export class AppStore {
     // dynamic zIndex
     public zIndexManager = new FloatingObjzIndexManager();
 
-    // ImportRegion
-    // Track whether ImportRegionAck has been received to determine file browser behavior during session resume
-    private hasReceivedImportRegionAck = false;
-
     private appContainer: HTMLElement;
     private fileCounter = 0;
     private previousConnectionStatus: ConnectionStatus;
@@ -1258,7 +1254,7 @@ export class AppStore {
         try {
             const ack = yield this.backendService.importRegion(directory, file, type, frame.frameInfo.fileId);
             if (frame && ack.success && ack.regions) {
-                this.hasReceivedImportRegionAck = true;
+                this.fileBrowserStore.setHasReceivedImportRegionAck(true);
                 const regions = Object.entries(ack.regions);
                 const regionStyleMap = new Map<string, CARTA.IRegionStyle>(Object.entries(ack.regionStyles));
                 let startIndex = 0;
@@ -1270,13 +1266,11 @@ export class AppStore {
                 this.fileBrowserStore.setImportingRegions(false);
                 this.fileBrowserStore.resetLoadingStates();
                 this.fileBrowserStore.hideFileBrowser();
-                this.hasReceivedImportRegionAck = false;
             }
         } catch (err) {
             console.error(err);
             this.fileBrowserStore.setImportingRegions(false);
             this.fileBrowserStore.resetLoadingStates();
-            this.hasReceivedImportRegionAck = false;
             AppToaster.show(ErrorToast(err));
         }
     }
@@ -2551,11 +2545,10 @@ export class AppStore {
         // Reset file browser loading states
         if (this.fileBrowserStore.isImportingRegions) {
             this.fileBrowserStore.setImportingRegions(false);
-            this.fileBrowserStore.resetLoadingStates();
-            if (this.hasReceivedImportRegionAck) {
+            if (this.fileBrowserStore.hasReceivedImportRegionAck) {
                 this.fileBrowserStore.hideFileBrowser();
-                this.hasReceivedImportRegionAck = false;
             }
+            this.fileBrowserStore.resetLoadingStates();
         }
 
         const frame = this.activeFrame;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -165,6 +165,10 @@ export class AppStore {
     // dynamic zIndex
     public zIndexManager = new FloatingObjzIndexManager();
 
+    // ImportRegion
+    // true if there is a successful message to be processed, false if no message needs to be processed
+    private hasReceivedImportRegionAck = false;
+
     private appContainer: HTMLElement;
     private fileCounter = 0;
     private previousConnectionStatus: ConnectionStatus;
@@ -1254,6 +1258,7 @@ export class AppStore {
         try {
             const ack = yield this.backendService.importRegion(directory, file, type, frame.frameInfo.fileId);
             if (frame && ack.success && ack.regions) {
+                this.hasReceivedImportRegionAck = true;
                 const regions = Object.entries(ack.regions);
                 const regionStyleMap = new Map<string, CARTA.IRegionStyle>(Object.entries(ack.regionStyles));
                 let startIndex = 0;
@@ -1265,11 +1270,13 @@ export class AppStore {
                 this.fileBrowserStore.setImportingRegions(false);
                 this.fileBrowserStore.resetLoadingStates();
                 this.fileBrowserStore.hideFileBrowser();
+                this.hasReceivedImportRegionAck = false;
             }
         } catch (err) {
             console.error(err);
             this.fileBrowserStore.setImportingRegions(false);
             this.fileBrowserStore.resetLoadingStates();
+            this.hasReceivedImportRegionAck = false;
             AppToaster.show(ErrorToast(err));
         }
     }
@@ -2540,6 +2547,14 @@ export class AppStore {
         this.initRequirements();
         this.resumingSession = false;
         this.backendService.connectionDropped = false;
+
+        // Reset file browser loading states
+        this.fileBrowserStore.resetLoadingStates();
+        this.fileBrowserStore.setImportingRegions(false);
+        if (this.hasReceivedImportRegionAck) {
+            this.fileBrowserStore.hideFileBrowser();
+            this.hasReceivedImportRegionAck = false;
+        }
     };
 
     @flow.bound

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2549,8 +2549,8 @@ export class AppStore {
         this.backendService.connectionDropped = false;
 
         // Reset file browser loading states
-        this.fileBrowserStore.resetLoadingStates();
         this.fileBrowserStore.setImportingRegions(false);
+        this.fileBrowserStore.resetLoadingStates();
         if (this.hasReceivedImportRegionAck) {
             this.fileBrowserStore.hideFileBrowser();
             this.hasReceivedImportRegionAck = false;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2549,11 +2549,50 @@ export class AppStore {
         this.backendService.connectionDropped = false;
 
         // Reset file browser loading states
-        this.fileBrowserStore.setImportingRegions(false);
-        this.fileBrowserStore.resetLoadingStates();
-        if (this.hasReceivedImportRegionAck) {
-            this.fileBrowserStore.hideFileBrowser();
-            this.hasReceivedImportRegionAck = false;
+        if (this.fileBrowserStore.isImportingRegions) {
+            this.fileBrowserStore.setImportingRegions(false);
+            this.fileBrowserStore.resetLoadingStates();
+            if (this.hasReceivedImportRegionAck) {
+                this.fileBrowserStore.hideFileBrowser();
+                this.hasReceivedImportRegionAck = false;
+            }
+        }
+
+        const frame = this.activeFrame;
+
+        // Reset PV generator states
+        if (frame?.isRequestingPV) {
+            frame.resetPvRequestState();
+            frame.setIsRequestPVCancelling(false);
+            this.endFileLoading();
+        }
+
+        // Reset moment generator states
+        if (frame?.isRequestingMoments) {
+            frame.resetMomentRequestState();
+            this.endFileLoading();
+        }
+
+        // Reset cube histogram states
+        if (frame?.renderConfig?.useCubeHistogram) {
+            frame.renderConfig.setUseCubeHistogram(false);
+            this.cancelCubeHistogramRequest();
+        }
+
+        // Reset cube histogram states for contour
+        const dataSource = this.contourDataSource;
+        if (dataSource?.renderConfig?.useCubeHistogramContours) {
+            dataSource.renderConfig.setUseCubeHistogramContours(false);
+            this.cancelCubeHistogramRequest(dataSource.frameInfo.fileId);
+        }
+
+        // Reset fitting states
+        const fittingStore = this.imageFittingStore;
+        if (fittingStore?.isFitting) {
+            if (this.fileLoading) {
+                this.endFileLoading();
+            }
+            fittingStore.resetFittingState();
         }
     };
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -166,7 +166,7 @@ export class AppStore {
     public zIndexManager = new FloatingObjzIndexManager();
 
     // ImportRegion
-    // true if there is a successful message to be processed, false if no message needs to be processed
+    // Track whether ImportRegionAck has been received to determine file browser behavior during session resume
     private hasReceivedImportRegionAck = false;
 
     private appContainer: HTMLElement;

--- a/src/stores/FileBrowserStore/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore/FileBrowserStore.ts
@@ -72,6 +72,7 @@ export class FileBrowserStore {
     @observable selectedTab: TabId = FileInfoType.IMAGE_FILE;
     @observable loadingList = false;
     @observable isImportingRegions = false;
+    @observable hasReceivedImportRegionAck = false;
     @observable extendedLoading = false;
     @observable loadingInfo = false;
     @observable fileInfoResp = false;
@@ -131,6 +132,10 @@ export class FileBrowserStore {
 
     @action setImportingRegions = (isImportingRegions: boolean) => {
         this.isImportingRegions = isImportingRegions;
+    };
+
+    @action setHasReceivedImportRegionAck = (hasReceivedImportRegionAck: boolean) => {
+        this.hasReceivedImportRegionAck = hasReceivedImportRegionAck;
     };
 
     @action showFileBrowser = (mode: BrowserMode, append = false) => {
@@ -705,6 +710,7 @@ export class FileBrowserStore {
         this.clearExtendedDelayTimer(true);
         this.isLoadingDialogOpen = false;
         this.updateLoadingState(0, 0, 0);
+        this.hasReceivedImportRegionAck = false;
     };
 
     @action cancelRequestingFileList = () => {


### PR DESCRIPTION
**Description**

Closes #2082.

After resuming a session, the window lock will be reset.

This works for importing regions, image fitting, PV generation, moment generation, and cube histogram (including that from contour generation) generation.

_For importing regions:_
The behavior of the file browser depends on whether **ImportRegionAck** has been received:
1. If **ImportRegionAck** has **_not_** been received: the file browser remains open.
2. If **ImportRegionAck** has been received: the file browser will be closed.

**How to test:**
1. Load an image
2. Importing regions 
2.1. Import regions using this file
[test_region_10000_point.crtf.zip](https://github.com/user-attachments/files/22419957/test_region_10000_point.crtf.zip)
2.2 Terminate the backend at one of the following stages:
    - After the progress bar is displayed, but before it starts to increase.
        - The window lock is cleared.
        - The file browser remains open.
    - After the progress bar has started to increase, but before all regions have finished importing.
        - The window lock is cleared.
        - The file browser is closed.
        - All regions are successfully imported.
3. Other tasks
3.1 Find a cube with enough channels to terminate the backend before it completes.
3.2 Terminate the backend during processing.
3.3 Restart the backend.
3.4 Ensure the screen is not frozen by the progress bar.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)