### PR TITLE
Fix missing red vertical bars in the newly opened render configuration widget

### DIFF
--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -246,7 +246,19 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     };
 
     @action updateChart = (chartArea: ChartArea) => {
+        const wasUndefined = this.chartArea === undefined;
         this.chartArea = chartArea;
+        if (wasUndefined) {
+            // Ensure the component re-renders after chartArea is first set.
+            // This addresses a timing issue where the MobX-triggered forceUpdate
+            // may be batched by React 18 when chartArea is set during the initial
+            // mount sequence (inside a useEffect callback from react-chartjs-2).
+            // Scheduling a forceUpdate in the next macrotask ensures the re-render
+            // is processed and markers are drawn.
+            setTimeout(() => {
+                this.forceUpdate();
+            }, 0);
+        }
     };
 
     @action resize = (w, h) => {


### PR DESCRIPTION
**Description**

Closes #2692.
Fixed missing red vertical bars in the newly opened render configuration widget.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~unit test added (for functions with no dependenies)~~
- [x] ~~API documentation added (for public variables and methods in stores)~~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~~user manual prepared (for large new features)~~