### PR TITLE
fix a specific spectral matching due to default Helio rest frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Fixed a spectral matching case effected by the default Helio rest frame setting ([#2736](https://github.com/CARTAvis/carta-frontend/issues/2736)).
+* Fixed a spectral matching case affected by the default Helio rest frame setting ([#2736](https://github.com/CARTAvis/carta-frontend/issues/2736)).
 
 ## [6.0.0-beta.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed a spectral matching case effected by the default Helio rest frame setting ([#2736](https://github.com/CARTAvis/carta-frontend/issues/2736)).
+
 ## [6.0.0-beta.1]
 
 ### Fixed

--- a/src/utilities/wcs/wcs.ts
+++ b/src/utilities/wcs/wcs.ts
@@ -139,8 +139,8 @@ export function getTransformedChannel(srcTransform: AST.FrameSet, destTransform:
     // Set common spectral
     const copySrc = AST.copy(srcTransform);
     const copyDest = AST.copy(destTransform);
-    AST.set(copySrc, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
-    AST.set(copyDest, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
+    AST.set(copySrc, `System=${matchingType}, Unit=${defaultUnit}`);
+    AST.set(copyDest, `System=${matchingType}, Unit=${defaultUnit}`);
 
     // Get spectral value from forward transform
     const sourceSpectralValue = AST.transform3DPoint(copySrc, 0, 0, srcChannel, true);
@@ -176,8 +176,8 @@ export function getTransformedChannelList(srcTransform: AST.FrameSet, destTransf
     // Set common spectral
     const copySrc = AST.copy(srcTransform);
     const copyDest = AST.copy(destTransform);
-    AST.set(copySrc, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
-    AST.set(copyDest, `System=${matchingType}, StdOfRest=Helio, Unit=${defaultUnit}`);
+    AST.set(copySrc, `System=${matchingType}, Unit=${defaultUnit}`);
+    AST.set(copyDest, `System=${matchingType}, Unit=${defaultUnit}`);
 
     // Get a sensible pixel coordinate for the reverse transform by forward transforming first pixel in image
     const dummySpectralValue = AST.transform3DPoint(copyDest, 1, 1, 1, true);


### PR DESCRIPTION
**Description**

Close #2736. Some spectral matching is affected by the `StdOfRest=Helio` setting when computing the corresponding channel between source and reference frames. Removing `StdOfRest=Helio` from `getTransformedChannel` function resolves the issue.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)`
- [x] ~API documentation added (for public variables and methods in stores)`

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)`