### PR TITLE
overlay vector pixel averaging width step correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).
-* Vector overlay averaging pixel input UI ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612))..
 
 ## [5.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the incorrect WCS information when in image coordinate system ([#2614](https://github.com/CARTAvis/carta-frontend/issues/2614)).
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
+* Made vector overlay pixel averaging consistent between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the incorrect WCS information when in image coordinate system ([#2614](https://github.com/CARTAvis/carta-frontend/issues/2614)).
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
-* Fixed the inconsistent input behavior of vector overlay averaging pixel between the vector overlay dialog and preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
+* Fixed the inconsistent input of vector overlay pixel averaging between the vector overlay dialog and preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the incorrect WCS information when in image coordinate system ([#2614](https://github.com/CARTAvis/carta-frontend/issues/2614)).
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
-* Fixed the inconsistent input behavior of vector overlay averaging pixel between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
+* Fixed the inconsistent input behavior of vector overlay averaging pixel between the vector overlay dialog and preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the incorrect WCS information when in image coordinate system ([#2614](https://github.com/CARTAvis/carta-frontend/issues/2614)).
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
-* Made vector overlay pixel averaging consistent between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 * Fixed the inconsistent input behavior of vector overlay averaging pixel between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect colormap–name pairing ([#2628](https://github.com/CARTAvis/carta-frontend/issues/2628)).
 * Fixed vector overlay not updating after session resume ([#2217](https://github.com/CARTAvis/carta-frontend/issues/2217)).
 * Made vector overlay pixel averaging consistent between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
+* Fixed the inconsistent input behavior of vector overlay averaging pixel between the Vector Overlay dialog and Preferences dialog ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612)).
 ### Changed
 * Set the default aspect ratio to unity when images lacked valid WCS information ([#2604](https://github.com/CARTAvis/carta-frontend/issues/2604)).
 * Changed to retrieve all columns instead of default columns from vizier ([#1958](https://github.com/CARTAvis/carta-frontend/issues/1958)).
+* Vector overlay averaging pixel input UI ([#2612](https://github.com/CARTAvis/carta-frontend/issues/2612))..
 
 ## [5.0.3]
 

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -389,7 +389,7 @@ export class PreferenceDialogComponent extends React.Component {
                     <SafeNumericInput
                         placeholder="Default pixel averaging"
                         min={1}
-                        max={VectorOverlayDialogComponent.MAX_AVERAGING_PIXEL}
+                        max={VectorOverlayDialogComponent.MAX_PIXEL_AVERAGING}
                         value={preference.vectorOverlayPixelAveraging}
                         stepSize={1}
                         majorStepSize={2}

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -9,7 +9,7 @@ import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 import tinycolor from "tinycolor2";
 
-import {DraggableDialogComponent, LayoutMappingComponent} from "components/Dialogs";
+import {DraggableDialogComponent, LayoutMappingComponent, VectorOverlayDialogComponent} from "components/Dialogs";
 import {AppToaster, AutoColorPickerComponent, ColormapComponent, ColorPickerComponent, PointShapeSelectComponent, SafeNumericInput, ScalingSelectComponent, ScrollShadow, SuccessToast} from "components/Shared";
 import {CompressionQuality, ConvertToGB, CursorInfoVisibility, CursorPosition, Event, FileFilterMode, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
 import {TelemetryMode} from "services";
@@ -386,18 +386,16 @@ export class PreferenceDialogComponent extends React.Component {
         const vectorOverlayConfigPanel = (
             <React.Fragment>
                 <FormGroup inline={true} label="Default pixel averaging">
-                    <Tooltip content="Only even numbers are allowed (minimum: 2)" position="top">
-                        <SafeNumericInput
-                            placeholder="Default pixel averaging"
-                            min={2}
-                            max={64}
-                            value={preference.vectorOverlayPixelAveraging}
-                            majorStepSize={2}
-                            minorStepSize={2}
-                            stepSize={2}
-                            onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, Math.pow(2, Math.round(Math.log2(value))))}
-                        />
-                    </Tooltip>
+                    <SafeNumericInput
+                        placeholder="Default pixel averaging"
+                        min={1}
+                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
+                        value={preference.vectorOverlayPixelAveraging}
+                        stepSize={1}
+                        majorStepSize={2}
+                        minorStepSize={1}
+                        onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, Math.round(value))}
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Use fractional intensity">
                     <Switch checked={preference.vectorOverlayFractionalIntensity} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_FRACTIONAL_INTENSITY, ev.currentTarget.checked)} />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -386,15 +386,18 @@ export class PreferenceDialogComponent extends React.Component {
         const vectorOverlayConfigPanel = (
             <React.Fragment>
                 <FormGroup inline={true} label="Default pixel averaging">
-                    <SafeNumericInput
-                        placeholder="Default pixel averaging"
-                        min={0}
-                        max={64}
-                        value={preference.vectorOverlayPixelAveraging}
-                        majorStepSize={2}
-                        stepSize={2}
-                        onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, value)}
-                    />
+                    <Tooltip content="Only even numbers are allowed (minimum: 2)" position="top">
+                        <SafeNumericInput
+                            placeholder="Default pixel averaging"
+                            min={2}
+                            max={64}
+                            value={preference.vectorOverlayPixelAveraging}
+                            majorStepSize={2}
+                            minorStepSize={2}
+                            stepSize={2}
+                            onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, Math.pow(2, Math.round(Math.log2(value))))}
+                        />
+                    </Tooltip>
                 </FormGroup>
                 <FormGroup inline={true} label="Use fractional intensity">
                     <Switch checked={preference.vectorOverlayFractionalIntensity} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_FRACTIONAL_INTENSITY, ev.currentTarget.checked)} />

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -395,6 +395,7 @@ export class PreferenceDialogComponent extends React.Component {
                         majorStepSize={2}
                         minorStepSize={1}
                         onValueChange={value => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_PIXEL_AVERAGING, Math.round(value))}
+                        onBlur={ev => (ev.currentTarget.value = preference.vectorOverlayPixelAveraging.toString())}
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Use fractional intensity">

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -389,7 +389,7 @@ export class PreferenceDialogComponent extends React.Component {
                     <SafeNumericInput
                         placeholder="Default pixel averaging"
                         min={1}
-                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
+                        max={VectorOverlayDialogComponent.MAX_AVERAGING_PIXEL}
                         value={preference.vectorOverlayPixelAveraging}
                         stepSize={1}
                         majorStepSize={2}

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
@@ -39,12 +39,12 @@
                 margin-left: 8px;
 
                 .#{$ns}-slider {
-                    min-width: 120px;
+                    min-width: 180px;
                 }
 
                 .#{$ns}-numeric-input .#{$ns}-input-group {
                     margin-left: 15px;
-                    width: 48px;
+                    width: 40px;
                     flex-shrink: 0;
                 }
 

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
@@ -32,6 +32,27 @@
                 min-width: 10em;
                 width: 10em;
             }
+
+            // Averaging width slider and numeric input layout
+            .#{$ns}-form-group.averaging-width-input .#{$ns}-form-content {
+                display: flex;
+                margin-left: 8px;
+
+                .#{$ns}-slider {
+                    min-width: 120px;
+                }
+
+                .#{$ns}-numeric-input .#{$ns}-input-group {
+                    margin-left: 15px;
+                    width: 48px;
+                    flex-shrink: 0;
+                }
+
+                .lock-button {
+                    margin-left: 5px;
+                    padding: 0px;
+                }
+            }
         }
 
         .parameter-line {

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.scss
@@ -32,27 +32,6 @@
                 min-width: 10em;
                 width: 10em;
             }
-
-            // Averaging width slider and numeric input layout
-            .#{$ns}-form-group.averaging-width-input .#{$ns}-form-content {
-                display: flex;
-                margin-left: 8px;
-
-                .#{$ns}-slider {
-                    min-width: 180px;
-                }
-
-                .#{$ns}-numeric-input .#{$ns}-input-group {
-                    margin-left: 15px;
-                    width: 40px;
-                    flex-shrink: 0;
-                }
-
-                .lock-button {
-                    margin-left: 5px;
-                    padding: 0px;
-                }
-            }
         }
 
         .parameter-line {

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {ColorResult} from "react-color";
-import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Switch, Tab, Tabs} from "@blueprintjs/core";
+import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import {action, computed, makeObservable, observable} from "mobx";
@@ -152,10 +152,14 @@ export class VectorOverlayDialogComponent extends React.Component {
 
     @action private handlePixelAveragingEnabledChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
         this.pixelAveragingEnabled = ev.currentTarget.checked;
+        // When enabling averaging, normalize the width to a valid positive even number
+        if (ev.currentTarget.checked && this.pixelAveraging < 2) {
+            this.pixelAveraging = 2;
+        }
     };
 
     @action private handlePixelAveragingChanged = (value: number) => {
-        this.pixelAveraging = Math.floor(value * 0.5) * 2.0;
+        this.pixelAveraging = Math.max(2, Math.floor(value * 0.5) * 2.0);
     };
 
     @action private handleThresholdEnabledChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -318,17 +322,20 @@ export class VectorOverlayDialogComponent extends React.Component {
                     <Switch checked={this.pixelAveragingEnabled} onChange={this.handlePixelAveragingEnabledChanged} data-testid="vector-field-averaging-toggle" />
                 </FormGroup>
                 <FormGroup inline={true} label="Averaging width" labelInfo="(px)" disabled={!this.pixelAveragingEnabled}>
-                    <SafeNumericInput
-                        placeholder="Width (px)"
-                        min={2}
-                        max={64}
-                        value={this.pixelAveraging}
-                        majorStepSize={2}
-                        stepSize={2}
-                        onValueChange={this.handlePixelAveragingChanged}
-                        disabled={!this.pixelAveragingEnabled}
-                        data-testid="vector-field-averaging-width-input"
-                    />
+                    <Tooltip content="Only even numbers are allowed (minimum: 2)" position="top">
+                        <SafeNumericInput
+                            placeholder="Width (px)"
+                            min={2}
+                            max={64}
+                            value={this.pixelAveraging}
+                            majorStepSize={2}
+                            minorStepSize={2}
+                            stepSize={2}
+                            onValueChange={this.handlePixelAveragingChanged}
+                            disabled={!this.pixelAveragingEnabled}
+                            data-testid="vector-field-averaging-width-input"
+                        />
+                    </Tooltip>
                 </FormGroup>
                 <FormGroup inline={true} label="Polarization intensity" disabled={this.intensitySource === VectorOverlaySource.None}>
                     <RadioGroup inline={true} onChange={this.handleFractionalIntensityChanged} selectedValue={this.fractionalIntensity ? 1 : 0} disabled={this.intensitySource === VectorOverlaySource.None}>

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -28,7 +28,6 @@ export class VectorOverlayDialogComponent extends React.Component {
     @observable currentTab: VectorOverlayDialogTabs = VectorOverlayDialogTabs.Configuration;
     @observable angularSource: VectorOverlaySource;
     @observable intensitySource: VectorOverlaySource;
-    @observable pixelAveragingEnabled: boolean;
     @observable pixelAveraging: number;
     @observable thresholdEnabled: boolean;
     @observable threshold: number;
@@ -67,7 +66,6 @@ export class VectorOverlayDialogComponent extends React.Component {
         if (config) {
             this.angularSource = config.angularSource;
             this.intensitySource = config.intensitySource;
-            this.pixelAveragingEnabled = config.pixelAveragingEnabled;
             this.pixelAveraging = config.pixelAveraging;
             this.fractionalIntensity = config.fractionalIntensity;
             this.threshold = config.threshold;
@@ -78,7 +76,6 @@ export class VectorOverlayDialogComponent extends React.Component {
             this.angularSource = VectorOverlaySource.Current;
             this.intensitySource = VectorOverlaySource.Current;
             this.pixelAveraging = preferences.vectorOverlayPixelAveraging;
-            this.pixelAveragingEnabled = preferences.vectorOverlayPixelAveraging > 0;
             this.fractionalIntensity = preferences.vectorOverlayFractionalIntensity;
             this.thresholdEnabled = false;
             this.threshold = 0;
@@ -93,7 +90,6 @@ export class VectorOverlayDialogComponent extends React.Component {
             if (
                 config.angularSource !== this.angularSource ||
                 config.intensitySource !== this.intensitySource ||
-                config.pixelAveragingEnabled !== this.pixelAveragingEnabled ||
                 config.pixelAveraging !== this.pixelAveraging ||
                 config.thresholdEnabled !== this.thresholdEnabled ||
                 config.debiasing !== this.debiasing ||
@@ -125,7 +121,6 @@ export class VectorOverlayDialogComponent extends React.Component {
             dataSource.vectorOverlayConfig.setVectorOverlayConfiguration(
                 this.angularSource,
                 this.intensitySource,
-                this.pixelAveragingEnabled,
                 this.pixelAveraging,
                 this.fractionalIntensity,
                 this.thresholdEnabled,
@@ -153,7 +148,6 @@ export class VectorOverlayDialogComponent extends React.Component {
 
     @action private handlePixelAveragingChanged = (value: number) => {
         this.pixelAveraging = Math.round(value);
-        this.pixelAveragingEnabled = this.pixelAveraging !== 1;
     };
 
     @action private handlePixelAveragingBlurred = (ev: React.FocusEvent<HTMLInputElement>) => {

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -42,7 +42,7 @@ export class VectorOverlayDialogComponent extends React.Component {
     private static readonly DefaultHeight = 720;
     private static readonly MinWidth = 425;
     private static readonly MinHeight = 400;
-    public static readonly MaxAveragingWidth = 64;
+    public static readonly MAX_AVERAGING_PIXEL = 64;
 
     private cachedFrame: FrameStore;
 
@@ -319,7 +319,7 @@ export class VectorOverlayDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Averaging width" labelInfo="(px)" className="averaging-width-input">
                     <SafeNumericInput
                         min={1}
-                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
+                        max={VectorOverlayDialogComponent.MAX_AVERAGING_PIXEL}
                         value={this.pixelAveraging}
                         stepSize={1}
                         majorStepSize={2}

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {ColorResult} from "react-color";
-import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
+import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Slider, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import {action, computed, makeObservable, observable} from "mobx";
@@ -30,6 +30,7 @@ export class VectorOverlayDialogComponent extends React.Component {
     @observable intensitySource: VectorOverlaySource;
     @observable pixelAveragingEnabled: boolean;
     @observable pixelAveraging: number;
+    @observable pixelAveragingLocked: boolean = false;
     @observable thresholdEnabled: boolean;
     @observable threshold: number;
     @observable fractionalIntensity: boolean;
@@ -42,6 +43,7 @@ export class VectorOverlayDialogComponent extends React.Component {
     private static readonly DefaultHeight = 720;
     private static readonly MinWidth = 425;
     private static readonly MinHeight = 400;
+    public static readonly MaxAveragingWidth = 64;
 
     private cachedFrame: FrameStore;
 
@@ -150,16 +152,15 @@ export class VectorOverlayDialogComponent extends React.Component {
         this.intensitySource = parseInt(ev.currentTarget.value) as VectorOverlaySource;
     };
 
-    @action private handlePixelAveragingEnabledChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
-        this.pixelAveragingEnabled = ev.currentTarget.checked;
-        // When enabling averaging, normalize the width to a valid positive even number
-        if (ev.currentTarget.checked && this.pixelAveraging < 2) {
-            this.pixelAveraging = 2;
+    @action private handlePixelAveragingChanged = (value: number) => {
+        if (!this.pixelAveragingLocked) {
+            this.pixelAveraging = Math.round(value);
+            this.pixelAveragingEnabled = this.pixelAveraging !== 1;
         }
     };
 
-    @action private handlePixelAveragingChanged = (value: number) => {
-        this.pixelAveraging = Math.max(2, Math.floor(value * 0.5) * 2.0);
+    @action private handlePixelAveragingLocked = () => {
+        this.pixelAveragingLocked = !this.pixelAveragingLocked;
     };
 
     @action private handleThresholdEnabledChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -318,23 +319,27 @@ export class VectorOverlayDialogComponent extends React.Component {
                         )}
                     </HTMLSelect>
                 </FormGroup>
-                <FormGroup inline={true} label="Pixel averaging">
-                    <Switch checked={this.pixelAveragingEnabled} onChange={this.handlePixelAveragingEnabledChanged} data-testid="vector-field-averaging-toggle" />
-                </FormGroup>
-                <FormGroup inline={true} label="Averaging width" labelInfo="(px)" disabled={!this.pixelAveragingEnabled}>
-                    <Tooltip content="Only even numbers are allowed (minimum: 2)" position="top">
-                        <SafeNumericInput
-                            placeholder="Width (px)"
-                            min={2}
-                            max={64}
-                            value={this.pixelAveraging}
-                            majorStepSize={2}
-                            minorStepSize={2}
-                            stepSize={2}
-                            onValueChange={this.handlePixelAveragingChanged}
-                            disabled={!this.pixelAveragingEnabled}
-                            data-testid="vector-field-averaging-width-input"
-                        />
+                <FormGroup inline={true} label="Averaging width" labelInfo="(px)" className="averaging-width-input">
+                    <Slider
+                        min={1}
+                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
+                        value={this.pixelAveraging}
+                        onChange={this.handlePixelAveragingChanged}
+                        stepSize={1}
+                        labelStepSize={VectorOverlayDialogComponent.MaxAveragingWidth - 1}
+                        showTrackFill={false}
+                        data-testid="vector-field-averaging-width-slider"
+                    />
+                    <SafeNumericInput
+                        min={1}
+                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
+                        value={this.pixelAveraging}
+                        onValueChange={this.handlePixelAveragingChanged}
+                        buttonPosition="none"
+                        data-testid="vector-field-averaging-width-input"
+                    />
+                    <Tooltip content={this.pixelAveragingLocked ? "Unlock averaging width" : "Lock averaging width"}>
+                        <Button className="lock-button" icon={this.pixelAveragingLocked ? "lock" : "unlock"} onClick={this.handlePixelAveragingLocked} />
                     </Tooltip>
                 </FormGroup>
                 <FormGroup inline={true} label="Polarization intensity" disabled={this.intensitySource === VectorOverlaySource.None}>

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -44,9 +44,9 @@ export class VectorOverlayDialogComponent extends React.Component {
     private static readonly DefaultHeight = 720;
     private static readonly MinWidth = 425;
     private static readonly MinHeight = 400;
-    /** 
+    /**
      * The maximum pixel width for averaging the vector overlay.
-    */
+     */
     public static readonly MAX_PIXEL_AVERAGING = 64;
 
     private cachedFrame: FrameStore;

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {ColorResult} from "react-color";
-import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Slider, Switch, Tab, Tabs} from "@blueprintjs/core";
+import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Switch, Tab, Tabs} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import {action, computed, makeObservable, observable} from "mobx";
@@ -317,23 +317,15 @@ export class VectorOverlayDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Averaging width" labelInfo="(px)" className="averaging-width-input">
-                    <Slider
-                        min={1}
-                        max={VectorOverlayDialogComponent.MaxAveragingWidth}
-                        value={this.pixelAveraging}
-                        onChange={this.handlePixelAveragingChanged}
-                        stepSize={1}
-                        labelStepSize={VectorOverlayDialogComponent.MaxAveragingWidth - 1}
-                        showTrackFill={false}
-                        data-testid="vector-field-averaging-width-slider"
-                    />
                     <SafeNumericInput
                         min={1}
                         max={VectorOverlayDialogComponent.MaxAveragingWidth}
                         value={this.pixelAveraging}
+                        stepSize={1}
+                        majorStepSize={2}
+                        minorStepSize={1}
                         onValueChange={this.handlePixelAveragingChanged}
                         onBlur={this.handlePixelAveragingBlurred}
-                        buttonPosition="none"
                         data-testid="vector-field-averaging-width-input"
                     />
                 </FormGroup>

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -28,6 +28,9 @@ export class VectorOverlayDialogComponent extends React.Component {
     @observable currentTab: VectorOverlayDialogTabs = VectorOverlayDialogTabs.Configuration;
     @observable angularSource: VectorOverlaySource;
     @observable intensitySource: VectorOverlaySource;
+    /**
+     * Pixel width for boxcar averaging the vector overlay. Must be an integer. 1 means no averaging.
+     */
     @observable pixelAveraging: number;
     @observable thresholdEnabled: boolean;
     @observable threshold: number;
@@ -41,7 +44,10 @@ export class VectorOverlayDialogComponent extends React.Component {
     private static readonly DefaultHeight = 720;
     private static readonly MinWidth = 425;
     private static readonly MinHeight = 400;
-    public static readonly MAX_AVERAGING_PIXEL = 64;
+    /** 
+     * The maximum pixel width for averaging the vector overlay.
+    */
+    public static readonly MAX_PIXEL_AVERAGING = 64;
 
     private cachedFrame: FrameStore;
 
@@ -313,7 +319,7 @@ export class VectorOverlayDialogComponent extends React.Component {
                 <FormGroup inline={true} label="Averaging width" labelInfo="(px)" className="averaging-width-input">
                     <SafeNumericInput
                         min={1}
-                        max={VectorOverlayDialogComponent.MAX_AVERAGING_PIXEL}
+                        max={VectorOverlayDialogComponent.MAX_PIXEL_AVERAGING}
                         value={this.pixelAveraging}
                         stepSize={1}
                         majorStepSize={2}

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {ColorResult} from "react-color";
-import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Slider, Switch, Tab, Tabs, Tooltip} from "@blueprintjs/core";
+import {AnchorButton, Button, Classes, DialogProps, FormGroup, HTMLSelect, Intent, MenuItem, NonIdealState, Radio, RadioGroup, Slider, Switch, Tab, Tabs} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import {CARTA} from "carta-protobuf";
 import {action, computed, makeObservable, observable} from "mobx";
@@ -30,7 +30,6 @@ export class VectorOverlayDialogComponent extends React.Component {
     @observable intensitySource: VectorOverlaySource;
     @observable pixelAveragingEnabled: boolean;
     @observable pixelAveraging: number;
-    @observable pixelAveragingLocked: boolean = false;
     @observable thresholdEnabled: boolean;
     @observable threshold: number;
     @observable fractionalIntensity: boolean;
@@ -153,14 +152,12 @@ export class VectorOverlayDialogComponent extends React.Component {
     };
 
     @action private handlePixelAveragingChanged = (value: number) => {
-        if (!this.pixelAveragingLocked) {
-            this.pixelAveraging = Math.round(value);
-            this.pixelAveragingEnabled = this.pixelAveraging !== 1;
-        }
+        this.pixelAveraging = Math.round(value);
+        this.pixelAveragingEnabled = this.pixelAveraging !== 1;
     };
 
-    @action private handlePixelAveragingLocked = () => {
-        this.pixelAveragingLocked = !this.pixelAveragingLocked;
+    @action private handlePixelAveragingBlurred = (ev: React.FocusEvent<HTMLInputElement>) => {
+        ev.currentTarget.value = this.pixelAveraging.toString();
     };
 
     @action private handleThresholdEnabledChanged = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -335,12 +332,10 @@ export class VectorOverlayDialogComponent extends React.Component {
                         max={VectorOverlayDialogComponent.MaxAveragingWidth}
                         value={this.pixelAveraging}
                         onValueChange={this.handlePixelAveragingChanged}
+                        onBlur={this.handlePixelAveragingBlurred}
                         buttonPosition="none"
                         data-testid="vector-field-averaging-width-input"
                     />
-                    <Tooltip content={this.pixelAveragingLocked ? "Unlock averaging width" : "Lock averaging width"}>
-                        <Button className="lock-button" icon={this.pixelAveragingLocked ? "lock" : "unlock"} onClick={this.handlePixelAveragingLocked} />
-                    </Tooltip>
                 </FormGroup>
                 <FormGroup inline={true} label="Polarization intensity" disabled={this.intensitySource === VectorOverlaySource.None}>
                     <RadioGroup inline={true} onChange={this.handleFractionalIntensityChanged} selectedValue={this.fractionalIntensity ? 1 : 0} disabled={this.intensitySource === VectorOverlaySource.None}>

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -41,7 +41,6 @@ export interface WorkspaceVectorOverlayConfig {
     angularSource: VectorOverlaySource;
     intensitySource: VectorOverlaySource;
     fractionalIntensity: boolean;
-    pixelAveragingEnabled: boolean;
     pixelAveraging: number;
     thresholdEnabled: boolean;
     threshold: number;

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2538,7 +2538,7 @@ export class AppStore {
                         yMin: 0,
                         yMax: frame.frameInfo.fileInfoExtended.height
                     },
-                    smoothingFactor: frame.vectorOverlayConfig.pixelAveragingEnabled ? frame.vectorOverlayConfig.pixelAveraging : 1,
+                    smoothingFactor: frame.vectorOverlayConfig.pixelAveraging > 1 ? frame.vectorOverlayConfig.pixelAveraging : 1,
                     fractional: frame.vectorOverlayConfig.fractionalIntensity,
                     threshold: frame.vectorOverlayConfig.thresholdEnabled ? frame.vectorOverlayConfig.threshold : NaN,
                     thresholdOption: frame.vectorOverlayConfig.thresholdEnabled ? frame.vectorOverlayConfig.thresholdOption : NaN,

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2538,7 +2538,7 @@ export class AppStore {
                         yMin: 0,
                         yMax: frame.frameInfo.fileInfoExtended.height
                     },
-                    smoothingFactor: frame.vectorOverlayConfig.pixelAveraging > 1 ? frame.vectorOverlayConfig.pixelAveraging : 1,
+                    smoothingFactor: frame.vectorOverlayConfig.pixelAveraging,
                     fractional: frame.vectorOverlayConfig.fractionalIntensity,
                     threshold: frame.vectorOverlayConfig.thresholdEnabled ? frame.vectorOverlayConfig.threshold : NaN,
                     thresholdOption: frame.vectorOverlayConfig.thresholdEnabled ? frame.vectorOverlayConfig.thresholdOption : NaN,

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2947,7 +2947,7 @@ export class FrameStore {
                 yMin: 0,
                 yMax: this.frameInfo.fileInfoExtended.height
             },
-            smoothingFactor: config.pixelAveragingEnabled ? config.pixelAveraging : 1,
+            smoothingFactor: config.pixelAveraging > 1 ? config.pixelAveraging : 1,
             fractional: config.fractionalIntensity,
             threshold: config.thresholdEnabled ? config.threshold : NaN,
             thresholdOption: config.thresholdEnabled ? config.thresholdOption : NaN,

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2947,7 +2947,7 @@ export class FrameStore {
                 yMin: 0,
                 yMax: this.frameInfo.fileInfoExtended.height
             },
-            smoothingFactor: config.pixelAveraging > 1 ? config.pixelAveraging : 1,
+            smoothingFactor: config.pixelAveraging,
             fractional: config.fractionalIntensity,
             threshold: config.thresholdEnabled ? config.threshold : NaN,
             thresholdOption: config.thresholdEnabled ? config.thresholdOption : NaN,

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
@@ -19,7 +19,6 @@ export class VectorOverlayConfigStore {
     @observable angularSource: VectorOverlaySource;
     @observable intensitySource: VectorOverlaySource;
     @observable fractionalIntensity: boolean;
-    @observable pixelAveragingEnabled: boolean;
     @observable pixelAveraging: number;
     @observable thresholdEnabled: boolean;
     @observable threshold: number;
@@ -54,7 +53,6 @@ export class VectorOverlayConfigStore {
         this.intensitySource = frame.hasLinearStokes ? VectorOverlaySource.Computed : VectorOverlaySource.Current;
         this.fractionalIntensity = this.preferenceStore.vectorOverlayFractionalIntensity;
         this.pixelAveraging = this.preferenceStore.vectorOverlayPixelAveraging;
-        this.pixelAveragingEnabled = this.preferenceStore.vectorOverlayPixelAveraging > 0;
         this.threshold = 0;
         this.thresholdEnabled = false;
         this.debiasing = false;
@@ -89,7 +87,6 @@ export class VectorOverlayConfigStore {
     @action setVectorOverlayConfiguration = (
         angularSource: VectorOverlaySource,
         intensitySource: VectorOverlaySource,
-        pixelAveragingEnabled: boolean,
         pixelAveraging: number,
         fractionalIntensity: boolean,
         thresholdEnabled: boolean,
@@ -101,7 +98,6 @@ export class VectorOverlayConfigStore {
     ) => {
         this.angularSource = angularSource;
         this.intensitySource = intensitySource;
-        this.pixelAveragingEnabled = pixelAveragingEnabled;
         this.pixelAveraging = pixelAveraging;
         this.fractionalIntensity = fractionalIntensity;
         this.thresholdEnabled = thresholdEnabled;
@@ -165,7 +161,6 @@ export class VectorOverlayConfigStore {
     @action updateFromWorkspace = (config: WorkspaceVectorOverlayConfig) => {
         this.angularSource = config.angularSource;
         this.intensitySource = config.intensitySource;
-        this.pixelAveragingEnabled = config.pixelAveragingEnabled;
         this.pixelAveraging = config.pixelAveraging;
         this.fractionalIntensity = config.fractionalIntensity;
         this.thresholdEnabled = config.thresholdEnabled;


### PR DESCRIPTION
**Description**

Close #2612. 

- Make the input behavior of vector overlay pixel-averaging width consistent between the vector and the preference dialogs. 
- Update the description in the [protobuf](https://github.com/CARTAvis/carta-protobuf/pull/107). Notice that no protobuf message is modified.
- Remove `pixelAveragingEnabled` variable. Notice that `pixelAveragingEnabled` in workspace_schema_1.json should be cleaned at some point.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~