### PR TITLE
Hide the improper WCS information when the coordinate system is "Image"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased the precision of the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 * Fixed incorrect angular sizes for catalog sources when size data was missing or zero ([#2609](https://github.com/CARTAvis/carta-frontend/issues/2609)).
 * Fixed missing data in the newly enabled catalog columns ([#2611](https://github.com/CARTAvis/carta-frontend/issues/2611)).
+* Removed the incorrect WCS information when in image coordinate system ([#2614](https://github.com/CARTAvis/carta-frontend/issues/2614)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -76,9 +76,14 @@ export class FittingDialogComponent extends React.Component {
     };
 
     private renderInfoString = (point: Point2D, pointWcs: WCSPoint2D) => {
+        const isImgCoordinates = AppStore.Instance.overlaySettings.isImgCoordinates;
         return (
             <span className="info-string">
-                {this.coord === CoordinateMode.Image ? `WCS: ${pointWcs?.x || pointWcs?.y ? WCSPoint2D.ToString(pointWcs) : "-"}` : `Image: ${isFinite(point?.x) || isFinite(point?.y) ? Point2D.ToString(point, "px", 3) : "-"}`}
+                {this.coord === CoordinateMode.Image
+                    ? isImgCoordinates
+                        ? ""
+                        : `WCS: ${pointWcs?.x || pointWcs?.y ? WCSPoint2D.ToString(pointWcs) : "-"}`
+                    : `Image: ${isFinite(point?.x) || isFinite(point?.y) ? Point2D.ToString(point, "px", 3) : "-"}`}
             </span>
         );
     };

--- a/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
+++ b/src/components/Dialogs/FittingDialog/FittingDialogComponent.tsx
@@ -80,9 +80,7 @@ export class FittingDialogComponent extends React.Component {
         return (
             <span className="info-string">
                 {this.coord === CoordinateMode.Image
-                    ? isImgCoordinates
-                        ? ""
-                        : `WCS: ${pointWcs?.x || pointWcs?.y ? WCSPoint2D.ToString(pointWcs) : "-"}`
+                    ? `WCS: ${!isImgCoordinates && (pointWcs?.x || pointWcs?.y) ? WCSPoint2D.ToString(pointWcs) : "-"}`
                     : `Image: ${isFinite(point?.x) || isFinite(point?.y) ? Point2D.ToString(point, "px", 3) : "-"}`}
             </span>
         );

--- a/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
@@ -143,12 +143,12 @@ export class CompassRulerRegionForm extends React.Component<{region: RegionStore
                 )}
                 <FormGroup label={region.regionType === CARTA.RegionType.ANNCOMPASS ? "Origin" : "Start"} labelInfo={wcsInfo ? "" : " (px)"} inline={true}>
                     {this.coordinateInput(WCSStart, WCSFinish, false)}
-                    {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[0], "px", 3)}` : isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(WCSStart)}`}</span> : ""}
+                    {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[0], "px", 3)}` : `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(WCSStart)}`}</span> : ""}
                 </FormGroup>
                 {region.regionType === CARTA.RegionType.ANNRULER && (
                     <FormGroup label="Finish" labelInfo={wcsInfo ? "" : " (px)"} inline={true}>
                         {this.coordinateInput(WCSStart, WCSFinish, true)}
-                        {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[1], "px", 3)}` : isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(WCSFinish)}`}</span> : ""}
+                        {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[1], "px", 3)}` : `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(WCSFinish)}`}</span> : ""}
                     </FormGroup>
                 )}
             </div>

--- a/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/CompassRulerRegionForm/CompassRulerRegionForm.tsx
@@ -102,13 +102,14 @@ export class CompassRulerRegionForm extends React.Component<{region: RegionStore
     };
 
     render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const appStore = AppStore.Instance;
-        const system = appStore.overlaySettings.global.explicitSystem;
-        const formatX = appStore.overlaySettings.numbers.formatTypeX;
-        const formatY = appStore.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region;
         const wcsInfo = this.props.wcsInfo;
@@ -142,12 +143,12 @@ export class CompassRulerRegionForm extends React.Component<{region: RegionStore
                 )}
                 <FormGroup label={region.regionType === CARTA.RegionType.ANNCOMPASS ? "Origin" : "Start"} labelInfo={wcsInfo ? "" : " (px)"} inline={true}>
                     {this.coordinateInput(WCSStart, WCSFinish, false)}
