### PR TITLE
Fix negative zero image coordinates in the cursor info bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).
 * Fixed sliders selecting incorrect values after their widgets are resized ([#2875](https://github.com/CARTAvis/carta-frontend/issues/2875)).
+* Fixed the image viewer cursor info bar displaying image coordinates as negative zero, e.g. "(-0, -0)" ([#2910](https://github.com/CARTAvis/carta-frontend/issues/2910)).
 
 ## [6.0.0]
 

--- a/src/utilities/units/units.test.ts
+++ b/src/utilities/units/units.test.ts
@@ -1,6 +1,34 @@
-import {getValueFromArcsecString, pixelToFluxDensityUnit} from "./units";
+import {getValueFromArcsecString, pixelToFluxDensityUnit, toFixed} from "./units";
 
 jest.mock("models", () => ({}));
+
+describe("toFixed", () => {
+    it("rounds to the requested number of decimals", () => {
+        expect(toFixed(0.284)).toBe("0");
+        expect(toFixed(-0.5)).toBe("-1");
+        expect(toFixed(-1.2345, 3)).toBe("-1.234");
+        expect(toFixed(1.5, 1)).toBe("1.5");
+    });
+
+    it("does not display negative zero", () => {
+        expect(toFixed(-0.284)).toBe("0");
+        expect(toFixed(-0)).toBe("0");
+        expect(toFixed(-0.0001, 3)).toBe("0.000");
+        expect(toFixed(-0.284, 0)).toBe("0");
+    });
+
+    it("keeps the sign of values that do not round to zero", () => {
+        expect(toFixed(-0.284, 3)).toBe("-0.284");
+        expect(toFixed(-0.06, 1)).toBe("-0.1");
+    });
+
+    it("leaves non-finite values as is", () => {
+        expect(toFixed(NaN)).toBe("NaN");
+        expect(toFixed(Infinity)).toBe("Infinity");
+        expect(toFixed(-Infinity)).toBe("-Infinity");
+        expect(toFixed(1.234, -1)).toBe("1.234");
+    });
+});
 
 describe("pixelToFluxDensityUnit", () => {
     it("removes specific substrings from the pixel unit string", () => {

--- a/src/utilities/units/units.ts
+++ b/src/utilities/units/units.ts
@@ -38,7 +38,9 @@ export function toExponential(val: number, decimals: number = 0): string {
 // According to MDN, toFixed only works for up to 20 decimals
 export function toFixed(val: number, decimals: number = 0): string {
     if (isFinite(val) && isFinite(decimals) && decimals >= 0 && decimals <= 20) {
-        return val.toFixed(decimals);
+        const fixed = val.toFixed(decimals);
+        // small negative values that round to zero produce "-0", "-0.000", etc.; display them without the sign
+        return /^-0(\.0*)?$/.test(fixed) ? fixed.substring(1) : fixed;
     }
     // leave undefined or non-finite values as is (+- INF, NaN and undefined will still appear properly)
     return String(val);


### PR DESCRIPTION
**Description**

Fixes #2910. The cursor info bar in the image viewer displays image coordinates rounded to integers. For small negative positions (e.g. hovering in the lower-left half of pixel (0, 0), where the position is (-0.284, -0.198)), JavaScript's native `Number.prototype.toFixed` preserves the sign when rounding to zero, so the bar showed `Image: (-0, -0)` instead of `Image: (0, 0)`.

This is fixed centrally in the `toFixed()` wrapper in `src/utilities/units/units.ts`. When the rounded string is a negative zero (`"-0"`, `"-0.000"`, …), the sign is stripped. Genuinely negative values are unaffected (`-0.5` still rounds to `"-1"`; `toFixed(-0.284, 3)` still returns `"-0.284"`). Fixing the shared formatter also removes the same artifact from every other display that uses it, e.g., the Cursor Info widget can no longer show `-0.000` for tiny negative values. Unit tests for `toFixed` are added in `src/utilities/units/units.test.ts`.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated ~/ no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped /~ no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed) /~ no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~