### PR TITLE
region list Mobx error

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -4,7 +4,7 @@ import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import type Konva from "konva";
 import * as _ from "lodash";
-import {action, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, type IReactionDisposer, makeObservable, observable, reaction, runInAction} from "mobx";
 import {observer} from "mobx-react";
 
 import {DialogId, ImageViewLayer, RegionMode} from "enums";
@@ -285,7 +285,9 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
         if (regionType === CARTA.RegionType.POLYGON || regionType === CARTA.RegionType.POLYLINE || regionType === CARTA.RegionType.ANNPOLYGON || regionType === CARTA.RegionType.ANNPOLYLINE) {
             // avoid mouse up event triggering region creation start
             setTimeout(() => {
-                this.creatingRegion = null;
+                runInAction(() => {
+                    this.creatingRegion = null;
+                });
             }, 1);
         } else {
             this.creatingRegion = null;

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import {List} from "react-window";
 import {AnchorButton, ButtonGroup, Classes, Icon, NonIdealState, Position, Spinner, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
+import {action, computed, makeObservable, observable} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";
@@ -58,37 +58,46 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     @observable lastVisibleRow: number = 0;
     @observable regionsVisibility: RegionsOpacity = RegionsOpacity.Visible;
     @observable regionsLock: boolean = false;
-    private readonly disposers: IReactionDisposer[] = [];
+    private lastScrolledRegionId: number | null = null;
+    private lastScrolledRowCount: number = -1;
+    private lastScrolledSelectedIndex: number = -1;
 
-    private scrollToSelected = (selected: any) => {
+    private scrollToSelected = (selected: number) => {
         const listRefCurrent = this.listRef.current;
-        if (!listRefCurrent || !isFinite(selected) || selected < 0) {
+        const rowCount = this.validRegions.length;
+        if (!listRefCurrent || !isFinite(selected) || selected < 0 || selected >= rowCount) {
             return;
-        } else {
-            this.listRef.current.scrollToRow({index: selected, align: "smart"});
         }
+        listRefCurrent.scrollToRow({index: selected, align: "smart"});
+    };
+
+    private syncScrollToSelectedRegion = () => {
+        const selectedRegionId = AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId ?? null;
+        const rowCount = this.validRegions.length;
+        const selectedIndex = selectedRegionId && selectedRegionId > 0 ? this.validRegions.findIndex(region => region.regionId === selectedRegionId) : -1;
+
+        if (selectedRegionId === this.lastScrolledRegionId && rowCount === this.lastScrolledRowCount && selectedIndex === this.lastScrolledSelectedIndex) {
+            return;
+        }
+
+        this.lastScrolledRegionId = selectedRegionId;
+        this.lastScrolledRowCount = rowCount;
+        this.lastScrolledSelectedIndex = selectedIndex;
+
+        this.scrollToSelected(selectedIndex);
     };
 
     constructor(props: any) {
         super(props);
         makeObservable(this);
-
-        this.disposers.push(
-            reaction(
-                () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
-                id => {
-                    if (id && id > 0) {
-                        const validRegionId = this.validRegions.map(el => el.regionId);
-                        this.scrollToSelected(validRegionId.findIndex(element => element === id));
-                    }
-                }
-            )
-        );
     }
 
-    componentWillUnmount() {
-        this.disposers.forEach(disposer => disposer());
-        this.disposers.length = 0;
+    componentDidMount() {
+        this.syncScrollToSelectedRegion();
+    }
+
+    componentDidUpdate() {
+        this.syncScrollToSelectedRegion();
     }
 
     @action private onResize = (width: number, height: number) => {
@@ -436,8 +445,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                 );
             }
 
-            const style = {...props.style};
-            style.overflowX = "hidden";
+            const style = {...props.style, overflowX: "hidden" as const};
 
             return (
                 <div className={className} key={region.regionId} onClick={() => frame.regionSet.selectRegion(region)} style={style} data-testid={"region-list-table-row-" + (props.index + 1)}>

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -4,7 +4,7 @@ import {List} from "react-window";
 import {AnchorButton, ButtonGroup, Classes, Icon, NonIdealState, Position, Spinner, Tooltip} from "@blueprintjs/core";
 import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
-import {action, computed, makeObservable, observable} from "mobx";
+import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 import {observer} from "mobx-react";
 
 import {ResizeDetector} from "components/Shared";
@@ -29,6 +29,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private static readonly ROW_HEIGHT = 35;
     private static readonly HEADER_ROW_HEIGHT = 25;
     private listRef = React.createRef<any>();
+    private readonly disposers: IReactionDisposer[] = [];
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -58,9 +59,6 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     @observable lastVisibleRow: number = 0;
     @observable regionsVisibility: RegionsOpacity = RegionsOpacity.Visible;
     @observable regionsLock: boolean = false;
-    private lastScrolledRegionId: number | null = null;
-    private lastScrolledRowCount: number = -1;
-    private lastScrolledSelectedIndex: number = -1;
 
     private scrollToSelected = (selected: number) => {
         const listRefCurrent = this.listRef.current;
@@ -71,33 +69,31 @@ export class RegionListComponent extends React.Component<WidgetProps> {
         listRefCurrent.scrollToRow({index: selected, align: "smart"});
     };
 
-    private syncScrollToSelectedRegion = () => {
-        const selectedRegionId = AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId ?? null;
-        const rowCount = this.validRegions.length;
-        const selectedIndex = selectedRegionId && selectedRegionId > 0 ? this.validRegions.findIndex(region => region.regionId === selectedRegionId) : -1;
-
-        if (selectedRegionId === this.lastScrolledRegionId && rowCount === this.lastScrolledRowCount && selectedIndex === this.lastScrolledSelectedIndex) {
-            return;
-        }
-
-        this.lastScrolledRegionId = selectedRegionId;
-        this.lastScrolledRowCount = rowCount;
-        this.lastScrolledSelectedIndex = selectedIndex;
-
-        this.scrollToSelected(selectedIndex);
-    };
-
     constructor(props: any) {
         super(props);
         makeObservable(this);
     }
 
     componentDidMount() {
-        this.syncScrollToSelectedRegion();
+        this.disposers.push(
+            reaction(
+                () => AppStore.Instance.activeFrame?.regionSet?.selectedRegion?.regionId,
+                id => {
+                    if (id && id > 0) {
+                        const idx = this.validRegions.findIndex(r => r.regionId === id);
+                        // Defer scroll to after React re-renders the List with updated rowCount,
+                        // and to avoid modifying observables (via onListRendered) inside a reaction
+                        setTimeout(() => this.scrollToSelected(idx), 0);
+                    }
+                },
+                {fireImmediately: true}
+            )
+        );
     }
 
-    componentDidUpdate() {
-        this.syncScrollToSelectedRegion();
+    componentWillUnmount() {
+        this.disposers.forEach(disposer => disposer());
+        this.disposers.length = 0;
     }
 
     @action private onResize = (width: number, height: number) => {

--- a/src/components/RegionList/RegionListComponent.tsx
+++ b/src/components/RegionList/RegionListComponent.tsx
@@ -30,6 +30,7 @@ export class RegionListComponent extends React.Component<WidgetProps> {
     private static readonly HEADER_ROW_HEIGHT = 25;
     private listRef = React.createRef<any>();
     private readonly disposers: IReactionDisposer[] = [];
+    private pendingScrollTarget = -1;
 
     public static get WIDGET_CONFIG(): DefaultWidgetConfig {
         return {
@@ -81,14 +82,29 @@ export class RegionListComponent extends React.Component<WidgetProps> {
                 id => {
                     if (id && id > 0) {
                         const idx = this.validRegions.findIndex(r => r.regionId === id);
-                        // Defer scroll to after React re-renders the List with updated rowCount,
-                        // and to avoid modifying observables (via onListRendered) inside a reaction
-                        setTimeout(() => this.scrollToSelected(idx), 0);
+                        // Store scroll target; componentDidUpdate will process it after the List
+                        // re-renders with the updated rowCount, avoiding an out-of-range error.
+                        this.pendingScrollTarget = idx;
                     }
                 },
                 {fireImmediately: true}
             )
         );
+        // For the fireImmediately case the List is already rendered, but we still need to run
+        // outside the reaction to avoid modifying observables (via onListRendered).
+        if (this.pendingScrollTarget >= 0) {
+            const target = this.pendingScrollTarget;
+            this.pendingScrollTarget = -1;
+            setTimeout(() => this.scrollToSelected(target), 0);
+        }
+    }
+
+    componentDidUpdate() {
+        if (this.pendingScrollTarget >= 0) {
+            const target = this.pendingScrollTarget;
+            this.pendingScrollTarget = -1;
+            this.scrollToSelected(target);
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
**Description**

Close #2776. There is a mobx error in the console when creating regions because `scrollToSelected` triggers re-rendering before regions have settled. Add `pendingScrollTarget` to avoid out-of-range error in the region list.

Also, fix the mobx warning in the console when creating a polygon region.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~changelog updated~ / no changelog update needed
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~