### PR TITLE
fix spectral widget selection in line query widget

### DIFF
--- a/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
+++ b/src/stores/Widgets/SpectralLineQueryWidgetStore/SpectralLineQueryWidgetStore.ts
@@ -554,7 +554,7 @@ export class SpectralLineQueryWidgetStore {
 
         // update selected spectral profiler when currently selected is closed
         autorun(() => {
-            if (!this.selectedSpectralProfilerID || AppStore.Instance.widgetsStore.getSpectralWidgetStoreByID(this.selectedSpectralProfilerID)) {
+            if (!this.selectedSpectralProfilerID || !AppStore.Instance.widgetsStore.getSpectralWidgetStoreByID(this.selectedSpectralProfilerID)) {
                 this.selectedSpectralProfilerID = AppStore.Instance.widgetsStore.spectralProfilerList.length > 0 ? AppStore.Instance.widgetsStore.spectralProfilerList[0] : undefined;
             }
         });


### PR DESCRIPTION
**Description**

Close #2694. This is a regression back to v5-beta. Condition related to `getSpectralWidgetStoreByID` in `SpectralLineQueryWidgetStore` is wrong. 

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~