### PR TITLE
Change beta numbering in release guidelines

### DIFF
--- a/docs_website/docs/contributing/release-guidelines.md
+++ b/docs_website/docs/contributing/release-guidelines.md
@@ -10,29 +10,29 @@ In this document, 123 is a placeholder for the current release number, and 124 f
 
 ### Beta release
 
-1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.0`.
+1. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
 2. `dev` branch: update the user manual URL if necessary.
 3. Create a `release/123.0` branch using the `dev` branch.
-4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.0`. Run `npm install` to update `package-lock.json`.
-5. Create a `v123.0.0-beta.0` tag using the release branch.
+4. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
+5. Create a `v123.0.0-beta.1` tag using the release branch.
 6. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 7. Create packages from the release branch.
 
 ### After beta release
 
 1. `dev` branch: update `CHANGELOG.md`. Create a new `Unreleased` section.
-2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#versioning)). Create a new version `123.0.0-beta.0`.
+2. `dev` branch: update the documentation website ([guidelines](./documentation-guidelines/#versioning)). Create a new version `123.0.0-beta.1`.
 
 ### Additional beta release
 
 This process should be followed if changes have to be made after the beta packages have already been published (or even provided to a limited number of users). If there are significant changes in `dev` that should _not_ be included in the beta release, follow the point release procedure instead (but adjust the version strings as required).
 
 1. Make the required fixes in `dev`.
-2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.1`.
+2. `dev` branch: update `CHANGELOG.md`. Change the `Unreleased` heading to `123.0.0-beta.2`.
 3. `dev` branch: update the user manual URL if necessary.
 4. Merge the `dev` branch into the `release/123.0` branch.
-5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.1`. Run `npm install` to update `package-lock.json`.
-6. Create a `v123.0.0-beta.1` tag using the release branch.
+5. `release/123.0` branch: update the `package.json` version string to `123.0.0-beta.2`. Run `npm install` to update `package-lock.json`.
+6. Create a `v123.0.0-beta.2` tag using the release branch.
 7. Test the release branch. Make any required fixes in the `dev` branch, and merge them into the release branch. Ideally, bump the version and create a new tag every time changes are merged. If you don't want to bump the version, remember to destroy and recreate the latest tag.
 8. Create packages from the release branch.
 


### PR DESCRIPTION
**Description**

This originally counted from 1, then we changed it to 0, but we started counting from 1 anyway -- so I'm changing it back! I have made the same change in the backend docs (in [the post-release PR](https://github.com/CARTAvis/carta-backend/pull/1583)).

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [X] reviewers and assignee added
- [ ] GitHub Project estimate added
- [X] no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] protobuf version bumped / no protobuf version bumped needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)