### PR TITLE
Fix authenticated status detection in ApiService

### DIFF
--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -49,8 +49,8 @@ export class ApiService {
     private static PreferenceValidator = new Ajv({strictTypes: false, allErrors: true}).compile(preferencesSchema);
     private static SnippetValidator = new Ajv({strictTypes: false, allErrors: true}).compile(snippetSchema);
 
-    @observable private _accessToken: string | undefined = "no_auth_configured";
-    @observable private _tokenLifetime: number = Number.MAX_VALUE;
+    @observable private _accessToken: string | undefined = "";
+    @observable private _tokenLifetime: number = 0;
     private _tokenExpiryHandler: ReturnType<typeof setTimeout> | undefined;
     private axiosInstance: AxiosInstance;
 
@@ -94,6 +94,9 @@ export class ApiService {
         this.axiosInstance = axios.create();
         if (localStorage.getItem("authenticationType") || ApiService.RuntimeConfig.tokenRefreshAddress) {
             this.onTokenExpired();
+        } else {
+            this._accessToken = "no_auth_configured";
+            this._tokenLifetime = Number.MAX_VALUE;
         }
     }
 

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -49,8 +49,8 @@ export class ApiService {
     private static PreferenceValidator = new Ajv({strictTypes: false, allErrors: true}).compile(preferencesSchema);
     private static SnippetValidator = new Ajv({strictTypes: false, allErrors: true}).compile(snippetSchema);
 
-    @observable private _accessToken: string | undefined;
-    private _tokenLifetime: number;
+    @observable private _accessToken: string | undefined = "no_auth_configured";
+    @observable private _tokenLifetime: number = Number.MAX_VALUE;
     private _tokenExpiryHandler: ReturnType<typeof setTimeout> | undefined;
     private axiosInstance: AxiosInstance;
 
@@ -90,14 +90,11 @@ export class ApiService {
     }
 
     constructor() {
+        makeObservable(this);
         this.axiosInstance = axios.create();
         if (localStorage.getItem("authenticationType") || ApiService.RuntimeConfig.tokenRefreshAddress) {
             this.onTokenExpired();
-        } else {
-            this._accessToken = "no_auth_configured";
-            this._tokenLifetime = Number.MAX_VALUE;
         }
-        makeObservable(this);
     }
 
     private onTokenExpired = async () => {

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -345,14 +345,12 @@ export class ApiService {
                 }
             } catch (err) {
                 console.error(err);
-                console.error(err);
                 return undefined;
             }
         } else {
             try {
                 savedLayouts = JSON.parse(localStorage.getItem("savedLayouts") ?? "{}");
             } catch (err) {
-                console.error(err);
                 console.error(err);
                 return undefined;
             }


### PR DESCRIPTION
**Description**

#2711 resolves issue where the authenticated status of the connection was stuck using a cached value resulting in CARTA failing to initialize.
