### PR TITLE
Let Cmd/Ctrl+C copy highlighted text instead of the selected region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).
 * Fixed sliders selecting incorrect values after their widgets are resized ([#2875](https://github.com/CARTAvis/carta-frontend/issues/2875)).
+* Fixed Cmd/Ctrl+C copying the selected region instead of highlighted text in widgets such as the File Header ([#2892](https://github.com/CARTAvis/carta-frontend/issues/2892)).
 
 ## [6.0.0]
 

--- a/src/HotkeyWrapper.test.ts
+++ b/src/HotkeyWrapper.test.ts
@@ -1,0 +1,68 @@
+import {AppStore} from "stores";
+
+import {HotkeyService} from "./HotkeyWrapper";
+
+const MockSelection = (text: string) => ({isCollapsed: text.length === 0, toString: () => text}) as unknown as Selection;
+
+const MakeKeyboardEvent = () => {
+    const event = new KeyboardEvent("keydown", {key: "c", metaKey: true, cancelable: true});
+    jest.spyOn(event, "preventDefault");
+    jest.spyOn(event, "stopPropagation");
+    return event;
+};
+
+describe("HotkeyService.copyRegion", () => {
+    const copySelectedRegion = jest.fn();
+
+    beforeEach(() => {
+        copySelectedRegion.mockReset();
+        copySelectedRegion.mockReturnValue(true);
+        // copySelectedRegion is a non-writable MobX action field, so stub the store instance rather than the method
+        jest.spyOn(AppStore, "Instance", "get").mockReturnValue({copySelectedRegion} as unknown as AppStore);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("copies the focused region when no text is highlighted", () => {
+        jest.spyOn(window, "getSelection").mockReturnValue(MockSelection(""));
+        const event = MakeKeyboardEvent();
+
+        HotkeyService.copyRegion(event);
+
+        expect(copySelectedRegion).toHaveBeenCalledTimes(1);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    test("copies the focused region when getSelection is unavailable", () => {
+        jest.spyOn(window, "getSelection").mockReturnValue(null);
+
+        HotkeyService.copyRegion(MakeKeyboardEvent());
+
+        expect(copySelectedRegion).toHaveBeenCalledTimes(1);
+    });
+
+    test("leaves the event to the browser when text is highlighted (issue #2892)", () => {
+        jest.spyOn(window, "getSelection").mockReturnValue(MockSelection("NAXIS2 = 800"));
+        const event = MakeKeyboardEvent();
+
+        HotkeyService.copyRegion(event);
+
+        expect(copySelectedRegion).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
+
+    test("does not prevent the default copy when there is no region to copy", () => {
+        copySelectedRegion.mockReturnValue(false);
+        jest.spyOn(window, "getSelection").mockReturnValue(MockSelection(""));
+        const event = MakeKeyboardEvent();
+
+        HotkeyService.copyRegion(event);
+
+        expect(copySelectedRegion).toHaveBeenCalledTimes(1);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+});

--- a/src/HotkeyWrapper.tsx
+++ b/src/HotkeyWrapper.tsx
@@ -135,7 +135,17 @@ export class HotkeyService extends React.Component<{}> {
         }
     };
 
+    // true when the user has highlighted text somewhere in the document (e.g. in the File Header widget)
+    private static hasTextSelection(): boolean {
+        const selection = window.getSelection();
+        return !!selection && !selection.isCollapsed && selection.toString().length > 0;
+    }
+
     public static copyRegion = (event: KeyboardEvent) => {
+        // let the browser copy highlighted text instead of the focused region
+        if (HotkeyService.hasTextSelection()) {
+            return;
+        }
         if (AppStore.Instance.copySelectedRegion()) {
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
**Description**

Fixes #2892. With a region selected in the image viewer, pressing `Cmd/Ctrl+C` over highlighted text in a widget such as the File Header showed "Region copied to clipboard," and the text was never copied.

`mod+c` is registered in `HotkeyWrapper.tsx` as a **global** Blueprint hotkey (`HotkeyService.copyRegion`). Its `allowInInput: false` only exempts inputs/textareas. It knows nothing about text the user has highlighted in ordinary (non-input) widgets. So the handler copied the focused region and called `preventDefault()` / `stopPropagation()`, which suppressed the browser's native text copy.

**How to fix**

- `copyRegion` now checks `window.getSelection()` first. If the document has a non-collapsed, non-empty selection, the handler returns without touching the event, so the browser performs its normal text copy.
- Otherwise it behaves exactly as before: copies the focused region, shows the toast, and consumes the event.
- No change to `mod+v` (paste region). There is no equivalent text conflict outside inputs.

Selecting a region, by clicking it in the image viewer or its row in the Region List, clears the browser's text selection, so a leftover text highlight cannot block the region copy.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated ~/ no changelog update needed~
- [x] unit test added (for functions with no dependenies)
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped /~ no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed) /~ no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~