### PR TITLE
Prevent spectral profile widget from reverting to original position or size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disable text selection in file browser ([#2574](https://github.com/CARTAvis/carta-frontend/issues/2574)).
 * Fixed VizieR database query ([#2480](https://github.com/CARTAvis/carta-frontend/issues/2480)).
 * Fixed an issue where the PV generator widget and progress bar did not appear when creating a new PV image while another PV image was already open ([#2349](https://github.com/CARTAvis/carta-frontend/issues/2349)).
+* Fixed spectral profile widget reverting to original position or size when profile is updated ([#482](https://github.com/CARTAvis/carta-frontend/issues/482)).
 
 ## [5.0.3]
 

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -25,19 +25,20 @@ class FloatingWidgetComponentProps {
 
 @observer
 export class FloatingWidgetComponent extends React.Component<FloatingWidgetComponentProps> {
+    private static readonly HEADER_HEIGHT = 25;
+    private static readonly ROOT_MENU_HEIGHT = 40;
     private pinElementRef: HTMLElement;
     private rnd: Rnd;
 
     componentDidMount() {
         this.updateDragSource();
-        this.rnd.updateSize({width: this.props.widgetConfig.defaultWidth, height: this.props.widgetConfig.defaultHeight});
-        this.rnd.updatePosition({x: this.props.widgetConfig.defaultX, y: this.props.widgetConfig.defaultY});
+        const widgetConfig = this.props.widgetConfig;
+        this.rnd.updateSize({width: widgetConfig.defaultWidth, height: widgetConfig.defaultHeight + FloatingWidgetComponent.HEADER_HEIGHT});
+        this.rnd.updatePosition({x: widgetConfig.defaultX, y: widgetConfig.defaultY});
     }
 
     componentDidUpdate() {
         this.updateDragSource();
-        this.rnd.updateSize({width: this.props.widgetConfig.defaultWidth, height: this.props.widgetConfig.defaultHeight});
-        this.rnd.updatePosition({x: this.props.widgetConfig.defaultX, y: this.props.widgetConfig.defaultY});
     }
 
     updateDragSource() {
@@ -72,6 +73,23 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
             }
         }
     }
+
+    private handleResizeStop = (e: any, direction: any, element: HTMLElement, delta: any, position: any) => {
+        const widgetConfig = this.props.widgetConfig;
+
+        // manually add the height of the root-menu div to position y
+        // work-around for the change of the position definition from react-rnd v9 (absolute position) to v10 (relative position from the bounds)
+        const absPosition = {x: position.x, y: position.y + FloatingWidgetComponent.ROOT_MENU_HEIGHT};
+
+        const newWidth = widgetConfig.defaultWidth + delta.width;
+        const newHeight = widgetConfig.defaultHeight + delta.height;
+
+        widgetConfig.setDefaultPosition(absPosition.x, absPosition.y);
+        widgetConfig.setDefaultSize(newWidth, newHeight);
+
+        this.rnd.updatePosition(absPosition);
+        this.rnd.updateSize({width: newWidth, height: newHeight + FloatingWidgetComponent.HEADER_HEIGHT});
+    };
 
     private onClickHelpButton = () => {
         const centerX = (this.rnd.draggable.state as any).x + this.rnd.resizable.size.width * 0.5;
@@ -113,7 +131,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
     };
 
     public render() {
-        const headerHeight = 25;
+        const headerHeight = FloatingWidgetComponent.HEADER_HEIGHT;
         const appStore = AppStore.Instance;
         const className = classNames("floating-widget", {[Classes.DARK]: appStore.darkTheme});
         const titleClass = classNames("floating-header", {selected: this.props.isSelected, [Classes.DARK]: appStore.darkTheme});
@@ -142,15 +160,9 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
                 onMouseDown={this.props.onSelected}
                 onDragStop={(e, data) => {
                     widgetConfig.setDefaultPosition(data.lastX, data.lastY);
+                    this.rnd.updatePosition({x: data.lastX, y: data.lastY});
                 }}
-                onResizeStop={(e, direction, element, delta, position) => {
-                    // manually add the height of the root-menu div to position y
-                    // work-around for the change of the position definition from react-rnd v9 (absolute position) to v10 (relative position from the bounds)
-                    const rootMenuHeight = 40;
-                    const absPosition = {x: position.x, y: position.y + rootMenuHeight};
-                    widgetConfig.setDefaultPosition(absPosition.x, absPosition.y);
-                    widgetConfig.setDefaultSize(widgetConfig.defaultWidth + delta.width, widgetConfig.defaultHeight + delta.height);
-                }}
+                onResizeStop={this.handleResizeStop}
             >
                 <div className={titleClass}>
                     <div className={"floating-title"} data-testid={this.props.widgetConfig?.id + "-header-title"}>

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -32,13 +32,24 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
 
     componentDidMount() {
         this.updateDragSource();
-        const widgetConfig = this.props.widgetConfig;
-        this.rnd.updateSize({width: widgetConfig.defaultWidth, height: widgetConfig.defaultHeight + FloatingWidgetComponent.HEADER_HEIGHT});
-        this.rnd.updatePosition({x: widgetConfig.defaultX, y: widgetConfig.defaultY});
+        this.updatePositionAndSize();
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: FloatingWidgetComponentProps) {
         this.updateDragSource();
+
+        const prevConfig = prevProps.widgetConfig;
+        const currConfig = this.props.widgetConfig;
+        
+        if (
+            prevConfig !== currConfig ||
+            prevConfig.defaultX !== currConfig.defaultX ||
+            prevConfig.defaultY !== currConfig.defaultY ||
+            prevConfig.defaultWidth !== currConfig.defaultWidth ||
+            prevConfig.defaultHeight !== currConfig.defaultHeight
+        ) {
+            this.updatePositionAndSize();
+        }
     }
 
     updateDragSource() {
@@ -74,21 +85,10 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
         }
     }
 
-    private handleResizeStop = (e: any, direction: any, element: HTMLElement, delta: any, position: any) => {
+    private updatePositionAndSize = () => {
         const widgetConfig = this.props.widgetConfig;
-
-        // manually add the height of the root-menu div to position y
-        // work-around for the change of the position definition from react-rnd v9 (absolute position) to v10 (relative position from the bounds)
-        const absPosition = {x: position.x, y: position.y + FloatingWidgetComponent.ROOT_MENU_HEIGHT};
-
-        const newWidth = widgetConfig.defaultWidth + delta.width;
-        const newHeight = widgetConfig.defaultHeight + delta.height;
-
-        widgetConfig.setDefaultPosition(absPosition.x, absPosition.y);
-        widgetConfig.setDefaultSize(newWidth, newHeight);
-
-        this.rnd.updatePosition(absPosition);
-        this.rnd.updateSize({width: newWidth, height: newHeight + FloatingWidgetComponent.HEADER_HEIGHT});
+        this.rnd.updateSize({width: widgetConfig.defaultWidth, height: widgetConfig.defaultHeight + FloatingWidgetComponent.HEADER_HEIGHT});
+        this.rnd.updatePosition({x: widgetConfig.defaultX, y: widgetConfig.defaultY});
     };
 
     private onClickHelpButton = () => {
@@ -160,9 +160,14 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
                 onMouseDown={this.props.onSelected}
                 onDragStop={(e, data) => {
                     widgetConfig.setDefaultPosition(data.lastX, data.lastY);
-                    this.rnd.updatePosition({x: data.lastX, y: data.lastY});
                 }}
-                onResizeStop={this.handleResizeStop}
+                onResizeStop={(e, direction, element, delta, position) => {
+                    // manually add the height of the root-menu div to position y
+                    // work-around for the change of the position definition from react-rnd v9 (absolute position) to v10 (relative position from the bounds)
+                    const absPosition = {x: position.x, y: position.y + FloatingWidgetComponent.ROOT_MENU_HEIGHT};
+                    widgetConfig.setDefaultPosition(absPosition.x, absPosition.y);
+                    widgetConfig.setDefaultSize(widgetConfig.defaultWidth + delta.width, widgetConfig.defaultHeight + delta.height);
+                }}
             >
                 <div className={titleClass}>
                     <div className={"floating-title"} data-testid={this.props.widgetConfig?.id + "-header-title"}>

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -40,7 +40,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
 
         const prevConfig = prevProps.widgetConfig;
         const currConfig = this.props.widgetConfig;
-        
+
         if (
             prevConfig !== currConfig ||
             prevConfig.defaultX !== currConfig.defaultX ||

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -25,8 +25,8 @@ class FloatingWidgetComponentProps {
 
 @observer
 export class FloatingWidgetComponent extends React.Component<FloatingWidgetComponentProps> {
-    private static readonly HEADER_HEIGHT = 25;
-    private static readonly ROOT_MENU_HEIGHT = 40;
+    private static readonly HeaderHeight = 25;
+    private static readonly RootMenuHeight = 40;
     private pinElementRef: HTMLElement;
     private rnd: Rnd;
 
@@ -87,7 +87,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
 
     private updatePositionAndSize = () => {
         const widgetConfig = this.props.widgetConfig;
-        this.rnd.updateSize({width: widgetConfig.defaultWidth, height: widgetConfig.defaultHeight + FloatingWidgetComponent.HEADER_HEIGHT});
+        this.rnd.updateSize({width: widgetConfig.defaultWidth, height: widgetConfig.defaultHeight + FloatingWidgetComponent.HeaderHeight});
         this.rnd.updatePosition({x: widgetConfig.defaultX, y: widgetConfig.defaultY});
     };
 
@@ -131,7 +131,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
     };
 
     public render() {
-        const headerHeight = FloatingWidgetComponent.HEADER_HEIGHT;
+        const headerHeight = FloatingWidgetComponent.HeaderHeight;
         const appStore = AppStore.Instance;
         const className = classNames("floating-widget", {[Classes.DARK]: appStore.darkTheme});
         const titleClass = classNames("floating-header", {selected: this.props.isSelected, [Classes.DARK]: appStore.darkTheme});
@@ -164,7 +164,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
                 onResizeStop={(e, direction, element, delta, position) => {
                     // manually add the height of the root-menu div to position y
                     // work-around for the change of the position definition from react-rnd v9 (absolute position) to v10 (relative position from the bounds)
-                    const absPosition = {x: position.x, y: position.y + FloatingWidgetComponent.ROOT_MENU_HEIGHT};
+                    const absPosition = {x: position.x, y: position.y + FloatingWidgetComponent.RootMenuHeight};
                     widgetConfig.setDefaultPosition(absPosition.x, absPosition.y);
                     widgetConfig.setDefaultSize(widgetConfig.defaultWidth + delta.width, widgetConfig.defaultHeight + delta.height);
                 }}


### PR DESCRIPTION
**Description**

Closes #482.

This PR introduces the following fixes:
1. Prevents the spectral profile widget from reverting to its original position or size.
    - Achieved by detecting changes between `prevConfig` and `currConfig`.
2. Ensures that the height in RND is always equal to widgetConfig.defaultHeight + headerHeight.

**How to test**
1. Open an image with a large number of channels (e.g., > 10,000).
2. Draw a rectangle or point region.
4. Open the spectral profile widget.
5. While the spectral profile is still updating, move and resize the widget.
6. Ensure that the position and size do not revert back to the original ones.

**Additional test**
1. Open a spectral profile widget.
2. Change the size and position of this widget.
3. Save layout.

_Test 1:_
1. Close widget.
2. Apply layout.
3. See the widget shows on the saved position with the saved size.

_Test 2:_
1. Do not close the widget.
2. Change the position and size of the widget.
3. Apply layout.
5. See the widget moves to the saved position with the saved size.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)