### PR TITLE
fix pv preview size display regression

### DIFF
--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -102,8 +102,8 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
 
         // Find percentage of selected channel range
         const imageDepth = frame.frameInfo.fileInfoExtended.depth;
-        const channelIndexMin = frame.findChannelIndexByValue(this.widgetStore.range?.min);
-        const channelIndexMax = frame.findChannelIndexByValue(this.widgetStore.range?.max);
+        const channelIndexMin = frame.findChannelIndexByValue(this.widgetStore.range.min);
+        const channelIndexMax = frame.findChannelIndexByValue(this.widgetStore.range.max);
 
         if (channelIndexMin === undefined || channelIndexMax === undefined) {
             return undefined;
@@ -130,7 +130,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         const regionBoundSize = region?.regionId === -1 ? null : (region?.boundingBoxArea ?? 0) * bytePix * imageDepth;
 
         // Calculate estimated size using selected range of channels and rebin values
-        const estimatedSize = ((regionBoundSize || imageSize) * channelRangePercentage) / (this.widgetStore.xyRebin * this.widgetStore.zRebin);
+        const estimatedSize = ((regionBoundSize || imageSize) * channelRangePercentage) / (this.widgetStore.xyRebin * this.widgetStore.xyRebin * this.widgetStore.zRebin);
 
         if (region?.regionType !== CARTA.RegionType.RECTANGLE && !estimatedSize) {
             return undefined;

--- a/src/components/PvGenerator/PvGeneratorComponent.tsx
+++ b/src/components/PvGenerator/PvGeneratorComponent.tsx
@@ -105,7 +105,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         const channelIndexMin = frame.findChannelIndexByValue(this.widgetStore.range?.min);
         const channelIndexMax = frame.findChannelIndexByValue(this.widgetStore.range?.max);
 
-        if (!channelIndexMin || !channelIndexMax) {
+        if (channelIndexMin === undefined || channelIndexMax === undefined) {
             return undefined;
         }
 
@@ -246,7 +246,7 @@ export class PvGeneratorComponent extends React.Component<WidgetProps> {
         const channelIndexMin = frame.findChannelIndexByValue(this.widgetStore.range?.min);
         const channelIndexMax = frame.findChannelIndexByValue(this.widgetStore.range?.max);
 
-        if (!channelIndexMin || !channelIndexMax) {
+        if (channelIndexMin === undefined || channelIndexMax === undefined) {
             this.setisValidSpectralRange(false);
             return;
         }

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2182,7 +2182,7 @@ export class FrameStore {
             } else {
                 if ((this.spectralAxis && !this.spectralAxis.valid) || this.isSpectralPropsEqual) {
                     return this.channelInfo.getChannelIndexWCS(x);
-                } else if (this.spectralFrame && this.spectralType && this.spectralUnit && this.spectralSystem) {
+                } else {
                     // invert x in selected widget wcs to frame's default wcs
                     const tx = AST.transformSpectralPoint(this.spectralFrame, this.spectralType, this.spectralUnit, this.spectralSystem, x, false);
                     return this.channelInfo.getChannelIndexWCS(tx);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2005,7 +2005,7 @@ export class FrameStore {
     };
 
     public convertToNativeWCS = (value: number): number | undefined => {
-        if (!this.spectralFrame || !isFinite(value) || !this.spectralType || !this.spectralUnit) {
+        if (!this.spectralFrame || !isFinite(value)) {
             return undefined;
         }
         return AST.transformSpectralPoint(this.spectralFrame, this.spectralType, this.spectralUnit, this.spectralSystem, value, false);


### PR DESCRIPTION
**Description**

close #2690. 
- Fix the regression that the pv preview size is not displayed by correcting the if condition.
- Fix preview cube size estimate. The preview cube size should be divided by the square xy rebin. For example, xy rebin is 2, the preview cube size will be 1/4 of the original size.
- Fix no preview cube size for non-standard header fits because of the wrong if conditions.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)`

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~