### PR TITLE
Improve region movement performance and prevent reaction leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
 * Fixed the inconsistent input of vector overlay pixel averaging between the vector overlay dialog and preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
+* Improved region dragging performance after toggling the spectral profile widget several times ([#2637](https://github.com/CARTAvis/carta-frontend/issues/2637)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -6,7 +6,7 @@ import {Cell, Column, Regions, RenderMode, SelectionModes, Table2} from "@bluepr
 import * as ScrollUtils from "@blueprintjs/table/lib/esm/common/internal/scrollUtils";
 import {CARTA} from "carta-protobuf";
 import FuzzySearch from "fuzzy-search";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ClearableNumericInputComponent, FilterableTableComponent, type FilterableTableComponentProps, ResizeDetector} from "components/Shared";
@@ -28,6 +28,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
     private prevPosition: number = 60;
     private static readonly ExpectedColumnCount: number = 5; // Name, Unit, Type, Display, Description
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     private catalogHeaderTableRef: Table2 | undefined = undefined;
     private catalogFileNames: Map<number, string>;
@@ -153,29 +154,36 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
         makeObservable(this);
 
-        autorun(() => {
-            const appStore = AppStore.Instance;
-            const frame = appStore.activeFrame;
-            const catalogFileIds = CatalogStore.Instance.activeCatalogFiles;
-            const profileStore = this.profileStore;
+        this.disposers.push(
+            autorun(() => {
+                const appStore = AppStore.Instance;
+                const frame = appStore.activeFrame;
+                const catalogFileIds = CatalogStore.Instance.activeCatalogFiles;
+                const profileStore = this.profileStore;
 
-            if (profileStore) {
-                let progressString = "";
-                const fileName = profileStore.catalogInfo.fileInfo.name;
-                const progress = profileStore.progress;
-                if (progress && isFinite(progress) && progress < 1) {
-                    progressString = `[${toFixed(progress * 100)}% complete]`;
-                }
+                if (profileStore) {
+                    let progressString = "";
+                    const fileName = profileStore.catalogInfo.fileInfo.name;
+                    const progress = profileStore.progress;
+                    if (progress && isFinite(progress) && progress < 1) {
+                        progressString = `[${toFixed(progress * 100)}% complete]`;
+                    }
 
-                if (frame && catalogFileIds?.length) {
-                    WidgetsStore.Instance.setWidgetComponentTitle(this.widgetId, `Catalog : ${fileName} ${progressString}`);
+                    if (frame && catalogFileIds?.length) {
+                        WidgetsStore.Instance.setWidgetComponentTitle(this.widgetId, `Catalog : ${fileName} ${progressString}`);
+                    } else {
+                        WidgetsStore.Instance.setWidgetComponentTitle(this.widgetId, `Catalog`);
+                    }
                 } else {
                     WidgetsStore.Instance.setWidgetComponentTitle(this.widgetId, `Catalog`);
                 }
-            } else {
-                WidgetsStore.Instance.setWidgetComponentTitle(this.widgetId, `Catalog`);
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onCatalogDataTableRefUpdated = ref => {

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -6,7 +6,7 @@ import {Cell, Column, Regions, RenderMode, SelectionModes, Table2} from "@bluepr
 import * as ScrollUtils from "@blueprintjs/table/lib/esm/common/internal/scrollUtils";
 import {CARTA} from "carta-protobuf";
 import FuzzySearch from "fuzzy-search";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ClearableNumericInputComponent, FilterableTableComponent, type FilterableTableComponentProps, ResizeDetector} from "components/Shared";

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {AnchorButton, Button, ButtonGroup, Classes, Collapse, Colors, FormGroup, Icon, MenuItem, PopoverPosition, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
 import {type ItemPredicate, type ItemRendererProps, Select} from "@blueprintjs/select";
 import FuzzySearch from "fuzzy-search";
-import {action, autorun, computed, makeObservable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {CatalogOverlayComponent} from "components";
@@ -41,6 +41,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
     private catalogFileNames: Map<number, string>;
     private widgetId: string;
     private floatingSettingsId: string | undefined;
+    private readonly disposers: IReactionDisposer[] = [];
     private catalogOverlayShape: Array<CatalogOverlayShape> = [
         CatalogOverlayShape.BOX_LINED,
         CatalogOverlayShape.CIRCLE_FILLED,
@@ -113,28 +114,35 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
 
         makeObservable(this);
 
-        autorun(() => {
-            const catalogStore = CatalogStore.Instance;
-            const catalogFileId = this.catalogFileId;
-            if (catalogFileId !== undefined) {
-                const catalogWidgetStoreId = catalogStore.catalogWidgets.get(catalogFileId);
-                const activeFiles = catalogStore.activeCatalogFiles;
-                if (!catalogWidgetStoreId) {
-                    WidgetsStore.Instance.addCatalogWidget(catalogFileId);
-                }
+        this.disposers.push(
+            autorun(() => {
+                const catalogStore = CatalogStore.Instance;
+                const catalogFileId = this.catalogFileId;
+                if (catalogFileId !== undefined) {
+                    const catalogWidgetStoreId = catalogStore.catalogWidgets.get(catalogFileId);
+                    const activeFiles = catalogStore.activeCatalogFiles;
+                    if (!catalogWidgetStoreId) {
+                        WidgetsStore.Instance.addCatalogWidget(catalogFileId);
+                    }
 
-                if (activeFiles?.includes(catalogFileId)) {
-                    const fileName = catalogStore.getCatalogFileNames([catalogFileId]).get(catalogFileId);
-                    if (fileName && this.floatingSettingsId) {
-                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Catalog Settings: ${fileName}`);
-                    }
-                } else {
-                    if (this.floatingSettingsId) {
-                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Catalog Settings`);
+                    if (activeFiles?.includes(catalogFileId)) {
+                        const fileName = catalogStore.getCatalogFileNames([catalogFileId]).get(catalogFileId);
+                        if (fileName && this.floatingSettingsId) {
+                            appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Catalog Settings: ${fileName}`);
+                        }
+                    } else {
+                        if (this.floatingSettingsId) {
+                            appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Catalog Settings`);
+                        }
                     }
                 }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action handleCatalogFileChange = (fileId: number) => {

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {AnchorButton, Button, ButtonGroup, Classes, Collapse, Colors, FormGroup, Icon, MenuItem, PopoverPosition, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
 import {type ItemPredicate, type ItemRendererProps, Select} from "@blueprintjs/select";
 import FuzzySearch from "fuzzy-search";
-import {action, autorun, computed, IReactionDisposer, makeObservable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {CatalogOverlayComponent} from "components";

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -6,7 +6,7 @@ import {CARTA} from "carta-protobuf";
 import FuzzySearch from "fuzzy-search";
 import * as GSL from "gsl_wrapper";
 import * as _ from "lodash";
-import {action, autorun, computed, makeObservable, observable, reaction, runInAction} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction, runInAction} from "mobx";
 import {observer} from "mobx-react";
 import type * as Plotly from "plotly.js";
 
@@ -31,6 +31,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
     private histogramY: {yMin?: number; yMax?: number};
     private static emptyColumn = "None";
     private catalogFileNames: Map<number, string>;
+    private readonly disposers: IReactionDisposer[] = [];
     private widgetId: string;
 
     private static readonly UnsupportedDataTypes = [CARTA.ColumnType.String, CARTA.ColumnType.Bool, CARTA.ColumnType.UnsupportedType];
@@ -61,53 +62,64 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
 
         makeObservable(this);
 
-        autorun(() => {
-            const profileStore = this.profileStore;
-            const widgetStore = this.widgetStore;
-            const catalogFileIds = CatalogStore.Instance.activeCatalogFiles;
-            if (!catalogFileIds?.includes(this.catalogFileId) && catalogFileIds?.length > 0) {
-                runInAction(() => {
-                    this.catalogFileId = catalogFileIds[0];
-                });
-            }
-            if (widgetStore) {
-                this.plotType = widgetStore.plotType;
-            }
-            if (profileStore) {
-                let progressString = "";
-                const catalogFile = profileStore.catalogInfo;
-                const fileName = catalogFile.fileInfo.name || "";
-                const appStore = AppStore.Instance;
-                const frame = appStore.activeFrame;
-                const progress = profileStore.progress;
-                if (progress && isFinite(progress) && progress < 1) {
-                    progressString = `[${toFixed(progress * 100)}% complete]`;
+        this.disposers.push(
+            autorun(() => {
+                const profileStore = this.profileStore;
+                const widgetStore = this.widgetStore;
+                const catalogFileIds = CatalogStore.Instance.activeCatalogFiles;
+                if (!catalogFileIds?.includes(this.catalogFileId) && catalogFileIds?.length > 0) {
+                    runInAction(() => {
+                        this.catalogFileId = catalogFileIds[0];
+                    });
                 }
-                if (frame && catalogFileIds?.length) {
-                    WidgetsStore.Instance.setWidgetTitle(this.widgetId, `Catalog ${this.plotType} : ${fileName} ${progressString}`);
+                if (widgetStore) {
+                    this.plotType = widgetStore.plotType;
+                }
+                if (profileStore) {
+                    let progressString = "";
+                    const catalogFile = profileStore.catalogInfo;
+                    const fileName = catalogFile.fileInfo.name || "";
+                    const appStore = AppStore.Instance;
+                    const frame = appStore.activeFrame;
+                    const progress = profileStore.progress;
+                    if (progress && isFinite(progress) && progress < 1) {
+                        progressString = `[${toFixed(progress * 100)}% complete]`;
+                    }
+                    if (frame && catalogFileIds?.length) {
+                        WidgetsStore.Instance.setWidgetTitle(this.widgetId, `Catalog ${this.plotType} : ${fileName} ${progressString}`);
+                    } else {
+                        WidgetsStore.Instance.setWidgetTitle(this.widgetId, `Catalog ${this.plotType}`);
+                    }
                 } else {
                     WidgetsStore.Instance.setWidgetTitle(this.widgetId, `Catalog ${this.plotType}`);
                 }
-            } else {
-                WidgetsStore.Instance.setWidgetTitle(this.widgetId, `Catalog ${this.plotType}`);
-            }
-        });
+            })
+        );
 
-        reaction(
-            () => this.widgetStore?.statisticColumnName,
-            () => {
-                if (this.widgetStore?.enableStatistic) {
+        this.disposers.push(
+            reaction(
+                () => this.widgetStore?.statisticColumnName,
+                () => {
+                    if (this.widgetStore?.enableStatistic) {
+                        this.updateStatistic();
+                    }
+                }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.profileStore?.selectedPointIndices,
+                () => {
                     this.updateStatistic();
                 }
-            }
+            )
         );
+    }
 
-        reaction(
-            () => this.profileStore?.selectedPointIndices,
-            () => {
-                this.updateStatistic();
-            }
-        );
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onResize = (width: number, height: number) => {

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -6,7 +6,7 @@ import {CARTA} from "carta-protobuf";
 import FuzzySearch from "fuzzy-search";
 import * as GSL from "gsl_wrapper";
 import * as _ from "lodash";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction, runInAction} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, reaction, runInAction} from "mobx";
 import {observer} from "mobx-react";
 import type * as Plotly from "plotly.js";
 

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -4,7 +4,7 @@ import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import * as _ from "lodash";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, runInAction} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, runInAction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent, TaskProgressDialogComponent} from "components/Dialogs";

--- a/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourDialogComponent.tsx
@@ -4,7 +4,7 @@ import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import * as _ from "lodash";
-import {action, autorun, computed, makeObservable, observable, runInAction} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, runInAction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent, TaskProgressDialogComponent} from "components/Dialogs";
@@ -47,6 +47,7 @@ export class ContourDialogComponent extends React.Component {
     private readonly widgetStore: RenderConfigWidgetStore;
     private cachedFrame: FrameStore | null;
     private cachedHistogram: CARTA.IHistogram;
+    private readonly disposers: IReactionDisposer[] = [];
 
     constructor(props: {appStore: AppStore}) {
         super(props);
@@ -56,23 +57,30 @@ export class ContourDialogComponent extends React.Component {
 
         makeObservable(this);
 
-        autorun(() => {
-            const appStore = AppStore.Instance;
-            if (appStore.contourDataSource) {
-                const newHist = appStore.contourDataSource.renderConfig.contourHistogram;
-                if (newHist !== this.cachedHistogram) {
-                    this.cachedHistogram = newHist;
-                    this.widgetStore.clearXYBounds();
+        this.disposers.push(
+            autorun(() => {
+                const appStore = AppStore.Instance;
+                if (appStore.contourDataSource) {
+                    const newHist = appStore.contourDataSource.renderConfig.contourHistogram;
+                    if (newHist !== this.cachedHistogram) {
+                        this.cachedHistogram = newHist;
+                        this.widgetStore.clearXYBounds();
+                    }
                 }
-            }
-            const widgetStore = this.widgetStore;
-            if (widgetStore) {
-                const currentData = this.plotData;
-                if (currentData) {
-                    widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                const widgetStore = this.widgetStore;
+                if (widgetStore) {
+                    const currentData = this.plotData;
+                    if (currentData) {
+                        widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                    }
                 }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action setDefaultContourParameters() {

--- a/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect, Intent, Label, NonIdealState, type OptionProps, Switch, Text} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ClearableNumericInputComponent, SafeNumericInput, ScrollShadow, SpectralSettingsComponent} from "components/Shared";
@@ -12,19 +12,28 @@ import "./ImageSaveComponent.scss";
 
 @observer
 export class ImageSaveComponent extends React.Component {
+    private readonly disposers: IReactionDisposer[] = [];
+
     constructor(props: any) {
         super(props);
         makeObservable(this);
 
-        autorun(() => {
-            const appStore = AppStore.Instance;
-            const numChannels = appStore.activeFrame?.numChannels;
-            if ((numChannels !== undefined && numChannels <= 1) || (this.validSaveSpectralRangeStart && this.validSaveSpectralRangeEnd)) {
-                appStore.endFileSaving();
-            } else {
-                appStore.startFileSaving();
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                const appStore = AppStore.Instance;
+                const numChannels = appStore.activeFrame?.numChannels;
+                if ((numChannels !== undefined && numChannels <= 1) || (this.validSaveSpectralRangeStart && this.validSaveSpectralRangeEnd)) {
+                    appStore.endFileSaving();
+                } else {
+                    appStore.startFileSaving();
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @computed get validSaveSpectralRangeStart() {

--- a/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/ImageSave/ImageSaveComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect, Intent, Label, NonIdealState, type OptionProps, Switch, Text} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, IReactionDisposer, makeObservable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ClearableNumericInputComponent, SafeNumericInput, ScrollShadow, SpectralSettingsComponent} from "components/Shared";

--- a/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
+++ b/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
@@ -4,7 +4,7 @@ import {type ItemRendererProps, Select} from "@blueprintjs/select";
 import {Cell, Column, SelectionModes, Table2} from "@blueprintjs/table";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";

--- a/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
+++ b/src/components/Dialogs/StokesDialog/StokesDialogComponent.tsx
@@ -4,7 +4,7 @@ import {type ItemRendererProps, Select} from "@blueprintjs/select";
 import {Cell, Column, SelectionModes, Table2} from "@blueprintjs/table";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, makeObservable, observable, reaction} from "mobx";
+import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DraggableDialogComponent} from "components/Dialogs";
@@ -23,6 +23,7 @@ export class StokesDialogComponent extends React.Component {
 
     @observable stokes: Map<string, CARTA.IStokesFile> = new Map();
     @observable stokesHeader: Map<string, CARTA.IFileInfoExtended> = new Map();
+    private readonly disposers: IReactionDisposer[] = [];
 
     @action updateStokesType = (fileName: string, type: CARTA.PolarizationType) => {
         const currentStoke = this.stokes.get(fileName);
@@ -79,23 +80,30 @@ export class StokesDialogComponent extends React.Component {
         super(props);
         makeObservable(this);
 
-        reaction(
-            () => this.stokesDialogVisible,
-            stokesDialogVisible => {
-                if (stokesDialogVisible) {
-                    const fileBrowserStore = AppStore.Instance.fileBrowserStore;
-                    this.stokes = new Map();
-                    fileBrowserStore.selectedFiles.forEach(async file => {
-                        if (fileBrowserStore.fileList?.directory && file.fileInfo?.name && file.hdu !== undefined) {
-                            const stokes = await fileBrowserStore.getStokesFile(fileBrowserStore.fileList.directory, file.fileInfo.name, file.hdu);
-                            if (stokes) {
-                                this.setStokes(file.fileInfo.name, stokes);
+        this.disposers.push(
+            reaction(
+                () => this.stokesDialogVisible,
+                stokesDialogVisible => {
+                    if (stokesDialogVisible) {
+                        const fileBrowserStore = AppStore.Instance.fileBrowserStore;
+                        this.stokes = new Map();
+                        fileBrowserStore.selectedFiles.forEach(async file => {
+                            if (fileBrowserStore.fileList?.directory && file.fileInfo?.name && file.hdu !== undefined) {
+                                const stokes = await fileBrowserStore.getStokesFile(fileBrowserStore.fileList.directory, file.fileInfo.name, file.hdu);
+                                if (stokes) {
+                                    this.setStokes(file.fileInfo.name, stokes);
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 }
-            }
+            )
         );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     render() {

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -39,8 +39,8 @@ export class FileInfoComponent extends React.Component<{
     private splitLengthArray: Array<Array<number>> = [];
     private matchedLocationArray: Array<{line: number; num: number}> = [];
     private listRef = React.createRef<any>();
-    private clickMatchedTimer;
-    private clickMatchedTimerStart;
+    private clickMatchedTimer: ReturnType<typeof setInterval> | undefined;
+    private clickMatchedTimerStart: ReturnType<typeof setTimeout> | undefined;
 
     @action onMouseEnter = () => {
         this.isMouseEntered = true;
@@ -150,7 +150,9 @@ export class FileInfoComponent extends React.Component<{
         }
         if (mode === 0) {
             clearTimeout(this.clickMatchedTimerStart);
+            this.clickMatchedTimerStart = undefined;
             clearInterval(this.clickMatchedTimer);
+            this.clickMatchedTimer = undefined;
         } else {
             const clickMatched = () => {
                 if (mode === -1 || mode === -99) {
@@ -182,8 +184,8 @@ export class FileInfoComponent extends React.Component<{
 
     componentWillUnmount() {
         clearTimeout(this.clickMatchedTimerStart);
-        clearInterval(this.clickMatchedTimer);
         this.clickMatchedTimerStart = undefined;
+        clearInterval(this.clickMatchedTimer);
         this.clickMatchedTimer = undefined;
     }
 

--- a/src/components/FileInfo/FileInfoComponent.tsx
+++ b/src/components/FileInfo/FileInfoComponent.tsx
@@ -186,6 +186,13 @@ export class FileInfoComponent extends React.Component<{
         makeObservable(this);
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.clickMatchedTimerStart);
+        clearInterval(this.clickMatchedTimer);
+        this.clickMatchedTimerStart = undefined;
+        this.clickMatchedTimer = undefined;
+    }
+
     private renderInfoTabs = () => {
         const infoTypes = this.props.infoTypes;
         const tabEntries = infoTypes.map(infoType => {

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {NonIdealState} from "@blueprintjs/core";
 import {type CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {autorun, computed, IReactionDisposer, makeObservable} from "mobx";
+import {autorun, computed, type IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent} from "components/Shared";

--- a/src/components/Histogram/HistogramComponent.tsx
+++ b/src/components/Histogram/HistogramComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {NonIdealState} from "@blueprintjs/core";
 import {type CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {autorun, computed, makeObservable} from "mobx";
+import {autorun, computed, IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent} from "components/Shared";
@@ -20,6 +20,7 @@ import "./HistogramComponent.scss";
 @observer
 export class HistogramComponent extends React.Component<WidgetProps> {
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -162,32 +163,39 @@ export class HistogramComponent extends React.Component<WidgetProps> {
         makeObservable(this);
 
         // Update widget title when region or coordinate changes
-        autorun(() => {
-            if (this.widgetStore && this.widgetStore.effectiveFrame) {
-                let regionString = "Unknown";
-                const regionId = this.widgetStore.effectiveRegionId;
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore && this.widgetStore.effectiveFrame) {
+                    let regionString = "Unknown";
+                    const regionId = this.widgetStore.effectiveRegionId;
 
-                if (regionId === -1) {
-                    regionString = "Image";
-                } else if (this.widgetStore.effectiveFrame.regionSet) {
-                    const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
-                    if (region) {
-                        regionString = region.nameString;
+                    if (regionId === -1) {
+                        regionString = "Image";
+                    } else if (this.widgetStore.effectiveFrame.regionSet) {
+                        const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
+                        if (region) {
+                            regionString = region.nameString;
+                        }
+                    }
+                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Histogram: ${regionString} ${selectedString}`);
+                } else {
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Histogram`);
+                }
+                const widgetStore = this.widgetStore;
+                if (widgetStore) {
+                    const currentData = this.plotData;
+                    if (currentData) {
+                        widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
                     }
                 }
-                const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `Histogram: ${regionString} ${selectedString}`);
-            } else {
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `Histogram`);
-            }
-            const widgetStore = this.widgetStore;
-            if (widgetStore) {
-                const currentData = this.plotData;
-                if (currentData) {
-                    widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
-                }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     componentDidUpdate() {

--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Tab, Tabs} from "@blueprintjs/core";
-import {autorun, computed, IReactionDisposer} from "mobx";
+import {autorun, computed, type IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 import type {LineKey} from "models";
 

--- a/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
+++ b/src/components/Histogram/HistogramSettingsPanelComponent/HistogramSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Tab, Tabs} from "@blueprintjs/core";
-import {autorun, computed} from "mobx";
+import {autorun, computed, IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 import type {LineKey} from "models";
 
@@ -20,6 +20,7 @@ const KEYCODE_ENTER = 13;
 export class HistogramSettingsPanelComponent extends React.Component<WidgetProps> {
     private widgetId: string;
     private floatingSettingsId: string | undefined;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -55,30 +56,37 @@ export class HistogramSettingsPanelComponent extends React.Component<WidgetProps
         this.floatingSettingsId = props.floatingSettingsId;
 
         // Update widget title when region or coordinate changes
-        autorun(() => {
-            const appStore = AppStore.Instance;
-            if (this.widgetStore && this.widgetStore.effectiveFrame) {
-                let regionString = "Unknown";
-                const regionId = this.widgetStore.effectiveRegionId;
+        this.disposers.push(
+            autorun(() => {
+                const appStore = AppStore.Instance;
+                if (this.widgetStore && this.widgetStore.effectiveFrame) {
+                    let regionString = "Unknown";
+                    const regionId = this.widgetStore.effectiveRegionId;
 
-                if (regionId === -1) {
-                    regionString = "Image";
-                } else if (this.widgetStore.effectiveFrame.regionSet) {
-                    const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
-                    if (region) {
-                        regionString = region.nameString;
+                    if (regionId === -1) {
+                        regionString = "Image";
+                    } else if (this.widgetStore.effectiveFrame.regionSet) {
+                        const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
+                        if (region) {
+                            regionString = region.nameString;
+                        }
+                    }
+                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                    if (this.floatingSettingsId) {
+                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Histogram Settings: ${regionString} ${selectedString}`);
+                    }
+                } else {
+                    if (this.floatingSettingsId) {
+                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Histogram Settings`);
                     }
                 }
-                const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                if (this.floatingSettingsId) {
-                    appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Histogram Settings: ${regionString} ${selectedString}`);
-                }
-            } else {
-                if (this.floatingSettingsId) {
-                    appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Histogram Settings`);
-                }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     private handleLogScaleChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
+++ b/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect} from "@blueprintjs/core";
-import {autorun, IReactionDisposer} from "mobx";
+import {autorun, type IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {RegionSelectorComponent} from "components/Shared";

--- a/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
+++ b/src/components/Histogram/HistogramToolbarComponent/HistogramToolbarComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect} from "@blueprintjs/core";
-import {autorun} from "mobx";
+import {autorun, IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {RegionSelectorComponent} from "components/Shared";
@@ -12,6 +12,8 @@ import "./HistogramToolbarComponent.scss";
 
 @observer
 export class HistogramToolbarComponent extends React.Component<{widgetStore: HistogramWidgetStore}> {
+    private readonly disposers: IReactionDisposer[] = [];
+
     private handleCoordinateChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
         this.props.widgetStore.setCoordinate(changeEvent.target.value);
     };
@@ -20,11 +22,18 @@ export class HistogramToolbarComponent extends React.Component<{widgetStore: His
         super(props);
         const widgetStore = this.props.widgetStore;
         // When frame is changed(coordinateOptions changes), coordinate stays unchanged if new frame also supports it, otherwise defaults to 'z'
-        autorun(() => {
-            if (widgetStore.effectiveFrame && (!widgetStore.effectiveFrame.coordinateOptionsZ.find(option => option.value === widgetStore.coordinate) || !widgetStore.effectiveFrame.polarizationInfo)) {
-                widgetStore.setCoordinate("z");
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (widgetStore.effectiveFrame && (!widgetStore.effectiveFrame.coordinateOptionsZ.find(option => option.value === widgetStore.coordinate) || !widgetStore.effectiveFrame.polarizationInfo)) {
+                    widgetStore.setCoordinate("z");
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     public render() {

--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -66,6 +66,13 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
         AppStore.Instance.resetImageRatio();
     }
 
+    componentWillUnmount() {
+        if (this.mouseEnterHandle) {
+            clearTimeout(this.mouseEnterHandle);
+            this.mouseEnterHandle = undefined;
+        }
+    }
+
     private handleMouseMove = event => {
         const appStore = AppStore.Instance;
         const frame = this.props.frame;

--- a/src/components/ImageView/Colorbar/ColorbarComponent.tsx
+++ b/src/components/ImageView/Colorbar/ColorbarComponent.tsx
@@ -21,7 +21,7 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
     @observable hoverInfoText: string = "";
     @observable isHovering: boolean = false;
     @observable cursorY: number = -1;
-    private mouseEnterHandle;
+    private mouseEnterHandle: ReturnType<typeof setTimeout> | undefined;
     private layerRef = React.createRef<any>();
 
     private static readonly HoverDelay = 500;
@@ -42,9 +42,8 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
     };
 
     @action onMouseEnter = () => {
-        if (this.mouseEnterHandle) {
-            clearTimeout(this.mouseEnterHandle);
-        }
+        clearTimeout(this.mouseEnterHandle);
+        this.mouseEnterHandle = undefined;
         this.mouseEnterHandle = setTimeout(() => {
             this.setMouseHovering(true);
         }, ColorbarComponent.HoverDelay);
@@ -52,9 +51,8 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
 
     @action onMouseLeave = () => {
         this.setMouseHovering(false);
-        if (this.mouseEnterHandle) {
-            clearTimeout(this.mouseEnterHandle);
-        }
+        clearTimeout(this.mouseEnterHandle);
+        this.mouseEnterHandle = undefined;
         this.props.onCursorHoverValueChanged(NaN);
     };
 
@@ -67,10 +65,8 @@ export class ColorbarComponent extends React.Component<ColorbarComponentProps> {
     }
 
     componentWillUnmount() {
-        if (this.mouseEnterHandle) {
-            clearTimeout(this.mouseEnterHandle);
-            this.mouseEnterHandle = undefined;
-        }
+        clearTimeout(this.mouseEnterHandle);
+        this.mouseEnterHandle = undefined;
     }
 
     private handleMouseMove = event => {

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {NonIdealState, Spinner} from "@blueprintjs/core";
 import $ from "jquery";
-import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {NonIdealState, Spinner} from "@blueprintjs/core";
 import $ from "jquery";
-import {action, autorun, makeObservable, observable} from "mobx";
+import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";
@@ -184,6 +184,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     private ratioIndicatorTimeoutHandle;
     private cachedImageSize: Point2D;
     private cachedGridSize: Point2D;
+    private readonly disposers: IReactionDisposer[] = [];
 
     @observable showRatioIndicator: boolean = false;
 
@@ -209,30 +210,39 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         this.imagePanelRefs = [];
 
         const appStore = AppStore.Instance;
-        autorun(() => {
-            const visibleFrames = appStore.imageViewConfigStore.visibleFrames;
-            if (!visibleFrames.length) {
-                return;
-            }
 
-            const firstFrame = visibleFrames[0];
-            if (!firstFrame) {
-                return;
-            }
+        this.disposers.push(
+            autorun(() => {
+                const visibleFrames = appStore.imageViewConfigStore.visibleFrames;
+                if (!visibleFrames.length) {
+                    return;
+                }
 
-            const imageSize = {x: firstFrame.overlayStore.renderWidth, y: firstFrame.overlayStore.renderHeight};
-            const imageGridSize = {x: appStore.imageViewConfigStore.numImageColumns, y: appStore.imageViewConfigStore.numImageRows};
-            // Compare to cached image size to prevent duplicate events when changing frames
-            const imageSizeChanged = !this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y;
-            const gridSizeChanged = !this.cachedGridSize || this.cachedGridSize.x !== imageGridSize.x || this.cachedGridSize.y !== imageGridSize.y;
-            if (imageSizeChanged || gridSizeChanged) {
-                this.cachedImageSize = imageSize;
-                this.cachedGridSize = imageGridSize;
-                clearTimeout(this.ratioIndicatorTimeoutHandle);
-                this.setRatioIndicatorVisible(true);
-                this.ratioIndicatorTimeoutHandle = setTimeout(() => this.setRatioIndicatorVisible(false), 1000);
-            }
-        });
+                const firstFrame = visibleFrames[0];
+                if (!firstFrame) {
+                    return;
+                }
+
+                const imageSize = {x: firstFrame.overlayStore.renderWidth, y: firstFrame.overlayStore.renderHeight};
+                const imageGridSize = {x: appStore.imageViewConfigStore.numImageColumns, y: appStore.imageViewConfigStore.numImageRows};
+                // Compare to cached image size to prevent duplicate events when changing frames
+                const imageSizeChanged = !this.cachedImageSize || this.cachedImageSize.x !== imageSize.x || this.cachedImageSize.y !== imageSize.y;
+                const gridSizeChanged = !this.cachedGridSize || this.cachedGridSize.x !== imageGridSize.x || this.cachedGridSize.y !== imageGridSize.y;
+                if (imageSizeChanged || gridSizeChanged) {
+                    this.cachedImageSize = imageSize;
+                    this.cachedGridSize = imageGridSize;
+                    clearTimeout(this.ratioIndicatorTimeoutHandle);
+                    this.setRatioIndicatorVisible(true);
+                    this.ratioIndicatorTimeoutHandle = setTimeout(() => this.setRatioIndicatorVisible(false), 1000);
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+        clearTimeout(this.ratioIndicatorTimeoutHandle);
     }
 
     private collectImagePanelRef = ref => {

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -181,7 +181,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
     }
 
     private imagePanelRefs: any[];
-    private ratioIndicatorTimeoutHandle;
+    private ratioIndicatorTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
     private cachedImageSize: Point2D;
     private cachedGridSize: Point2D;
     private readonly disposers: IReactionDisposer[] = [];
@@ -232,6 +232,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     this.cachedImageSize = imageSize;
                     this.cachedGridSize = imageGridSize;
                     clearTimeout(this.ratioIndicatorTimeoutHandle);
+                    this.ratioIndicatorTimeoutHandle = undefined;
                     this.setRatioIndicatorVisible(true);
                     this.ratioIndicatorTimeoutHandle = setTimeout(() => this.setRatioIndicatorVisible(false), 1000);
                 }
@@ -243,6 +244,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
         this.disposers.forEach(disposer => disposer());
         this.disposers.length = 0;
         clearTimeout(this.ratioIndicatorTimeoutHandle);
+        this.ratioIndicatorTimeoutHandle = undefined;
     }
 
     private collectImagePanelRef = ref => {

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {Button, Classes, Collapse, Divider, FormGroup, HTMLSelect, InputGroup, Position, Switch, Tab, type TabId, Tabs, Tooltip} from "@blueprintjs/core";
 import classNames from "classnames";
-import {action, autorun, makeObservable, observable} from "mobx";
+import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {AutoColorPickerComponent, CoordinateComponent, CoordNumericInput, fontSelect, SafeNumericInput, ScrollShadow, SpectralSettingsComponent} from "components/Shared";
@@ -31,6 +31,7 @@ enum ImageViewSettingsPanelTabs {
 export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps> {
     @observable selectedTab: TabId = ImageViewSettingsPanelTabs.PAN_AND_ZOOM;
     @observable panAndZoomCoord: CoordinateMode = CoordinateMode.World;
+    private readonly disposers: IReactionDisposer[] = [];
 
     @action private setSelectedTab = (tab: TabId) => {
         this.selectedTab = tab;
@@ -44,11 +45,18 @@ export class ImageViewSettingsPanelComponent extends React.Component<WidgetProps
         super(props);
         makeObservable(this);
 
-        autorun(() => {
-            if (!AppStore.Instance.activeFrame?.isPVImage && this.selectedTab === ImageViewSettingsPanelTabs.CONVERSION) {
-                this.selectedTab = ImageViewSettingsPanelTabs.GLOBAL;
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (!AppStore.Instance.activeFrame?.isPVImage && this.selectedTab === ImageViewSettingsPanelTabs.CONVERSION) {
+                    this.selectedTab = ImageViewSettingsPanelTabs.GLOBAL;
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {

--- a/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
+++ b/src/components/ImageView/ImageViewSettingsPanel/ImageViewSettingsPanelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {Button, Classes, Collapse, Divider, FormGroup, HTMLSelect, InputGroup, Position, Switch, Tab, type TabId, Tabs, Tooltip} from "@blueprintjs/core";
 import classNames from "classnames";
-import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {AutoColorPickerComponent, CoordinateComponent, CoordNumericInput, fontSelect, SafeNumericInput, ScrollShadow, SpectralSettingsComponent} from "components/Shared";

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -48,6 +48,11 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
         AppStore.Instance.resetImageRatio();
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.addControlPointTimer);
+        this.addControlPointTimer = undefined;
+    }
+
     private handleContextMenu = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
         konvaEvent.evt.preventDefault();
     };

--- a/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
+++ b/src/components/ImageView/RegionView/LineSegmentRegionComponent.tsx
@@ -37,7 +37,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
     @observable hoverIntersection: Point2D | null = null;
 
     private previousCursorStyle: string;
-    private addControlPointTimer;
+    private addControlPointTimer: ReturnType<typeof setTimeout> | undefined;
 
     constructor(props: any) {
         super(props);
@@ -59,6 +59,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
 
     private handleDoubleClick = () => {
         clearTimeout(this.addControlPointTimer);
+        this.addControlPointTimer = undefined;
         this.props.onDoubleClick?.(this.props.region);
     };
 
@@ -82,6 +83,7 @@ export class LineSegmentRegionComponent extends React.Component<LineSegmentRegio
                 currentControlPoints.splice(this.hoverIndex + 1, 0, this.hoverIntersection);
                 // Skip SET_REGION update, since the new control point lies on the line between two existing points
                 clearTimeout(this.addControlPointTimer);
+                this.addControlPointTimer = undefined;
                 this.addControlPointTimer = setTimeout(() => {
                     region.setControlPoints(currentControlPoints, true, false);
                     this.hoverIntersection = null;

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -102,16 +102,16 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         );
     }
 
-    componentWillUnmount() {
-        this.disposers.forEach(disposer => disposer());
-        this.disposers.length = 0;
-    }
-
     componentDidMount() {
         const frame = this.frame?.spatialReference ?? this.frame;
         if (frame) {
             this.syncStage(frame.centerMovement, frame.zoomLevel);
         }
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action componentDidUpdate(prevProps) {

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import type Konva from "konva";
 import * as _ from "lodash";
-import {action, makeObservable, observable, reaction} from "mobx";
+import {action, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DialogId, ImageViewLayer, RegionMode} from "enums";
@@ -44,6 +44,7 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     @observable currentCursorPos: Point2D = {x: 0, y: 0};
     @observable private frame: FrameStore;
 
+    private readonly disposers: IReactionDisposer[] = [];
     private stageRef;
     private stageResizeOffset: Point2D;
     private regionStartPoint: Point2D;
@@ -55,7 +56,6 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     private initialPinchZoom: number;
     private initialPinchDistance: number;
     private layerRef = React.createRef<any>();
-    private disposers: Array<() => void> = [];
 
     constructor(props: any) {
         super(props);
@@ -102,6 +102,11 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         );
     }
 
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    }
+
     componentDidMount() {
         const frame = this.frame?.spatialReference ?? this.frame;
         if (frame) {
@@ -132,10 +137,6 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
                 }
             }
         }
-    }
-
-    componentWillUnmount() {
-        this.disposers.forEach(dispose => dispose());
     }
 
     updateCursorPos = _.throttle((x: number, y: number) => {

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import type Konva from "konva";
 import * as _ from "lodash";
-import {action, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DialogId, ImageViewLayer, RegionMode} from "enums";

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -27,11 +27,16 @@ export class RootMenuComponent extends React.Component {
         this.disableCheckRelease = !this.disableCheckRelease;
     };
 
-    private documentationAlertTimeoutHandle;
+    private documentationAlertTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     constructor(props: any) {
         super(props);
         makeObservable(this);
+    }
+
+    componentWillUnmount() {
+        clearTimeout(this.documentationAlertTimeoutHandle);
+        this.documentationAlertTimeoutHandle = undefined;
     }
 
     private handleDashboardClicked = () => {
@@ -540,6 +545,7 @@ export class RootMenuComponent extends React.Component {
         if (process.env.PUBLIC_REACT_APP_TARGET !== "linux" && process.env.PUBLIC_REACT_APP_TARGET !== "darwin") {
             this.documentationAlertVisible = true;
             clearTimeout(this.documentationAlertTimeoutHandle);
+            this.documentationAlertTimeoutHandle = undefined;
             this.documentationAlertTimeoutHandle = setTimeout(() => (this.documentationAlertVisible = false), 10000);
         }
     };

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import {FixedSizeList, type ListOnItemsRenderedProps} from "react-window";
 import {AnchorButton, ButtonGroup, Classes, Icon, NonIdealState, Position, Spinner, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import {FixedSizeList, type ListOnItemsRenderedProps} from "react-window";
 import {AnchorButton, ButtonGroup, Classes, Icon, NonIdealState, Position, Spinner, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, makeObservable, observable, reaction} from "mobx";
+import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";
@@ -58,6 +58,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     @observable lastVisibleRow: number = 0;
     @observable regionsVisibility: RegionsOpacity = RegionsOpacity.Visible;
     @observable regionsLock: boolean = false;
+    private readonly disposers: IReactionDisposer[] = [];
 
     private scrollToSelected = (selected: any) => {
         const listRefCurrent = this.listRef.current;
@@ -73,15 +74,22 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         super(props);
         makeObservable(this);
 
-        reaction(
-            () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
-            id => {
-                if (id && id > 0) {
-                    const validRegionId = this.validRegions.map(el => el.regionId);
-                    this.scrollToSelected(validRegionId.findIndex(element => element === id));
+        this.disposers.push(
+            reaction(
+                () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
+                id => {
+                    if (id && id > 0) {
+                        const validRegionId = this.validRegions.map(el => el.regionId);
+                        this.scrollToSelected(validRegionId.findIndex(element => element === id));
+                    }
                 }
-            }
+            )
         );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onResize = (width: number, height: number) => {

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Button, ButtonGroup, Colors, FormGroup, HTMLSelect, NonIdealState, type OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {action, autorun, makeObservable, observable} from "mobx";
+import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {TaskProgressDialogComponent} from "components/Dialogs";
@@ -27,6 +27,8 @@ const COLORSCALE_LENGTH = 2048;
 
 @observer
 export class RenderConfigComponent extends React.Component<WidgetProps> {
+    private readonly disposers: IReactionDisposer[] = [];
+
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
             id: "render-config",
@@ -128,22 +130,29 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
             }
         }
 
-        autorun(() => {
-            if (appStore.activeFrame) {
-                const newHist = appStore.activeFrame.renderConfig.histogram;
-                if (newHist !== this.cachedHistogram) {
-                    this.cachedHistogram = newHist;
-                    this.widgetStore.clearXYBounds();
+        this.disposers.push(
+            autorun(() => {
+                if (appStore.activeFrame) {
+                    const newHist = appStore.activeFrame.renderConfig.histogram;
+                    if (newHist !== this.cachedHistogram) {
+                        this.cachedHistogram = newHist;
+                        this.widgetStore.clearXYBounds();
+                    }
                 }
-            }
-            const widgetStore = this.widgetStore;
-            if (widgetStore) {
-                const currentData = this.plotData;
-                if (currentData) {
-                    widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                const widgetStore = this.widgetStore;
+                if (widgetStore) {
+                    const currentData = this.plotData;
+                    if (currentData) {
+                        widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                    }
                 }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     componentDidUpdate() {

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {Button, ButtonGroup, Colors, FormGroup, HTMLSelect, NonIdealState, type OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {TaskProgressDialogComponent} from "components/Dialogs";

--- a/src/components/Shared/BiasContrastSelectComponent/BiasContrastSelectComponent.tsx
+++ b/src/components/Shared/BiasContrastSelectComponent/BiasContrastSelectComponent.tsx
@@ -62,6 +62,11 @@ export class BiasContrastSelectComponent extends React.Component<BiasContrastSel
         return <Button icon={"refresh"} minimal={true} small={true} onClick={handleClick} />;
     };
 
+    componentWillUnmount() {
+        clearTimeout(this.updateValuesTimer);
+        this.updateValuesTimer = undefined;
+    }
+
     render() {
         const twoDimensionBoard = (
             <React.Fragment>

--- a/src/components/Shared/BiasContrastSelectComponent/BiasContrastSelectComponent.tsx
+++ b/src/components/Shared/BiasContrastSelectComponent/BiasContrastSelectComponent.tsx
@@ -27,10 +27,11 @@ interface BiasContrastSelectComponentProps {
 
 @observer
 export class BiasContrastSelectComponent extends React.Component<BiasContrastSelectComponentProps> {
-    private updateValuesTimer;
+    private updateValuesTimer: ReturnType<typeof setTimeout> | undefined;
 
     private updateValues = (x: number, y: number, interval: number) => {
         clearTimeout(this.updateValuesTimer);
+        this.updateValuesTimer = undefined;
         this.updateValuesTimer = setTimeout(() => {
             const bias = (clamp(x, 0, this.props.boardWidth) / this.props.boardWidth) * (this.props.biasMax - this.props.biasMin) + this.props.biasMin;
             const contrast = this.props.contrastMax - (clamp(y, 0, this.props.boardHeight) / this.props.boardHeight) * (this.props.contrastMax - this.props.contrastMin);
@@ -41,6 +42,7 @@ export class BiasContrastSelectComponent extends React.Component<BiasContrastSel
 
     private handleDoubleClick = () => {
         clearTimeout(this.updateValuesTimer);
+        this.updateValuesTimer = undefined;
         this.props.resetBias();
         this.props.resetContrast();
     };

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -151,6 +151,11 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         return this.interactionMode === InteractionMode.PANNING;
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.pendingClickHandle);
+        this.pendingClickHandle = undefined;
+    }
+
     get zoomMode(): ZoomMode {
         const absDelta = {x: Math.abs(this.selectionBoxEnd.x - this.selectionBoxStart.x), y: Math.abs(this.selectionBoxEnd.y - this.selectionBoxStart.y)};
         if (this.props.selectingMode === LinePlotSelectingMode.LINE) {

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -106,6 +106,7 @@ export class LinePlotComponentProps {
     order?: number;
     multiPlotPropsMap?: Map<string, MultiPlotProps>;
     fullResolutionData?: Point2D[];
+    exportCommentsGenerator?: (plotKey: string, plot: MultiPlotProps) => string[] | undefined;
 }
 
 // Maximum time between double clicks
@@ -725,7 +726,8 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             if (this.props.comments && this.props.comments.length > 0) {
                 comment += "\n" + this.props.comments.map(c => "# " + c).join("\n");
             }
-            multiPlotProp.comments?.forEach(comment => rows.push(`# ${comment}\t`));
+            const commentsForExport = this.props.exportCommentsGenerator?.(key, multiPlotProp) ?? multiPlotProp.comments;
+            commentsForExport?.forEach(comment => rows.push(`# ${comment}\t`));
 
             // data part
             let columnsHeader = "# x\ty";

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -130,7 +130,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     private stageClickStartY?: number;
     private panPrevious: number;
     private previousClickTime: number;
-    private pendingClickHandle;
+    private pendingClickHandle: ReturnType<typeof setTimeout> | undefined;
 
     @observable chartArea: ChartArea;
     @observable hoveredMarker: LineMarker;
@@ -479,8 +479,11 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         if (delta < DOUBLE_CLICK_THRESHOLD) {
             this.onStageDoubleClick();
             clearTimeout(this.pendingClickHandle);
+            this.pendingClickHandle = undefined;
             return;
         } else {
+            clearTimeout(this.pendingClickHandle);
+            this.pendingClickHandle = undefined;
             this.pendingClickHandle = setTimeout(() => {
                 // Ignore click-drags for click handling
                 const mouseMoveDist = {x: Math.abs(mousePoint.x - (this.stageClickStartX ?? 0)), y: Math.abs(mousePoint.y - (this.stageClickStartY ?? 0))};

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -111,6 +111,10 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
         makeObservable(this);
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.pendingClickHandle);
+    }
+
     onPlotRefUpdated = plotRef => {
         this.plotRef = plotRef;
     };

--- a/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
+++ b/src/components/Shared/ScatterPlot/ScatterPlotComponent.tsx
@@ -84,7 +84,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
     private markerOpacity = 0.8;
     private plotRef: Chart;
     private previousClickTime: number;
-    private pendingClickHandle: NodeJS.Timeout;
+    private pendingClickHandle: ReturnType<typeof setTimeout> | undefined;
     private stageClickStartX: number;
     private stageClickStartY: number;
     private panPrevious: {x: number; y: number};
@@ -113,6 +113,7 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
 
     componentWillUnmount() {
         clearTimeout(this.pendingClickHandle);
+        this.pendingClickHandle = undefined;
     }
 
     onPlotRefUpdated = plotRef => {
@@ -486,8 +487,11 @@ export class ScatterPlotComponent extends React.Component<ScatterPlotComponentPr
         if (delta < DOUBLE_CLICK_THRESHOLD) {
             this.onStageDoubleClick();
             clearTimeout(this.pendingClickHandle);
+            this.pendingClickHandle = undefined;
             return;
         } else {
+            clearTimeout(this.pendingClickHandle);
+            this.pendingClickHandle = undefined;
             this.pendingClickHandle = setTimeout(() => {
                 // Ignore click-drags for click handling
                 const mouseMoveDist = {x: Math.abs(mousePoint.x - this.stageClickStartX), y: Math.abs(mousePoint.y - this.stageClickStartY)};

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -4,7 +4,7 @@ import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 import type {Tick} from "chart.js";
 import * as _ from "lodash";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent, RegionSelectorComponent, ResizeDetector, VERTICAL_RANGE_PADDING} from "components/Shared";
@@ -40,6 +40,7 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
 
     private cachedFormattedCoordinates: string[];
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     @observable width: number = 650;
     @observable height: number = 250;
@@ -348,38 +349,47 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
             }
         }
         // Update widget title when region or coordinate changes
-        autorun(() => {
-            if (this.widgetStore) {
-                const coordinate = this.widgetStore.coordinate;
-                const currentData = this.plotData;
-                if (appStore && coordinate) {
-                    const coordinateString = this.widgetStore.isLineOrPolyline ? "" : coordinate.toUpperCase();
-                    const regionString = this.widgetStore.effectiveRegionId === RegionId.CURSOR ? "Cursor" : `Region #${this.widgetStore.effectiveRegionId}`;
-                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `${coordinateString} Profile: ${regionString}`);
-                }
-                if (currentData) {
-                    this.widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
-                }
-            } else {
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `X Profile: Cursor`);
-            }
-        });
-
-        autorun(
-            () => {
-                if (!this.frame || !this.width) {
-                    return;
-                }
-                if (this.lineAxis) {
-                    this.setAutoScaleBounds(this.lineAxis.min, this.lineAxis.max);
-                } else if (this.widgetStore.isXProfile) {
-                    this.setAutoScaleBounds(clamp(this.frame.requiredFrameView.xMin, 0, this.frame.frameInfo.fileInfoExtended.width), clamp(this.frame.requiredFrameView.xMax, 0, this.frame.frameInfo.fileInfoExtended.width));
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore) {
+                    const coordinate = this.widgetStore.coordinate;
+                    const currentData = this.plotData;
+                    if (appStore && coordinate) {
+                        const coordinateString = this.widgetStore.isLineOrPolyline ? "" : coordinate.toUpperCase();
+                        const regionString = this.widgetStore.effectiveRegionId === RegionId.CURSOR ? "Cursor" : `Region #${this.widgetStore.effectiveRegionId}`;
+                        appStore.widgetsStore.setWidgetTitle(this.widgetId, `${coordinateString} Profile: ${regionString}`);
+                    }
+                    if (currentData) {
+                        this.widgetStore.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                    }
                 } else {
-                    this.setAutoScaleBounds(clamp(this.frame.requiredFrameView.yMin, 0, this.frame.frameInfo.fileInfoExtended.height), clamp(this.frame.requiredFrameView.yMax, 0, this.frame.frameInfo.fileInfoExtended.height));
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `X Profile: Cursor`);
                 }
-            },
-            {delay: AUTOSCALE_THROTTLE_TIME}
+            })
         );
+
+        this.disposers.push(
+            autorun(
+                () => {
+                    if (!this.frame || !this.width) {
+                        return;
+                    }
+                    if (this.lineAxis) {
+                        this.setAutoScaleBounds(this.lineAxis.min, this.lineAxis.max);
+                    } else if (this.widgetStore.isXProfile) {
+                        this.setAutoScaleBounds(clamp(this.frame.requiredFrameView.xMin, 0, this.frame.frameInfo.fileInfoExtended.width), clamp(this.frame.requiredFrameView.xMax, 0, this.frame.frameInfo.fileInfoExtended.width));
+                    } else {
+                        this.setAutoScaleBounds(clamp(this.frame.requiredFrameView.yMin, 0, this.frame.frameInfo.fileInfoExtended.height), clamp(this.frame.requiredFrameView.yMax, 0, this.frame.frameInfo.fileInfoExtended.height));
+                    }
+                },
+                {delay: AUTOSCALE_THROTTLE_TIME}
+            )
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private setAutoScaleBounds = (min: number, max: number) => {

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -4,7 +4,7 @@ import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 import type {Tick} from "chart.js";
 import * as _ from "lodash";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent, RegionSelectorComponent, ResizeDetector, VERTICAL_RANGE_PADDING} from "components/Shared";

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {FormGroup, Tab, Tabs} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {autorun, IReactionDisposer} from "mobx";
+import {autorun, type IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotSettingsPanelComponent, type LinePlotSettingsPanelComponentProps, SafeNumericInput, ScrollShadow, SmoothingSettingsComponent} from "components/Shared";
@@ -69,7 +69,7 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
                     } else {
                         appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `X Spatial Profile Settings: Cursor`);
                     }
-            }
+                }
             })
         );
     }

--- a/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerSettingsPanelComponent/SpatialProfilerSettingsPanelComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {FormGroup, Tab, Tabs} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {autorun} from "mobx";
+import {autorun, IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotSettingsPanelComponent, type LinePlotSettingsPanelComponentProps, SafeNumericInput, ScrollShadow, SmoothingSettingsComponent} from "components/Shared";
@@ -19,6 +19,7 @@ const KEYCODE_ENTER = 13;
 export class SpatialProfilerSettingsPanelComponent extends React.Component<WidgetProps> {
     private widgetId: string;
     private floatingSettingsId: string | undefined;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -55,20 +56,27 @@ export class SpatialProfilerSettingsPanelComponent extends React.Component<Widge
 
         const appStore = AppStore.Instance;
         // Update widget title when region or coordinate changes
-        autorun(() => {
-            if (this.floatingSettingsId) {
-                if (this.widgetStore) {
-                    const coordinate = this.widgetStore.coordinate;
-                    if (appStore && coordinate) {
-                        const coordinateString = this.widgetStore.isLineOrPolyline ? "" : coordinate.toUpperCase();
-                        const regionString = this.widgetStore.effectiveRegionId === RegionId.CURSOR ? "Cursor" : `Region #${this.widgetStore.effectiveRegionId}`;
-                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `${coordinateString} Spatial Profile Settings: ${regionString}`);
+        this.disposers.push(
+            autorun(() => {
+                if (this.floatingSettingsId) {
+                    if (this.widgetStore) {
+                        const coordinate = this.widgetStore.coordinate;
+                        if (appStore && coordinate) {
+                            const coordinateString = this.widgetStore.isLineOrPolyline ? "" : coordinate.toUpperCase();
+                            const regionString = this.widgetStore.effectiveRegionId === RegionId.CURSOR ? "Cursor" : `Region #${this.widgetStore.effectiveRegionId}`;
+                            appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `${coordinateString} Spatial Profile Settings: ${regionString}`);
+                        }
+                    } else {
+                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `X Spatial Profile Settings: Cursor`);
                     }
-                } else {
-                    appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `X Spatial Profile Settings: Cursor`);
-                }
             }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     handleWcsAxisChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -47,6 +47,11 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
         this.widgetId = props.id;
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.scrollToTopHandle);
+        this.scrollToTopHandle = undefined;
+    }
+
     @computed get widgetStore(): SpectralLineQueryWidgetStore {
         const widgetsStore = WidgetsStore.Instance;
         if (widgetsStore.spectralLineQueryWidgets) {

--- a/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
+++ b/src/components/SpectralLineQuery/SpectralLineQueryComponent.tsx
@@ -25,7 +25,7 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
     private widgetId: string;
     private headerTableRef: Table2 | undefined;
     private resultTableRef: Table2 | undefined;
-    private scrollToTopHandle;
+    private scrollToTopHandle: ReturnType<typeof setTimeout> | undefined;
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -218,12 +218,14 @@ export class SpectralLineQueryComponent extends React.Component<WidgetProps> {
         }
         this.widgetStore.filter();
         clearTimeout(this.scrollToTopHandle);
+        this.scrollToTopHandle = undefined;
         this.scrollToTopHandle = setTimeout(() => this.resultTableRef?.scrollToRegion(Regions.row(0)), 20);
     };
 
     private handleResetFilter = () => {
         this.widgetStore.resetFilter();
         clearTimeout(this.scrollToTopHandle);
+        this.scrollToTopHandle = undefined;
         this.scrollToTopHandle = setTimeout(() => this.resultTableRef?.scrollToRegion(Regions.row(0)), 20);
     };
 

--- a/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
+++ b/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {AnchorButton, Button, FormGroup, HTMLSelect, Intent, Popover, Pre, Slider, Switch, Text, Tooltip} from "@blueprintjs/core";
-import {action, autorun, makeObservable, observable} from "mobx";
+import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {SafeNumericInput} from "components/Shared";
@@ -22,6 +22,7 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
     @observable isShowingResultButton: boolean = false;
     private fittingStore: ProfileFittingStore;
     private widgetStore: SpectralProfileWidgetStore;
+    private readonly disposers: IReactionDisposer[] = [];
 
     private onFunctionChanged = ev => {
         this.reset();
@@ -197,16 +198,23 @@ export class ProfileFittingComponent extends React.Component<ProfileFittingCompo
         this.fittingStore = props.fittingStore;
         this.widgetStore = props.widgetStore;
 
-        autorun(() => {
-            // clear fitting data when the profile data changed
-            if (this.widgetStore?.profileSelectionStore?.profiles[0]) {
-                this.reset();
-            }
+        this.disposers.push(
+            autorun(() => {
+                // clear fitting data when the profile data changed
+                if (this.widgetStore?.profileSelectionStore?.profiles[0]) {
+                    this.reset();
+                }
 
-            if (this.widgetStore?.smoothingStore?.type) {
-                this.reset();
-            }
-        });
+                if (this.widgetStore?.smoothingStore?.type) {
+                    this.reset();
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     render() {

--- a/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
+++ b/src/components/SpectralProfiler/ProfileFittingComponent/ProfileFittingComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {AnchorButton, Button, FormGroup, HTMLSelect, Intent, Popover, Pre, Slider, Switch, Text, Tooltip} from "@blueprintjs/core";
-import {action, autorun, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {SafeNumericInput} from "components/Shared";

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -9,8 +9,8 @@ import {observer} from "mobx-react";
 import {type LineMarker, LinePlotComponent, type LinePlotComponentProps} from "components/Shared";
 import {FittingContinuum, HelpType, LinePlotSelectingMode, PlotType, SmoothingType, SpectralType, TickType} from "enums";
 import {type Point2D} from "models";
-import {AnimatorStore, AppStore, type DefaultWidgetConfig, type WidgetProps} from "stores";
-import {type MultiPlotData, type SpectralProfileWidgetStore} from "stores/Widgets";
+import {AnimatorStore, AppStore, type DefaultWidgetConfig, type WidgetProps, WidgetsStore} from "stores";
+import {type MultiPlotData, SpectralProfileWidgetStore} from "stores/Widgets";
 import {binarySearchByX, clamp, formattedExponential, getColorForTheme, toExponential, toFixed, toFormattedNotationByDiff} from "utilities";
 
 import {type MultiPlotProps} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";
@@ -25,7 +25,6 @@ const INFO_HEIGHT_MAX = 100;
 @observer
 export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     private widgetId: string;
-    private readonly widgetStoreRef: SpectralProfileWidgetStore;
     private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
@@ -43,7 +42,15 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     }
 
     @computed get widgetStore(): SpectralProfileWidgetStore {
-        return this.widgetStoreRef;
+        const widgetsStore = WidgetsStore.Instance;
+        if (widgetsStore.spectralProfileWidgets) {
+            const widgetStore = widgetsStore.spectralProfileWidgets.get(this.widgetId);
+            if (widgetStore) {
+                return widgetStore;
+            }
+        }
+        console.log("can't find store for widget");
+        return new SpectralProfileWidgetStore();
     }
 
     @computed get plotData(): MultiPlotData | null {
@@ -75,12 +82,6 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 appStore.widgetsStore.addSpectralProfileWidget(this.widgetId);
             }
         }
-
-        const widgetStore = appStore.widgetsStore.spectralProfileWidgets.get(this.widgetId);
-        if (!widgetStore) {
-            throw new Error(`Can't find SpectralProfileWidgetStore for widget id=${this.widgetId}`);
-        }
-        this.widgetStoreRef = widgetStore;
 
         // Update widget title
         this.disposers.push(

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -3,7 +3,7 @@ import SplitPane, {Pane} from "react-split-pane";
 import {Colors, NonIdealState} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as _ from "lodash";
-import {autorun, computed, makeObservable} from "mobx";
+import {autorun, computed, IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {type LineMarker, LinePlotComponent, type LinePlotComponentProps} from "components/Shared";
@@ -25,6 +25,7 @@ const INFO_HEIGHT_MAX = 100;
 @observer
 export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -83,20 +84,27 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         }
 
         // Update widget title
-        autorun(() => {
-            let title = "Z Profile";
-            const currentData = this.plotData;
-            if (this.widgetStore && currentData && isFinite(currentData.progress)) {
-                if (currentData.progress < 1.0) {
-                    const totalProgress = currentData.numProfiles * 100;
-                    title += `: [${toFixed(currentData.progress * totalProgress)}%/${totalProgress}% complete]`;
-                    this.widgetStore.updateStreamingDataStatus(true);
-                } else {
-                    this.widgetStore.updateStreamingDataStatus(false);
+        this.disposers.push(
+            autorun(() => {
+                let title = "Z Profile";
+                const currentData = this.plotData;
+                if (this.widgetStore && currentData && isFinite(currentData.progress)) {
+                    if (currentData.progress < 1.0) {
+                        const totalProgress = currentData.numProfiles * 100;
+                        title += `: [${toFixed(currentData.progress * totalProgress)}%/${totalProgress}% complete]`;
+                        this.widgetStore.updateStreamingDataStatus(true);
+                    } else {
+                        this.widgetStore.updateStreamingDataStatus(false);
+                    }
                 }
-            }
-            appStore.widgetsStore.setWidgetTitle(this.widgetId, title);
-        });
+                appStore.widgetsStore.setWidgetTitle(this.widgetId, title);
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     onChannelChanged = (x: number) => {

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -378,7 +378,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             data: currentPlotData.data[i],
                             type: this.widgetStore.plotType,
                             borderColor: currentPlotData.colors?.[i],
-                            comments: currentPlotData.comments?.[i],
+                            comments: this.widgetStore.profileComments?.[i],
                             order: 1,
                             hidden: smoothingStore.type !== SmoothingType.NONE && !smoothingStore.isOverlayOn,
                             followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult && smoothingStore.type === SmoothingType.NONE ? ["fittingModel", "fittingResidual"] : undefined
@@ -396,7 +396,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             borderWidth: currentPlotData.numProfiles > 1 ? this.widgetStore.lineWidth + 1 : smoothingStore.lineWidth,
                             pointRadius: smoothingStore.pointRadius,
                             order: 0,
-                            comments: [...(currentPlotData.comments?.[i] ?? []), ...smoothingStore.comments],
+                            comments: [...(this.widgetStore.profileComments?.[i] ?? []), ...smoothingStore.comments],
                             followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult ? ["fittingModel", "fittingResidual"] : undefined
                         });
                     }

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -25,7 +25,7 @@ const INFO_HEIGHT_MAX = 100;
 @observer
 export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     private widgetId: string;
-    private widgetStoreRef!: SpectralProfileWidgetStore;
+    private readonly widgetStoreRef: SpectralProfileWidgetStore;
     private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -317,6 +317,27 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         return spectralLineMarkers;
     };
 
+    private getExportComments = (plotKey: string): string[] => {
+        const match = plotKey.match(/^(profile|smoothedProfile)(\d+)$/);
+        if (!match) {
+            return [];
+        }
+
+        const seriesType = match[1];
+        const profileIndex = parseInt(match[2], 10);
+        const profile = this.widgetStore.profileSelectionStore.profiles?.[profileIndex];
+        if (!profile) {
+            return [];
+        }
+
+        const frame = AppStore.Instance.getFrame(profile.fileId ?? NaN);
+        const regionComments = frame ? frame.getRegionProperties(profile.regionId ?? NaN) : [];
+        if (seriesType === "smoothedProfile") {
+            return [...regionComments, ...this.widgetStore.smoothingStore.comments];
+        }
+        return regionComments;
+    };
+
     render() {
         const appStore = AppStore.Instance;
         if (!this.widgetStore) {
@@ -348,7 +369,8 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
             insideTexts: this.widgetStore.fittingStore.componentResultNumber,
             zeroLineWidth: 2,
             order: 1,
-            multiPlotPropsMap: new Map<string, MultiPlotProps>()
+            multiPlotPropsMap: new Map<string, MultiPlotProps>(),
+            exportCommentsGenerator: this.getExportComments
         };
 
         const frame = this.widgetStore.effectiveFrame;
@@ -378,7 +400,6 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             data: currentPlotData.data[i],
                             type: this.widgetStore.plotType,
                             borderColor: currentPlotData.colors?.[i],
-                            comments: this.widgetStore.profileComments?.[i],
                             order: 1,
                             hidden: smoothingStore.type !== SmoothingType.NONE && !smoothingStore.isOverlayOn,
                             followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult && smoothingStore.type === SmoothingType.NONE ? ["fittingModel", "fittingResidual"] : undefined
@@ -396,7 +417,6 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                             borderWidth: currentPlotData.numProfiles > 1 ? this.widgetStore.lineWidth + 1 : smoothingStore.lineWidth,
                             pointRadius: smoothingStore.pointRadius,
                             order: 0,
-                            comments: [...(this.widgetStore.profileComments?.[i] ?? []), ...smoothingStore.comments],
                             followingData: this.widgetStore.profileNum === 1 && fittingStore.hasResult ? ["fittingModel", "fittingResidual"] : undefined
                         });
                     }

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -3,14 +3,14 @@ import SplitPane, {Pane} from "react-split-pane";
 import {Colors, NonIdealState} from "@blueprintjs/core";
 import classNames from "classnames";
 import * as _ from "lodash";
-import {autorun, computed, IReactionDisposer, makeObservable} from "mobx";
+import {autorun, computed, type IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 
 import {type LineMarker, LinePlotComponent, type LinePlotComponentProps} from "components/Shared";
 import {FittingContinuum, HelpType, LinePlotSelectingMode, PlotType, SmoothingType, SpectralType, TickType} from "enums";
 import {type Point2D} from "models";
-import {AnimatorStore, AppStore, type DefaultWidgetConfig, type WidgetProps, WidgetsStore} from "stores";
-import {type MultiPlotData, SpectralProfileWidgetStore} from "stores/Widgets";
+import {AnimatorStore, AppStore, type DefaultWidgetConfig, type WidgetProps} from "stores";
+import {type MultiPlotData, type SpectralProfileWidgetStore} from "stores/Widgets";
 import {binarySearchByX, clamp, formattedExponential, getColorForTheme, toExponential, toFixed, toFormattedNotationByDiff} from "utilities";
 
 import {type MultiPlotProps} from "../Shared/LinePlot/PlotContainer/PlotContainerComponent";

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -25,6 +25,7 @@ const INFO_HEIGHT_MAX = 100;
 @observer
 export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     private widgetId: string;
+    private widgetStoreRef!: SpectralProfileWidgetStore;
     private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
@@ -42,15 +43,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
     }
 
     @computed get widgetStore(): SpectralProfileWidgetStore {
-        const widgetsStore = WidgetsStore.Instance;
-        if (widgetsStore.spectralProfileWidgets) {
-            const widgetStore = widgetsStore.spectralProfileWidgets.get(this.widgetId);
-            if (widgetStore) {
-                return widgetStore;
-            }
-        }
-        console.log("can't find store for widget");
-        return new SpectralProfileWidgetStore();
+        return this.widgetStoreRef;
     }
 
     @computed get plotData(): MultiPlotData | null {
@@ -82,6 +75,12 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                 appStore.widgetsStore.addSpectralProfileWidget(this.widgetId);
             }
         }
+
+        const widgetStore = appStore.widgetsStore.spectralProfileWidgets.get(this.widgetId);
+        if (!widgetStore) {
+            throw new Error(`Can't find SpectralProfileWidgetStore for widget id=${this.widgetId}`);
+        }
+        this.widgetStoreRef = widgetStore;
 
         // Update widget title
         this.disposers.push(

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect, Switch, Tab, Tabs} from "@blueprintjs/core";
-import {autorun, IReactionDisposer} from "mobx";
+import {autorun, type IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotSettingsPanelComponent, type LinePlotSettingsPanelComponentProps, ScrollShadow, SmoothingSettingsComponent, SpectralSettingsComponent} from "components/Shared";

--- a/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerSettingsPanelComponent/SpectralProfilerSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {FormGroup, HTMLSelect, Switch, Tab, Tabs} from "@blueprintjs/core";
-import {autorun} from "mobx";
+import {autorun, IReactionDisposer} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotSettingsPanelComponent, type LinePlotSettingsPanelComponentProps, ScrollShadow, SmoothingSettingsComponent, SpectralSettingsComponent} from "components/Shared";
@@ -20,6 +20,7 @@ const KEYCODE_ENTER = 13;
 export class SpectralProfilerSettingsPanelComponent extends React.Component<WidgetProps> {
     private widgetId: string;
     private floatingSettingsId: string | undefined;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -61,20 +62,27 @@ export class SpectralProfilerSettingsPanelComponent extends React.Component<Widg
         this.floatingSettingsId = props.floatingSettingsId;
 
         const appStore = AppStore.Instance;
-        autorun(() => {
-            if (this.widgetStore) {
-                const frame = this.widgetStore.effectiveFrame;
-                if (frame) {
-                    const regionId = this.widgetStore.effectiveRegionId;
-                    const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
-                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    const id = this.floatingSettingsId;
-                    if (id) {
-                        appStore.widgetsStore.setWidgetTitle(id, `Z Profile Settings: ${regionString} ${selectedString}`);
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore) {
+                    const frame = this.widgetStore.effectiveFrame;
+                    if (frame) {
+                        const regionId = this.widgetStore.effectiveRegionId;
+                        const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
+                        const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                        const id = this.floatingSettingsId;
+                        if (id) {
+                            appStore.widgetsStore.setWidgetTitle(id, `Z Profile Settings: ${regionString} ${selectedString}`);
+                        }
                     }
                 }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     handleMeanRmsChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {FormGroup, HTMLSelect, HTMLTable, NonIdealState} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {RegionSelectorComponent, ResizeDetector} from "components/Shared";

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {FormGroup, HTMLSelect, HTMLTable, NonIdealState} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {RegionSelectorComponent, ResizeDetector} from "components/Shared";
@@ -18,6 +18,7 @@ import "./StatsComponent.scss";
 @observer
 export class StatsComponent extends React.Component<WidgetProps> {
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -119,32 +120,41 @@ export class StatsComponent extends React.Component<WidgetProps> {
             }
         }
         // Update widget title when region or coordinate changes
-        autorun(() => {
-            if (this.widgetStore && this.widgetStore.effectiveFrame) {
-                let regionString = "Unknown";
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore && this.widgetStore.effectiveFrame) {
+                    let regionString = "Unknown";
 
-                const regionId = this.widgetStore.effectiveRegionId;
-                const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                if (regionId === -1) {
-                    regionString = "Image";
-                } else if (this.widgetStore.effectiveFrame.regionSet) {
-                    const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
-                    if (region) {
-                        regionString = region.nameString;
+                    const regionId = this.widgetStore.effectiveRegionId;
+                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                    if (regionId === -1) {
+                        regionString = "Image";
+                    } else if (this.widgetStore.effectiveFrame.regionSet) {
+                        const region = this.widgetStore.effectiveFrame.regionSet.regions.find(r => r.regionId === regionId);
+                        if (region) {
+                            regionString = region.nameString;
+                        }
                     }
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Statistics: ${regionString} ${selectedString}`);
+                } else {
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Statistics`);
                 }
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `Statistics: ${regionString} ${selectedString}`);
-            } else {
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `Statistics`);
-            }
-        });
+            })
+        );
 
         // When frame is changed(coordinateOptions changes), coordinate stays unchanged if new frame also supports it, otherwise defaults to 'z'
-        autorun(() => {
-            if (this.widgetStore.effectiveFrame && (!this.widgetStore.effectiveFrame.coordinateOptionsZ.find(option => option.value === this.widgetStore.coordinate) || !this.widgetStore.effectiveFrame.polarizationInfo)) {
-                this.widgetStore.setCoordinate("z");
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore.effectiveFrame && (!this.widgetStore.effectiveFrame.coordinateOptionsZ.find(option => option.value === this.widgetStore.coordinate) || !this.widgetStore.effectiveFrame.polarizationInfo)) {
+                    this.widgetStore.setCoordinate("z");
+                }
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onResize = (width: number, height: number) => {

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -3,7 +3,7 @@ import {Colors, NonIdealState} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import type {ChartArea} from "chart.js";
 import * as _ from "lodash";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent, ResizeDetector, ScatterPlotComponent, type ScatterPlotComponentProps, VERTICAL_RANGE_PADDING} from "components/Shared";
@@ -26,6 +26,7 @@ type Point3D = {x: number; y: number; z?: number};
 @observer
 export class StokesAnalysisComponent extends React.Component<WidgetProps> {
     private widgetId: string;
+    private readonly disposers: IReactionDisposer[] = [];
     private pointDefaultColor = Colors.GRAY2;
     private opacityOutRange = 0.1;
     private channelBorder: {xMin: number; xMax: number};
@@ -112,28 +113,35 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
             }
         }
 
-        autorun(() => {
-            if (this.widgetStore) {
-                const frame = this.widgetStore.effectiveFrame;
-                let progressString = "";
-                const currentData = this.plotData;
-                if (currentData && isFinite(currentData.qProgress) && isFinite(currentData.uProgress)) {
-                    const minProgress = Math.min(currentData.qProgress, currentData.uProgress, currentData.iProgress);
-                    if (minProgress < 1) {
-                        progressString = `[${toFixed(minProgress * 100)}% complete]`;
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore) {
+                    const frame = this.widgetStore.effectiveFrame;
+                    let progressString = "";
+                    const currentData = this.plotData;
+                    if (currentData && isFinite(currentData.qProgress) && isFinite(currentData.uProgress)) {
+                        const minProgress = Math.min(currentData.qProgress, currentData.uProgress, currentData.iProgress);
+                        if (minProgress < 1) {
+                            progressString = `[${toFixed(minProgress * 100)}% complete]`;
+                        }
+                        this.minProgress = minProgress;
                     }
-                    this.minProgress = minProgress;
+                    if (frame) {
+                        const regionId = this.widgetStore.effectiveRegionId;
+                        const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
+                        const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                        appStore.widgetsStore.setWidgetTitle(this.widgetId, `Stokes Analysis : ${regionString} ${selectedString} ${progressString}`);
+                    }
+                } else {
+                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Stokes Analysis: Cursor`);
                 }
-                if (frame) {
-                    const regionId = this.widgetStore.effectiveRegionId;
-                    const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
-                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    appStore.widgetsStore.setWidgetTitle(this.widgetId, `Stokes Analysis : ${regionString} ${selectedString} ${progressString}`);
-                }
-            } else {
-                appStore.widgetsStore.setWidgetTitle(this.widgetId, `Stokes Analysis: Cursor`);
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onResize = (width: number, height: number) => {

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -3,7 +3,7 @@ import {Colors, NonIdealState} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import type {ChartArea} from "chart.js";
 import * as _ from "lodash";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {LinePlotComponent, type LinePlotComponentProps, ProfilerInfoComponent, ResizeDetector, ScatterPlotComponent, type ScatterPlotComponentProps, VERTICAL_RANGE_PADDING} from "components/Shared";

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Tab, Tabs} from "@blueprintjs/core";
-import {autorun, IReactionDisposer, makeObservable} from "mobx";
+import {autorun, type IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 import type {LineKey} from "models";
 

--- a/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisSettingsPanelComponent/StokesAnalysisSettingsPanelComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Tab, Tabs} from "@blueprintjs/core";
-import {autorun, makeObservable} from "mobx";
+import {autorun, IReactionDisposer, makeObservable} from "mobx";
 import {observer} from "mobx-react";
 import type {LineKey} from "models";
 
@@ -23,6 +23,7 @@ import "./StokesAnalysisSettingsPanelComponent.scss";
 export class StokesAnalysisSettingsPanelComponent extends React.Component<WidgetProps> {
     private widgetId: string;
     private floatingSettingsId: string | undefined;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -59,17 +60,24 @@ export class StokesAnalysisSettingsPanelComponent extends React.Component<Widget
         this.widgetId = props.id;
         this.floatingSettingsId = props.floatingSettingsId;
 
-        autorun(() => {
-            if (this.widgetStore && this.floatingSettingsId) {
-                const frame = this.widgetStore.effectiveFrame;
-                if (frame) {
-                    const regionId = this.widgetStore.effectiveRegionId;
-                    const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
-                    const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
-                    appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Stokes Analysis Settings: ${regionString} ${selectedString}`);
+        this.disposers.push(
+            autorun(() => {
+                if (this.widgetStore && this.floatingSettingsId) {
+                    const frame = this.widgetStore.effectiveFrame;
+                    if (frame) {
+                        const regionId = this.widgetStore.effectiveRegionId;
+                        const regionString = regionId === 0 ? "Cursor" : `Region #${regionId}`;
+                        const selectedString = this.widgetStore.matchesSelectedRegion ? "(Active)" : "";
+                        appStore.widgetsStore.setWidgetTitle(this.floatingSettingsId, `Stokes Analysis Settings: ${regionString} ${selectedString}`);
+                    }
                 }
-            }
-        });
+            })
+        );
+    }
+
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     handleEqualAxesValuesChanged = (changeEvent: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -51,7 +51,7 @@ export class ApiService {
 
     @observable private _accessToken: string | undefined;
     private _tokenLifetime: number;
-    private _tokenExpiryHandler: any;
+    private _tokenExpiryHandler: ReturnType<typeof setTimeout> | undefined;
     private axiosInstance: AxiosInstance;
 
     @action setToken = (tokenString: string, tokenLifetime: number = Number.MAX_VALUE) => {
@@ -102,6 +102,7 @@ export class ApiService {
 
     private onTokenExpired = async () => {
         clearTimeout(this._tokenExpiryHandler);
+        this._tokenExpiryHandler = undefined;
         const tokenRefreshed = await this.refreshAccessToken();
         if (tokenRefreshed) {
             console.debug("Authenticated");
@@ -113,7 +114,13 @@ export class ApiService {
         }
     };
 
+    public dispose = () => {
+        clearTimeout(this._tokenExpiryHandler);
+        this._tokenExpiryHandler = undefined;
+    };
+
     private handleAuthLost = () => {
+        this.dispose();
         if (ApiService.RuntimeConfig.dashboardAddress) {
             this.clearToken();
             const redirectParams = btoa(window.location.search);
@@ -147,6 +154,7 @@ export class ApiService {
     };
 
     public logout = async () => {
+        this.dispose();
         // An existing login session will be assumed to exists if this is found in local storage
         localStorage.removeItem("authenticationType");
         window.open(ApiService.RuntimeConfig.logoutAddress, "_self");

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -70,6 +70,7 @@ export class BackendService {
     private lastPongTime: number;
     private deferredMap: Map<number, Deferred<IBackendResponse>>;
     private eventCounter: number;
+    private pingIntervalHandle: ReturnType<typeof setInterval> | undefined;
 
     readonly rasterTileStream: Subject<CARTA.RasterTileData>;
     readonly rasterSyncStream: Subject<CARTA.RasterTileSync>;
@@ -156,8 +157,15 @@ export class BackendService {
         ]);
 
         // check ping every 5 seconds
-        setInterval(this.sendPing, 5000);
+        this.pingIntervalHandle = setInterval(this.sendPing, 5000);
+        window.addEventListener("unload", this.dispose);
     }
+
+    public dispose = () => {
+        clearInterval(this.pingIntervalHandle);
+        this.pingIntervalHandle = undefined;
+        window.removeEventListener("unload", this.dispose);
+    };
 
     @action("connect")
     async connect(url: string): Promise<CARTA.IRegisterViewerAck> {

--- a/src/services/TelemetryService.ts
+++ b/src/services/TelemetryService.ts
@@ -65,6 +65,7 @@ export class TelemetryService {
     private db: IDBPDatabase<TelemetryDb>;
     @observable private uuid: string = "";
     @observable private skipTelemetry: boolean = false;
+    private telemetrySubmissionHandle: ReturnType<typeof setInterval> | undefined;
 
     private constructor() {
         this.axiosInstance = axios.create({
@@ -78,9 +79,16 @@ export class TelemetryService {
             ev.preventDefault();
         };
 
-        setInterval(this.flushTelemetry, TelemetryService.SubmissionIntervalSeconds * 1000);
+        this.telemetrySubmissionHandle = setInterval(this.flushTelemetry, TelemetryService.SubmissionIntervalSeconds * 1000);
+        window.addEventListener("unload", this.dispose);
         makeObservable(this);
     }
+
+    public dispose = () => {
+        clearInterval(this.telemetrySubmissionHandle);
+        this.telemetrySubmissionHandle = undefined;
+        window.removeEventListener("unload", this.dispose);
+    };
 
     @flow.bound *checkAndGenerateId(flush: boolean = false, forceNewId: boolean = false) {
         const url = new URL(window.location.href);

--- a/src/stores/AnimatorStore/AnimatorStore.ts
+++ b/src/stores/AnimatorStore/AnimatorStore.ts
@@ -55,6 +55,7 @@ export class AnimatorStore {
         if (this.animationMode === AnimationMode.FRAME) {
             if (this.animateHandle !== undefined) {
                 clearInterval(this.animateHandle);
+                this.animateHandle = undefined;
             }
             this.animationActive = true;
             this.animate();
@@ -125,13 +126,15 @@ export class AnimatorStore {
             console.error(err);
             appStore.tileService.setAnimationEnabled(false);
         }
-        if (this.stopHandle !== undefined) {
-            clearTimeout(this.stopHandle);
-        }
+        clearTimeout(this.stopHandle);
+        this.stopHandle = undefined;
         this.stopHandle = setTimeout(this.stopAnimation, 1000 * 60 * preferenceStore.stopAnimationPlaybackMinutes);
     }
 
     @action stopAnimation = () => {
+        clearTimeout(this.stopHandle);
+        this.stopHandle = undefined;
+
         // Ignore stop when not playing
         if (!this.animationActive) {
             return;
@@ -148,6 +151,7 @@ export class AnimatorStore {
         if (this.animationMode === AnimationMode.FRAME) {
             if (this.animateHandle !== undefined) {
                 clearInterval(this.animateHandle);
+                this.animateHandle = undefined;
             }
         } else {
             const endFrame: CARTA.IAnimationFrame = {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -159,7 +159,7 @@ export class AppStore {
     private appContainer: HTMLElement | null = null;
     private fileCounter = 0;
     private previousConnectionStatus: ConnectionStatus;
-    private canvasUpdatedTimer;
+    private canvasUpdatedTimer: ReturnType<typeof setTimeout> | undefined;
 
     public getAppContainer = (): HTMLElement | null => {
         return this.appContainer;
@@ -3467,6 +3467,7 @@ export class AppStore {
 
     setCanvasUpdated = () => {
         clearTimeout(this.canvasUpdatedTimer);
+        this.canvasUpdatedTimer = undefined;
         this.canvasUpdatedTimer = setTimeout(() => this.setIsCanvasUpdated(true), EXPORT_IMAGE_DELAY);
     };
 

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -944,6 +944,8 @@ export class AppStore {
                 f.clearSpectralReference();
             }
 
+            frame.dispose?.();
+
             const removedFrameIsSpatialReference = frame === this.spatialReference;
             const removedFrameIsSpectralReference = frame === this.spectralReference;
             const removedFrameIsRasterScalingReference = frame === this.rasterScalingReference;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -944,8 +944,6 @@ export class AppStore {
                 f.clearSpectralReference();
             }
 
-            frame.dispose?.();
-
             const removedFrameIsSpatialReference = frame === this.spatialReference;
             const removedFrameIsSpectralReference = frame === this.spectralReference;
             const removedFrameIsRasterScalingReference = frame === this.rasterScalingReference;
@@ -1047,6 +1045,8 @@ export class AppStore {
                         CatalogStore.Instance.resetActiveCatalogFile(firstFrame.frameInfo.fileId);
                     }
                 }
+
+                frame.dispose?.();
             }
         }
     };
@@ -1069,6 +1069,7 @@ export class AppStore {
                 this.widgetsStore.removeFloatingWidget(key);
             });
             this.frames.forEach(frame => {
+                frame.dispose?.();
                 frame.clearContours(false);
                 const fileId = frame.frameInfo.fileId;
                 this.telemetryService.addFileCloseEntry(fileId);
@@ -1088,6 +1089,8 @@ export class AppStore {
      * @param previewId - The file id of the image cube from which the PV preview was created.
      */
     @action removePreviewFrame = (previewId: number) => {
+        const previewFrame = this.previewFrames.get(previewId);
+        previewFrame?.dispose?.();
         if (this.previewFrames.delete(previewId)) {
             this.backendService.closePvPreview(previewId);
             this.setActiveImage(this.imageViewConfigStore.visibleImages[0]);

--- a/src/stores/FileBrowserStore/FileBrowserStore.ts
+++ b/src/stores/FileBrowserStore/FileBrowserStore.ts
@@ -79,7 +79,7 @@ export class FileBrowserStore {
     @observable saveRestFreq: Freq = {value: 0, unit: FrequencyUnit.MHZ};
     @observable shouldDropDegenerateAxes: boolean = false;
 
-    private extendedDelayHandle: any;
+    private extendedDelayHandle: ReturnType<typeof setTimeout> | undefined;
 
     constructor() {
         makeObservable(this);
@@ -170,10 +170,8 @@ export class FileBrowserStore {
     }
 
     private clearExtendedDelayTimer(resetState: boolean = false) {
-        if (this.extendedDelayHandle) {
-            clearTimeout(this.extendedDelayHandle);
-            this.extendedDelayHandle = null;
-        }
+        clearTimeout(this.extendedDelayHandle);
+        this.extendedDelayHandle = undefined;
         if (resetState) {
             this.setExtendedLoading(false);
         }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -131,6 +131,7 @@ export class FrameStore {
     public spatialTransformAST: AST.Mapping | null = null;
     private cursorMovementHandle: NodeJS.Timeout | undefined = undefined;
     private readonly disposers: IReactionDisposer[] = [];
+    private isDisposed = false;
 
     public restFreqStore: RestFreqStore;
 
@@ -403,6 +404,7 @@ export class FrameStore {
             adjTranslation = rotate2D(adjTranslation, -this.spatialTransform.rotation);
             if ((this.cachedTransformedWcsInfo as number) > 0) {
                 AST.deleteObject(this.cachedTransformedWcsInfo);
+                this.cachedTransformedWcsInfo = -1;
             }
 
             if (this.spatialReference.isOffsetCoord && !this.wcsInfoOffset) {
@@ -1551,10 +1553,34 @@ export class FrameStore {
     }
 
     public dispose = () => {
+        if (this.isDisposed) {
+            return;
+        }
+        this.isDisposed = true;
+
         this.disposers.forEach(disposer => disposer());
         this.disposers.length = 0;
         clearTimeout(this.zoomTimeoutHandler);
         clearTimeout(this.cursorMovementHandle);
+
+        // Release AST handles owned by this frame to avoid leaking objects in the WASM heap.
+        const astHandles = [
+            this.spectralFrame,
+            this.wcsInfo,
+            this.wcsInfo3D,
+            this.wcsInfoForTransformation,
+            this.wcsInfoOffset,
+            this.spatialTransformAST,
+            this.spectralTransformAST,
+            this.cachedTransformedWcsInfo
+        ] as unknown[];
+        const deletedHandles = new Set<number>();
+        astHandles.forEach(handle => {
+            if (typeof handle === "number" && handle > 0 && !deletedHandles.has(handle)) {
+                AST.deleteObject(handle as unknown as AST.AstObject);
+                deletedHandles.add(handle);
+            }
+        });
     };
 
     updateWcsSystem = (formatStringX: string | undefined, formatStyingY: string | undefined, explicitSystem: SystemType | undefined) => {
@@ -1957,6 +1983,9 @@ export class FrameStore {
 
     public updateSpectralVsDirectionWcs = () => {
         if (this.wcsInfo3D) {
+            if (this.wcsInfo && this.wcsInfo !== this.wcsInfo3D) {
+                AST.deleteObject(this.wcsInfo);
+            }
             this.wcsInfo = AST.makeSwappedFrameSet(this.wcsInfo3D, this.dirAxis, this.spectral, this.requiredChannel, this.dirAxisSize);
             AST.set(this.wcsInfo, `Format(${this.dirAxis})=${this.dirAxisFormat}, Unit(${this.dirAxis})=""`);
         }
@@ -2317,6 +2346,7 @@ export class FrameStore {
             if (this.wcsInfo && this.offsetCenter) {
                 if (this.wcsInfoOffset) {
                     AST.deleteObject(this.wcsInfoOffset);
+                    this.wcsInfoOffset = undefined as any;
                 }
 
                 const centerInRad = getUnformattedWCSPoint(this.wcsInfo, this.offsetCenter);
@@ -2326,6 +2356,9 @@ export class FrameStore {
                     for (const frame of this.secondarySpatialImages) {
                         const frameCenterInRad = getUnformattedWCSPoint(frame.wcsInfo, frame.offsetCenter);
                         if (frame.isOffsetCoord && frameCenterInRad && frame.spatialTransform) {
+                            if (frame.wcsInfoOffset) {
+                                AST.deleteObject(frame.wcsInfoOffset);
+                            }
                             frame.wcsInfoOffset = AST.createOffsetFrameset(
                                 frame.wcsInfo,
                                 frameCenterInRad.x,
@@ -3019,6 +3052,10 @@ export class FrameStore {
             }
         }
 
+        if (this.spatialTransformAST) {
+            AST.deleteObject(this.spatialTransformAST);
+            this.spatialTransformAST = null;
+        }
         this.spatialTransformAST = AST.getSpatialMapping(this.wcsInfo, frame.wcsInfo);
 
         if (!this.spatialTransformAST) {
@@ -3150,6 +3187,10 @@ export class FrameStore {
         }
         AST.invert(copySrc);
         AST.invert(copyDest);
+        if (this.spectralTransformAST) {
+            AST.deleteObject(this.spectralTransformAST);
+            this.spectralTransformAST = null;
+        }
         this.spectralTransformAST = AST.convert(copySrc, copyDest, "");
         AST.deleteObject(copySrc);
         AST.deleteObject(copyDest);
@@ -3360,6 +3401,12 @@ export class FrameStore {
         // Update wcsInfo
         const astFrameSet = this.initPVFrame();
         if (astFrameSet) {
+            if (this.spectralFrame) {
+                AST.deleteObject(this.spectralFrame);
+            }
+            if (this.wcsInfo && this.wcsInfo !== this.wcsInfo3D) {
+                AST.deleteObject(this.wcsInfo);
+            }
             this.spectralFrame = AST.getSpectralFrame(astFrameSet);
             this.wcsInfo = AST.copy(astFrameSet);
             AST.deleteObject(astFrameSet);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1,7 +1,7 @@
 import type {NumberRange} from "@blueprintjs/core";
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {POLARIZATIONS, RegionId, SpectralSystem, SpectralType, SpectralUnit, SystemType} from "enums";
 import {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -103,7 +103,7 @@ export class FrameStore {
 
     private spectralTransformAST: AST.FrameSet | null = null;
     private cachedTransformedWcsInfo: AST.FrameSet = -1;
-    private zoomTimeoutHandler;
+    private zoomTimeoutHandler: ReturnType<typeof setTimeout> | undefined;
 
     private dirAxis: number = -1;
     private dirAxisSize: number = -1;
@@ -129,7 +129,7 @@ export class FrameStore {
     public spectralCoordsSupported: Map<string | undefined, {type: SpectralType | null; unit: SpectralUnit | null}> | null = null;
     public spectralSystemsSupported: Array<SpectralSystem> | null = null;
     public spatialTransformAST: AST.Mapping | null = null;
-    private cursorMovementHandle: NodeJS.Timeout | undefined = undefined;
+    private cursorMovementHandle: ReturnType<typeof setTimeout> | undefined = undefined;
     private readonly disposers: IReactionDisposer[] = [];
     private isDisposed = false;
 
@@ -1561,7 +1561,9 @@ export class FrameStore {
         this.disposers.forEach(disposer => disposer());
         this.disposers.length = 0;
         clearTimeout(this.zoomTimeoutHandler);
+        this.zoomTimeoutHandler = undefined;
         clearTimeout(this.cursorMovementHandle);
+        this.cursorMovementHandle = undefined;
 
         // Release AST handles owned by this frame to avoid leaking objects in the WASM heap.
         const astHandles = [this.spectralFrame, this.wcsInfo, this.wcsInfo3D, this.wcsInfoForTransformation, this.wcsInfoOffset, this.spatialTransformAST, this.spectralTransformAST, this.cachedTransformedWcsInfo] as unknown[];
@@ -2009,10 +2011,8 @@ export class FrameStore {
     }
 
     private replaceZoomTimeoutHandler = () => {
-        if (this.zoomTimeoutHandler) {
-            clearTimeout(this.zoomTimeoutHandler);
-        }
-
+        clearTimeout(this.zoomTimeoutHandler);
+        this.zoomTimeoutHandler = undefined;
         this.zoomTimeoutHandler = setTimeout(this.endZoom, FrameStore.ZoomInertiaDuration);
     };
 
@@ -2826,6 +2826,7 @@ export class FrameStore {
         }
         this.cursorMoving = true;
         clearTimeout(this.cursorMovementHandle);
+        this.cursorMovementHandle = undefined;
         this.cursorMovementHandle = setTimeout(this.endCursorMove, FrameStore.CursorMovementDuration);
     };
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1,7 +1,7 @@
 import type {NumberRange} from "@blueprintjs/core";
 import * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {POLARIZATIONS, RegionId, SpectralSystem, SpectralType, SpectralUnit, SystemType} from "enums";
 import {
@@ -130,6 +130,7 @@ export class FrameStore {
     public spectralSystemsSupported: Array<SpectralSystem> | null = null;
     public spatialTransformAST: AST.Mapping | null = null;
     private cursorMovementHandle: NodeJS.Timeout | undefined = undefined;
+    private readonly disposers: IReactionDisposer[] = [];
 
     public restFreqStore: RestFreqStore;
 
@@ -1435,105 +1436,126 @@ export class FrameStore {
         this.cursorValue = {position: {x: NaN, y: NaN}, channel: 0, value: NaN};
         this.cursorMoving = false;
 
-        reaction(
-            () => this.restFreqStore.restFreqInHz,
-            restFreq => {
-                if (this.restFreqStore.inValidInput || !restFreq || !isFinite(restFreq)) {
-                    return;
-                }
+        this.disposers.push(
+            reaction(
+                () => this.restFreqStore.restFreqInHz,
+                restFreq => {
+                    if (this.restFreqStore.inValidInput || !restFreq || !isFinite(restFreq)) {
+                        return;
+                    }
 
-                if (this.wcsInfo3D) {
-                    AST.set(this.wcsInfo3D, `RestFreq=${restFreq} Hz`);
-                }
-                if (this.spectralFrame) {
-                    AST.set(this.spectralFrame, `RestFreq=${restFreq} Hz`);
-                }
+                    if (this.wcsInfo3D) {
+                        AST.set(this.wcsInfo3D, `RestFreq=${restFreq} Hz`);
+                    }
+                    if (this.spectralFrame) {
+                        AST.set(this.spectralFrame, `RestFreq=${restFreq} Hz`);
+                    }
 
-                if (this.spectralReference) {
-                    const spectralReference = this.spectralReference;
-                    this.clearSpectralReference();
-                    this.setSpectralReference(spectralReference);
-                } else if (this.secondarySpectralImages.length > 0) {
-                    for (const frame of this.secondarySpectralImages) {
-                        frame.clearSpectralReference();
-                        frame.setSpectralReference(this);
+                    if (this.spectralReference) {
+                        const spectralReference = this.spectralReference;
+                        this.clearSpectralReference();
+                        this.setSpectralReference(spectralReference);
+                    } else if (this.secondarySpectralImages.length > 0) {
+                        for (const frame of this.secondarySpectralImages) {
+                            frame.clearSpectralReference();
+                            frame.setSpectralReference(this);
+                        }
                     }
                 }
-            }
+            )
         );
 
-        autorun(() => {
-            const overlaySettings = AppStore.Instance.overlaySettings;
-            const formatStringX = overlaySettings?.numbers?.formatStringX;
-            const formatStyingY = overlaySettings?.numbers?.formatStringY;
-            const explicitSystem = overlaySettings?.global?.explicitSystem;
-            this.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
-        });
+        this.disposers.push(
+            autorun(() => {
+                const overlaySettings = AppStore.Instance.overlaySettings;
+                const formatStringX = overlaySettings?.numbers?.formatStringX;
+                const formatStyingY = overlaySettings?.numbers?.formatStringY;
+                const explicitSystem = overlaySettings?.global?.explicitSystem;
+                this.updateWcsSystem(formatStringX, formatStyingY, explicitSystem);
+            })
+        );
 
         // requiredFrameViewForRegionRender is a copy of requiredFrameView in non-observable version,
         // to avoid triggering wasted render() in PointRegionComponent/SimpleShapeRegionComponent/LineSegmentRegionComponent
-        autorun(() => {
-            if (this.requiredFrameView) {
-                this.requiredFrameViewForRegionRender = this.requiredFrameView;
-            }
-        });
-
-        autorun(() => {
-            // update zoomLevel when image viewer is available for drawing
-            if (this.isRenderable && this.zoomLevel <= 0) {
-                this.setZoom(this.zoomLevelForFit);
-            }
-        });
-
-        autorun(() => {
-            const type = this.spectralType;
-            const unit = this.spectralUnit;
-            /* eslint-disable @typescript-eslint/no-unused-vars */
-            const specsys = this.spectralSystem;
-            const restFreq = this.restFreqStore.restFreqInHz;
-            /* eslint-enable @typescript-eslint/no-unused-vars */
-            if (this.channelInfo) {
-                if (!type && !unit) {
-                    this.setChannelValues(this.channelInfo.values);
-                } else if (this.isCoordChannel) {
-                    this.setChannelValues(this.channelInfo.indexes);
-                } else {
-                    this.setChannelValues(this.isSpectralPropsEqual ? this.channelInfo.values : this.convertSpectral(this.channelInfo.values));
+        this.disposers.push(
+            autorun(() => {
+                if (this.requiredFrameView) {
+                    this.requiredFrameViewForRegionRender = this.requiredFrameView;
                 }
-            }
-        });
+            })
+        );
 
-        autorun(() => {
-            const typeSecondary = this.spectralTypeSecondary;
-            const unitSecondary = this.spectralUnitSecondary;
-            /* eslint-disable @typescript-eslint/no-unused-vars */
-            const specsys = this.spectralSystem;
-            const restFreq = this.restFreqStore.restFreqInHz;
-            /* eslint-enable @typescript-eslint/no-unused-vars */
-            if (this.channelInfo) {
-                if (!typeSecondary && !unitSecondary) {
-                    this.setChannelSecondaryValues(this.channelInfo.values);
-                } else if (this.isCoordChannelSecondary) {
-                    this.setChannelSecondaryValues(this.channelInfo.indexes);
-                } else {
-                    this.setChannelSecondaryValues(this.isSecondarySpectralPropsEqual ? this.channelInfo.values : this.convertSpectralSecondary(this.channelInfo.values));
+        this.disposers.push(
+            autorun(() => {
+                // update zoomLevel when image viewer is available for drawing
+                if (this.isRenderable && this.zoomLevel <= 0) {
+                    this.setZoom(this.zoomLevelForFit);
                 }
-            }
-        });
+            })
+        );
+
+        this.disposers.push(
+            autorun(() => {
+                const type = this.spectralType;
+                const unit = this.spectralUnit;
+                /* eslint-disable @typescript-eslint/no-unused-vars */
+                const specsys = this.spectralSystem;
+                const restFreq = this.restFreqStore.restFreqInHz;
+                /* eslint-enable @typescript-eslint/no-unused-vars */
+                if (this.channelInfo) {
+                    if (!type && !unit) {
+                        this.setChannelValues(this.channelInfo.values);
+                    } else if (this.isCoordChannel) {
+                        this.setChannelValues(this.channelInfo.indexes);
+                    } else {
+                        this.setChannelValues(this.isSpectralPropsEqual ? this.channelInfo.values : this.convertSpectral(this.channelInfo.values));
+                    }
+                }
+            })
+        );
+
+        this.disposers.push(
+            autorun(() => {
+                const typeSecondary = this.spectralTypeSecondary;
+                const unitSecondary = this.spectralUnitSecondary;
+                /* eslint-disable @typescript-eslint/no-unused-vars */
+                const specsys = this.spectralSystem;
+                const restFreq = this.restFreqStore.restFreqInHz;
+                /* eslint-enable @typescript-eslint/no-unused-vars */
+                if (this.channelInfo) {
+                    if (!typeSecondary && !unitSecondary) {
+                        this.setChannelSecondaryValues(this.channelInfo.values);
+                    } else if (this.isCoordChannelSecondary) {
+                        this.setChannelSecondaryValues(this.channelInfo.indexes);
+                    } else {
+                        this.setChannelSecondaryValues(this.isSecondarySpectralPropsEqual ? this.channelInfo.values : this.convertSpectralSecondary(this.channelInfo.values));
+                    }
+                }
+            })
+        );
 
         // Update the image view raster tiles in channel map mode
-        reaction(
-            () => this.stokes,
-            () => {
-                const channelMapStore = AppStore.Instance.channelMapStore;
-                if (this.requiredFrameView && channelMapStore.channelMapEnabled) {
-                    channelMapStore.handlePolarizationChanged(this);
+        this.disposers.push(
+            reaction(
+                () => this.stokes,
+                () => {
+                    const channelMapStore = AppStore.Instance.channelMapStore;
+                    if (this.requiredFrameView && channelMapStore.channelMapEnabled) {
+                        channelMapStore.handlePolarizationChanged(this);
+                    }
                 }
-            }
+            )
         );
 
         makeObservable(this);
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+        clearTimeout(this.zoomTimeoutHandler);
+        clearTimeout(this.cursorMovementHandle);
+    };
 
     updateWcsSystem = (formatStringX: string | undefined, formatStyingY: string | undefined, explicitSystem: SystemType | undefined) => {
         if (formatStringX !== undefined && formatStyingY !== undefined && explicitSystem !== undefined) {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1564,16 +1564,7 @@ export class FrameStore {
         clearTimeout(this.cursorMovementHandle);
 
         // Release AST handles owned by this frame to avoid leaking objects in the WASM heap.
-        const astHandles = [
-            this.spectralFrame,
-            this.wcsInfo,
-            this.wcsInfo3D,
-            this.wcsInfoForTransformation,
-            this.wcsInfoOffset,
-            this.spatialTransformAST,
-            this.spectralTransformAST,
-            this.cachedTransformedWcsInfo
-        ] as unknown[];
+        const astHandles = [this.spectralFrame, this.wcsInfo, this.wcsInfo3D, this.wcsInfoForTransformation, this.wcsInfoOffset, this.spatialTransformAST, this.spectralTransformAST, this.cachedTransformedWcsInfo] as unknown[];
         const deletedHandles = new Set<number>();
         astHandles.forEach(handle => {
             if (typeof handle === "number" && handle > 0 && !deletedHandles.has(handle)) {

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -1,6 +1,6 @@
 import {Colors} from "@blueprintjs/core";
 import * as CARTACompute from "carta_computation";
-import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {AngularSizeUnit, CatalogDisplayMode, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogSizeUnits, CatalogTextureType, FrameScaling} from "enums";
 import {FACTOR_TO_ARCSEC} from "models";

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -1,6 +1,6 @@
 import {Colors} from "@blueprintjs/core";
 import * as CARTACompute from "carta_computation";
-import {action, computed, makeObservable, observable, reaction} from "mobx";
+import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {AngularSizeUnit, CatalogDisplayMode, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogSizeUnits, CatalogTextureType, FrameScaling} from "enums";
 import {FACTOR_TO_ARCSEC} from "models";
@@ -111,118 +111,149 @@ export class CatalogWidgetStore {
     @observable angleMax: number = CatalogWidgetStore.MaxAngle;
     @observable angleMin: number = CatalogWidgetStore.MinAngle;
 
+    private readonly disposers: IReactionDisposer[] = [];
+
     constructor(catalogFileId: number) {
         this.catalogFileId = catalogFileId;
         makeObservable(this);
 
-        reaction(
-            () => this.sizeMapData,
-            column => {
-                const result = minMaxArray(column);
-                this.setSizeColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                this.setSizeColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
-            }
-        );
-
-        reaction(
-            () => this.sizeArray(),
-            size => {
-                if (size.length) {
-                    CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, size, CatalogTextureType.Size);
+        this.disposers.push(
+            reaction(
+                () => this.sizeMapData,
+                column => {
+                    const result = minMaxArray(column);
+                    this.setSizeColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
+                    this.setSizeColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.sizeColumnMin.clipd,
-            sizeColumnMin => {
-                if (this.sizeColumnMinLocked) {
-                    this.sizeMinorColumnMin.clipd = sizeColumnMin;
+        this.disposers.push(
+            reaction(
+                () => this.sizeArray(),
+                size => {
+                    if (size.length) {
+                        CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, size, CatalogTextureType.Size);
+                    }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.sizeColumnMax.clipd,
-            sizeColumnMax => {
-                if (this.sizeColumnMaxLocked) {
-                    this.sizeMinorColumnMax.clipd = sizeColumnMax;
+        this.disposers.push(
+            reaction(
+                () => this.sizeColumnMin.clipd,
+                sizeColumnMin => {
+                    if (this.sizeColumnMinLocked) {
+                        this.sizeMinorColumnMin.clipd = sizeColumnMin;
+                    }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.sizeMinorMapData,
-            column => {
-                const result = minMaxArray(column);
-                this.setSizeMinorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                this.setSizeMinorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
-            }
-        );
-
-        reaction(
-            () => this.sizeMinorArray(),
-            size => {
-                if (size.length) {
-                    CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, size, CatalogTextureType.SizeMinor);
+        this.disposers.push(
+            reaction(
+                () => this.sizeColumnMax.clipd,
+                sizeColumnMax => {
+                    if (this.sizeColumnMaxLocked) {
+                        this.sizeMinorColumnMax.clipd = sizeColumnMax;
+                    }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.sizeMinorColumnMin.clipd,
-            sizeMinorColumnMin => {
-                if (this.sizeMinorColumnMinLocked) {
-                    this.sizeColumnMin.clipd = sizeMinorColumnMin;
+        this.disposers.push(
+            reaction(
+                () => this.sizeMinorMapData,
+                column => {
+                    const result = minMaxArray(column);
+                    this.setSizeMinorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
+                    this.setSizeMinorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.sizeMinorColumnMax.clipd,
-            sizeMinorColumnMax => {
-                if (this.sizeMinorColumnMaxLocked) {
-                    this.sizeColumnMax.clipd = sizeMinorColumnMax;
+        this.disposers.push(
+            reaction(
+                () => this.sizeMinorArray(),
+                size => {
+                    if (size.length) {
+                        CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, size, CatalogTextureType.SizeMinor);
+                    }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.colorMapData,
-            column => {
-                const result = minMaxArray(column);
-                this.setColorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                this.setColorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
-            }
-        );
-
-        reaction(
-            () => this.colorArray(),
-            color => {
-                if (color.length) {
-                    CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, color, CatalogTextureType.Color);
+        this.disposers.push(
+            reaction(
+                () => this.sizeMinorColumnMin.clipd,
+                sizeMinorColumnMin => {
+                    if (this.sizeMinorColumnMinLocked) {
+                        this.sizeColumnMin.clipd = sizeMinorColumnMin;
+                    }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.orientationMapData,
-            column => {
-                const result = minMaxArray(column);
-                this.setOrientationMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                this.setOrientationMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
-            }
-        );
-
-        reaction(
-            () => this.orientationArray(),
-            orientation => {
-                if (orientation.length) {
-                    CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, orientation, CatalogTextureType.Orientation);
+        this.disposers.push(
+            reaction(
+                () => this.sizeMinorColumnMax.clipd,
+                sizeMinorColumnMax => {
+                    if (this.sizeMinorColumnMaxLocked) {
+                        this.sizeColumnMax.clipd = sizeMinorColumnMax;
+                    }
                 }
-            }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.colorMapData,
+                column => {
+                    const result = minMaxArray(column);
+                    this.setColorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
+                    this.setColorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.colorArray(),
+                color => {
+                    if (color.length) {
+                        CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, color, CatalogTextureType.Color);
+                    }
+                }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.orientationMapData,
+                column => {
+                    const result = minMaxArray(column);
+                    this.setOrientationMin(isFinite(result.minVal) ? result.minVal : 0, "default");
+                    this.setOrientationMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.orientationArray(),
+                orientation => {
+                    if (orientation.length) {
+                        CatalogWebGLService.Instance.updateDataTexture(this.catalogFileId, orientation, CatalogTextureType.Orientation);
+                    }
+                }
+            )
         );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 
     /**
      * Reset all settings of catalog source plot to default

--- a/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
+++ b/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {HistogramSettingsTabs, LineSettings, PlotType, POLARIZATIONS, RegionsType} from "enums";
@@ -34,6 +34,8 @@ export class HistogramWidgetStore extends RegionWidgetStore {
     @observable currentMaxPix: number | undefined = undefined;
     @observable currentAutoBins: boolean = true;
     @observable currentNumBins: number | null | undefined = null;
+
+    private readonly disposers: IReactionDisposer[] = [];
 
     // Maximum number of histogram bins on the slider
     @observable maxNumBins: number;
@@ -343,29 +345,36 @@ export class HistogramWidgetStore extends RegionWidgetStore {
 
         makeObservable(this);
 
-        autorun(() => {
-            // Update the config parameters
-            if (this.isAbleToGenerate) {
-                if (this.currentAutoBounds) {
-                    this.fixedBounds = false;
-                    this.minPix = 0;
-                    this.maxPix = 0;
-                } else {
-                    this.fixedBounds = true;
-                    this.minPix = this.currentMinPix;
-                    this.maxPix = this.currentMaxPix;
-                }
+        this.disposers.push(
+            autorun(() => {
+                // Update the config parameters
+                if (this.isAbleToGenerate) {
+                    if (this.currentAutoBounds) {
+                        this.fixedBounds = false;
+                        this.minPix = 0;
+                        this.maxPix = 0;
+                    } else {
+                        this.fixedBounds = true;
+                        this.minPix = this.currentMinPix;
+                        this.maxPix = this.currentMaxPix;
+                    }
 
-                if (this.currentAutoBins) {
-                    this.fixedNumBins = false;
-                    this.numBins = -1;
-                } else {
-                    this.fixedNumBins = true;
-                    this.numBins = this.currentNumBins;
+                    if (this.currentAutoBins) {
+                        this.fixedNumBins = false;
+                        this.numBins = -1;
+                    } else {
+                        this.fixedNumBins = true;
+                        this.numBins = this.currentNumBins;
+                    }
                 }
-            }
-        });
+            })
+        );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 
     // settings
     @action setPrimaryLineColor = (color: string) => {

--- a/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
+++ b/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {HistogramSettingsTabs, LineSettings, PlotType, POLARIZATIONS, RegionsType} from "enums";

--- a/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
+++ b/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
@@ -1,6 +1,6 @@
 import type {OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, computed, makeObservable, observable, reaction} from "mobx";
+import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {PreferenceKeys, RegionId, RegionsType, type SpectralSystem, TelemetryAction} from "enums";
 import {TelemetryService} from "services";
@@ -22,6 +22,8 @@ export class PvGeneratorWidgetStore extends RegionWidgetStore {
     @observable pvCutRegionId: number | null = null;
     @observable previewFullViewWidth: number = 1;
     @observable previewFullViewHeight: number = 1;
+
+    private readonly disposers: IReactionDisposer[] = [];
 
     @computed get regionOptions(): OptionProps[] {
         const appStore = AppStore.Instance;
@@ -205,13 +207,20 @@ export class PvGeneratorWidgetStore extends RegionWidgetStore {
 
         this.regionIdMap.set(ACTIVE_FILE_ID, RegionId.NONE);
 
-        reaction(
-            () => this.effectiveFrame?.channelValueBounds,
-            channelValueBounds => {
-                if (channelValueBounds) {
-                    this.setSpectralRange(channelValueBounds);
+        this.disposers.push(
+            reaction(
+                () => this.effectiveFrame?.channelValueBounds,
+                channelValueBounds => {
+                    if (channelValueBounds) {
+                        this.setSpectralRange(channelValueBounds);
+                    }
                 }
-            }
+            )
         );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 }

--- a/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
+++ b/src/stores/Widgets/PvGeneratorWidgetStore/PvGeneratorWidgetStore.ts
@@ -1,6 +1,6 @@
 import type {OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {PreferenceKeys, RegionId, RegionsType, type SpectralSystem, TelemetryAction} from "enums";
 import {TelemetryService} from "services";

--- a/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
@@ -1,6 +1,6 @@
 import {CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, override} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, override} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {LineSettings, PlotType, POLARIZATIONS, RegionId, RegionsType, SpatialProfilerSettingsTabs} from "enums";

--- a/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
@@ -1,6 +1,6 @@
 import {CARTA} from "carta-protobuf";
 import * as _ from "lodash";
-import {action, autorun, computed, makeObservable, observable, override} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, override} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {LineSettings, PlotType, POLARIZATIONS, RegionId, RegionsType, SpatialProfilerSettingsTabs} from "enums";
@@ -34,6 +34,8 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
     @observable linePlotInitXYBoundaries: {minXVal: number; maxXVal: number; minYVal: number; maxYVal: number} = {minXVal: 0, maxXVal: 0, minYVal: 0, maxYVal: 0};
     readonly smoothingStore: ProfileSmoothingStore = new ProfileSmoothingStore();
     @observable settingsTabId: SpatialProfilerSettingsTabs = SpatialProfilerSettingsTabs.STYLING;
+
+    private readonly disposers: IReactionDisposer[] = [];
 
     @override setRegionId = (fileId: number, regionId: number) => {
         this.regionIdMap.set(fileId, regionId);
@@ -121,15 +123,22 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
         if (coordinate !== undefined) {
             this.coordinate = coordinate;
         }
-        autorun(() => {
-            if (this.effectiveFrame) {
-                action(() => {
-                    this.selectedStokes = DEFAULT_STOKES;
-                })();
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (this.effectiveFrame) {
+                    action(() => {
+                        this.selectedStokes = DEFAULT_STOKES;
+                    })();
+                }
+            })
+        );
         makeObservable(this);
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 
     @computed get isXProfile(): boolean {
         return this.coordinate?.includes("x");

--- a/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
+++ b/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
@@ -1,7 +1,7 @@
 import type {NumberRange} from "@blueprintjs/core";
 import {type Table2} from "@blueprintjs/table";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, flow, IReactionDisposer, makeObservable, observable} from "mobx";
+import {action, autorun, computed, flow, type IReactionDisposer, makeObservable, observable} from "mobx";
 
 import {RedshiftType, SpectralLineHeaders, SpectralLineQueryRangeType, SpectralLineQueryUnit} from "enums";
 import {SplatalogueService} from "services";

--- a/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
+++ b/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
@@ -1,7 +1,7 @@
 import type {NumberRange} from "@blueprintjs/core";
 import {type Table2} from "@blueprintjs/table";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, flow, makeObservable, observable} from "mobx";
+import {action, autorun, computed, flow, IReactionDisposer, makeObservable, observable} from "mobx";
 
 import {RedshiftType, SpectralLineHeaders, SpectralLineQueryRangeType, SpectralLineQueryUnit} from "enums";
 import {SplatalogueService} from "services";
@@ -90,6 +90,7 @@ export class SpectralLineQueryWidgetStore {
     @observable controlHeader: Map<string, ControlHeader> = new Map<string, ControlHeader>();
     @observable sortingInfo: {columnName: string | null; sortingType: CARTA.SortingType | null} = {columnName: null, sortingType: null};
     @observable sortedIndexMap: Array<number> = [];
+    private readonly disposers: IReactionDisposer[] = [];
 
     // raw copy of the shifted frequency column, does not apply shifting factor
     private shiftedFreqColumnRawData: Array<number>;
@@ -553,10 +554,17 @@ export class SpectralLineQueryWidgetStore {
         this.initSortedIndexMap();
 
         // update selected spectral profiler when currently selected is closed
-        autorun(() => {
-            if (!this.selectedSpectralProfilerID || AppStore.Instance.widgetsStore.getSpectralWidgetStoreByID(this.selectedSpectralProfilerID)) {
-                this.selectedSpectralProfilerID = AppStore.Instance.widgetsStore.spectralProfilerList.length > 0 ? AppStore.Instance.widgetsStore.spectralProfilerList[0] : undefined;
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (!this.selectedSpectralProfilerID || AppStore.Instance.widgetsStore.getSpectralWidgetStoreByID(this.selectedSpectralProfilerID)) {
+                    this.selectedSpectralProfilerID = AppStore.Instance.widgetsStore.spectralProfilerList.length > 0 ? AppStore.Instance.widgetsStore.spectralProfilerList[0] : undefined;
+                }
+            })
+        );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {MultiProfileCategory, POLARIZATIONS, RegionId} from "enums";
 import {GetIntensityOptions, type IntensityConfig, type LineKey, type LineOption, POLARIZATION_LABELS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
@@ -48,6 +48,7 @@ export class SpectralProfileSelectionStore {
 
     private readonly widgetStore: SpectralProfileWidgetStore;
     private readonly DEFAULT_COORDINATE: string;
+    private readonly disposers: IReactionDisposer[] = [];
 
     // getFormattedSpectralConfigs() is a simple converter to transform this.profileConfigs to SpectralConfig,
     // and SpectralConfig is specially for CalculateRequirementsMap in SpectralProfileWidgetStore.
@@ -699,66 +700,81 @@ export class SpectralProfileSelectionStore {
         this.initSingleMode();
 
         // Handle empty frame: reset
-        autorun(() => {
-            if (!this.selectedFrame) {
-                this.initSingleMode();
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                if (!this.selectedFrame) {
+                    this.initSingleMode();
+                }
+            })
+        );
 
         // When selected region was deleted: remove regionId in selectedRegionIds if it does not existed in region options
-        autorun(() => {
-            if (this.activeProfileCategory === MultiProfileCategory.REGION) {
-                this.selectedRegionIds?.forEach(selectedRegionId => {
-                    if (!this.regionOptions?.find(regionOption => selectedRegionId === regionOption.value)) {
-                        this.removeSelectedRegionMultiMode(selectedRegionId);
-                    }
-                });
-
-                // Once selectedRegionIds becomes empty, add cursor region (active region is disabled in multi selection mode)
-                if (this.selectedRegionIds?.length === 0) {
-                    this.selectRegionMultiMode(RegionId.CURSOR);
-                }
-            } else {
-                if (this.selectedRegionIds?.length > 0 && !this.regionOptions?.find(regionOption => this.selectedRegionIds[0] === regionOption.value)) {
-                    this.selectRegionSingleMode(RegionId.ACTIVE);
-                }
-            }
-        });
-
-        // When frame is changed(coordinateOptions changes), selected stokes stay unchanged if new frame also support them, otherwise to default('z')
-        autorun(() => {
-            if (this.selectedCoordinates?.some(coordinate => !this.coordinateOptions?.find(coordinateOption => coordinate === coordinateOption.value))) {
-                this.selectCoordinateSingleMode(this.DEFAULT_COORDINATE);
-            }
-        });
-
-        // Selecting active frame in the single frame mode
-        autorun(() => {
-            if (this.activeProfileCategory !== MultiProfileCategory.IMAGE) {
-                this.selectFrame(ACTIVE_FILE_ID);
-            }
-        });
-
-        reaction(
-            () => {
-                const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
-                return matchedFileIds;
-            },
-            matchedFileIds => {
-                if (this.activeProfileCategory === MultiProfileCategory.IMAGE) {
-                    // remove the profile if it is unmatched
-                    this.selectedFileIds.forEach(fileId => {
-                        if (!matchedFileIds?.includes(fileId)) {
-                            this.removeSelectedFileMultiMode(fileId);
+        this.disposers.push(
+            autorun(() => {
+                if (this.activeProfileCategory === MultiProfileCategory.REGION) {
+                    this.selectedRegionIds?.forEach(selectedRegionId => {
+                        if (!this.regionOptions?.find(regionOption => selectedRegionId === regionOption.value)) {
+                            this.removeSelectedRegionMultiMode(selectedRegionId);
                         }
                     });
 
-                    // if no selected frame under the multi-frame mode, add the selected frame
-                    if (this.selectedFileIds.length === 0 && this.selectedFrameFileId !== undefined) {
-                        this.selectedFileIds = [this.selectedFrameFileId];
+                    // Once selectedRegionIds becomes empty, add cursor region (active region is disabled in multi selection mode)
+                    if (this.selectedRegionIds?.length === 0) {
+                        this.selectRegionMultiMode(RegionId.CURSOR);
+                    }
+                } else {
+                    if (this.selectedRegionIds?.length > 0 && !this.regionOptions?.find(regionOption => this.selectedRegionIds[0] === regionOption.value)) {
+                        this.selectRegionSingleMode(RegionId.ACTIVE);
                     }
                 }
-            }
+            })
+        );
+
+        // When frame is changed(coordinateOptions changes), selected stokes stay unchanged if new frame also support them, otherwise to default('z')
+        this.disposers.push(
+            autorun(() => {
+                if (this.selectedCoordinates?.some(coordinate => !this.coordinateOptions?.find(coordinateOption => coordinate === coordinateOption.value))) {
+                    this.selectCoordinateSingleMode(this.DEFAULT_COORDINATE);
+                }
+            })
+        );
+
+        // Selecting active frame in the single frame mode
+        this.disposers.push(
+            autorun(() => {
+                if (this.activeProfileCategory !== MultiProfileCategory.IMAGE) {
+                    this.selectFrame(ACTIVE_FILE_ID);
+                }
+            })
+        );
+
+        this.disposers.push(
+            reaction(
+                () => {
+                    const matchedFileIds = AppStore.Instance.spatialAndSpectalMatchedFileIds;
+                    return matchedFileIds;
+                },
+                matchedFileIds => {
+                    if (this.activeProfileCategory === MultiProfileCategory.IMAGE) {
+                        // remove the profile if it is unmatched
+                        this.selectedFileIds.forEach(fileId => {
+                            if (!matchedFileIds?.includes(fileId)) {
+                                this.removeSelectedFileMultiMode(fileId);
+                            }
+                        });
+
+                        // if no selected frame under the multi-frame mode, add the selected frame
+                        if (this.selectedFileIds.length === 0 && this.selectedFrameFileId !== undefined) {
+                            this.selectedFileIds = [this.selectedFrameFileId];
+                        }
+                    }
+                }
+            )
         );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+    };
 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -25,6 +25,8 @@ interface SpectralConfig extends CARTA.SetSpectralRequirements.ISpectralConfig {
 const MAXIMUM_PROFILES = 16;
 
 type Profile = {
+    fileId: number | undefined;
+    regionId: number | null;
     channelValues: number[];
     channelSecondaryValues: number[];
     data: ProcessedSpectralProfile | null | undefined;
@@ -33,7 +35,6 @@ type Profile = {
         image: string | undefined;
         plot: string;
     };
-    comments: string[];
     intensityConfig: IntensityConfig;
     intensityUnit: string | undefined;
 };
@@ -193,12 +194,13 @@ export class SpectralProfileSelectionStore {
             const profileData = regionProfileStoreMap?.getProfile(profileConfig.coordinate, profileConfig.statsType);
             if (frame) {
                 profiles.push({
+                    fileId: profileConfig.fileId,
+                    regionId: profileConfig.regionId,
                     channelValues: frame.channelValues,
                     channelSecondaryValues: frame.channelSecondaryValues,
                     data: profileData,
                     colorKey: profileConfig.colorKey,
                     label: profileConfig.label,
-                    comments: frame.getRegionProperties(profileConfig.regionId ?? NaN),
                     intensityConfig: frame.intensityConfig,
                     intensityUnit: frame.intensityUnit
                 });

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {MultiProfileCategory, POLARIZATIONS, RegionId} from "enums";
 import {GetIntensityOptions, type IntensityConfig, type LineKey, type LineOption, POLARIZATION_LABELS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -1,6 +1,6 @@
 import type {NumberRange, OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, makeObservable, observable, override, reaction} from "mobx";
+import {action, autorun, computed, IReactionDisposer, makeObservable, observable, override, reaction} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {VERTICAL_RANGE_PADDING} from "components/Shared";
@@ -76,6 +76,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     readonly smoothingStore: ProfileSmoothingStore;
     readonly profileSelectionStore: SpectralProfileSelectionStore;
     readonly fittingStore: ProfileFittingStore;
+
+    private readonly disposers: IReactionDisposer[] = [];
 
     /**
      * Set region for the spectral profiler.
@@ -366,58 +368,76 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.profileSelectionStore = new SpectralProfileSelectionStore(this, coordinate);
         this.setMultiProfileIntensityUnit(this.effectiveFrame?.headerUnit);
 
-        reaction(
-            () => this.effectiveFrame,
-            frame => {
-                if (frame) {
-                    const isMultiProfileActive = this.profileSelectionStore.activeProfileCategory === MultiProfileCategory.IMAGE;
-                    if (isMultiProfileActive) {
-                        this.setMultiProfileIntensityUnit(GetIntensityConversion(frame.intensityConfig, this.intensityUnit) ? this.intensityUnit : frame.headerUnit);
+        this.disposers.push(
+            reaction(
+                () => this.effectiveFrame,
+                frame => {
+                    if (frame) {
+                        const isMultiProfileActive = this.profileSelectionStore.activeProfileCategory === MultiProfileCategory.IMAGE;
+                        if (isMultiProfileActive) {
+                            this.setMultiProfileIntensityUnit(GetIntensityConversion(frame.intensityConfig, this.intensityUnit) ? this.intensityUnit : frame.headerUnit);
+                        }
                     }
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.profileSelectionStore.activeProfileCategory,
-            () => {
-                this.setMultiProfileIntensityUnit(this.intensityOptions[0]);
-            }
-        );
-
-        reaction(
-            () => this.effectiveFrame?.requiredPolarization,
-            polarization => {
-                if (this.effectiveFrame && polarization !== undefined && [POLARIZATIONS.PFtotal, POLARIZATIONS.PFlinear, POLARIZATIONS.Pangle].includes(polarization)) {
-                    this.setMultiProfileIntensityUnit(this.effectiveFrame.headerUnit);
+        this.disposers.push(
+            reaction(
+                () => this.profileSelectionStore.activeProfileCategory,
+                () => {
+                    this.setMultiProfileIntensityUnit(this.intensityOptions[0]);
                 }
-            }
+            )
         );
 
-        reaction(
-            () => this.effectiveFrame?.channelValueBounds,
-            channelValueBounds => {
-                if (channelValueBounds) {
+        this.disposers.push(
+            reaction(
+                () => this.effectiveFrame?.requiredPolarization,
+                polarization => {
+                    if (this.effectiveFrame && polarization !== undefined && [POLARIZATIONS.PFtotal, POLARIZATIONS.PFlinear, POLARIZATIONS.Pangle].includes(polarization)) {
+                        this.setMultiProfileIntensityUnit(this.effectiveFrame.headerUnit);
+                    }
+                }
+            )
+        );
+
+        this.disposers.push(
+            reaction(
+                () => this.effectiveFrame?.channelValueBounds,
+                channelValueBounds => {
+                    if (channelValueBounds) {
+                        this.updateRanges();
+                    }
+                }
+            )
+        );
+
+        this.disposers.push(
+            autorun(() => {
+                if (this.effectiveFrame) {
                     this.updateRanges();
+                    this.selectMomentRegion(RegionId.IMAGE);
                 }
-            }
+            })
         );
-
-        autorun(() => {
-            if (this.effectiveFrame) {
-                this.updateRanges();
-                this.selectMomentRegion(RegionId.IMAGE);
-            }
-        });
 
         // Update boundaries
-        autorun(() => {
-            const currentData = this.plotData;
-            if (currentData) {
-                this.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
-            }
-        });
+        this.disposers.push(
+            autorun(() => {
+                const currentData = this.plotData;
+                if (currentData) {
+                    this.initXYBoundaries(currentData.xMin, currentData.xMax, currentData.yMin, currentData.yMax);
+                }
+            })
+        );
     }
+
+    public dispose = () => {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
+        this.profileSelectionStore.dispose?.();
+    };
 
     @computed private get intensityConfig(): IntensityConfig | undefined {
         const frame = this.effectiveFrame;

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -14,7 +14,6 @@ import {clamp, genColorFromIndex, getColorForTheme, isAutoColor, pixelToFluxDens
 type XBound = {xMin: number | undefined; xMax: number | undefined};
 type YBound = {yMin: number; yMax: number};
 type DataPoints = Point2D[];
-type Comments = string[];
 export type MultiPlotData = {
     numProfiles: number;
     data: DataPoints[];
@@ -23,7 +22,6 @@ export type MultiPlotData = {
     fittingData: {x: number[]; y: Float32Array | Float64Array | undefined} | undefined;
     colors: (string | undefined)[];
     labels: {image: string | undefined; plot: string}[];
-    comments: Comments[];
     plotName: {image: string; plot: string};
     xMin: number | undefined;
     xMax: number | undefined;
@@ -506,7 +504,6 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
                 const profileColor = profileColorMap.get(profile.colorKey ?? "");
                 colors.push(profileColor === undefined ? undefined : getColorForTheme(profileColor));
                 labels.push(profile.label);
-                comments.push(profile.comments);
 
                 const intensityConversion = GetIntensityConversion(profile.intensityConfig, isMultiProfileActive ? this.intensityUnit : profile.intensityUnit);
                 const intensityValues = intensityConversion && profile.data.values ? intensityConversion(profile.data.values) : profile.data.values;
@@ -585,7 +582,6 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
             fittingData,
             colors,
             labels,
-            comments,
             plotName: this.profileSelectionStore.profilesPlotName,
             xMin,
             xMax,
@@ -595,6 +591,22 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
             yRms,
             progress: progressSum / numProfiles
         };
+    }
+
+    @computed get profileComments(): string[][] {
+        const profiles = this.profileSelectionStore.profiles;
+        if (!(profiles?.length > 0)) {
+            return [];
+        }
+
+        let comments: string[][] = [];
+        profiles.forEach(profile => {
+            if (profile?.data) {
+                const frame = AppStore.Instance.getFrame(profile.fileId ?? NaN);
+                comments.push(frame ? frame.getRegionProperties(profile.regionId ?? NaN) : []);
+            }
+        });
+        return comments;
     }
 
     @computed get isAutoScaledX() {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -592,22 +592,6 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         };
     }
 
-    @computed get profileComments(): string[][] {
-        const profiles = this.profileSelectionStore.profiles;
-        if (!(profiles?.length > 0)) {
-            return [];
-        }
-
-        const comments: string[][] = [];
-        profiles.forEach(profile => {
-            if (profile?.data) {
-                const frame = AppStore.Instance.getFrame(profile.fileId ?? NaN);
-                comments.push(frame ? frame.getRegionProperties(profile.regionId ?? NaN) : []);
-            }
-        });
-        return comments;
-    }
-
     @computed get isAutoScaledX() {
         return this.minX === undefined || this.maxX === undefined;
     }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -434,7 +434,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     public dispose = () => {
         this.disposers.forEach(disposer => disposer());
         this.disposers.length = 0;
-        this.profileSelectionStore.dispose?.();
+        this.profileSelectionStore.dispose();
     };
 
     @computed private get intensityConfig(): IntensityConfig | undefined {

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -1,6 +1,6 @@
 import type {NumberRange, OptionProps} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
-import {action, autorun, computed, IReactionDisposer, makeObservable, observable, override, reaction} from "mobx";
+import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, override, reaction} from "mobx";
 import tinycolor from "tinycolor2";
 
 import {VERTICAL_RANGE_PADDING} from "components/Shared";
@@ -487,7 +487,6 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         const smoothedData: Point2D[][] = [];
         const colors: (string | undefined)[] = [];
         const labels: {image: string | undefined; plot: string}[] = [];
-        const comments: string[][] = [];
         const xBound = {xMin: Number.MAX_VALUE, xMax: -Number.MAX_VALUE};
         const yBound = {yMin: Number.MAX_VALUE, yMax: -Number.MAX_VALUE};
         let yMean: number | undefined;
@@ -599,7 +598,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
             return [];
         }
 
-        let comments: string[][] = [];
+        const comments: string[][] = [];
         profiles.forEach(profile => {
             if (profile?.data) {
                 const frame = AppStore.Instance.getFrame(profile.fileId ?? NaN);

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -122,6 +122,10 @@ export class WidgetProps {
     floatingSettingsId?: string;
 }
 
+interface Disposable {
+    dispose(): void;
+}
+
 export class WidgetsStore {
     private static staticInstance: WidgetsStore;
 
@@ -504,13 +508,17 @@ export class WidgetsStore {
         return this.defaultFloatingWidgetOffset;
     };
 
+    private static isDisposable = (store: unknown): store is Disposable => {
+        return typeof (store as Disposable | undefined)?.dispose === "function";
+    };
+
     public removeWidget = (widgetId: string, widgetType: string) => {
         const widgets = this.widgetsMap.get(widgetType);
         if (widgets) {
             // remove associated floating settings according current widgetId
             this.removeAssociatedFloatingSetting(widgetId);
-            const store: any = widgets.get(widgetId);
-            if (store && typeof store.dispose === "function") {
+            const store = widgets.get(widgetId) as unknown;
+            if (WidgetsStore.isDisposable(store)) {
                 try {
                     store.dispose();
                 } catch (err) {

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -509,6 +509,14 @@ export class WidgetsStore {
         if (widgets) {
             // remove associated floating settings according current widgetId
             this.removeAssociatedFloatingSetting(widgetId);
+            const store: any = widgets.get(widgetId);
+            if (store && typeof store.dispose === "function") {
+                try {
+                    store.dispose();
+                } catch (err) {
+                    console.error(`Failed to dispose widget store (type=${widgetType}, id=${widgetId})`, err);
+                }
+            }
             widgets.delete(widgetId);
         }
         // remove floating settings according floating settings Id


### PR DESCRIPTION
### Description

Closes #2637.

This PR addresses several performance and lifecycle issues in the spectral profile widget that could lead to unnecessary recomputation, accumulated background processing, and avoidable reactive overhead.

### Changes

#### 1. Avoid unnecessary recomputation in the data pipeline

Region movement updates region comments, which changes `frame.getRegionProperties` and previously caused `profiles` and downstream `plotData` to be recomputed.

Since `plotData` computation is expensive, especially with multiple listeners, this resulted in noticeable performance degradation.

**Change**:

* Moved `frame.getRegionProperties` outside of `profiles` so region movement no longer invalidates the `profiles → plotData` computation chain.

#### 2. Properly dispose MobX reactions on widget unmount

MobX `autorun` / `reaction` listeners created by the widget were not explicitly disposed when the widget was closed. Reopening the widget multiple times could leave “zombie” reactions running in the background.

**Change**:

* Introduced a `disposer` collection to explicitly track reactions created by the widget.
* Added `componentWillUnmount` to dispose all tracked reactions when the widget is removed, preventing background listeners from accumulating and eliminating potential memory leaks.

#### 3. Defer export comments to export-time (lazy generation)

Previously, per-profile region comments could still participate in reactive render paths.
Now, spectral profile export comments are generated only when exporting data.

**Change**:
- Added `exportCommentsGenerator` to `LinePlotComponent`.
- Removed render-time wiring of spectral profile comments.
- `SpectralProfilerComponent` now generates region/WCS comments on-demand during export.

#### 4. Additional timer/lifecycle hardening included in this PR

This branch also includes timer handle typing/cleanup and explicit dispose paths in services/stores.

**Change**:
- Standardized timeout/interval handle typing (`ReturnType<typeof setTimeout|setInterval>`).
- Ensured clear + reset on reuse/unmount/dispose paths.
- Added explicit `dispose()` cleanup for long-lived service timers.

### Testing steps

1. Open an image with a lot of channels (e.g., 80000 channels)
2. Place a point region
3. Open the spectral profile widget and wait until receiving the full profile.
4. Toggle the spectral profile widget multiple times.
5. Move the point region again and see **NO** laggy movement
6. Keep one Spectral Profile widget open and drag a point region: verify no lag.
7. Export spectral profile data and verify region pixel/WCS header comments are still present.

### Checklist

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [x] ~~unit test added (for functions with no dependenies)~~
- [x] ~~API documentation added (for public variables and methods in stores)~~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~~user manual prepared (for large new features)~~