### PR TITLE
Restore profile highlights when zooming the Stokes scatter plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).
 * Fixed sliders selecting incorrect values after their widgets are resized ([#2875](https://github.com/CARTAvis/carta-frontend/issues/2875)).
+* Fixed zooming the Stokes analysis scatter plot not graying out the out-of-range parts of the profile plots ([#2847](https://github.com/CARTAvis/carta-frontend/issues/2847)).
 
 ## [6.0.0]
 

--- a/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
+++ b/src/components/StokesAnalysis/StokesAnalysisComponent.tsx
@@ -548,6 +548,21 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
             const values: Array<Point3D> = [];
             // centered origin and equal scaler
             const equalScalerBorder = this.resizeScatterData(border.xMin, border.xMax, border.yMin, border.yMax);
+            // the visible scatter range: zoomed bounds when the user has zoomed, otherwise the full plot range
+            const widgetStore = this.widgetStore;
+            const visibleBorder: Border = widgetStore.areAxesEqual
+                ? {
+                      xMin: widgetStore.quScatterEqualXmin ?? equalScalerBorder.xMin,
+                      xMax: widgetStore.quScatterEqualXmax ?? equalScalerBorder.xMax,
+                      yMin: widgetStore.quScatterEqualYmin ?? equalScalerBorder.yMin,
+                      yMax: widgetStore.quScatterEqualYmax ?? equalScalerBorder.yMax
+                  }
+                : {
+                      xMin: widgetStore.quScatterMinX ?? equalScalerBorder.xMin,
+                      xMax: widgetStore.quScatterMaxX ?? equalScalerBorder.xMax,
+                      yMin: widgetStore.quScatterMinY ?? equalScalerBorder.yMin,
+                      yMax: widgetStore.quScatterMaxY ?? equalScalerBorder.yMax
+                  };
             this.widgetStore.scatterOutRangePointsZIndex = [];
             for (let i = 0; i < channelValues.length; i++) {
                 const x = qProfile[i];
@@ -556,7 +571,7 @@ export class StokesAnalysisComponent extends React.Component<WidgetProps> {
                 values.push({x, y, z});
 
                 // update line plot color array
-                if (x < border.xMin || x > border.xMax || y < border.yMin || y > border.yMax) {
+                if (x < visibleBorder.xMin || x > visibleBorder.xMax || y < visibleBorder.yMin || y > visibleBorder.yMax) {
                     this.widgetStore.scatterOutRangePointsZIndex.push(z);
                 }
             }


### PR DESCRIPTION
**Description**

Fixes #2847. In the Stokes analysis widget, zooming the Q–U scatter plot no longer grays out the parts of the profile plots (I, Q, U, PI, PA, …) whose channels fall outside the visible scatter range. The profiles stay fully colored regardless of the scatter zoom, so the link between the two views is lost. This is a regression from #2533, which removed the clamping of the scatter border to the zoomed bounds; since then, the out-of-range check in `assembleScatterPlotData` always compares against the full data extent, so no channel is ever classified as out of range.

`assembleScatterPlotData` now computes a `visibleBorder`, the zoomed scatter bounds when the user has zoomed, otherwise the full (equal-scaled) plot range, and uses it to populate `scatterOutRangePointsZIndex`. The visible bounds are read from the widget store according to the axis mode, mirroring the selection already used for rendering: `quScatterEqual*` when "Equal axes" is on, `quScatterMin/Max*` otherwise, with the full range as the fallback when nothing is zoomed.

The border returned for the scatter plot itself is unchanged, so the zero-reference-line fix from #2533 is preserved. Because the zoom bounds are MobX observables read inside the `@computed plotData`, the profile highlights update reactively on zoom and on zoom reset (double-click), in both axis modes.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated ~/ no changelog update needed~
- [x] ~unit test added (for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped /~ no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed) /~ no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~