### PR TITLE
Restore carta-python APIs

### DIFF
--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -1995,6 +1995,28 @@ export class FrameStore {
         this.zooming = false;
     };
 
+    /**
+     * Converts positions from WCS coordinates to image coordinates.
+     * Note: This function is used by carta-python and must not be removed.
+     *
+     * @param wcsList - An array of positions in WCS coordinates.
+     * @returns An array of corresponding positions in image coordinates.
+     */
+    getImagePosFromWCS = (wcsList: WCSPoint2D[]): Point2D[] => {
+        return wcsList.map(wcs => getPixelValueFromWCS(this.wcsInfoForTransformation, wcs));
+    };
+
+    /**
+     * Converts positions from image coordinates to WCS coordinates.
+     * Note: This function is used by carta-python and must not be removed.
+     *
+     * @param posList - An array of positions in image coordinates.
+     * @returns An array of corresponding positions in WCS coordinates.
+     */
+    getWCSFromImagePos = (posList: Point2D[]): WCSPoint2D[] => {
+        return posList.map(p => getFormattedWCSPoint(this.wcsInfoForTransformation, p));
+    };
+
     public getRegion = (regionId: number): RegionStore | undefined => {
         return this.regionSet?.regions?.find(r => r.regionId === regionId);
     };

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2003,7 +2003,7 @@ export class FrameStore {
      * @returns An array of corresponding positions in image coordinates.
      */
     getImagePosFromWCS = (wcsList: WCSPoint2D[]): Point2D[] => {
-        return wcsList.map(wcs => getPixelValueFromWCS(this.wcsInfoForTransformation, wcs));
+        return wcsList.map(wcs => getPixelValueFromWCS(this.wcsInfoForTransformation, wcs)).filter((point): point is Point2D => point !== null);
     };
 
     /**
@@ -2014,7 +2014,7 @@ export class FrameStore {
      * @returns An array of corresponding positions in WCS coordinates.
      */
     getWCSFromImagePos = (posList: Point2D[]): WCSPoint2D[] => {
-        return posList.map(p => getFormattedWCSPoint(this.wcsInfoForTransformation, p));
+        return posList.map(p => getFormattedWCSPoint(this.wcsInfoForTransformation, p)).filter((point): point is WCSPoint2D => point !== null);
     };
 
     public getRegion = (regionId: number): RegionStore | undefined => {


### PR DESCRIPTION
**Description**

Closes #2646.
Restore accidentally removed `carta-python` APIs and add clear comments indicating that these functions are used by `carta-python` and must not be removed.

These APIs are required by `carta-python` and are not called anywhere in the frontend codebase directly.

**Checklist**
For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)