### PR TITLE
Update contour progress when coordinates are empty

### DIFF
--- a/src/stores/Frame/ContourStore/ContourStore.ts
+++ b/src/stores/Frame/ContourStore/ContourStore.ts
@@ -42,10 +42,15 @@ export class ContourStore {
         this.addContourData(indexOffsets, vertexData, progress);
     };
 
+    @action setProgress = (progress: number) => {
+        this.progress = progress;
+    };
+
     @action addContourData = (indexOffsets: Int32Array, sourceVertices: Float32Array, progress: number) => {
         const numVertices = sourceVertices.length / 2;
 
         if (!numVertices) {
+            this.progress = progress;
             return;
         }
 

--- a/src/stores/Frame/ContourStore/ContourStore.ts
+++ b/src/stores/Frame/ContourStore/ContourStore.ts
@@ -48,9 +48,9 @@ export class ContourStore {
 
     @action addContourData = (indexOffsets: Int32Array, sourceVertices: Float32Array, progress: number) => {
         const numVertices = sourceVertices.length / 2;
+        this.progress = progress;
 
         if (!numVertices) {
-            this.progress = progress;
             return;
         }
 
@@ -67,7 +67,6 @@ export class ContourStore {
         const vertexData = CARTACompute.GenerateVertexData(sourceVertices, indexOffsets);
         this.vertexData.push(vertexData);
         this.indexOffsets.push(indexOffsets);
-        this.progress = progress;
         this.numGeneratedVertices.push(vertexData.length / (ContourStore.vertexDataElements / 2));
 
         const index = this.vertexData.length - 1;

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -2659,8 +2659,10 @@ export class FrameStore {
                     this.contourStores.set(contourSet.level, contourStore);
                 }
 
-                if (processedData.progress != null && contourSet.coordinates) {
-                    if (!contourStore.isComplete && processedData.progress > 0) {
+                if (processedData.progress != null) {
+                    if (!contourSet.coordinates) {
+                        contourStore.setProgress(processedData.progress);
+                    } else if (!contourStore.isComplete && processedData.progress > 0) {
                         contourStore.addContourData(contourSet.indexOffsets, contourSet.coordinates, processedData.progress);
                     } else {
                         contourStore.setContourData(contourSet.indexOffsets, contourSet.coordinates, processedData.progress);


### PR DESCRIPTION
**Description**

This is a complementary PR for PR #2812 of Issue #2805.
This PR fixes the problem that empty `ContourImageData` protobuf messages are skipped so progress does not update accordingly.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] ~~unit test added (for functions with no dependenies)~~
- [x] ~~API documentation added (for public variables and methods in stores)~~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [x] ~~user manual prepared (for large new features)~~