-                    {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[0], "px", 3)}` : `WCS: ${WCSPoint2D.ToString(WCSStart)}`}</span> : ""}
+                    {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[0], "px", 3)}` : isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(WCSStart)}`}</span> : ""}
                 </FormGroup>
                 {region.regionType === CARTA.RegionType.ANNRULER && (
                     <FormGroup label="Finish" labelInfo={wcsInfo ? "" : " (px)"} inline={true}>
                         {this.coordinateInput(WCSStart, WCSFinish, true)}
-                        {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[1], "px", 3)}` : `WCS: ${WCSPoint2D.ToString(WCSFinish)}`}</span> : ""}
+                        {wcsInfo ? <span className="info-string">{isWCS && wcsInfo ? `Image: ${Point2D.ToString(region?.controlPoints[1], "px", 3)}` : isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(WCSFinish)}`}</span> : ""}
                     </FormGroup>
                 )}
             </div>

--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -169,7 +169,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         const size = region.size;
         const sizeWCS = this.sizeWCS;
@@ -197,7 +197,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
                 customPlaceholder="Semi-minor"
             />
         );
-        const sizeInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `(Semi-major, Semi-minor): ${WCSPoint2D.ToString(sizeWCS)}`) : `Image: ${Point2D.ToString(size, "px", 3)}`;
+        const sizeInfoString = region.coordinate === CoordinateMode.Image ? `(Semi-major, Semi-minor): ${isImgCoordinates ? "-" : WCSPoint2D.ToString(sizeWCS)}` : `Image: ${Point2D.ToString(size, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (
             <div className="region-form">

--- a/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/EllipticalRegionForm/EllipticalRegionForm.tsx
@@ -131,12 +131,14 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
     };
 
     public render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const system = AppStore.Instance.overlaySettings.global.explicitSystem;
-        const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
-        const formatY = AppStore.Instance.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region;
         if (!region || region.controlPoints.length !== 2 || (region.regionType !== CARTA.RegionType.ELLIPSE && region.regionType !== CARTA.RegionType.ANNELLIPSE)) {
@@ -167,7 +169,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         const size = region.size;
         const sizeWCS = this.sizeWCS;
@@ -195,7 +197,7 @@ export class EllipticalRegionForm extends React.Component<{region: RegionStore; 
                 customPlaceholder="Semi-minor"
             />
         );
-        const sizeInfoString = region.coordinate === CoordinateMode.Image ? `(Semi-major, Semi-minor): ${WCSPoint2D.ToString(sizeWCS)}` : `Image: ${Point2D.ToString(size, "px", 3)}`;
+        const sizeInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `(Semi-major, Semi-minor): ${WCSPoint2D.ToString(sizeWCS)}`) : `Image: ${Point2D.ToString(size, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (
             <div className="region-form">

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -306,7 +306,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !startWCSPoint}
             />
         );
-        const startInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(startWCSPoint)}`) : `Image: ${Point2D.ToString(this.startPoint, "px", 3)}`;
+        const startInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(startWCSPoint)}` : `Image: ${Point2D.ToString(this.startPoint, "px", 3)}`;
 
         // end
         const endPoint = this.endPoint;
@@ -333,7 +333,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !endWCSPoint}
             />
         );
-        const endInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(endWCSPoint)}`) : `Image: ${Point2D.ToString(this.endPoint, "px", 3)}`;
+        const endInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(endWCSPoint)}` : `Image: ${Point2D.ToString(this.endPoint, "px", 3)}`;
 
         // center
         const centerPoint = region.center;
@@ -360,7 +360,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const centerInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const centerInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         // length
 
@@ -378,7 +378,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 customPlaceholder="Length"
             />
         );
-        const lengthInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${this.lengthWCS}`) : `Image: ${length.toFixed(3)} px`;
+        const lengthInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : this.lengthWCS}` : `Image: ${length.toFixed(3)} px`;
 
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (

--- a/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/LineRegionForm/LineRegionForm.tsx
@@ -267,12 +267,14 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
     };
 
     public render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const system = AppStore.Instance.overlaySettings.global.explicitSystem;
-        const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
-        const formatY = AppStore.Instance.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region;
         if (!region || region.controlPoints.length !== 2 || (region.regionType !== CARTA.RegionType.LINE && region.regionType !== CARTA.RegionType.ANNLINE && region.regionType !== CARTA.RegionType.ANNVECTOR)) {
@@ -304,7 +306,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !startWCSPoint}
             />
         );
-        const startInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(startWCSPoint)}` : `Image: ${Point2D.ToString(this.startPoint, "px", 3)}`;
+        const startInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(startWCSPoint)}`) : `Image: ${Point2D.ToString(this.startPoint, "px", 3)}`;
 
         // end
         const endPoint = this.endPoint;
@@ -331,7 +333,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !endWCSPoint}
             />
         );
-        const endInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(endWCSPoint)}` : `Image: ${Point2D.ToString(this.endPoint, "px", 3)}`;
+        const endInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(endWCSPoint)}`) : `Image: ${Point2D.ToString(this.endPoint, "px", 3)}`;
 
         // center
         const centerPoint = region.center;
@@ -358,7 +360,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const centerInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const centerInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         // length
 
@@ -376,7 +378,7 @@ export class LineRegionForm extends React.Component<{region: RegionStore; frame:
                 customPlaceholder="Length"
             />
         );
-        const lengthInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${this.lengthWCS}` : `Image: ${length.toFixed(3)} px`;
+        const lengthInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${this.lengthWCS}`) : `Image: ${length.toFixed(3)} px`;
 
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -70,12 +70,14 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
     };
 
     public render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const system = AppStore.Instance.overlaySettings.global.explicitSystem;
-        const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
-        const formatY = AppStore.Instance.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region as PointAnnotationStore;
         if (!region || (region.regionType !== CARTA.RegionType.POINT && region.regionType !== CARTA.RegionType.ANNPOINT)) {
@@ -107,7 +109,7 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
             />
         );
 
-        const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (
             <div className="region-form">

--- a/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PointRegionForm/PointRegionForm.tsx
@@ -109,7 +109,7 @@ export class PointRegionForm extends React.Component<{region: RegionStore; wcsIn
             />
         );
 
-        const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
         return (
             <div className="region-form">

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -100,7 +100,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                     wcsDisabled={!this.props.wcsInfo || !pointWCS}
                 />
             );
-            const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(pointWCS)}`) : `Image: ${Point2D.ToString(point, "px", 3)}`;
+            const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(pointWCS)}` : `Image: ${Point2D.ToString(point, "px", 3)}`;
             return (
                 <FormGroup label={`Point ${index}`} labelInfo={pxUnit} inline={true} key={index}>
                     {xInput}

--- a/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/PolygonRegionForm/PolygonRegionForm.tsx
@@ -56,12 +56,14 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
     };
 
     public render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const system = AppStore.Instance.overlaySettings.global.explicitSystem;
-        const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
-        const formatY = AppStore.Instance.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region;
         if (
@@ -98,7 +100,7 @@ export class PolygonRegionForm extends React.Component<{region: RegionStore; wcs
                     wcsDisabled={!this.props.wcsInfo || !pointWCS}
                 />
             );
-            const infoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(pointWCS)}` : `Image: ${Point2D.ToString(point, "px", 3)}`;
+            const infoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(pointWCS)}`) : `Image: ${Point2D.ToString(point, "px", 3)}`;
             return (
                 <FormGroup label={`Point ${index}`} labelInfo={pxUnit} inline={true} key={index}>
                     {xInput}

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -303,12 +303,14 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
     };
 
     public render() {
+        const overlaySettings = AppStore.Instance.overlaySettings;
         // dummy variables related to wcs to trigger re-render
         /* eslint-disable @typescript-eslint/no-unused-vars */
-        const system = AppStore.Instance.overlaySettings.global.explicitSystem;
-        const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
-        const formatY = AppStore.Instance.overlaySettings.numbers.formatTypeY;
+        const system = overlaySettings.global.explicitSystem;
+        const formatX = overlaySettings.numbers.formatTypeX;
+        const formatY = overlaySettings.numbers.formatTypeY;
         /* eslint-enable @typescript-eslint/no-unused-vars */
+        const isImgCoordinates = overlaySettings.isImgCoordinates;
 
         const region = this.props.region;
         const isTextAnnotation = region.regionType === CARTA.RegionType.ANNTEXT;
@@ -341,7 +343,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const centerInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const centerInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         const isRotated = Math.abs(region.rotation) > 1e-3;
         // bottom left
@@ -371,7 +373,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !bottomLeftWCSPoint || isRotated}
             />
         );
-        const bottomLeftInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(bottomLeftWCSPoint)}` : `Image: ${Point2D.ToString(this.bottomLeftPoint, "px", 3)}`;
+        const bottomLeftInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(bottomLeftWCSPoint)}`) : `Image: ${Point2D.ToString(this.bottomLeftPoint, "px", 3)}`;
 
         // top right
         const topRightPoint = this.topRightPoint;
@@ -400,7 +402,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !topRightWCSPoint || isRotated}
             />
         );
-        const topRightInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(topRightWCSPoint)}` : `Image: ${Point2D.ToString(this.topRightPoint, "px", 3)}`;
+        const topRightInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(topRightWCSPoint)}`) : `Image: ${Point2D.ToString(this.topRightPoint, "px", 3)}`;
 
         // size
         const size = isTextAnnotation ? scale2D(region.size, AppStore.Instance.imageRatio / this.props.frame.zoomLevel) : region.size;
@@ -429,7 +431,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 customPlaceholder="Height"
             />
         );
-        const sizeInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${WCSPoint2D.ToString(this.sizeWCS)}` : `Image: ${Point2D.ToString(size, "px", 3)}`;
+        const sizeInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(this.sizeWCS)}`) : `Image: ${Point2D.ToString(size, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
 
         return (

--- a/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
+++ b/src/components/Dialogs/RegionDialog/RectangularRegionForm/RectangularRegionForm.tsx
@@ -343,7 +343,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !centerWCSPoint}
             />
         );
-        const centerInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(centerWCSPoint)}`) : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
+        const centerInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(centerWCSPoint)}` : `Image: ${Point2D.ToString(centerPoint, "px", 3)}`;
 
         const isRotated = Math.abs(region.rotation) > 1e-3;
         // bottom left
