### PR TITLE
Improve GSL download retry and mirror fallback

### DIFF
--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -16,20 +16,12 @@ if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/nu
 
     rm -f "${gsl_tar}"
     for gsl_url in "${gsl_urls[@]}"; do
-        retry_count=0
-        while (( retry_count < max_retries )); do
-            if wget --tries=1 -O "${gsl_tar}" "${gsl_url}" && md5sum -c gsl.md5 &>/dev/null; then
-                downloaded=true
-                break 2
-            fi
+        if wget --tries="${max_retries}" --waitretry=10 -O "${gsl_tar}" "${gsl_url}" && md5sum -c gsl.md5 &>/dev/null; then
+            downloaded=true
+            break
+        fi
 
-            rm -f "${gsl_tar}"
-            ((retry_count++))
-            if (( retry_count < max_retries )); then
-                echo "Download failed from ${gsl_url}. Trying again."
-                sleep 10
-            fi
-        done
+        rm -f "${gsl_tar}"
         echo "Failed to fetch GSL 2.6 from ${gsl_url}"
     done
 

--- a/wasm_libs/build_gsl.sh
+++ b/wasm_libs/build_gsl.sh
@@ -3,29 +3,39 @@ command -v emcc >/dev/null 2>&1 || { echo "Script requires emcc but it's not ins
 cd "${0%/*}"
 if ! [[ $(find gsl-2.6.tar.gz -type f 2>/dev/null && md5sum -c gsl.md5 &>/dev/null) ]]; then
     echo "Fetching GSL 2.6"
-    retry_count=0
+    gsl_tar="gsl-2.6.tar.gz"
+    gsl_urls=(
+        "https://ftpmirror.gnu.org/gsl/${gsl_tar}"
+        "https://mirror.ossplanet.net/gnu/gsl/${gsl_tar}"
+        "https://ftp.jaist.ac.jp/pub/GNU/gsl/${gsl_tar}"
+        "https://mirrors.ocf.berkeley.edu/gnu/gsl/${gsl_tar}"
+        "https://mirror.dogado.de/gnu/gsl/${gsl_tar}"
+    )
     max_retries=2
-    while (( retry_count < max_retries )); do
-        wget http://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz && break
-        ((retry_count++))
-        echo "Download failed. Trying again."
-        sleep 10
-    done
-    if (( retry_count == max_retries )); then
-        echo "Failed to fetch GSL 2.6 from http://ftpmirror.gnu.org"
-        if ! wget https://mirror.ossplanet.net/gnu/gsl/gsl-2.6.tar.gz; then
-            echo "Failed to fetch GSL 2.6 from https://mirror.ossplanet.net"
-            if ! wget https://ftp.jaist.ac.jp/pub/GNU/gsl/gsl-2.6.tar.gz; then
-                echo "Failed to fetch GSL 2.6 from https://ftp.jaist.ac.jp" 
-                if ! wget https://mirrors.ocf.berkeley.edu/gnu/gsl/gsl-2.6.tar.gz; then
-                    echo "Failed to fetch GSL 2.6 from https://mirrors.ocf.berkeley.edu"
-                     if ! wget https://mirror.dogado.de/gnu/gsl/gsl-2.6.tar.gz; then
-                         echo "Failed to fetch GSL 2.6 from https://mirror.dogado.de"
-                         exit 1
-                     fi
-                fi
+    downloaded=false
+
+    rm -f "${gsl_tar}"
+    for gsl_url in "${gsl_urls[@]}"; do
+        retry_count=0
+        while (( retry_count < max_retries )); do
+            if wget --tries=1 -O "${gsl_tar}" "${gsl_url}" && md5sum -c gsl.md5 &>/dev/null; then
+                downloaded=true
+                break 2
             fi
-        fi
+
+            rm -f "${gsl_tar}"
+            ((retry_count++))
+            if (( retry_count < max_retries )); then
+                echo "Download failed from ${gsl_url}. Trying again."
+                sleep 10
+            fi
+        done
+        echo "Failed to fetch GSL 2.6 from ${gsl_url}"
+    done
+
+    if [[ "${downloaded}" != true ]]; then
+        echo "Failed to fetch GSL 2.6."
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
**Description**

Closes #2807.

This PR improves the GSL download step in `wasm_libs/build_gsl.sh` by making retry and mirror fallback behavior more robust.

**What is implemented:**
- Replace nested mirror fallback logic with a maintainable URL list loop.
- Use `wget` built-in retry support with `--tries` and `--waitretry`.
- Remove partial or invalid downloads before trying the next mirror.
- Verify the downloaded GSL tarball with `md5sum` before accepting it.

**How to test:**
Need to activate emcc first.
```bash
npm install
npm run build-libs
npm run build
```


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~unit test added (for functions with no dependenies)~~
- [x] ~~API documentation added (for public variables and methods in stores)~~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~~user manual prepared (for large new features)~~