### PR TITLE
CI upgrade with node version 22 test (issue #2700)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,7 +5,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./docs_website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./docs_website
     needs: doc-format-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -46,7 +46,7 @@ jobs:
       - name: Test build website
         run: npm run build
 
-  node-v18:
+  node-v22:
     runs-on: [self-hosted, Linux, X64, Docker]
     needs: format-check
     container:
@@ -54,7 +54,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -68,22 +68,22 @@ jobs:
           source /emsdk/emsdk_env.sh
           ./wasm_libs/build_libs.sh
 
-      - name: npm install with node 18
+      - name: npm install with node 22
         shell: bash
         run: |
-          n 18
-          n exec 18 node -v
-          n exec 18 npm install
+          n 22
+          n exec 22 node -v
+          n exec 22 npm install
 
-      - name: Production build with node 18
+      - name: Production build with node 22
         shell: bash
         run: |
           source /emsdk/emsdk_env.sh
-          n exec 18 npm run build
+          n exec 22 npm run build
 
       - name: Run unit tests
         shell: bash
-        run: n exec 18 npm test
+        run: n exec 22 npm test
 
   node-v20:
     runs-on: [self-hosted, Linux, X64, Docker]
@@ -93,7 +93,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -127,7 +127,7 @@ jobs:
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, node-v18, node-v20]
+    needs: [format-check, node-v20, node-v22]
     if: always()
     steps:
       - name: Notify Slack


### PR DESCRIPTION
**Description**

1. linked issues and companion PRs (#2700 CI upgrade), testing node 20 and 22 and removing node 18 test
2. upgrade actions/checkout@v6

**Checklist**

For the pull request:
- reviewers and assignee added
- only change tests of github actions-runner, no changelog update needed
- no unit test added
- since all CI runners' version > 2.329, upgrade actions/checkout from v4 to v6