### PR TITLE
Fix spectral profile TSV region headers for matched images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a missing vertical indicator line in the spatial profile and a misplaced green box above the histogram ([#2749](https://github.com/CARTAvis/carta-frontend/issues/2749) and [#2716](https://github.com/CARTAvis/carta-frontend/issues/2716)).
 * Fixed a spectral matching case affected by the default Helio rest frame setting ([#2736](https://github.com/CARTAvis/carta-frontend/issues/2736)).
 * Fix the spatial profile chart that occasionally disappears when the line region is outside the image ([#2775](https://github.com/CARTAvis/carta-frontend/issues/2775)).
+* Fixed incorrect region properties in spectral profile TSV exports for spatially matched images with different pixel sizes ([#2804](https://github.com/CARTAvis/carta-frontend/issues/2804)).
 
 ## [6.0.0-beta.1]
 

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -48,9 +48,10 @@ import {
     getHeaderNumericValue,
     getPixelSizes,
     getPixelValueFromWCS,
-    getRegionProperties,
+    getRegionPixelProperties,
     GetRequiredTiles,
     getTransformedChannel,
+    getTransformedRegionProperties,
     getUnformattedWCSPoint,
     getValueFromArcsecString,
     isAstBadPoint,
@@ -60,7 +61,6 @@ import {
     ProtobufProcessing,
     rotate2D,
     round2D,
-    scale2D,
     setAstStringSystem,
     setAstSystem,
     subtract2D,
@@ -2241,9 +2241,12 @@ export class FrameStore {
         const region = this.getRegion(regionId);
         if (region) {
             const regionFrameProperties = this.getRegionFrameProperties(region);
-            propertyString.push(getRegionProperties(region.regionType, regionFrameProperties.controlPoints, regionFrameProperties.rotation));
+            const controlPoints = regionFrameProperties.controlPoints;
+            const rotation = regionFrameProperties.rotation;
+
+            propertyString.push(getRegionPixelProperties(region.regionType, controlPoints, rotation));
             if (this.validWcs) {
-                propertyString.push(this.genRegionWcsProperties(region.regionType, regionFrameProperties.controlPoints, regionFrameProperties.rotation, region.regionId));
+                propertyString.push(this.genRegionWcsProperties(region.regionType, controlPoints, rotation, region.regionId));
             }
         }
         return propertyString;
@@ -2260,29 +2263,7 @@ export class FrameStore {
             return {controlPoints: region.controlPoints, rotation: region.rotation};
         }
 
-        switch (region.regionType) {
-            case CARTA.RegionType.RECTANGLE:
-            case CARTA.RegionType.ELLIPSE:
-            case CARTA.RegionType.ANNRECTANGLE:
-            case CARTA.RegionType.ANNELLIPSE:
-            case CARTA.RegionType.ANNTEXT: {
-                const center = transformPoint(spatialTransformAST, region.center, false);
-                if (isAstBadPoint(center)) {
-                    return {controlPoints: [center, region.size], rotation: region.rotation};
-                }
-
-                const transform = new Transform2D(spatialTransformAST, center);
-                return {
-                    controlPoints: [center, scale2D(region.size, 1.0 / transform.scale)],
-                    rotation: region.rotation - (transform.rotation * 180) / Math.PI
-                };
-            }
-            default:
-                return {
-                    controlPoints: region.controlPoints.map(point => transformPoint(spatialTransformAST, point, false)),
-                    rotation: region.rotation
-                };
-        }
+        return getTransformedRegionProperties(region, spatialTransformAST);
     }
 
     public genRegionWcsProperties = (regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number, regionId: number = -1): string => {

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -48,6 +48,7 @@ import {
     getHeaderNumericValue,
     getPixelSizes,
     getPixelValueFromWCS,
+    getRegionProperties,
     GetRequiredTiles,
     getTransformedChannel,
     getUnformattedWCSPoint,
@@ -59,6 +60,7 @@ import {
     ProtobufProcessing,
     rotate2D,
     round2D,
+    scale2D,
     setAstStringSystem,
     setAstSystem,
     subtract2D,
@@ -2238,17 +2240,50 @@ export class FrameStore {
         const propertyString: string[] = [];
         const region = this.getRegion(regionId);
         if (region) {
-            propertyString.push(region.regionProperties);
+            const regionFrameProperties = this.getRegionFrameProperties(region);
+            propertyString.push(getRegionProperties(region.regionType, regionFrameProperties.controlPoints, regionFrameProperties.rotation));
             if (this.validWcs) {
-                propertyString.push(this.getRegionWcsProperties(region));
+                propertyString.push(this.genRegionWcsProperties(region.regionType, regionFrameProperties.controlPoints, regionFrameProperties.rotation, region.regionId));
             }
         }
         return propertyString;
     }
 
     public getRegionWcsProperties = (region: RegionStore): string => {
-        return this.genRegionWcsProperties(region.regionType, region.controlPoints, region.rotation, region.regionId);
+        const regionFrameProperties = this.getRegionFrameProperties(region);
+        return this.genRegionWcsProperties(region.regionType, regionFrameProperties.controlPoints, regionFrameProperties.rotation, region.regionId);
     };
+
+    private getRegionFrameProperties(region: RegionStore): {controlPoints: Point2D[]; rotation: number} {
+        const spatialTransformAST = this.spatialTransformAST;
+        if (!this.spatialReference || !spatialTransformAST) {
+            return {controlPoints: region.controlPoints, rotation: region.rotation};
+        }
+
+        switch (region.regionType) {
+            case CARTA.RegionType.RECTANGLE:
+            case CARTA.RegionType.ELLIPSE:
+            case CARTA.RegionType.ANNRECTANGLE:
+            case CARTA.RegionType.ANNELLIPSE:
+            case CARTA.RegionType.ANNTEXT: {
+                const center = transformPoint(spatialTransformAST, region.center, false);
+                if (isAstBadPoint(center)) {
+                    return {controlPoints: [center, region.size], rotation: region.rotation};
+                }
+
+                const transform = new Transform2D(spatialTransformAST, center);
+                return {
+                    controlPoints: [center, scale2D(region.size, 1.0 / transform.scale)],
+                    rotation: region.rotation - (transform.rotation * 180) / Math.PI
+                };
+            }
+            default:
+                return {
+                    controlPoints: region.controlPoints.map(point => transformPoint(spatialTransformAST, point, false)),
+                    rotation: region.rotation
+                };
+        }
+    }
 
     public genRegionWcsProperties = (regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number, regionId: number = -1): string => {
         const centerPoint = controlPoints[CENTER_POINT_INDEX];

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -10,7 +10,22 @@ import {IsValidWcsPoint, type Point2D} from "models";
 import {type BackendService} from "services";
 import {AppStore, PreferenceStore, WidgetsStore} from "stores";
 import {type FrameStore} from "stores/Frame";
-import {add2D, getApproximateEllipsePoints, getApproximatePolygonPoints, isAstBadPoint, length2D, midpoint2D, minMax2D, rotate2D, scale2D, simplePolygonPointTest, simplePolygonTest, subtract2D, toFixed, transformPoint} from "utilities";
+import {
+    add2D,
+    getApproximateEllipsePoints,
+    getApproximatePolygonPoints,
+    getRegionProperties,
+    isAstBadPoint,
+    length2D,
+    midpoint2D,
+    minMax2D,
+    rotate2D,
+    scale2D,
+    simplePolygonPointTest,
+    simplePolygonTest,
+    subtract2D,
+    transformPoint
+} from "utilities";
 
 export const CURSOR_REGION_ID = 0;
 export const FOCUS_REGION_RATIO = 0.4;
@@ -334,7 +349,7 @@ export class RegionStore {
     }
 
     @computed get regionProperties(): string {
-        return RegionStore.GetRegionProperties(this.regionType, this.controlPoints, this.rotation);
+        return getRegionProperties(this.regionType, this.controlPoints, this.rotation);
     }
 
     @computed get isPreviewCut(): boolean {
@@ -345,43 +360,6 @@ export class RegionStore {
         }
         return false;
     }
-
-    public static GetRegionProperties = (regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number): string => {
-        const point = controlPoints[CENTER_POINT_INDEX];
-        const center = isFinite(point.x) && isFinite(point.y) ? `${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix` : "Invalid";
-
-        switch (regionType) {
-            case CARTA.RegionType.POINT:
-                return `Point (pixel) [${center}]`;
-            case CARTA.RegionType.LINE:
-                let lineProperties = "Line (pixel) [";
-                controlPoints.forEach((point, index) => {
-                    lineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
-                    lineProperties += index !== controlPoints.length - 1 ? ", " : "]";
-                });
-                return lineProperties;
-            case CARTA.RegionType.RECTANGLE:
-                return `rotbox[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
-            case CARTA.RegionType.ELLIPSE:
-                return `ellipse[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
-            case CARTA.RegionType.POLYGON:
-                let polygonProperties = "poly[";
-                controlPoints.forEach((point, index) => {
-                    polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
-                    polygonProperties += index !== controlPoints.length - 1 ? ", " : "]";
-                });
-                return polygonProperties;
-            case CARTA.RegionType.POLYLINE:
-                let polylineProperties = "Polyline (pixel) [";
-                controlPoints.forEach((point, index) => {
-                    polylineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
-                    polylineProperties += index !== controlPoints.length - 1 ? ", " : "]";
-                });
-                return polylineProperties;
-            default:
-                return "Not Implemented";
-        }
-    };
 
     public getRegionApproximation(astTransform: AST.Mapping): Point2D[] {
         let approximatePoints = this.regionApproximationMap.get(astTransform);

--- a/src/stores/Frame/Region/RegionStore.ts
+++ b/src/stores/Frame/Region/RegionStore.ts
@@ -14,7 +14,7 @@ import {
     add2D,
     getApproximateEllipsePoints,
     getApproximatePolygonPoints,
-    getRegionProperties,
+    getRegionPixelProperties,
     isAstBadPoint,
     length2D,
     midpoint2D,
@@ -349,7 +349,7 @@ export class RegionStore {
     }
 
     @computed get regionProperties(): string {
-        return getRegionProperties(this.regionType, this.controlPoints, this.rotation);
+        return getRegionPixelProperties(this.regionType, this.controlPoints, this.rotation);
     }
 
     @computed get isPreviewCut(): boolean {

--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -7,7 +7,7 @@ import {AngularSize, IsValidWcsPoint, type Point2D, type WCSPoint2D} from "model
 import {AppStore} from "stores";
 import {type FrameStore, WCS_PRECISION} from "stores/Frame";
 import {ACTIVE_FILE_ID} from "stores/Widgets";
-import {angle2D, formattedArcsec, getFormattedWCSPoint, getPixelValueFromWCS, getRegionProperties, getValueFromArcsecString, isWCSStringFormatValid, pointDistance, rotate2D, scale2D, subtract2D, toExponential} from "utilities";
+import {angle2D, formattedArcsec, getFormattedWCSPoint, getPixelValueFromWCS, getRegionPixelProperties, getValueFromArcsecString, isWCSStringFormatValid, pointDistance, rotate2D, scale2D, subtract2D, toExponential} from "utilities";
 
 const FOV_REGION_ID = 0;
 const IMAGE_REGION_ID = -1;
@@ -544,7 +544,7 @@ export class ImageFittingStore {
             case FOV_REGION_ID:
                 log += "Region: field of view\n";
                 if (fovInfo && fovInfo.regionType !== null && fovInfo.regionType !== undefined && fovInfo.rotation !== null && fovInfo.rotation !== undefined) {
-                    log += getRegionProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
+                    log += getRegionPixelProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
                     log += this.effectiveFrame?.genRegionWcsProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
                 }
                 break;

--- a/src/stores/ImageFittingStore/ImageFittingStore.ts
+++ b/src/stores/ImageFittingStore/ImageFittingStore.ts
@@ -5,9 +5,9 @@ import {AppToaster, SuccessToast} from "components/Shared";
 import {AngularSizeUnit, NumberFormatType} from "enums";
 import {AngularSize, IsValidWcsPoint, type Point2D, type WCSPoint2D} from "models";
 import {AppStore} from "stores";
-import {type FrameStore, RegionStore, WCS_PRECISION} from "stores/Frame";
+import {type FrameStore, WCS_PRECISION} from "stores/Frame";
 import {ACTIVE_FILE_ID} from "stores/Widgets";
-import {angle2D, formattedArcsec, getFormattedWCSPoint, getPixelValueFromWCS, getValueFromArcsecString, isWCSStringFormatValid, pointDistance, rotate2D, scale2D, subtract2D, toExponential} from "utilities";
+import {angle2D, formattedArcsec, getFormattedWCSPoint, getPixelValueFromWCS, getRegionProperties, getValueFromArcsecString, isWCSStringFormatValid, pointDistance, rotate2D, scale2D, subtract2D, toExponential} from "utilities";
 
 const FOV_REGION_ID = 0;
 const IMAGE_REGION_ID = -1;
@@ -544,7 +544,7 @@ export class ImageFittingStore {
             case FOV_REGION_ID:
                 log += "Region: field of view\n";
                 if (fovInfo && fovInfo.regionType !== null && fovInfo.regionType !== undefined && fovInfo.rotation !== null && fovInfo.rotation !== undefined) {
-                    log += RegionStore.GetRegionProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
+                    log += getRegionProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
                     log += this.effectiveFrame?.genRegionWcsProperties(fovInfo.regionType, fovInfo.controlPoints as Point2D[], fovInfo.rotation) + "\n";
                 }
                 break;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -10,6 +10,7 @@ export * from "./math/math";
 export * from "./math2d/math2d";
 export * from "./parsing/parsing";
 export * from "./Processed/Processed";
+export * from "./region/region";
 export * from "./sorting/sorting";
 export * from "./table/table";
 export * from "./templates/templates";

--- a/src/utilities/region/region.ts
+++ b/src/utilities/region/region.ts
@@ -1,12 +1,21 @@
+import type * as AST from "ast_wrapper";
 import {CARTA} from "carta-protobuf";
 
-import {type Point2D} from "models";
-import {toFixed} from "utilities/units/units";
+import {type Point2D, Transform2D} from "models";
+import {isAstBadPoint, scale2D, toFixed, transformPoint} from "utilities";
 
 const CENTER_POINT_INDEX = 0;
 const SIZE_POINT_INDEX = 1;
 
-export function getRegionProperties(regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number): string {
+export interface RegionTransformSource {
+    regionType: CARTA.RegionType;
+    center: Point2D;
+    size: Point2D;
+    controlPoints: Point2D[];
+    rotation: number;
+}
+
+export function getRegionPixelProperties(regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number): string {
     const point = controlPoints[CENTER_POINT_INDEX];
     const center = isFinite(point.x) && isFinite(point.y) ? `${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix` : "Invalid";
 
@@ -16,29 +25,67 @@ export function getRegionProperties(regionType: CARTA.RegionType, controlPoints:
         case CARTA.RegionType.LINE:
             let lineProperties = "Line (pixel) [";
             controlPoints.forEach((point, index) => {
-                lineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                lineProperties += getPointPixelString(point);
                 lineProperties += index !== controlPoints.length - 1 ? ", " : "]";
             });
             return lineProperties;
-        case CARTA.RegionType.RECTANGLE:
-            return `rotbox[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
-        case CARTA.RegionType.ELLIPSE:
-            return `ellipse[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
+        case CARTA.RegionType.RECTANGLE: {
+            const size = getSizePixelString(controlPoints[SIZE_POINT_INDEX]);
+            return `rotbox[[${center}], [${size}], ${toFixed(rotation, 6)}deg]`;
+        }
+        case CARTA.RegionType.ELLIPSE: {
+            const size = getSizePixelString(controlPoints[SIZE_POINT_INDEX]);
+            return `ellipse[[${center}], [${size}], ${toFixed(rotation, 6)}deg]`;
+        }
         case CARTA.RegionType.POLYGON:
             let polygonProperties = "poly[";
             controlPoints.forEach((point, index) => {
-                polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                polygonProperties += getPointPixelString(point);
                 polygonProperties += index !== controlPoints.length - 1 ? ", " : "]";
             });
             return polygonProperties;
         case CARTA.RegionType.POLYLINE:
             let polylineProperties = "Polyline (pixel) [";
             controlPoints.forEach((point, index) => {
-                polylineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                polylineProperties += getPointPixelString(point);
                 polylineProperties += index !== controlPoints.length - 1 ? ", " : "]";
             });
             return polylineProperties;
         default:
             return "Not Implemented";
     }
+}
+
+export function getTransformedRegionProperties(region: RegionTransformSource, spatialTransformAST: AST.Mapping): {controlPoints: Point2D[]; rotation: number} {
+    switch (region.regionType) {
+        case CARTA.RegionType.RECTANGLE:
+        case CARTA.RegionType.ELLIPSE:
+        case CARTA.RegionType.ANNRECTANGLE:
+        case CARTA.RegionType.ANNELLIPSE:
+        case CARTA.RegionType.ANNTEXT: {
+            const center = transformPoint(spatialTransformAST, region.center, false);
+            if (isAstBadPoint(center)) {
+                return {controlPoints: [center, region.size], rotation: region.rotation};
+            }
+
+            const transform = new Transform2D(spatialTransformAST, center);
+            return {
+                controlPoints: [center, scale2D(region.size, 1.0 / transform.scale)],
+                rotation: region.rotation - (transform.rotation * 180) / Math.PI
+            };
+        }
+        default:
+            return {
+                controlPoints: region.controlPoints.map(point => transformPoint(spatialTransformAST, point, false)),
+                rotation: region.rotation
+            };
+    }
+}
+
+function getPointPixelString(point: Point2D): string {
+    return isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+}
+
+function getSizePixelString(point: Point2D): string {
+    return `${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix`;
 }

--- a/src/utilities/region/region.ts
+++ b/src/utilities/region/region.ts
@@ -1,0 +1,44 @@
+import {CARTA} from "carta-protobuf";
+
+import {type Point2D} from "models";
+import {toFixed} from "utilities/units/units";
+
+const CENTER_POINT_INDEX = 0;
+const SIZE_POINT_INDEX = 1;
+
+export function getRegionProperties(regionType: CARTA.RegionType, controlPoints: Point2D[], rotation: number): string {
+    const point = controlPoints[CENTER_POINT_INDEX];
+    const center = isFinite(point.x) && isFinite(point.y) ? `${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix` : "Invalid";
+
+    switch (regionType) {
+        case CARTA.RegionType.POINT:
+            return `Point (pixel) [${center}]`;
+        case CARTA.RegionType.LINE:
+            let lineProperties = "Line (pixel) [";
+            controlPoints.forEach((point, index) => {
+                lineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                lineProperties += index !== controlPoints.length - 1 ? ", " : "]";
+            });
+            return lineProperties;
+        case CARTA.RegionType.RECTANGLE:
+            return `rotbox[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
+        case CARTA.RegionType.ELLIPSE:
+            return `ellipse[[${center}], [${toFixed(controlPoints[SIZE_POINT_INDEX].x, 6)}pix, ${toFixed(controlPoints[SIZE_POINT_INDEX].y, 6)}pix], ${toFixed(rotation, 6)}deg]`;
+        case CARTA.RegionType.POLYGON:
+            let polygonProperties = "poly[";
+            controlPoints.forEach((point, index) => {
+                polygonProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                polygonProperties += index !== controlPoints.length - 1 ? ", " : "]";
+            });
+            return polygonProperties;
+        case CARTA.RegionType.POLYLINE:
+            let polylineProperties = "Polyline (pixel) [";
+            controlPoints.forEach((point, index) => {
+                polylineProperties += isFinite(point.x) && isFinite(point.y) ? `[${toFixed(point.x, 6)}pix, ${toFixed(point.y, 6)}pix]` : "[Invalid]";
+                polylineProperties += index !== controlPoints.length - 1 ? ", " : "]";
+            });
+            return polylineProperties;
+        default:
+            return "Not Implemented";
+    }
+}


### PR DESCRIPTION
**Description**

Closes #2804.

- Fix spectral profile TSV export headers for spatially matched images with different pixel sizes.
- Transform shared region properties into the exporting frame's image coordinates before generating pixel and WCS header strings.
- Move region property string formatting into `src/utilities/region`.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [x] ~~unit test added (for functions with no dependenies)~~
- [x] ~~API documentation added (for public variables and methods in stores)~~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~~user manual prepared (for large new features)~~