### PR TITLE
fix angular size of catalog source if size value is empty or zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.4]
+
+### Fixed
+* Fixed incorrect angular sizes for catalog sources when size data was missing or zero ([#2609](https://github.com/CARTAvis/carta-frontend/issues/2609)).
+
 ## [5.0.3]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "carta-frontend",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "repository": "https://github.com/CARTAvis/carta-frontend",
     "description": "The browser-based frontend component of CARTA, a radio-astronomy visualization tool designed for the ALMA, the VLA and the SKA pathfinders.",
     "homepage": "./",

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -390,7 +390,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
                 minColumnWidth={30}
                 enableGhostCells={true}
                 numFrozenColumns={1}
-                columnWidths={this.widgetStore.headerTableColumnWidts}
+                columnWidths={this.widgetStore.headerTableColumnWidths}
                 onColumnWidthChanged={this.updateHeaderTableColumnSize}
                 enableRowResizing={false}
                 cellRendererDependencies={[headerDisplays, this.profileStore.loadingData]} // trigger re-render on controlHeader change
@@ -402,8 +402,8 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
     private updateHeaderTableColumnSize = (index: number, size: number) => {
         const widgetsStore = this.widgetStore;
-        if (widgetsStore.headerTableColumnWidts) {
-            widgetsStore.headerTableColumnWidts[index] = size;
+        if (widgetsStore.headerTableColumnWidths) {
+            widgetsStore.headerTableColumnWidths[index] = size;
         }
     };
 

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -216,17 +216,20 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         const val = changeEvent.target.checked;
         const header = profileStore.catalogControlHeader.get(columnName);
         profileStore.setHeaderDisplay(val, columnName);
-        if ((val === true || (header.filter !== "" && val === false)) && profileStore.isFileBasedCatalog) {
+
+        const needsFilterUpdate = (val === true || (header.filter !== "" && val === false)) && profileStore.isFileBasedCatalog;
+
+        if (needsFilterUpdate) {
             profileStore.setIsUpdateColumn(true);
             this.handleFilterRequest();
         }
+
         if (catalogWidgetStore.xAxis === columnName) {
             catalogWidgetStore.setxAxis(CatalogOverlay.NONE);
         }
         if (catalogWidgetStore.yAxis === columnName) {
             catalogWidgetStore.setyAxis(CatalogOverlay.NONE);
         }
-        profileStore.setIsUpdateColumn(false); // set to false after filter request sent even no filter request sent
     }
 
     private renderDataColumn(columnName: string, columnData: any) {
@@ -418,9 +421,14 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
     private handleFilterRequest = () => {
         const profileStore = this.profileStore;
-        if ((profileStore.loadOntoImage || !profileStore.updateTableView || !profileStore.hasFilter) && !profileStore.isUpdateColumnMode) {
+
+        // Skip if normal conditions prevent filtering AND we're not in column update mode
+        const shouldSkipRequest = !profileStore.isUpdateColumnMode && (profileStore.loadOntoImage || !profileStore.updateTableView || !profileStore.hasFilter);
+
+        if (shouldSkipRequest) {
             return;
         }
+
         const catalogWidgetStore = this.widgetStore;
         const appStore = AppStore.Instance;
         if (profileStore && appStore) {

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -58,7 +58,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
             minWidth: 720,
             minHeight: 400,
             defaultWidth: 720,
-            defaultHeight: 400,
+            defaultHeight: 600,
             title: "Catalog",
             isCloseable: true,
             helpType: HelpType.CATALOG_OVERLAY,
@@ -217,6 +217,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         const header = profileStore.catalogControlHeader.get(columnName);
         profileStore.setHeaderDisplay(val, columnName);
         if ((val === true || (header.filter !== "" && val === false)) && profileStore.isFileBasedCatalog) {
+            profileStore.setIsUpdateColumn(true);
             this.handleFilterRequest();
         }
         if (catalogWidgetStore.xAxis === columnName) {
@@ -225,6 +226,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         if (catalogWidgetStore.yAxis === columnName) {
             catalogWidgetStore.setyAxis(CatalogOverlay.NONE);
         }
+        profileStore.setIsUpdateColumn(false); // set to false after filter request sent even no filter request sent
     }
 
     private renderDataColumn(columnName: string, columnData: any) {
@@ -416,7 +418,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
     private handleFilterRequest = () => {
         const profileStore = this.profileStore;
-        if (profileStore.loadOntoImage || !profileStore.updateTableView || !profileStore.hasFilter) {
+        if ((profileStore.loadOntoImage || !profileStore.updateTableView || !profileStore.hasFilter) && !profileStore.isUpdateColumnMode) {
             return;
         }
         const catalogWidgetStore = this.widgetStore;

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -115,7 +115,7 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
         ev.currentTarget.value = existingValue;
     };
 
-    @action setHeaderTableColumnWidts(vals: Array<number>) {
+    @action setHeaderTableColumnWidths(vals: Array<number>) {
         this.headerTableColumnWidths = vals;
     }
 

--- a/src/models/AbstractCatalogProfile/AbstractCatalogProfile.ts
+++ b/src/models/AbstractCatalogProfile/AbstractCatalogProfile.ts
@@ -78,6 +78,7 @@ export abstract class AbstractCatalogProfileStore {
     @observable sortingInfo: {columnName: string | null; sortingType: CARTA.SortingType | null};
     @observable sortedIndexMap: number[];
     @observable filterIndexMap: number[];
+    @observable isUpdateColumnMode: boolean = false;
 
     private _catalogData: Map<number, ProcessedColumnData>;
     public static readonly CoordinateSystemName = new Map<CatalogSystemType, string>([
@@ -343,6 +344,10 @@ export abstract class AbstractCatalogProfileStore {
 
     @action setProgress(val: number) {
         this.progress = val;
+    }
+
+    @action setIsUpdateColumn(val: boolean) {
+        this.isUpdateColumnMode = val;
     }
 
     getSortedIndices(selectedPointIndices: number[]): number[] {

--- a/src/stores/Catalog/CatalogProfileStore.ts
+++ b/src/stores/Catalog/CatalogProfileStore.ts
@@ -146,6 +146,11 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
             this.setNumVisibleRows(numVisibleRows);
             this.subsetEndIndex = subsetEndIndex;
         }
+
+        // Reset column update mode flag after processing the filter response
+        if (this.isUpdateColumnMode) {
+            this.setIsUpdateColumn(false);
+        }
     }
 
     @action.bound setNumVisibleRows(val: number) {

--- a/src/stores/Catalog/CatalogProfileStore.ts
+++ b/src/stores/Catalog/CatalogProfileStore.ts
@@ -111,7 +111,7 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
         return destArr;
     }
 
-    updateCatalogData(catalogFilter: CARTA.CatalogFilterResponse, catalogData: Map<number, ProcessedColumnData>) {
+    @action updateCatalogData(catalogFilter: CARTA.CatalogFilterResponse, catalogData: Map<number, ProcessedColumnData>) {
         let subsetDataSize = catalogFilter.subsetDataSize;
         const subsetEndIndex = catalogFilter.subsetEndIndex;
         const startIndex = subsetEndIndex - subsetDataSize;
@@ -120,7 +120,7 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
         this.filterDataSize = catalogFilter.filterDataSize;
 
         if (this.subsetEndIndex <= this.filterDataSize) {
-            let numVisibleRows = this.numVisibleRows + subsetDataSize;
+            let numVisibleRows = this.isUpdateColumnMode ? this.numVisibleRows : this.numVisibleRows + subsetDataSize;
             catalogData.forEach((newData, key) => {
                 let currentData = this.catalogData.get(key);
                 if (!currentData) {
@@ -168,10 +168,12 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
     };
 
     @action resetFilterRequest() {
-        this.setUpdateMode(CatalogUpdateMode.TableUpdate);
-        this.clearData();
-        this.setNumVisibleRows(0);
-        this.setSubsetEndIndex(0);
+        if (!this.isUpdateColumnMode) {
+            this.setUpdateMode(CatalogUpdateMode.TableUpdate);
+            this.clearData();
+            this.setNumVisibleRows(0);
+            this.setSubsetEndIndex(0);
+        }
         this.setLoadingDataStatus(true);
     }
 
@@ -234,9 +236,9 @@ export class CatalogProfileStore extends AbstractCatalogProfileStore {
 
     @computed get updateRequestDataSize() {
         this.catalogFilterRequest.subsetStartIndex = this.subsetEndIndex;
-        if (this.maxRows <= this.numVisibleRows) {
+        if (this.maxRows <= this.numVisibleRows || this.isUpdateColumnMode) {
             this.catalogFilterRequest.subsetStartIndex = 0;
-            this.catalogFilterRequest.subsetDataSize = this.maxRows;
+            this.catalogFilterRequest.subsetDataSize = this.isUpdateColumnMode ? this.subsetEndIndex : this.maxRows;
             return this.catalogFilterRequest;
         }
         const dataSize = this.maxRows - this.numVisibleRows;

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -998,10 +998,10 @@ export class CatalogWidgetStore {
     sizeArray(): Float32Array {
         let column = this.sizeMapData;
         if (!this.disableSizeMap && column?.length && this.sizeColumnMin.clipd !== undefined && this.sizeColumnMax.clipd !== undefined) {
-            // in the CatalogDisplayMode.WORLD mode, column values are mapped to themselves, i.e., values don't change.
-            const pointSize = this.catalogDisplayMode === CatalogDisplayMode.WORLD ? {min: this.sizeColumnMin.clipd, max: this.sizeColumnMax.clipd} : this.pointSizebyType;
+            const pointSize = this.pointSizebyType;
             let min = (this.isImagePixelSize ? 0 : this.sizeArea ? this.shapeSettings?.areaBase : this.shapeSettings?.diameterBase) ?? NaN;
-            return CARTACompute.CalculateCatalogSize(column, this.sizeColumnMin.clipd, this.sizeColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeScalingType, this.sizeArea, this.pixelSizeFactor);
+            const isWorld = this.catalogDisplayMode === CatalogDisplayMode.WORLD;
+            return CARTACompute.CalculateCatalogSize(column, this.sizeColumnMin.clipd, this.sizeColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeScalingType, this.sizeArea, this.pixelSizeFactor, isWorld);
         }
         return new Float32Array(0);
     }
@@ -1009,10 +1009,20 @@ export class CatalogWidgetStore {
     sizeMinorArray(): Float32Array {
         let column = this.sizeMinorMapData;
         if (!this.disableSizeMinorMap && column?.length && this.sizeMinorColumnMin.clipd !== undefined && this.sizeMinorColumnMax.clipd !== undefined) {
-            // in the CatalogDisplayMode.WORLD mode, column values are mapped to themselves, i.e., values don't change.
-            const pointSize = this.catalogDisplayMode === CatalogDisplayMode.WORLD ? {min: this.sizeMinorColumnMin.clipd, max: this.sizeMinorColumnMax.clipd} : this.minorPointSizebyType;
+            const pointSize = this.minorPointSizebyType;
             let min = (this.isImagePixelSize ? 0 : this.sizeArea ? this.shapeSettings?.areaBase : this.shapeSettings?.diameterBase) ?? NaN;
-            return CARTACompute.CalculateCatalogSize(column, this.sizeMinorColumnMin.clipd, this.sizeMinorColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeMinorScalingType, this.sizeMinorArea, this.pixelSizeFactor);
+            const isWorld = this.catalogDisplayMode === CatalogDisplayMode.WORLD;
+            return CARTACompute.CalculateCatalogSize(
+                column,
+                this.sizeMinorColumnMin.clipd,
+                this.sizeMinorColumnMax.clipd,
+                pointSize.min + min,
+                pointSize.max + min,
+                this.sizeMinorScalingType,
+                this.sizeMinorArea,
+                this.pixelSizeFactor,
+                isWorld
+            );
         }
         return new Float32Array(0);
     }

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -618,11 +618,6 @@ export class CatalogWidgetStore {
             this.sizeMapColumn = column;
             this.sizeColumnMin = {default: undefined, clipd: undefined};
             this.sizeColumnMax = {default: undefined, clipd: undefined};
-            if (this.catalogDisplayMode === CatalogDisplayMode.WORLD) {
-                const result = minMaxArray(this.sizeMapData);
-                this.setSizeMax(result.maxVal);
-                this.setSizeMin(result.minVal);
-            }
             if (column === CatalogOverlay.NONE) {
                 this.sizeArea = false;
                 this.sizeColumnMinLocked = false;
@@ -757,11 +752,6 @@ export class CatalogWidgetStore {
             this.sizeMinorMapColumn = column;
             this.sizeMinorColumnMin = {default: undefined, clipd: undefined};
             this.sizeMinorColumnMax = {default: undefined, clipd: undefined};
-            if (this.catalogDisplayMode === CatalogDisplayMode.WORLD) {
-                const result = minMaxArray(this.sizeMinorMapData);
-                this.setMinorSizeMax(result.maxVal);
-                this.setMinorSizeMin(result.minVal);
-            }
             if (column === CatalogOverlay.NONE) {
                 this.sizeMinorArea = false;
                 this.sizeMinorColumnMinLocked = false;
@@ -1008,7 +998,8 @@ export class CatalogWidgetStore {
     sizeArray(): Float32Array {
         let column = this.sizeMapData;
         if (!this.disableSizeMap && column?.length && this.sizeColumnMin.clipd !== undefined && this.sizeColumnMax.clipd !== undefined) {
-            const pointSize = this.pointSizebyType;
+            // in the CatalogDisplayMode.WORLD mode, column values are mapped to themselves, i.e., values don't change.
+            const pointSize = this.catalogDisplayMode === CatalogDisplayMode.WORLD ? {min: this.sizeColumnMin.clipd, max: this.sizeColumnMax.clipd} : this.pointSizebyType;
             let min = (this.isImagePixelSize ? 0 : this.sizeArea ? this.shapeSettings?.areaBase : this.shapeSettings?.diameterBase) ?? NaN;
             return CARTACompute.CalculateCatalogSize(column, this.sizeColumnMin.clipd, this.sizeColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeScalingType, this.sizeArea, this.pixelSizeFactor);
         }
@@ -1018,7 +1009,8 @@ export class CatalogWidgetStore {
     sizeMinorArray(): Float32Array {
         let column = this.sizeMinorMapData;
         if (!this.disableSizeMinorMap && column?.length && this.sizeMinorColumnMin.clipd !== undefined && this.sizeMinorColumnMax.clipd !== undefined) {
-            const pointSize = this.minorPointSizebyType;
+            // in the CatalogDisplayMode.WORLD mode, column values are mapped to themselves, i.e., values don't change.
+            const pointSize = this.catalogDisplayMode === CatalogDisplayMode.WORLD ? {min: this.sizeMinorColumnMin.clipd, max: this.sizeMinorColumnMax.clipd} : this.minorPointSizebyType;
             let min = (this.isImagePixelSize ? 0 : this.sizeArea ? this.shapeSettings?.areaBase : this.shapeSettings?.diameterBase) ?? NaN;
             return CARTACompute.CalculateCatalogSize(column, this.sizeMinorColumnMin.clipd, this.sizeMinorColumnMax.clipd, pointSize.min + min, pointSize.max + min, this.sizeMinorScalingType, this.sizeMinorArea, this.pixelSizeFactor);
         }

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -99,8 +99,8 @@ export class CatalogWidgetStore {
     ]);
 
     @observable catalogFileId: number;
-    @observable headerTableColumnWidts: Array<number>;
-    @observable dataTableColumnWidts: Array<number>;
+    @observable headerTableColumnWidths: Array<number>;
+    @observable dataTableColumnWidths: Array<number>;
     @observable showSelectedData: boolean;
     @observable catalogTableAutoScroll: boolean;
     @observable catalogPlotType: CatalogPlotType;
@@ -156,7 +156,7 @@ export class CatalogWidgetStore {
     constructor(catalogFileId: number) {
         makeObservable(this);
         this.catalogFileId = catalogFileId;
-        this.headerTableColumnWidts = [150, 75, 65, 100, 230];
+        this.headerTableColumnWidths = [150, 75, 65, 100, 230];
         this.showSelectedData = false;
         this.catalogTableAutoScroll = false;
         this.catalogPlotType = CatalogPlotType.ImageOverlay;
@@ -806,12 +806,12 @@ export class CatalogWidgetStore {
         this.worldSizeUnit = unit;
     }
 
-    @action setHeaderTableColumnWidts(vals: Array<number>) {
-        this.headerTableColumnWidts = vals;
+    @action setHeaderTableColumnWidths(vals: Array<number>) {
+        this.headerTableColumnWidths = vals;
     }
 
-    @action setDataTableColumnWidts(vals: Array<number>) {
-        this.dataTableColumnWidts = vals;
+    @action setDataTableColumnWidths(vals: Array<number>) {
+        this.dataTableColumnWidths = vals;
     }
 
     @action setShowSelectedData(val: boolean) {

--- a/wasm_src/carta_computation/carta_computation.cc
+++ b/wasm_src/carta_computation/carta_computation.cc
@@ -30,7 +30,8 @@ typedef enum {
     SIZE_DIAMETER = 0,
     SIZE_AREA = 1,
     COLOR = 2,
-    ORIENTATION = 3
+    ORIENTATION = 3,
+    SIZE_DIAMETER_ANGULAR = 4
 } CatalogMapType;
 
 const float MiterLimit = 1.5f;
@@ -277,6 +278,11 @@ void calculateCatalogMap(int mapType, float* data, size_t N, float dataMin, floa
                 float v = clamp(data[i], dataMin, dataMax);
                 float value = scaleValue(v, scaling, alpha, gamma);
                 data[i] = ((value - columnMin) / range * (clipMax - clipMin) + clipMin) * pixelSizeFactor;
+            }
+            break;
+        case SIZE_DIAMETER_ANGULAR:
+            for (size_t i = 0; i < N; i++) {
+                data[i] = data[i] * pixelSizeFactor;
             }
             break;
         case SIZE_AREA:

--- a/wasm_src/carta_computation/post.ts
+++ b/wasm_src/carta_computation/post.ts
@@ -97,17 +97,22 @@ Module.GenerateVertexData = (sourceVertices: Float32Array, indexOffsets: Int32Ar
     return destHeapFloat;
 };
 
-Module.CalculateCatalogSize = (data: Float32Array, min: number, max: number, sizeMin: number, sizeMax: number, scaling: number, area: boolean, devicePixelRatio: number, alpha: number = 1000, gamma: number = 1.5): Float32Array => {
+Module.CalculateCatalogSize = (data: Float32Array, min: number, max: number, sizeMin: number, sizeMax: number, scaling: number, area: boolean, devicePixelRatio: number, isWorld: boolean = false, alpha: number = 1000, gamma: number = 1.5): Float32Array => {
     const N = data.length;
     const bytes_per_element = data.BYTES_PER_ELEMENT;
     const dataOnWasmHeap = Module._malloc(N * bytes_per_element);
 
     Module.HEAPF32.set(data, dataOnWasmHeap / bytes_per_element);
 
-    if (area) {
-        calculateCatalogMap(1, dataOnWasmHeap, N, min, max, sizeMin, sizeMax, scaling, alpha, gamma, devicePixelRatio, false);
+    if (isWorld) {
+        // calculate angular size with considering devicePixelRatio but no mapping
+        calculateCatalogMap(4, dataOnWasmHeap, N, min, max, sizeMin, sizeMax, scaling, alpha, gamma, devicePixelRatio, false);
     } else {
-        calculateCatalogMap(0, dataOnWasmHeap, N, min, max, sizeMin, sizeMax, scaling, alpha, gamma, devicePixelRatio, false);
+        if (area) {
+            calculateCatalogMap(1, dataOnWasmHeap, N, min, max, sizeMin, sizeMax, scaling, alpha, gamma, devicePixelRatio, false);
+        } else {
+            calculateCatalogMap(0, dataOnWasmHeap, N, min, max, sizeMin, sizeMax, scaling, alpha, gamma, devicePixelRatio, false);
+        }
     }
 
     const float32 = new Float32Array(Module.HEAPF32.buffer, dataOnWasmHeap, N);

--- a/wasm_src/carta_computation/typings.d.ts
+++ b/wasm_src/carta_computation/typings.d.ts
@@ -4,7 +4,7 @@ export const onReady: Promise<void>;
 export const Decompress: (src: Uint8Array, destSize: number) => Uint8Array;
 export const Decode: (src: Uint8Array, destSize: number, decimationFactor: number) => Float32Array;
 export const GenerateVertexData: (sourceVertices: Float32Array, indexOffsets: Int32Array) => Float32Array;
-export const CalculateCatalogSize: (data: Float32Array, min: number, max: number, sizeMin: number, sizeMax: number, scaling: number, area: boolean, devicePixelRatio: number, alpha?: number, gamma?: number) => Float32Array;
+export const CalculateCatalogSize: (data: Float32Array, min: number, max: number, sizeMin: number, sizeMax: number, scaling: number, area: boolean, devicePixelRatio: number, isWorld: boolean, alpha?: number, gamma?: number) => Float32Array;
 export const CalculateCatalogColor: (data: Float32Array, invert: boolean, min: number, max: number, scaling: number, alpha?: number, gamma?: number) => Float32Array;
 export const CalculateCatalogOrientation: (data: Float32Array, min: number, max: number, angleMin: number, angleMax: number, scaling: number, alpha?: number, gamma?: number)=> Float32Array;
 export const ConvertInt64Array: (data: Uint8Array, signed: boolean) => Float64Array;


### PR DESCRIPTION
**Description**

Closes #2609. The source angular sizes are incorrect in the image overlay if size values are missing or zero. If there is no size information, the sources shouldn't appear in the image overlay. The bug is due to the minimum mapping limit being 1; therefore, when encountering a zero value, the system will use the default minimum mapping value instead, and make sources that shouldn't appear have fake angular sizes.

Also closes #2611. There is missing table data for the newly added columns between 50 (initially loaded) and the scrolled row. Now the table is forced to reload from the zero row to the scrolled row when displaying new column data.

**Checklist**

- Sources without size information shouldn't appear in the `Angular size` mode.
- Sources have correct angular sizes.
- If there is missing data in the catalog table when adding a new column

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] ~API documentation added (for public variables and methods in stores)`

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~