### PR TITLE
Allow text wrapping in cursor info bar for narrow image panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased the precision of the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 * Fixed incorrect angular sizes for catalog sources when size data was missing or zero ([#2609](https://github.com/CARTAvis/carta-frontend/issues/2609)).
 * Fixed missing data in the newly enabled catalog columns ([#2611](https://github.com/CARTAvis/carta-frontend/issues/2611)).
-* Fixed cursor info bar not wrapping text properly when the image viewer panel is narrow ([#2621](https://github.com/CARTAvis/carta-frontend/issues/2621)).
+* Fixed cursor info bar not wrapping text properly when the image viewer panel is narrow ([#2626](https://github.com/CARTAvis/carta-frontend/issues/2626)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased the precision of the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 * Fixed incorrect angular sizes for catalog sources when size data was missing or zero ([#2609](https://github.com/CARTAvis/carta-frontend/issues/2609)).
 * Fixed missing data in the newly enabled catalog columns ([#2611](https://github.com/CARTAvis/carta-frontend/issues/2611)).
+* Fixed cursor info bar not wrapping text properly when the image viewer panel is narrow ([#2621](https://github.com/CARTAvis/carta-frontend/issues/2621)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased the precision of the coordinate used in the query ([#1669](https://github.com/CARTAvis/carta-frontend/issues/1669)).
 * Fixed incorrect angular sizes for catalog sources when size data was missing or zero ([#2609](https://github.com/CARTAvis/carta-frontend/issues/2609)).
 * Fixed missing data in the newly enabled catalog columns ([#2611](https://github.com/CARTAvis/carta-frontend/issues/2611)).
-* Fixed cursor info bar not wrapping text properly when the image viewer panel is narrow ([#2626](https://github.com/CARTAvis/carta-frontend/issues/2626)).
+* Fixed cursor info bar not wrapping text properly when the image viewer panel is narrow ([#2621](https://github.com/CARTAvis/carta-frontend/issues/2621)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.scss
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.scss
@@ -19,4 +19,9 @@
     span {
         pointer-events: auto;
     }
+
+    .cursor-info-item {
+        display: inline-block;
+        word-break: break-word;
+    }
 }

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -33,13 +33,13 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
         const cursorInfo = this.props.cursorInfo;
         let infoStrings: string[] = [];
         if (cursorInfo.infoWCS) {
-            infoStrings.push(`WCS:\u00a0(${cursorInfo.infoWCS.x},\u00a0${cursorInfo.infoWCS.y})`);
+            infoStrings.push(`WCS: (${cursorInfo.infoWCS.x}, ${cursorInfo.infoWCS.y})`);
         }
         if (cursorInfo.posImageSpace?.x !== -Number.MAX_VALUE || cursorInfo.posImageSpace?.y !== -Number.MAX_VALUE) {
-            infoStrings.push(`Image:\u00a0(${toFixed(cursorInfo.posImageSpace.x)},\u00a0${toFixed(cursorInfo.posImageSpace.y)})`);
+            infoStrings.push(`Image: (${toFixed(cursorInfo.posImageSpace.x)}, ${toFixed(cursorInfo.posImageSpace.y)})`);
         }
         if (this.props.cursorValue !== undefined) {
-            let valueString = `Value:\u00a0${this.props.cursorValueToPercentage ? toFixed(this.props.cursorValue, 1) + " %" : formattedExponential(this.props.cursorValue, 5, this.props.unit, true, true)}`;
+            let valueString = `Value: ${this.props.cursorValueToPercentage ? toFixed(this.props.cursorValue, 1) + " %" : formattedExponential(this.props.cursorValue, 5, this.props.unit, true, true)}`;
             if (isNaN(this.props.cursorValue)) {
                 valueString = "NaN";
             }
@@ -53,16 +53,16 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
             infoStrings.push(valueString);
         }
         if (this.props.spectralInfo.spectralString) {
-            infoStrings.push(this.props.spectralInfo.spectralString.replace(/\s/g, "\u00a0"));
+            infoStrings.push(this.props.spectralInfo.spectralString);
             if (this.props.spectralInfo.freqString) {
-                infoStrings.push(this.props.spectralInfo.freqString.replace(/\s/g, "\u00a0"));
+                infoStrings.push(this.props.spectralInfo.freqString);
             }
             if (this.props.spectralInfo.velocityString) {
-                infoStrings.push(this.props.spectralInfo.velocityString.replace(/\s/g, "\u00a0"));
+                infoStrings.push(this.props.spectralInfo.velocityString);
             }
         }
         if (this.props.currentStokes) {
-            infoStrings.push(`Polarization:\u00a0${this.props.currentStokes}`);
+            infoStrings.push(`Polarization: ${this.props.currentStokes}`);
         }
 
         const height = this.props.height !== undefined && this.props.height >= 0 ? this.props.height : 20;
@@ -89,7 +89,16 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
 
         return (
             <div className={className} style={{...styleProps, visibility: this.props.visible === false ? "hidden" : "visible"}} data-testid="viewer-cursor-info-bar">
-                <span>{infoStrings.length ? infoStrings.join("; ") : "\u00a0"}</span>
+                {infoStrings.length ? (
+                    infoStrings.map((info, index) => (
+                        <span key={index} className="cursor-info-item">
+                            {info}
+                            {index < infoStrings.length - 1 && "; "}
+                        </span>
+                    ))
+                ) : (
+                    <span>\u00a0</span>
+                )}
             </div>
         );
     }

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -93,7 +93,7 @@ export class CursorOverlayComponent extends React.Component<CursorOverlayProps> 
                     infoStrings.map((info, index) => (
                         <span key={index} className="cursor-info-item">
                             {info}
-                            {index < infoStrings.length - 1 && "; "}
+                            {index < infoStrings.length - 1 && ";\u00a0"}
                         </span>
                     ))
                 ) : (


### PR DESCRIPTION
**Description**
Closes #2621.
Fixed an issue where the cursor info bar text would not wrap properly when the image viewer panel width is limited, causing text overflow.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)