@@ -373,7 +373,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !bottomLeftWCSPoint || isRotated}
             />
         );
-        const bottomLeftInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(bottomLeftWCSPoint)}`) : `Image: ${Point2D.ToString(this.bottomLeftPoint, "px", 3)}`;
+        const bottomLeftInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(bottomLeftWCSPoint)}` : `Image: ${Point2D.ToString(this.bottomLeftPoint, "px", 3)}`;
 
         // top right
         const topRightPoint = this.topRightPoint;
@@ -402,7 +402,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 wcsDisabled={!this.props.wcsInfo || !topRightWCSPoint || isRotated}
             />
         );
-        const topRightInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(topRightWCSPoint)}`) : `Image: ${Point2D.ToString(this.topRightPoint, "px", 3)}`;
+        const topRightInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(topRightWCSPoint)}` : `Image: ${Point2D.ToString(this.topRightPoint, "px", 3)}`;
 
         // size
         const size = isTextAnnotation ? scale2D(region.size, AppStore.Instance.imageRatio / this.props.frame.zoomLevel) : region.size;
@@ -431,7 +431,7 @@ export class RectangularRegionForm extends React.Component<{region: RegionStore;
                 customPlaceholder="Height"
             />
         );
-        const sizeInfoString = region.coordinate === CoordinateMode.Image ? (isImgCoordinates ? "" : `WCS: ${WCSPoint2D.ToString(this.sizeWCS)}`) : `Image: ${Point2D.ToString(size, "px", 3)}`;
+        const sizeInfoString = region.coordinate === CoordinateMode.Image ? `WCS: ${isImgCoordinates ? "-" : WCSPoint2D.ToString(this.sizeWCS)}` : `Image: ${Point2D.ToString(size, "px", 3)}`;
         const pxUnit = region.coordinate === CoordinateMode.Image ? "(px)" : "";
 
         return (

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -93,7 +93,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
         const isPVImage = frame?.isPVImage;
 
         const getInfoString = (value: number, valueWcs: string | undefined) => {
-            return this.panAndZoomCoord === CoordinateMode.Image ? (global.system !== SystemType.Image ? `WCS: ${valueWcs}` : "") : `Image: ${toFixed(value, 3)} px`;
+            return this.panAndZoomCoord === CoordinateMode.Image ? `WCS: ${global.system !== SystemType.Image ? valueWcs : "-"}` : `Image: ${toFixed(value, 3)} px`;
         };
         const fovLabelInfo = this.panAndZoomCoord === CoordinateMode.Image ? "(px)" : "";
         const panAndZoomPanel = (

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -93,7 +93,7 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
         const isPVImage = frame?.isPVImage;
 
         const getInfoString = (value: number, valueWcs: string) => {
-            return this.panAndZoomCoord === CoordinateMode.Image ? `WCS: ${valueWcs}` : `Image: ${toFixed(value, 3)} px`;
+            return this.panAndZoomCoord === CoordinateMode.Image ? (global.system !== SystemType.Image ? `WCS: ${valueWcs}` : "") : `Image: ${toFixed(value, 3)} px`;
         };
         const fovLabelInfo = this.panAndZoomCoord === CoordinateMode.Image ? "(px)" : "";
         const panAndZoomPanel = (

--- a/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
+++ b/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
@@ -38,7 +38,7 @@ const WcsCoordNumericInput = ({inputType, valueWcs, onChangeWcs, disabled = fals
     };
 
     let tooltipContent = "";
-    switch (inputType) {
+    switch (valueWcs && inputType) {
         case InputType.XCoord:
             const formatX = AppStore.Instance.overlaySettings.numbers.formatTypeX;
             tooltipContent = `Format: ${NUMBER_FORMAT_LABEL.get(formatX)}`;

--- a/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
+++ b/src/components/Shared/CoordNumericInput/CoordNumericInput.tsx
@@ -128,9 +128,10 @@ interface CoordNumericInputProps {
 }
 
 export const CoordNumericInput = ({coord, inputType, value, onChange, valueWcs, onChangeWcs, disabled = false, wcsDisabled = false, customPlaceholder = ""}: CoordNumericInputProps) => {
+    const isImgCoordinates = AppStore.Instance.overlaySettings.isImgCoordinates;
     if (coord === CoordinateMode.Image) {
         return <ImageCoordNumericInput inputType={inputType} value={value} onChange={onChange} disabled={disabled} customPlaceholder={customPlaceholder} />;
     } else {
-        return <WcsCoordNumericInput inputType={inputType} valueWcs={valueWcs} onChangeWcs={onChangeWcs} disabled={disabled || wcsDisabled || AppStore.Instance.overlaySettings.isImgCoordinates} customPlaceholder={customPlaceholder} />;
+        return <WcsCoordNumericInput inputType={inputType} valueWcs={isImgCoordinates ? "" : valueWcs} onChangeWcs={onChangeWcs} disabled={disabled || wcsDisabled || isImgCoordinates} customPlaceholder={customPlaceholder} />;
     }
 };

--- a/src/components/Shared/CoordinateComponent/CoordinateComponent.tsx
+++ b/src/components/Shared/CoordinateComponent/CoordinateComponent.tsx
@@ -16,17 +16,15 @@ interface ICoordinateComponentProps {
 @observer
 export class CoordinateComponent extends React.Component<ICoordinateComponentProps> {
     public render() {
+        // exclude SystemType.Image from the dropdown options
+        const systemTypeOptions = Object.values(SystemType).filter(option => option !== SystemType.Image);
         return (
             <div className="coordinate-panel">
                 <RadioGroup inline={true} onChange={ev => this.props.onChange(ev.currentTarget.value as CoordinateMode)} selectedValue={this.props.selectedValue} disabled={this.props.disableCoordinate}>
                     <Radio label={CoordinateMode.Image} value={CoordinateMode.Image} />
                     <Radio label={CoordinateMode.World} value={CoordinateMode.World} />
                 </RadioGroup>
-                <HTMLSelect
-                    options={Object.keys(SystemType).map(key => ({label: key, value: SystemType[key]}))}
-                    value={AppStore.Instance.overlaySettings.global.system}
-                    onChange={ev => AppStore.Instance.overlaySettings.global.setSystem(ev.currentTarget.value as SystemType)}
-                />
+                <HTMLSelect options={systemTypeOptions} value={AppStore.Instance.overlaySettings.global.system} onChange={ev => AppStore.Instance.overlaySettings.global.setSystem(ev.currentTarget.value as SystemType)} />
             </div>
         );
     }

--- a/src/components/Shared/CoordinateComponent/CoordinateComponent.tsx
+++ b/src/components/Shared/CoordinateComponent/CoordinateComponent.tsx
@@ -16,15 +16,17 @@ interface ICoordinateComponentProps {
 @observer
 export class CoordinateComponent extends React.Component<ICoordinateComponentProps> {
     public render() {
-        // exclude SystemType.Image from the dropdown options
-        const systemTypeOptions = Object.values(SystemType).filter(option => option !== SystemType.Image);
         return (
             <div className="coordinate-panel">
                 <RadioGroup inline={true} onChange={ev => this.props.onChange(ev.currentTarget.value as CoordinateMode)} selectedValue={this.props.selectedValue} disabled={this.props.disableCoordinate}>
                     <Radio label={CoordinateMode.Image} value={CoordinateMode.Image} />
                     <Radio label={CoordinateMode.World} value={CoordinateMode.World} />
                 </RadioGroup>
-                <HTMLSelect options={systemTypeOptions} value={AppStore.Instance.overlaySettings.global.system} onChange={ev => AppStore.Instance.overlaySettings.global.setSystem(ev.currentTarget.value as SystemType)} />
+                <HTMLSelect
+                    options={Object.keys(SystemType).map(key => ({label: key, value: SystemType[key]}))}
+                    value={AppStore.Instance.overlaySettings.global.system}
+                    onChange={ev => AppStore.Instance.overlaySettings.global.setSystem(ev.currentTarget.value as SystemType)}
+                />
             </div>
         );
     }


### PR DESCRIPTION
**Description**

Close #2614. Hide the improper WCS information when the coordinate system is "Image".

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~