### PR TITLE
fix color handling in spectral profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a missing vertical indicator line in the spatial profile and a misplaced green box above the histogram ([#2749](https://github.com/CARTAvis/carta-frontend/issues/2749) and [#2716](https://github.com/CARTAvis/carta-frontend/issues/2716)).
 * Fixed a spectral matching case affected by the default Helio rest frame setting ([#2736](https://github.com/CARTAvis/carta-frontend/issues/2736)).
 * Fix the spatial profile chart that occasionally disappears when the line region is outside the image ([#2775](https://github.com/CARTAvis/carta-frontend/issues/2775)).
+* Fixed spectral profiler colors not updating when switching the GUI theme ([#2801](https://github.com/CARTAvis/carta-frontend/issues/2801)).
 
 ## [6.0.0-beta.1]
 

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -6,7 +6,7 @@ import {GetIntensityOptions, type IntensityConfig, type LineKey, type LineOption
 import {AppStore} from "stores";
 import {type FrameStore} from "stores/Frame";
 import {ACTIVE_FILE_ID, SpectralProfileWidgetStore} from "stores/Widgets";
-import {genColorFromIndex, type ProcessedSpectralProfile} from "utilities";
+import {AUTO_COLOR_OPTIONS, type ProcessedSpectralProfile} from "utilities";
 
 interface ProfileConfig {
     fileId: number | undefined;
@@ -540,11 +540,11 @@ export class SpectralProfileSelectionStore {
         const profileColor = widgetStore.getProfileColor(selectedId);
 
         if (!profileColor) {
-            let color: string = genColorFromIndex(0);
+            let color: string = AUTO_COLOR_OPTIONS[0];
 
             // find color that is not used by other profiles
             for (let i = 0; i < profileColors.length + 1; i++) {
-                color = genColorFromIndex(i);
+                color = AUTO_COLOR_OPTIONS[i % AUTO_COLOR_OPTIONS.length];
                 if (!profileColors.includes(color)) {
                     break;
                 }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -9,7 +9,7 @@ import {GetCommonIntensityOptions, GetIntensityConversion, GetIntensityOptions, 
 import {TelemetryService} from "services";
 import {AppStore, ProfileFittingStore, ProfileSmoothingStore} from "stores";
 import {RegionWidgetStore, type SpectralLine, SpectralProfileSelectionStore} from "stores/Widgets";
-import {clamp, genColorFromIndex, getColorForTheme, isAutoColor, pixelToFluxDensityUnit} from "utilities";
+import {clamp, getColorForTheme, isAutoColor, pixelToFluxDensityUnit} from "utilities";
 
 type XBound = {xMin: number | undefined; xMax: number | undefined};
 type YBound = {yMin: number; yMax: number};
@@ -49,8 +49,8 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
     // style settings
     @observable plotType: PlotType = PlotType.STEPS;
     @observable meanRmsVisible: boolean = false;
-    @observable primaryLineColor: string = genColorFromIndex(0); // default auto-blue color in Hex code
-    @observable lineColorMap: Map<LineKey, string> = new Map<LineKey, string>([[SpectralProfileWidgetStore.PRIMARY_LINE_KEY, genColorFromIndex(0)]]);
+    @observable primaryLineColor: string = "auto-blue";
+    @observable lineColorMap: Map<LineKey, string> = new Map<LineKey, string>([[SpectralProfileWidgetStore.PRIMARY_LINE_KEY, "auto-blue"]]);
     @observable lineWidth: number = 1;
     @observable linePlotPointSize: number = 1.5;
     @observable linePlotInitXYBoundaries: {minXVal: number | undefined; maxXVal: number | undefined; minYVal: number | undefined; maxYVal: number | undefined} = {minXVal: 0, maxXVal: 0, minYVal: 0, maxYVal: 0};

--- a/src/utilities/color/color.ts
+++ b/src/utilities/color/color.ts
@@ -5,7 +5,7 @@ import tinycolor from "tinycolor2";
 
 import {AppStore} from "stores";
 
-import {COLOR_MAPS_ALL, SELECTABLE_COLORS, SUPPORTED_AUTO_COLORS_REGEX} from "./constants";
+import {COLOR_MAPS_ALL, SUPPORTED_AUTO_COLORS_REGEX} from "./constants";
 
 function initContextWithSize(width: number, height: number) {
     const canvas = document.createElement("canvas") as HTMLCanvasElement;
@@ -41,11 +41,6 @@ export function getColorsFromHex(colorHex: string, startColorHex: string = "#000
 
 export function isAutoColor(color: string): boolean {
     return SUPPORTED_AUTO_COLORS_REGEX.test(color);
-}
-
-export function genColorFromIndex(index: number) {
-    const selectedColor = Number.isInteger(index) && index >= 0 ? SELECTABLE_COLORS[index % SELECTABLE_COLORS.length] : SELECTABLE_COLORS[0];
-    return Colors[`${selectedColor.toUpperCase()}${AppStore.Instance.darkTheme ? "4" : "2"}`];
 }
 
 export function getColorForTheme(color: string): string {


### PR DESCRIPTION


**Description**

Close #2801. The spectral profile color won't update when the GUI theme changes. 

- Replaced the genColorFromIndex function with AUTO_COLOR_OPTIONS for color assignment in SpectralProfileSelectionStore.
- Updated primaryLineColor and lineColorMap in SpectralProfileWidgetStore to use a default "auto-blue" color instead of generated colors.
- Removed genColorFromIndex function from color utilities as it is no longer needed.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped~ / no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed)~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~