### PR TITLE
Sort the file browser Size column by numerical size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).
 * Fixed sliders selecting incorrect values after their widgets are resized ([#2875](https://github.com/CARTAvis/carta-frontend/issues/2875)).
+* Fixed the file browser Size column sorting files by the leading digit instead of the numerical size ([#2859](https://github.com/CARTAvis/carta-frontend/issues/2859)).
 
 ## [6.0.0]
 

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.test.ts
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.test.ts
@@ -1,0 +1,118 @@
+import {CARTA} from "carta-protobuf";
+import Long from "long";
+import type {BrowserFileList} from "stores";
+
+import {BrowserMode, FileFilteringType} from "enums";
+
+import {FileListTableComponent, type FileListTableComponentProps} from "./FileListTableComponent";
+
+// 64-bit protobuf fields (size, date) arrive as Long objects; the example sizes come from issue #2859,
+// where string comparison of the digits orders them 75 MB < 8.0 GB < 9 kB
+const KB_9 = 9e3;
+const MB_75 = 75e6;
+const GB_8 = 8e9;
+
+const MakeImageFileList = (): BrowserFileList => ({
+    directory: "/images",
+    parent: "/",
+    subdirectories: [
+        {name: "dir_c", itemCount: 3, date: Long.fromNumber(1_700_000_000)},
+        {name: "dir_a", itemCount: 1, date: Long.fromNumber(1_600_000_000)},
+        {name: "dir_b", itemCount: 2, date: Long.fromNumber(1_650_000_000)}
+    ],
+    files: [
+        {name: "large.fits", type: CARTA.FileType.FITS, size: Long.fromNumber(GB_8), date: Long.fromNumber(1_600_000_000), HDUList: ["0"]},
+        {name: "small.fits", type: CARTA.FileType.FITS, size: Long.fromNumber(KB_9), date: Long.fromNumber(1_700_000_000), HDUList: ["0"]},
+        {name: "medium.fits", type: CARTA.FileType.FITS, size: Long.fromNumber(MB_75), date: Long.fromNumber(1_650_000_000), HDUList: ["0"]}
+    ]
+});
+
+const MakeCatalogFileList = (): BrowserFileList => ({
+    directory: "/catalogs",
+    parent: "/",
+    subdirectories: [],
+    files: [
+        {name: "large.xml", type: CARTA.CatalogFileType.VOTable, fileSize: Long.fromNumber(GB_8), date: Long.fromNumber(1_600_000_000)},
+        {name: "small.xml", type: CARTA.CatalogFileType.VOTable, fileSize: Long.fromNumber(KB_9), date: Long.fromNumber(1_700_000_000)},
+        {name: "medium.xml", type: CARTA.CatalogFileType.VOTable, fileSize: Long.fromNumber(MB_75), date: Long.fromNumber(1_650_000_000)}
+    ]
+});
+
+const MakeComponent = (fileList: BrowserFileList, sortingString: string, fileBrowserMode: BrowserMode = BrowserMode.File) => {
+    const props: FileListTableComponentProps = {
+        darkTheme: false,
+        fileList,
+        selectedFile: null,
+        selectedHDU: "",
+        filterType: FileFilteringType.Fuzzy,
+        sortingString,
+        fileBrowserMode,
+        onSortingChanged: jest.fn(),
+        onFileClicked: jest.fn(),
+        onSelectionChanged: jest.fn(),
+        onFileDoubleClicked: jest.fn(),
+        onFolderClicked: jest.fn(),
+        onListCancelled: jest.fn()
+    };
+    return new FileListTableComponent(props);
+};
+
+describe("FileListTableComponent sorting", () => {
+    it("sorts image files by numerical size, not by the leading digit", () => {
+        const ascending = MakeComponent(MakeImageFileList(), "+size").tableEntries.filter(entry => entry.isFile);
+        expect(ascending.map(entry => entry.filename)).toEqual(["small.fits", "medium.fits", "large.fits"]);
+        expect(ascending.map(entry => entry.size)).toEqual([KB_9, MB_75, GB_8]);
+
+        const descending = MakeComponent(MakeImageFileList(), "-size").tableEntries.filter(entry => entry.isFile);
+        expect(descending.map(entry => entry.filename)).toEqual(["large.fits", "medium.fits", "small.fits"]);
+    });
+
+    it("sorts across all size units (B, kB, MB, GB, TB) by the raw byte count", () => {
+        // display strings would order these as 1.20 TB < 1.8 GB < 2 B < 250.0 kB < 900.0 GB < 95.5 MB
+        const sizes = [1.2e12, 1.8e9, 2, 250e3, 900e9, 95.5e6];
+        const fileList: BrowserFileList = {
+            directory: "/images",
+            parent: "/",
+            subdirectories: [],
+            files: sizes.map((size, index) => ({name: `file${index}.fits`, type: CARTA.FileType.FITS, size: Long.fromNumber(size), date: Long.fromNumber(0), HDUList: ["0"]}))
+        };
+        const ascending = MakeComponent(fileList, "+size").tableEntries;
+        expect(ascending.map(entry => entry.size)).toEqual([2, 250e3, 95.5e6, 1.8e9, 900e9, 1.2e12]);
+        const descending = MakeComponent(fileList, "-size").tableEntries;
+        expect(descending.map(entry => entry.size)).toEqual([1.2e12, 900e9, 1.8e9, 95.5e6, 250e3, 2]);
+    });
+
+    it("sorts catalog files by numerical size", () => {
+        const ascending = MakeComponent(MakeCatalogFileList(), "+size", BrowserMode.Catalog).tableEntries;
+        expect(ascending.map(entry => entry.filename)).toEqual(["small.xml", "medium.xml", "large.xml"]);
+        expect(ascending.map(entry => entry.size)).toEqual([KB_9, MB_75, GB_8]);
+
+        const descending = MakeComponent(MakeCatalogFileList(), "-size", BrowserMode.Catalog).tableEntries;
+        expect(descending.map(entry => entry.filename)).toEqual(["large.xml", "medium.xml", "small.xml"]);
+    });
+
+    it("sorts directories by item count and keeps them ahead of files", () => {
+        const entries = MakeComponent(MakeImageFileList(), "+size").tableEntries;
+        expect(entries.slice(0, 3).map(entry => entry.filename)).toEqual(["dir_a", "dir_b", "dir_c"]);
+        expect(entries.slice(0, 3).every(entry => entry.isDirectory)).toBe(true);
+    });
+
+    it("sorts files and directories by numerical date", () => {
+        const ascending = MakeComponent(MakeImageFileList(), "+date").tableEntries;
+        expect(ascending.map(entry => entry.filename)).toEqual(["dir_a", "dir_b", "dir_c", "large.fits", "medium.fits", "small.fits"]);
+        expect(ascending.map(entry => entry.date)).toEqual([1_600_000_000, 1_650_000_000, 1_700_000_000, 1_600_000_000, 1_650_000_000, 1_700_000_000]);
+
+        const descending = MakeComponent(MakeImageFileList(), "-date").tableEntries;
+        expect(descending.map(entry => entry.filename)).toEqual(["dir_c", "dir_b", "dir_a", "small.fits", "medium.fits", "large.fits"]);
+    });
+
+    it("converts Long sizes and dates to plain numbers in the table entries", () => {
+        const entries = MakeComponent(MakeImageFileList(), "+filename").tableEntries;
+        for (const entry of entries) {
+            expect(typeof entry.date).toBe("number");
+            if (entry.isFile) {
+                expect(typeof entry.size).toBe("number");
+            }
+        }
+    });
+});

--- a/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
+++ b/src/components/Dialogs/FileBrowser/FileListTable/FileListTableComponent.tsx
@@ -5,6 +5,7 @@ import {CARTA} from "carta-protobuf";
 import classNames from "classnames";
 import FuzzySearch from "fuzzy-search";
 import globToRegExp from "glob-to-regexp";
+import Long from "long";
 import {action, makeObservable, observable, runInAction} from "mobx";
 import {observer} from "mobx-react";
 import moment from "moment";
@@ -81,6 +82,19 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
         return FileListTableComponent.CatalogFileTypeMap.get(type) || {type: "Unknown", description: "An unknown file format"};
     }
 
+    // 64-bit protobuf fields (file size, date) are decoded as Long objects, which have no valueOf(); comparing two of them
+    // with < or > falls back to comparing their decimal strings, so convert to a plain number before sorting or displaying
+    private static toNumber(value: number | Long | null | undefined): number {
+        if (value === null || value === undefined) {
+            return 0;
+        }
+        return Long.isLong(value) ? value.toNumber() : value;
+    }
+
+    private static compareNumbers(a: number | Long | null | undefined, b: number | Long | null | undefined): number {
+        return FileListTableComponent.toNumber(a) - FileListTableComponent.toNumber(b);
+    }
+
     private static getFileSizeDisplay(sizeInBytes: number): string {
         if (sizeInBytes >= 1e12) {
             return `${toFixed(sizeInBytes / 1e12, 2)} TB`;
@@ -151,10 +165,10 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     filteredSubdirectories.sort((a, b) => sortingConfig.direction * ((a.name || "").toLowerCase() < (b.name || "").toLowerCase() ? -1 : 1));
                     break;
                 case "size":
-                    filteredSubdirectories.sort((a, b) => sortingConfig.direction * ((a.itemCount || 0) < (b.itemCount || 0) ? -1 : 1));
+                    filteredSubdirectories.sort((a, b) => sortingConfig.direction * FileListTableComponent.compareNumbers(a.itemCount, b.itemCount));
                     break;
                 case "date":
-                    filteredSubdirectories.sort((a, b) => sortingConfig.direction * ((a.date || 0) < (b.date || 0) ? -1 : 1));
+                    filteredSubdirectories.sort((a, b) => sortingConfig.direction * FileListTableComponent.compareNumbers(a.date, b.date));
                     break;
                 default:
                     break;
@@ -165,8 +179,8 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     entries.push({
                         filename: directory.name || "",
                         typeInfo: FileListTableComponent.getFileTypeDisplay(directory.type),
-                        size: directory.size as number,
-                        date: directory.date as number,
+                        size: FileListTableComponent.toNumber(directory.size),
+                        date: FileListTableComponent.toNumber(directory.date),
                         isDirectory: true,
                         isFile: true,
                         fileInfo: {name: directory.name, type: directory.type, size: directory.size, HDUList: directory.HDUList, date: directory.date}
@@ -175,7 +189,7 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     entries.push({
                         filename: directory.name || "",
                         itemCount: directory.itemCount && directory.itemCount > 0 ? directory.itemCount : undefined,
-                        date: directory.date as number,
+                        date: FileListTableComponent.toNumber(directory.date),
                         isDirectory: true,
                         fileInfo: {name: directory.name}
                     });
@@ -192,10 +206,14 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     filteredFiles.sort((a, b) => sortingConfig.direction * (a.type < b.type ? -1 : 1));
                     break;
                 case "size":
-                    filteredFiles.sort((a, b) => sortingConfig.direction * (a.size < b.size ? -1 : 1));
+                    if (fileBrowserMode === BrowserMode.Catalog) {
+                        (filteredFiles as CARTA.CatalogFileInfo.$Properties[]).sort((a, b) => sortingConfig.direction * FileListTableComponent.compareNumbers(a.fileSize, b.fileSize));
+                    } else {
+                        (filteredFiles as CARTA.FileInfo.$Properties[]).sort((a, b) => sortingConfig.direction * FileListTableComponent.compareNumbers(a.size, b.size));
+                    }
                     break;
                 case "date":
-                    filteredFiles.sort((a, b) => sortingConfig.direction * (a.date < b.date ? -1 : 1));
+                    filteredFiles.sort((a, b) => sortingConfig.direction * FileListTableComponent.compareNumbers(a.date, b.date));
                     break;
                 default:
                     break;
@@ -206,8 +224,8 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     entries.push({
                         filename: file.name || "",
                         typeInfo: file.type != null ? FileListTableComponent.getCatalogFileTypeDisplay(file.type) : undefined,
-                        size: file.fileSize as number,
-                        date: file.date as number,
+                        size: FileListTableComponent.toNumber(file.fileSize),
+                        date: FileListTableComponent.toNumber(file.date),
                         fileInfo: file,
                         isFile: true
                     });
@@ -220,8 +238,8 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                             entries.push({
                                 filename,
                                 typeInfo: file.type != null ? FileListTableComponent.getFileTypeDisplay(file.type) : undefined,
-                                size: file.size as number,
-                                date: file.date as number,
+                                size: FileListTableComponent.toNumber(file.size),
+                                date: FileListTableComponent.toNumber(file.date),
                                 fileInfo: file,
                                 hdu,
                                 isFile: true
@@ -234,8 +252,8 @@ export class FileListTableComponent extends React.Component<FileListTableCompone
                     entries.push({
                         filename: file.name || "",
                         typeInfo: file.type != null ? FileListTableComponent.getFileTypeDisplay(file.type) : undefined,
-                        size: file.size as number,
-                        date: file.date as number,
+                        size: FileListTableComponent.toNumber(file.size),
+                        date: FileListTableComponent.toNumber(file.date),
                         fileInfo: file,
                         isFile: true
                     });


### PR DESCRIPTION
**Description**

Fixes #2859. The `size` / `fileSize` / `date` fields of `FileInfo` and `CatalogFileInfo` are protobuf `sfixed64`, which `carta-protobuf` decodes as Long.js objects (typed `number | Long`). `Long` has no `valueOf()`, so the sorter's `a.size < b.size` compared the two values' decimal **strings**, hence the digit-by-digit ordering. Two related problems surfaced while fixing it:

- the catalog file browser's Size sort never worked: it read `.size`, but catalog files carry `.fileSize`.
- the Date sort used the same string comparison and only worked because all current epoch timestamps have the same number of digits.

**How to fix**

- Add `toNumber()` / `compareNumbers()` helpers that convert `number | Long | null | undefined` to a plain number (`Long.isLong(v) ? v.toNumber() : v`).
- Sort files and directories by Size and Date with numeric comparison; in catalog mode, sort by `fileSize`.
- Store real numbers in the table entries (`size`, `date`) instead of casting Long objects `as number`.

No change to how sizes are displayed; sorting is by the raw byte count, so it is independent of the displayed unit (B, KB, MB, GB, and TB).

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated ~/ no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped /~ no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed) /~ no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~