### PR TITLE
set explicit splitter active size to avoid ambiguity in e2e test envi…

### DIFF
--- a/src/layout-flexlayout.scss
+++ b/src/layout-flexlayout.scss
@@ -20,7 +20,7 @@ $pt-dark-app-background-color: #252a31;
         --color-tabset-divider-line: white;
         --color-icon: #{$dark-gray4};
         --splitter-size: 4px;
-        --splitter-active-size: 4px;
+        --splitter-active-size: 4px !important;
 
         // Remove browser focus outlines (e.g. canvas click, button click)
         *:focus {
@@ -136,6 +136,7 @@ $pt-dark-app-background-color: #252a31;
     // --- Splitter bars ---
     .flexlayout__splitter {
         background-color: white;
+        --splitter-active-size: 4px !important;
 
         &:hover {
             background-color: $blue3;
@@ -246,6 +247,7 @@ $pt-dark-app-background-color: #252a31;
 
         .flexlayout__splitter {
             background-color: $dark-gray4;
+            --splitter-active-size: 4px !important;
 
             &:hover {
                 background-color: $blue4;

--- a/src/layout-flexlayout.scss
+++ b/src/layout-flexlayout.scss
@@ -247,7 +247,6 @@ $pt-dark-app-background-color: #252a31;
 
         .flexlayout__splitter {
             background-color: $dark-gray4;
-            --splitter-active-size: 4px !important;
 
             &:hover {
                 background-color: $blue4;


### PR DESCRIPTION
**Description**

When running e2e test on ubuntu and using chrome in *headless* mode (GUI works fine), the flexlayout splitter active size for some reason (could be due to misinterpretation of a touch-screen environment) is set to 30px, not 4 px as defined in the flexlayout css file. This therefore blocks an element that e2e test needs to interact with, resulting many test failures. This PR is to explicitly set the splitter active size to 4px with !important to prevent the misinterpretation by flexlayout. Alternative attempts such as fix the chromedriver configuration flag, or fix the test codes were tried but none of them worked. The root cause is likely due to the flexlayout engine and its isDesktop function (as speculated by AI), so fixing in the main codebase is a better and working solution.

Note that without this fix, on macOS, e2e tests are working fine both headless and GUI modes. 


**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [ ] changelog updated / no changelog update needed
- [ ] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] protobuf version bumped / no protobuf version bumped needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)