### PR TITLE
spatial profile chart crash due to sparse array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix the spatial profile chart that occasionally disappears when the line region is outside the image ([#2775](https://github.com/CARTAvis/carta-frontend/issues/2775)).
+
 ## [6.0.0-beta.1]
 
 ### Fixed

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.test.ts
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.test.ts
@@ -1,0 +1,37 @@
+import {type Point2D} from "models";
+
+jest.mock("utilities", () => ({
+    clamp: (value: number) => value,
+    toExponential: (value: number) => `${value}`,
+    toFixed: (value: number) => `${value}`
+}));
+
+import {PlotContainerComponent, type PlotContainerProps} from "./PlotContainerComponent";
+
+test("[unit] PlotContainerComponent shouldComponentUpdate handles sparse spatial profile arrays", () => {
+    const sparseSpatialProfile = new Array<Point2D | undefined>(3);
+    sparseSpatialProfile[1] = {x: 1, y: 2};
+
+    const currentProps: PlotContainerProps = {
+        width: 120,
+        height: 80,
+        data: sparseSpatialProfile as Point2D[],
+        multiColorSingleLineColors: []
+    };
+    const nextProps: PlotContainerProps = {
+        ...currentProps,
+        data: [
+            {x: 0, y: 0},
+            {x: 1, y: 2},
+            {x: 2, y: 4}
+        ]
+    };
+
+    const component = new PlotContainerComponent(currentProps);
+    let shouldUpdate = false;
+
+    expect(() => {
+        shouldUpdate = component.shouldComponentUpdate(nextProps);
+    }).not.toThrow();
+    expect(shouldUpdate).toBe(true);
+});

--- a/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
+++ b/src/components/Shared/LinePlot/PlotContainer/PlotContainerComponent.tsx
@@ -328,7 +328,9 @@ export class PlotContainerComponent extends React.Component<PlotContainerProps> 
             return true;
         }
         for (let i = 0; i < props.data.length; i++) {
-            if (props.data[i].x !== nextProps.data[i].x || props.data[i].y !== nextProps.data[i].y) {
+            const currentPoint = props.data[i];
+            const nextPoint = nextProps.data[i];
+            if (!currentPoint || !nextPoint || currentPoint.x !== nextPoint.x || currentPoint.y !== nextPoint.y) {
                 return true;
             }
         }

--- a/src/utilities/array/array.test.ts
+++ b/src/utilities/array/array.test.ts
@@ -53,3 +53,11 @@ test("test binarySearchByX with sorted array in incremental/decremental order", 
     expect(binarySearchByX(empty, 5)).toEqual(null);
     expect(binarySearchByX(empty, 0)).toEqual(null);
 });
+
+test("test binarySearchByX with sparse spatial profile arrays", () => {
+    const sparseSpatialProfile = new Array<Point2D | undefined>(4);
+    sparseSpatialProfile[2] = {x: 2, y: 1};
+
+    expect(binarySearchByX(sparseSpatialProfile as Point2D[], 2)).toEqual(null);
+    expect(binarySearchByX(sparseSpatialProfile as Point2D[], 10)).toEqual(null);
+});

--- a/src/utilities/array/array.ts
+++ b/src/utilities/array/array.ts
@@ -7,18 +7,23 @@ export function binarySearchByX(sortedArray: readonly Point2D[], x: number): {po
     }
 
     const length = sortedArray.length;
-    const incremental = sortedArray[0].x <= sortedArray[length - 1].x;
+    const first = sortedArray[0];
+    const last = sortedArray[length - 1];
+    if (!first || !last) {
+        return null;
+    }
+    const incremental = first.x <= last.x;
     if (incremental) {
-        if (x <= sortedArray[0].x) {
-            return {point: sortedArray[0], index: 0};
-        } else if (x >= sortedArray[length - 1].x) {
-            return {point: sortedArray[length - 1], index: length - 1};
+        if (x <= first.x) {
+            return {point: first, index: 0};
+        } else if (x >= last.x) {
+            return {point: last, index: length - 1};
         }
     } else {
-        if (x >= sortedArray[0].x) {
-            return {point: sortedArray[0], index: 0};
-        } else if (x <= sortedArray[length - 1].x) {
-            return {point: sortedArray[length - 1], index: length - 1};
+        if (x >= first.x) {
+            return {point: first, index: 0};
+        } else if (x <= last.x) {
+            return {point: last, index: length - 1};
         }
     }
 
@@ -27,17 +32,21 @@ export function binarySearchByX(sortedArray: readonly Point2D[], x: number): {po
     let end = length - 1;
     while (start <= end) {
         const middle = Math.floor((start + end) / 2);
-        if (x === sortedArray[middle].x) {
-            return {point: sortedArray[middle], index: middle};
+        const midPoint = sortedArray[middle];
+        if (!midPoint) {
+            return null;
+        }
+        if (x === midPoint.x) {
+            return {point: midPoint, index: middle};
         }
         if (incremental) {
-            if (x < sortedArray[middle].x) {
+            if (x < midPoint.x) {
                 end = middle - 1;
             } else {
                 start = middle + 1;
             }
         } else {
-            if (x > sortedArray[middle].x) {
+            if (x > midPoint.x) {
                 end = middle - 1;
             } else {
                 start = middle + 1;
@@ -47,8 +56,13 @@ export function binarySearchByX(sortedArray: readonly Point2D[], x: number): {po
     if (start >= sortedArray.length || start < 0 || end >= sortedArray.length || end < 0) {
         return null;
     }
-    const closer = Math.abs(sortedArray[start].x - x) < Math.abs(x - sortedArray[end].x) ? start : end;
-    return {point: sortedArray[closer], index: closer};
+    const startPoint = sortedArray[start];
+    const endPoint = sortedArray[end];
+    if (!startPoint || !endPoint) {
+        return null;
+    }
+    const closer = Math.abs(startPoint.x - x) < Math.abs(x - endPoint.x) ? start : end;
+    return {point: sortedArray[closer]!, index: closer};
 }
 
 export const distinct = (value: any, index: number, self: Array<any>) => {


### PR DESCRIPTION
**Description**

Close #2775. The spatial profile chart crashes when receiving a sparse array. Add more existence checks for variables to avoid sparse array errors.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~