### PR TITLE
feat: add colormap inversion controls across overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added Astropy-style sinh and asinh image scaling options with hover previews in the scaling dropdown ([#1992](https://github.com/CARTAvis/carta-frontend/issues/1992)).
+* Added colormap inversion controls for image rendering, contours, and vector overlays, including preferences and workspace support ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 ### Fixed
+* Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).
 * Fixed sliders selecting incorrect values after their widgets are resized ([#2875](https://github.com/CARTAvis/carta-frontend/issues/2875)).
 

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -766,7 +766,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                     {this.renderScalingParameter(widgetStore.colorScalingType, widgetStore.colorScalingParameter, value => widgetStore.setColorScalingParameter(value), shouldDisableColorMap)}
                     <FormGroup inline={true} label="Colormap" disabled={shouldDisableColorMap}>
                         <ColormapComponent
-                            inverted={false}
+                            inverted={widgetStore.isInvertedColorMap}
                             selectedColormap={widgetStore.colorMap}
                             onColormapSelect={selected => this.handleColormapSelected(widgetStore, selected)}
                             onColormapHover={colormap => this.handleColormapHovered(widgetStore, colormap)}

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -775,7 +775,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                         />
                     </FormGroup>
                     <FormGroup label={"Invert colormap"} inline={true} disabled={shouldDisableColorMap}>
-                        <Switch checked={widgetStore.isInvertedColorMap} onChange={ev => widgetStore.setColorMapDirection(ev.currentTarget.checked)} disabled={shouldDisableColorMap} />
+                        <Switch checked={widgetStore.isInvertedColorMap} onChange={ev => widgetStore.setColorMapDirection(ev.currentTarget.checked)} disabled={shouldDisableColorMap} data-testid="catalog-settings-invert-colormap-toggle" />
                     </FormGroup>
                     <ClearableNumericInputComponent
                         label="Clip min"

--- a/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
@@ -119,7 +119,12 @@ export class ContourStylePanelComponent extends React.Component<{frame: FrameSto
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Invert colormap" disabled={!frame.contourConfig.isColormapEnabled}>
-                    <Switch checked={frame.contourConfig.isColormapInverted} onChange={ev => frame.contourConfig.setColormapInverted(ev.currentTarget.checked)} disabled={!frame.contourConfig.isColormapEnabled} />
+                    <Switch
+                        checked={frame.contourConfig.isColormapInverted}
+                        onChange={ev => frame.contourConfig.setColormapInverted(ev.currentTarget.checked)}
+                        disabled={!frame.contourConfig.isColormapEnabled}
+                        data-testid="contour-invert-colormap-toggle"
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Bias" disabled={!frame.contourConfig.isColormapEnabled}>
                     <SafeNumericInput

--- a/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
+++ b/src/components/Dialogs/ContourDialog/ContourStylePanel/ContourStylePanelComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {Button, FormGroup, HTMLSelect, MenuItem} from "@blueprintjs/core";
+import {Button, FormGroup, HTMLSelect, MenuItem, Switch} from "@blueprintjs/core";
 import {Select} from "@blueprintjs/select";
 import type {ColorResult} from "@uiw/react-color";
 import {observer} from "mobx-react";
@@ -110,13 +110,16 @@ export class ContourStylePanelComponent extends React.Component<{frame: FrameSto
                 </FormGroup>
                 <FormGroup inline={true} label="Colormap" disabled={!frame.contourConfig.isColormapEnabled}>
                     <ColormapComponent
-                        inverted={false}
+                        inverted={frame.contourConfig.isColormapInverted}
                         disabled={!frame.contourConfig.isColormapEnabled}
                         selectedColormap={frame.contourConfig.colormap}
                         onColormapSelect={colormap => this.handleColormapSelected(frame.contourConfig, colormap)}
                         onColormapHover={colormap => this.handleColormapHovered(frame.contourConfig, colormap)}
                         onDropdownOpenChange={isOpen => this.handleColormapDropdownOpenChange(isOpen)}
                     />
+                </FormGroup>
+                <FormGroup inline={true} label="Invert colormap" disabled={!frame.contourConfig.isColormapEnabled}>
+                    <Switch checked={frame.contourConfig.isColormapInverted} onChange={ev => frame.contourConfig.setColormapInverted(ev.currentTarget.checked)} disabled={!frame.contourConfig.isColormapEnabled} />
                 </FormGroup>
                 <FormGroup inline={true} label="Bias" disabled={!frame.contourConfig.isColormapEnabled}>
                     <SafeNumericInput

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -372,7 +372,14 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Default colormap">
-                    <ColormapComponent inverted={false} selectedColormap={preference.contourColormap} onColormapSelect={selected => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP, selected)} />
+                    <ColormapComponent
+                        inverted={preference.isContourColormapInverted}
+                        selectedColormap={preference.contourColormap}
+                        onColormapSelect={selected => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP, selected)}
+                    />
+                </FormGroup>
+                <FormGroup inline={true} label="Invert colormap">
+                    <Switch checked={preference.isContourColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -433,7 +433,14 @@ export class PreferenceDialogComponent extends React.Component {
                     </HTMLSelect>
                 </FormGroup>
                 <FormGroup inline={true} label="Default colormap">
-                    <ColormapComponent inverted={false} selectedColormap={preference.vectorOverlayColormap} onColormapSelect={selected => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP, selected)} />
+                    <ColormapComponent
+                        inverted={preference.isVectorOverlayColormapInverted}
+                        selectedColormap={preference.vectorOverlayColormap}
+                        onColormapSelect={selected => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP, selected)}
+                    />
+                </FormGroup>
+                <FormGroup inline={true} label="Invert colormap">
+                    <Switch checked={preference.isVectorOverlayColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_INVERTED, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -277,7 +277,11 @@ export class PreferenceDialogComponent extends React.Component {
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Invert colormap">
-                    <Switch checked={preference.isColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.RENDER_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)} />
+                    <Switch
+                        checked={preference.isColormapInverted}
+                        onChange={ev => preference.setPreference(PreferenceKeys.RENDER_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)}
+                        data-testid="preference-render-config-invert-colormap-toggle"
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Default percentile ranks">
                     <PercentileSelect
@@ -382,7 +386,11 @@ export class PreferenceDialogComponent extends React.Component {
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Invert colormap">
-                    <Switch checked={preference.isContourColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)} />
+                    <Switch
+                        checked={preference.isContourColormapInverted}
+                        onChange={ev => preference.setPreference(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)}
+                        data-testid="preference-contour-invert-colormap-toggle"
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent
@@ -443,7 +451,11 @@ export class PreferenceDialogComponent extends React.Component {
                     />
                 </FormGroup>
                 <FormGroup inline={true} label="Invert colormap">
-                    <Switch checked={preference.isVectorOverlayColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_INVERTED, ev.currentTarget.checked)} />
+                    <Switch
+                        checked={preference.isVectorOverlayColormapInverted}
+                        onChange={ev => preference.setPreference(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_INVERTED, ev.currentTarget.checked)}
+                        data-testid="preference-vector-overlay-invert-colormap-toggle"
+                    />
                 </FormGroup>
                 <FormGroup inline={true} label="Default color">
                     <ColorPickerComponent

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -266,7 +266,7 @@ export class PreferenceDialogComponent extends React.Component {
                 </FormGroup>
                 <FormGroup inline={true} label="Default colormap">
                     <ColormapComponent
-                        inverted={false}
+                        inverted={preference.isColormapInverted}
                         selectedColormap={preference.colormap}
                         onColormapSelect={selected => preference.setPreference(PreferenceKeys.RENDER_CONFIG_COLORMAP, selected)}
                         enableAdditionalColor={true}
@@ -275,6 +275,9 @@ export class PreferenceDialogComponent extends React.Component {
                         selectedCustomColor={preference.colormapHex}
                         customColorStart={preference.colormapHexStart}
                     />
+                </FormGroup>
+                <FormGroup inline={true} label="Invert colormap">
+                    <Switch checked={preference.isColormapInverted} onChange={ev => preference.setPreference(PreferenceKeys.RENDER_CONFIG_COLORMAP_INVERTED, ev.currentTarget.checked)} />
                 </FormGroup>
                 <FormGroup inline={true} label="Default percentile ranks">
                     <PercentileSelect

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -476,7 +476,11 @@ export class VectorOverlayDialogComponent extends React.Component {
                             />
                         </FormGroup>
                         <FormGroup inline={true} label="Invert colormap">
-                            <Switch checked={dataSource.vectorOverlayConfig.isColormapInverted} onChange={ev => dataSource.vectorOverlayConfig.setColormapInverted(ev.currentTarget.checked)} />
+                            <Switch
+                                checked={dataSource.vectorOverlayConfig.isColormapInverted}
+                                onChange={ev => dataSource.vectorOverlayConfig.setColormapInverted(ev.currentTarget.checked)}
+                                data-testid="vector-field-invert-colormap-toggle"
+                            />
                         </FormGroup>
                         <FormGroup inline={true} label="Bias">
                             <SafeNumericInput placeholder="Bias" min={-1.0} max={1.0} value={dataSource.vectorOverlayConfig.colormapBias} majorStepSize={0.1} stepSize={0.1} onValueChange={dataSource.vectorOverlayConfig.setColormapBias} />

--- a/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
+++ b/src/components/Dialogs/VectorOverlayDialog/VectorOverlayDialogComponent.tsx
@@ -468,12 +468,15 @@ export class VectorOverlayDialogComponent extends React.Component {
                     <React.Fragment>
                         <FormGroup inline={true} label="Colormap">
                             <ColormapComponent
-                                inverted={false}
+                                inverted={dataSource.vectorOverlayConfig.isColormapInverted}
                                 selectedColormap={dataSource.vectorOverlayConfig.colormap}
                                 onColormapSelect={colormap => this.handleColormapSelected(dataSource.vectorOverlayConfig, colormap)}
                                 onColormapHover={colormap => this.handleColormapHovered(dataSource.vectorOverlayConfig, colormap)}
                                 onDropdownOpenChange={isOpen => this.handleColormapDropdownOpenChange(isOpen)}
                             />
+                        </FormGroup>
+                        <FormGroup inline={true} label="Invert colormap">
+                            <Switch checked={dataSource.vectorOverlayConfig.isColormapInverted} onChange={ev => dataSource.vectorOverlayConfig.setColormapInverted(ev.currentTarget.checked)} />
                         </FormGroup>
                         <FormGroup inline={true} label="Bias">
                             <SafeNumericInput placeholder="Bias" min={-1.0} max={1.0} value={dataSource.vectorOverlayConfig.colormapBias} majorStepSize={0.1} stepSize={0.1} onValueChange={dataSource.vectorOverlayConfig.setColormapBias} />

--- a/src/components/ImageView/ContourView/ContourViewComponent.tsx
+++ b/src/components/ImageView/ContourView/ContourViewComponent.tsx
@@ -189,6 +189,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
         this.gl.uniform1f(this.contourWebGLService.shaderUniforms.LineThickness, lineThickness);
         this.gl.uniform1f(this.contourWebGLService.shaderUniforms.PixelRatio, frame.aspectRatio);
         this.gl.uniform1i(this.contourWebGLService.shaderUniforms.CmapEnabled, frame.contourConfig.isColormapEnabled ? 1 : 0);
+        this.gl.uniform1i(this.contourWebGLService.shaderUniforms.CmapInverted, frame.contourConfig.isColormapInverted ? 1 : 0);
         if (frame.contourConfig.isColormapEnabled) {
             this.gl.uniform1i(this.contourWebGLService.shaderUniforms.CmapIndex, COLOR_MAPS_ALL.indexOf(frame.contourConfig.colormap));
             this.gl.uniform1f(this.contourWebGLService.shaderUniforms.Bias, frame.contourConfig.colormapBias);
@@ -255,6 +256,7 @@ export class ContourViewComponent extends React.Component<ContourViewComponentPr
                 const config = frame.contourConfig;
                 const thickness = config.thickness;
                 const color = config.isColormapEnabled ? config.colormap : config.color;
+                const isInverted = config.isColormapInverted;
                 const dashMode = config.dashMode;
                 const bias = config.colormapBias;
                 const contrast = config.colormapContrast;

--- a/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
+++ b/src/components/ImageView/VectorOverlayView/VectorOverlayView.tsx
@@ -209,6 +209,7 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         // TODO: support non-uniform pixel ratios
         // this.gl.uniform1f(shaderUniforms.PixelRatio, frame.aspectRatio);
         this.gl.uniform1i(shaderUniforms.CmapEnabled, frame.vectorOverlayConfig.isColormapEnabled ? 1 : 0);
+        this.gl.uniform1i(shaderUniforms.CmapInverted, frame.vectorOverlayConfig.isColormapInverted ? 1 : 0);
         if (frame.vectorOverlayConfig.isColormapEnabled) {
             this.gl.uniform1i(shaderUniforms.CmapIndex, COLOR_MAPS_ALL.indexOf(frame.vectorOverlayConfig.colormap));
             this.gl.uniform1f(shaderUniforms.Bias, frame.vectorOverlayConfig.colormapBias);
@@ -248,7 +249,7 @@ export class VectorOverlayViewComponent extends React.Component<VectorOverlayVie
         if (overlayFrames) {
             for (const frame of overlayFrames) {
                 const config = frame.vectorOverlayConfig;
-                const {angularSource, intensitySource, thickness, rotationOffset, color, colormapBias, colormapContrast, isColormapEnabled, colormap, lengthMin, lengthMax, isVisible} = config;
+                const {angularSource, intensitySource, thickness, rotationOffset, color, colormapBias, colormapContrast, isColormapEnabled, isColormapInverted, colormap, lengthMin, lengthMax, isVisible} = config;
                 config.intensityMin = isFinite(config.intensityMin ?? NaN) ? config.intensityMin : frame.vectorOverlayStore.intensityMin;
                 config.intensityMax = isFinite(config.intensityMax ?? NaN) ? config.intensityMax : frame.vectorOverlayStore.intensityMax;
 

--- a/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
+++ b/src/components/RenderConfig/ColormapConfigComponent/ColormapConfigComponent.tsx
@@ -168,7 +168,7 @@ export class ColormapConfigComponent extends React.Component<ColormapConfigProps
                     />
                 </FormGroup>
                 <FormGroup label={"Invert colormap"} inline={true}>
-                    <Switch checked={renderConfig.isInverted} onChange={this.handleInvertedChanged} />
+                    <Switch checked={renderConfig.isInverted} onChange={this.handleInvertedChanged} data-testid="render-config-invert-colormap-toggle" />
                 </FormGroup>
                 {this.renderScalingParameter(renderConfig)}
                 <FormGroup inline={true}>

--- a/src/components/Shared/ScatterPlot/PlotSettings/ScatterPlotSettingsPanelComponent.tsx
+++ b/src/components/Shared/ScatterPlot/PlotSettings/ScatterPlotSettingsPanelComponent.tsx
@@ -86,7 +86,7 @@ export class ScatterPlotSettingsPanelComponent extends React.Component<ScatterPl
                         />
                     </FormGroup>
                     <FormGroup label={"Invert colormap"} inline={true}>
-                        <Switch checked={props.isColorMapInverted} onChange={props.handleInvertedColorMapChanged} />
+                        <Switch checked={props.isColorMapInverted} onChange={props.handleInvertedColorMapChanged} data-testid="scatter-plot-invert-colormap-toggle" />
                     </FormGroup>
                     <FormGroup inline={true} label="Symbol size" labelInfo="(px)">
                         <SafeNumericInput

--- a/src/enums/preference.ts
+++ b/src/enums/preference.ts
@@ -19,6 +19,7 @@ export enum PreferenceKeys {
 
     RENDER_CONFIG_SCALING = "scaling",
     RENDER_CONFIG_COLORMAP = "colormap",
+    RENDER_CONFIG_COLORMAP_INVERTED = "colormapInverted",
     RENDER_CONFIG_COLORMAP_HEX = "colormapHex",
     RENDER_CONFIG_COLORMAP_HEX_START = "colormapHexStart",
     RENDER_CONFIG_PERCENTILE = "percentile",

--- a/src/enums/preference.ts
+++ b/src/enums/preference.ts
@@ -39,6 +39,7 @@ export enum PreferenceKeys {
     CONTOUR_CONFIG_NUM_LEVELS = "contourNumLevels",
     CONTOUR_CONFIG_THICKNESS = "contourThickness",
     CONTOUR_CONFIG_COLORMAP_ENABLED = "contourColormapEnabled",
+    CONTOUR_CONFIG_COLORMAP_INVERTED = "contourColormapInverted",
     CONTOUR_CONFIG_COLOR = "contourColor",
     CONTOUR_CONFIG_COLORMAP = "contourColormap",
 

--- a/src/enums/preference.ts
+++ b/src/enums/preference.ts
@@ -47,6 +47,7 @@ export enum PreferenceKeys {
     VECTOR_OVERLAY_FRACTIONAL_INTENSITY = "vectorOverlayFractionalIntensity",
     VECTOR_OVERLAY_THICKNESS = "vectorOverlayThickness",
     VECTOR_OVERLAY_COLORMAP_ENABLED = "vectorOverlayColormapEnabled",
+    VECTOR_OVERLAY_COLORMAP_INVERTED = "vectorOverlayColormapInverted",
     VECTOR_OVERLAY_COLOR = "vectorOverlayColor",
     VECTOR_OVERLAY_COLORMAP = "vectorOverlayColormap",
 

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -58,6 +58,7 @@ export interface WorkspaceVectorOverlayConfig {
     visible: boolean;
     thickness: number;
     colormapEnabled: boolean;
+    colormapInverted?: boolean;
     color?: RgbaColor;
     colormap?: string;
     colormapContrast: number;
@@ -233,6 +234,7 @@ export class WorkspaceConfig {
             isVisible,
             thickness,
             isColormapEnabled,
+            isColormapInverted,
             color,
             colormap,
             colormapContrast,
@@ -262,6 +264,7 @@ export class WorkspaceConfig {
             visible: isVisible,
             thickness,
             colormapEnabled: isColormapEnabled,
+            colormapInverted: isColormapInverted,
             color,
             colormap,
             colormapContrast,

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -34,6 +34,7 @@ export interface WorkspaceContourConfig {
     smoothingFactor: number;
     color?: RgbaColor;
     colormapEnabled: boolean;
+    colormapInverted?: boolean;
     colormap?: string;
     colormapContrast: number;
     colormapBias: number;
@@ -194,7 +195,7 @@ export class WorkspaceConfig {
     }
 
     public static createContourConfig(contourConfig: ContourConfigStore): WorkspaceContourConfig | undefined {
-        const {isEnabled, levels, smoothingMode, smoothingFactor, color, isColormapEnabled, colormap, colormapContrast, colormapBias, dashMode, thickness, isVisible} = contourConfig;
+        const {isEnabled, levels, smoothingMode, smoothingFactor, color, isColormapEnabled, isColormapInverted, colormap, colormapContrast, colormapBias, dashMode, thickness, isVisible} = contourConfig;
 
         if (!isEnabled) {
             return undefined;
@@ -206,6 +207,7 @@ export class WorkspaceConfig {
             smoothingFactor,
             color,
             colormapEnabled: isColormapEnabled,
+            colormapInverted: isColormapInverted,
             colormap,
             colormapContrast,
             colormapBias,

--- a/src/services/ContourWebGLService.ts
+++ b/src/services/ContourWebGLService.ts
@@ -18,6 +18,7 @@ interface ShaderUniforms {
     CmapTexture: WebGLUniformLocation | null;
     NumCmaps: WebGLUniformLocation | null;
     CmapIndex: WebGLUniformLocation | null;
+    CmapInverted: WebGLUniformLocation | null;
     Bias: WebGLUniformLocation | null;
     Contrast: WebGLUniformLocation | null;
     ControlMapEnabled: WebGLUniformLocation | null;
@@ -80,6 +81,7 @@ export class ContourWebGLService {
                 CmapTexture: this.gl.getUniformLocation(shaderProgram, "uCmapTexture"),
                 NumCmaps: this.gl.getUniformLocation(shaderProgram, "uNumCmaps"),
                 CmapIndex: this.gl.getUniformLocation(shaderProgram, "uCmapIndex"),
+                CmapInverted: this.gl.getUniformLocation(shaderProgram, "uCmapInverted"),
                 Contrast: this.gl.getUniformLocation(shaderProgram, "uContrast"),
                 Bias: this.gl.getUniformLocation(shaderProgram, "uBias"),
                 ControlMapEnabled: this.gl.getUniformLocation(shaderProgram, "uControlMapEnabled"),

--- a/src/services/GLSL/pixel_shader_contours.glsl
+++ b/src/services/GLSL/pixel_shader_contours.glsl
@@ -12,6 +12,7 @@ uniform sampler2D uCmapTexture;
 uniform float uCmapValue;
 uniform int uNumCmaps;
 uniform int uCmapIndex;
+uniform int uCmapInverted;
 uniform float uBias;
 uniform float uContrast;
 
@@ -35,6 +36,10 @@ void main(void) {
         float x = clamp(uCmapValue - uBias, 0.0, 1.0);
         // contrast mod
         x = clamp((x - 0.5) * uContrast + 0.5, 0.0, 1.0);
+        // invert mod
+        if (uCmapInverted > 0) {
+            x = 1.0 - x;
+        }
         float cmapYVal = (float(uCmapIndex) + 0.5) / float(uNumCmaps);
         vec2 cmapCoords = vec2(x, cmapYVal);
         color = texture(uCmapTexture, cmapCoords);

--- a/src/services/GLSL/vertex_shader_overlay.glsl
+++ b/src/services/GLSL/vertex_shader_overlay.glsl
@@ -31,6 +31,7 @@ uniform sampler2D uCmapTexture;
 uniform float uCmapValue;
 uniform int uNumCmaps;
 uniform int uCmapIndex;
+uniform int uCmapInverted;
 uniform float uBias;
 uniform float uContrast;
 
@@ -87,6 +88,10 @@ void main() {
         x = clamp(x - uBias, 0.0, 1.0);
         // contrast mod
         x = clamp((x - 0.5) * uContrast + 0.5, 0.0, 1.0);
+        // invert mod
+        if (uCmapInverted > 0) {
+            x = 1.0 - x;
+        }
         float cmapYVal = (float(uCmapIndex) + 0.5) / float(uNumCmaps);
         vec2 cmapCoords = vec2(x, cmapYVal);
         v_colour = texture(uCmapTexture, cmapCoords);

--- a/src/services/VectorOverlayWebGLService.ts
+++ b/src/services/VectorOverlayWebGLService.ts
@@ -23,6 +23,7 @@ interface ShaderUniforms {
     CmapTexture: WebGLUniformLocation | null;
     NumCmaps: WebGLUniformLocation | null;
     CmapIndex: WebGLUniformLocation | null;
+    CmapInverted: WebGLUniformLocation | null;
     Bias: WebGLUniformLocation | null;
     Contrast: WebGLUniformLocation | null;
     LineColor: WebGLUniformLocation | null;
@@ -84,6 +85,7 @@ export class VectorOverlayWebGLService {
                 CmapTexture: this.gl.getUniformLocation(shaderProgram, "uCmapTexture"),
                 NumCmaps: this.gl.getUniformLocation(shaderProgram, "uNumCmaps"),
                 CmapIndex: this.gl.getUniformLocation(shaderProgram, "uCmapIndex"),
+                CmapInverted: this.gl.getUniformLocation(shaderProgram, "uCmapInverted"),
                 Contrast: this.gl.getUniformLocation(shaderProgram, "uContrast"),
                 Bias: this.gl.getUniformLocation(shaderProgram, "uBias"),
                 LineColor: this.gl.getUniformLocation(shaderProgram, "uLineColor"),

--- a/src/stores/Frame/ContourStore/ContourConfigStore.test.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.test.ts
@@ -1,0 +1,55 @@
+import {CARTA} from "carta-protobuf";
+
+import {ContourDashMode} from "enums/contour";
+import {type WorkspaceContourConfig} from "models/Workspace";
+import {type PreferenceStore} from "stores/PreferenceStore/PreferenceStore";
+
+import {ContourConfigStore} from "./ContourConfigStore";
+
+function createStore(isDefaultInverted: boolean): ContourConfigStore {
+    const preference = {
+        contourSmoothingMode: CARTA.SmoothingMode.NoSmoothing,
+        contourSmoothingFactor: 1,
+        contourColor: "#00ff00",
+        isContourColormapEnabled: true,
+        isContourColormapInverted: isDefaultInverted,
+        contourColormap: "viridis",
+        contourThickness: 1
+    } as PreferenceStore;
+
+    return new ContourConfigStore(preference);
+}
+
+function createWorkspaceConfig(isColormapInverted?: boolean): WorkspaceContourConfig {
+    return {
+        levels: [1],
+        smoothingMode: CARTA.SmoothingMode.NoSmoothing,
+        smoothingFactor: 1,
+        colormapEnabled: true,
+        colormapInverted: isColormapInverted,
+        colormap: "viridis",
+        colormapContrast: 1,
+        colormapBias: 0,
+        dashMode: ContourDashMode.None,
+        thickness: 1,
+        visible: true
+    };
+}
+
+describe("ContourConfigStore workspace colormap inversion", () => {
+    test("uses the historical non-inverted behavior when a legacy workspace omits the setting", () => {
+        const store = createStore(true);
+
+        store.updateFromWorkspace(createWorkspaceConfig());
+
+        expect(store.isColormapInverted).toBe(false);
+    });
+
+    test("restores an explicit inverted workspace setting", () => {
+        const store = createStore(false);
+
+        store.updateFromWorkspace(createWorkspaceConfig(true));
+
+        expect(store.isColormapInverted).toBe(true);
+    });
+});

--- a/src/stores/Frame/ContourStore/ContourConfigStore.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.ts
@@ -15,6 +15,7 @@ export class ContourConfigStore {
 
     @observable color: RgbaColor;
     @observable isColormapEnabled: boolean = false;
+    @observable isColormapInverted: boolean = false;
     @observable colormap: string;
     @observable colormapContrast: number = 1.0;
     @observable colormapBias: number = 0.0;
@@ -31,6 +32,7 @@ export class ContourConfigStore {
 
         this.color = tinycolor(this.preferenceStore.contourColor).toRgb();
         this.isColormapEnabled = this.preferenceStore.isContourColormapEnabled;
+        this.isColormapInverted = this.preferenceStore.isContourColormapInverted;
         this.colormap = this.preferenceStore.contourColormap;
         this.thickness = this.preferenceStore.contourThickness;
         makeObservable(this);
@@ -70,6 +72,10 @@ export class ContourConfigStore {
         this.isColormapEnabled = isColormapEnabled;
     };
 
+    @action setColormapInverted = (isColormapInverted: boolean) => {
+        this.isColormapInverted = isColormapInverted;
+    };
+
     @action setColormapBias = (val: number) => {
         this.colormapBias = val;
     };
@@ -97,6 +103,7 @@ export class ContourConfigStore {
         this.isVisible = config.visible;
 
         this.isColormapEnabled = config.colormapEnabled;
+        this.isColormapInverted = config.colormapInverted ?? this.isColormapInverted;
         if (config.color) {
             this.color = config.color;
         }

--- a/src/stores/Frame/ContourStore/ContourConfigStore.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.ts
@@ -103,7 +103,7 @@ export class ContourConfigStore {
         this.isVisible = config.visible;
 
         this.isColormapEnabled = config.colormapEnabled;
-        this.isColormapInverted = config.colormapInverted ?? this.isColormapInverted;
+        this.isColormapInverted = config.colormapInverted ?? false;
         if (config.color) {
             this.color = config.color;
         }

--- a/src/stores/Frame/RenderConfigStore/RenderConfigStore.ts
+++ b/src/stores/Frame/RenderConfigStore/RenderConfigStore.ts
@@ -74,6 +74,7 @@ export class RenderConfigStore {
         this.gamma = sanitizeScalingParameter(FrameScaling.GAMMA, preference.scalingGamma);
         this.scaling = preference.scaling;
         this.setColorMap(preference.colormap);
+        this.isInverted = preference.isColormapInverted;
         this.scaleMin = new Array<number>(stokesLength).fill(0);
         this.scaleMax = new Array<number>(stokesLength).fill(1);
         this.customColormapHexEnd = preference.colormapHex;

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.test.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.test.ts
@@ -1,0 +1,68 @@
+import {CARTA} from "carta-protobuf";
+
+import {VectorOverlaySource} from "enums/vector";
+import {type WorkspaceVectorOverlayConfig} from "models/Workspace";
+import {type FrameStore} from "stores/Frame/FrameStore";
+import {type PreferenceStore} from "stores/PreferenceStore/PreferenceStore";
+
+import {VectorOverlayConfigStore} from "./VectorOverlayConfigStore";
+
+function createStore(isDefaultInverted: boolean): VectorOverlayConfigStore {
+    const preference = {
+        vectorOverlayColor: "#00ff00",
+        isVectorOverlayColormapEnabled: true,
+        isVectorOverlayColormapInverted: isDefaultInverted,
+        vectorOverlayColormap: "viridis",
+        vectorOverlayThickness: 1,
+        isVectorOverlayFractionalIntensity: false,
+        vectorOverlayPixelAveraging: 1
+    } as PreferenceStore;
+    const frame = {hasLinearStokes: false} as FrameStore;
+
+    return new VectorOverlayConfigStore(preference, frame);
+}
+
+function createWorkspaceConfig(isColormapInverted?: boolean): WorkspaceVectorOverlayConfig {
+    return {
+        angularSource: VectorOverlaySource.Current,
+        intensitySource: VectorOverlaySource.Current,
+        fractionalIntensity: false,
+        pixelAveraging: 1,
+        thresholdEnabled: false,
+        threshold: 0,
+        debiasing: false,
+        qError: 0,
+        uError: 0,
+        thresholdOption: CARTA.PolarizationType.I,
+        visible: true,
+        thickness: 1,
+        colormapEnabled: true,
+        colormapInverted: isColormapInverted,
+        colormap: "viridis",
+        colormapContrast: 1,
+        colormapBias: 0,
+        lengthMin: 0,
+        lengthMax: 20,
+        intensityMin: undefined,
+        intensityMax: undefined,
+        rotationOffset: 0
+    };
+}
+
+describe("VectorOverlayConfigStore workspace colormap inversion", () => {
+    test("uses the historical non-inverted behavior when a legacy workspace omits the setting", () => {
+        const store = createStore(true);
+
+        store.updateFromWorkspace(createWorkspaceConfig());
+
+        expect(store.isColormapInverted).toBe(false);
+    });
+
+    test("restores an explicit inverted workspace setting", () => {
+        const store = createStore(false);
+
+        store.updateFromWorkspace(createWorkspaceConfig(true));
+
+        expect(store.isColormapInverted).toBe(true);
+    });
+});

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
@@ -170,7 +170,7 @@ export class VectorOverlayConfigStore {
         this.rotationOffset = config.rotationOffset;
 
         this.isColormapEnabled = config.colormapEnabled;
-        this.isColormapInverted = config.colormapInverted ?? this.isColormapInverted;
+        this.isColormapInverted = config.colormapInverted ?? false;
         if (config.color) {
             this.color = config.color;
         }

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
@@ -26,6 +26,7 @@ export class VectorOverlayConfigStore {
     @observable isVisible: boolean = true;
     @observable thickness: number = 1;
     @observable isColormapEnabled: boolean = false;
+    @observable isColormapInverted: boolean = false;
     @observable color: RgbaColor = {r: 0, g: 0, b: 0, a: 1};
     @observable colormap: string = "";
     @observable colormapContrast: number = 1.0;
@@ -50,6 +51,7 @@ export class VectorOverlayConfigStore {
 
         this.color = tinycolor(this.preferenceStore.vectorOverlayColor).toRgb();
         this.isColormapEnabled = this.preferenceStore.isVectorOverlayColormapEnabled;
+        this.isColormapInverted = this.preferenceStore.isVectorOverlayColormapInverted;
         this.colormap = this.preferenceStore.vectorOverlayColormap;
         this.thickness = this.preferenceStore.vectorOverlayThickness;
         makeObservable(this);
@@ -111,6 +113,10 @@ export class VectorOverlayConfigStore {
         this.isColormapEnabled = isColormapEnabled;
     };
 
+    @action setColormapInverted = (isColormapInverted: boolean) => {
+        this.isColormapInverted = isColormapInverted;
+    };
+
     @action setColormapBias = (val: number) => {
         this.colormapBias = val;
     };
@@ -164,6 +170,7 @@ export class VectorOverlayConfigStore {
         this.rotationOffset = config.rotationOffset;
 
         this.isColormapEnabled = config.colormapEnabled;
+        this.isColormapInverted = config.colormapInverted ?? this.isColormapInverted;
         if (config.color) {
             this.color = config.color;
         }

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -63,6 +63,7 @@ const DEFAULTS = {
         vectorOverlayFractionalIntensity: false,
         vectorOverlayThickness: 1,
         vectorOverlayColormapEnabled: false,
+        vectorOverlayColormapInverted: false,
         vectorOverlayColor: Colors.GREEN3,
         vectorOverlayColormap: ColorMap.Viridis
     },
@@ -376,6 +377,10 @@ export class PreferenceStore {
 
     @computed get isVectorOverlayColormapEnabled(): boolean {
         return this.preferences.get(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_ENABLED) ?? DEFAULTS.VECTOR_OVERLAY.vectorOverlayColormapEnabled;
+    }
+
+    @computed get isVectorOverlayColormapInverted(): boolean {
+        return this.preferences.get(PreferenceKeys.VECTOR_OVERLAY_COLORMAP_INVERTED) ?? DEFAULTS.VECTOR_OVERLAY.vectorOverlayColormapInverted;
     }
 
     @computed get vectorOverlayColor(): string {
@@ -820,6 +825,7 @@ export class PreferenceStore {
             PreferenceKeys.VECTOR_OVERLAY_COLOR,
             PreferenceKeys.VECTOR_OVERLAY_COLORMAP,
             PreferenceKeys.VECTOR_OVERLAY_COLORMAP_ENABLED,
+            PreferenceKeys.VECTOR_OVERLAY_COLORMAP_INVERTED,
             PreferenceKeys.VECTOR_OVERLAY_THICKNESS
         ]);
     };

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -54,6 +54,7 @@ const DEFAULTS = {
         contourNumLevels: 5,
         contourThickness: 1,
         contourColormapEnabled: false,
+        contourColormapInverted: false,
         contourColor: Colors.GREEN3,
         contourColormap: ColorMap.Viridis
     },
@@ -318,6 +319,10 @@ export class PreferenceStore {
 
     @computed get isContourColormapEnabled(): boolean {
         return this.preferences.get(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_ENABLED) ?? DEFAULTS.CONTOUR_CONFIG.contourColormapEnabled;
+    }
+
+    @computed get isContourColormapInverted(): boolean {
+        return this.preferences.get(PreferenceKeys.CONTOUR_CONFIG_COLORMAP_INVERTED) ?? DEFAULTS.CONTOUR_CONFIG.contourColormapInverted;
     }
 
     @computed get contourColormap(): string {
@@ -796,6 +801,7 @@ export class PreferenceStore {
             PreferenceKeys.CONTOUR_CONFIG_COLOR,
             PreferenceKeys.CONTOUR_CONFIG_COLORMAP,
             PreferenceKeys.CONTOUR_CONFIG_COLORMAP_ENABLED,
+            PreferenceKeys.CONTOUR_CONFIG_COLORMAP_INVERTED,
             PreferenceKeys.CONTOUR_CONFIG_GENERATOR_TYPE,
             PreferenceKeys.CONTOUR_CONFIG_NUM_LEVELS,
             PreferenceKeys.CONTOUR_CONFIG_SMOOTHING_FACTOR,

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -41,6 +41,7 @@ const DEFAULTS = {
     RENDER_CONFIG: {
         scaling: FrameScaling.LINEAR,
         colormap: ColorMap.Inferno,
+        colormapInverted: false,
         colormapHex: "#FFFFFF",
         colormapHexStart: "#000000",
         percentile: 99.9,
@@ -255,6 +256,10 @@ export class PreferenceStore {
 
     @computed get colormap(): string {
         return this.preferences.get(PreferenceKeys.RENDER_CONFIG_COLORMAP) ?? DEFAULTS.RENDER_CONFIG.colormap;
+    }
+
+    @computed get isColormapInverted(): boolean {
+        return this.preferences.get(PreferenceKeys.RENDER_CONFIG_COLORMAP_INVERTED) ?? DEFAULTS.RENDER_CONFIG.colormapInverted;
     }
 
     @computed get colormapHex(): string {
@@ -783,6 +788,7 @@ export class PreferenceStore {
     @action resetRenderConfigSettings = () => {
         this.clearPreferences([
             PreferenceKeys.RENDER_CONFIG_COLORMAP,
+            PreferenceKeys.RENDER_CONFIG_COLORMAP_INVERTED,
             PreferenceKeys.RENDER_CONFIG_COLORMAP_HEX,
             PreferenceKeys.RENDER_CONFIG_COLORMAP_HEX_START,
             PreferenceKeys.RENDER_CONFIG_NAN_COLOR_HEX,


### PR DESCRIPTION
**Description**

Closes #2030.

Schema updates needed in the end of this cycle.

Add colormap inversion controls across image rendering, contour rendering, vector overlays, and catalog overlays, with preference and workspace persistence.

What is implemented:
- Add inversion controls and reversed colormap previews for image rendering, contours, vector overlays, and catalog overlays.
- Persist inversion defaults in preferences and per-view inversion settings in workspaces, with schema support.
- Reset missing workspace inversion values to false when loading older configurations.

How to test:
- In Preferences, set the image, contour, or vector overlay default colormap to inverted and verify newly created views use the reversed direction.
- Enable color-mapped mode in the Contour and Vector Overlay dialogs, toggle `Invert colormap`, and verify the rendered colors reverse without changing the underlying geometry.
- In Catalog Overlay settings, toggle `Invert colormap` and verify both the colormap preview and catalog source colors follow the selected direction.


**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated / ~~no changelog update needed~~
- [x] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)