### PR TITLE
fix: preserve region selection after Shift-drag box selection

### DIFF
--- a/src/components/ImageView/RegionView/RegionViewComponent.test.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.test.tsx
@@ -1,0 +1,237 @@
+jest.mock("stores", () => ({
+    AppStore: {
+        Instance: {
+            imageRatio: 1,
+            updateActiveLayer: jest.fn(),
+            updateLayerPixelRatio: jest.fn(),
+            isCursorFrozen: false,
+            hoveredFrame: null,
+            setHoveredFrame: jest.fn(),
+            preferenceStore: {
+                isRegionCornerMode: false
+            },
+            fileBrowserStore: {
+                isLoadingDialogOpen: false
+            }
+        }
+    },
+    PreferenceStore: {
+        Instance: {
+            zoomPoint: "cursor",
+            regionSize: 10
+        }
+    }
+}));
+
+import {RegionMode} from "enums";
+
+import {RegionViewComponent} from "./RegionViewComponent";
+
+describe("RegionViewComponent shift+drag box selection click suppression", () => {
+    let mockFrame: any;
+    let mockRegionSet: any;
+    let component: RegionViewComponent;
+
+    beforeEach(() => {
+        mockRegionSet = {
+            mode: RegionMode.MOVING,
+            isLocked: false,
+            newRegionType: 0,
+            regionsAndAnnotationsForRender: [],
+            selectedRegionIds: new Set(),
+            applyRegionBoxSelection: jest.fn(),
+            clearSelection: jest.fn()
+        };
+
+        mockFrame = {
+            aspectRatio: 1,
+            zoomLevel: 1,
+            centerMovement: {x: 0, y: 0},
+            regionSet: mockRegionSet,
+            spatialReference: null,
+            wcsInfo: null,
+            isPreview: false
+        };
+
+        component = new RegionViewComponent({
+            frame: mockFrame,
+            dragPanningEnabled: true,
+            docked: false,
+            width: 800,
+            height: 600,
+            left: 0,
+            top: 0,
+            onClickToCenter: jest.fn()
+        });
+
+        (component as any).stageRef = {
+            current: {
+                getPosition: () => ({x: 0, y: 0}),
+                scaleX: () => 1
+            }
+        };
+    });
+
+    afterEach(() => {
+        component.componentWillUnmount();
+    });
+
+    test("shift+drag box selection suppresses subsequent stage click to prevent clearSelection", () => {
+        const stageTarget = {id: () => ""};
+        const mouseDownKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 100, offsetY: 100, x: 100, y: 100} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseDown(mouseDownKonvaEvent);
+
+        const moveKonvaEvent = {
+            evt: {offsetX: 200, offsetY: 200, x: 200, y: 200, buttons: 1} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        component.handleMove(moveKonvaEvent);
+
+        const mouseUpKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 200, offsetY: 200, x: 200, y: 200} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseUp(mouseUpKonvaEvent);
+
+        expect(mockRegionSet.applyRegionBoxSelection).toHaveBeenCalled();
+
+        const clickKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 200, offsetY: 200, x: 200, y: 200, ctrlKey: false, metaKey: false} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        component.handleClick(clickKonvaEvent);
+
+        expect(mockRegionSet.clearSelection).not.toHaveBeenCalled();
+    });
+
+    test("shift+click without drag does not suppress next stage click", () => {
+        const stageTarget = {id: () => ""};
+        const mouseDownKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 100, offsetY: 100, x: 100, y: 100} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseDown(mouseDownKonvaEvent);
+
+        const mouseUpKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 100, offsetY: 100, x: 100, y: 100} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseUp(mouseUpKonvaEvent);
+
+        expect(mockRegionSet.applyRegionBoxSelection).not.toHaveBeenCalled();
+
+        const clickKonvaEvent = {
+            evt: {button: 0, shiftKey: false, offsetX: 100, offsetY: 100, x: 100, y: 100, ctrlKey: false, metaKey: false} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        component.handleClick(clickKonvaEvent);
+
+        expect(mockRegionSet.clearSelection).toHaveBeenCalled();
+    });
+
+    test("shift+drag box selection suppresses subsequent region click selection", () => {
+        const stageTarget = {id: () => ""};
+        const mouseDownKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 50, offsetY: 50, x: 50, y: 50} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseDown(mouseDownKonvaEvent);
+
+        const moveKonvaEvent = {
+            evt: {offsetX: 150, offsetY: 150, x: 150, y: 150, buttons: 1} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        component.handleMove(moveKonvaEvent);
+
+        const mouseUpKonvaEvent = {
+            evt: {button: 0, shiftKey: true, offsetX: 150, offsetY: 150, x: 150, y: 150} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any;
+
+        (component as any).handleStageMouseUp(mouseUpKonvaEvent);
+
+        const shouldSuppress = (component as any).shouldSuppressRegionSelection({button: 0} as MouseEvent);
+        expect(shouldSuppress).toBe(true);
+
+        const shouldSuppressNext = (component as any).shouldSuppressRegionSelection({button: 0} as MouseEvent);
+        expect(shouldSuppressNext).toBe(false);
+    });
+
+    test("box selection suppression does not leak into a later gesture when no region click consumes it", () => {
+        const stageTarget = {id: () => ""};
+        const boxSelect = (from: number, to: number) => {
+            (component as any).handleStageMouseDown({
+                evt: {button: 0, shiftKey: true, offsetX: from, offsetY: from, x: from, y: from} as MouseEvent,
+                target: stageTarget,
+                currentTarget: stageTarget
+            } as any);
+            component.handleMove({
+                evt: {offsetX: to, offsetY: to, x: to, y: to, buttons: 1} as MouseEvent,
+                target: stageTarget,
+                currentTarget: stageTarget
+            } as any);
+            (component as any).handleStageMouseUp({
+                evt: {button: 0, shiftKey: true, offsetX: to, offsetY: to, x: to, y: to} as MouseEvent,
+                target: stageTarget,
+                currentTarget: stageTarget
+            } as any);
+        };
+
+        // The box selection ends over empty canvas, so no region click arrives to consume the flag.
+        boxSelect(50, 150);
+
+        // A later plain left click on a region must still select it.
+        (component as any).handleStageMouseDown({
+            evt: {button: 0, shiftKey: false, offsetX: 300, offsetY: 300, x: 300, y: 300} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any);
+
+        expect((component as any).shouldSuppressRegionSelection({button: 0} as MouseEvent)).toBe(false);
+    });
+
+    test("anchor drag selection is not suppressed after a box selection", () => {
+        const stageTarget = {id: () => ""};
+
+        (component as any).handleStageMouseDown({
+            evt: {button: 0, shiftKey: true, offsetX: 50, offsetY: 50, x: 50, y: 50} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any);
+        component.handleMove({
+            evt: {offsetX: 150, offsetY: 150, x: 150, y: 150, buttons: 1} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any);
+        (component as any).handleStageMouseUp({
+            evt: {button: 0, shiftKey: true, offsetX: 150, offsetY: 150, x: 150, y: 150} as MouseEvent,
+            target: stageTarget,
+            currentTarget: stageTarget
+        } as any);
+
+        // Anchor drag start calls onSelect without a mouse event and must keep updating the selection.
+        expect((component as any).shouldSuppressRegionSelection()).toBe(false);
+    });
+});

--- a/src/components/ImageView/RegionView/RegionViewComponent.tsx
+++ b/src/components/ImageView/RegionView/RegionViewComponent.tsx
@@ -674,13 +674,13 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     };
 
     private clearSuppressedClick = (button?: number): void => {
-        if (this.suppressedClickButton && (button === undefined || this.suppressedClickButton === "all" || this.suppressedClickButton === button)) {
+        if (this.suppressedClickButton !== null && (button === undefined || this.suppressedClickButton === "all" || this.suppressedClickButton === button)) {
             this.suppressedClickButton = null;
         }
     };
 
     private shouldSuppressClick = (mouseEvent: MouseEvent): boolean => {
-        if (!this.suppressedClickButton) {
+        if (this.suppressedClickButton === null) {
             return false;
         }
 
@@ -720,6 +720,9 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     };
 
     @action private handleStageMouseDown = (konvaEvent: Konva.KonvaEventObject<MouseEvent>) => {
+        // The suppression flag is only valid for the click that immediately follows a box selection, so a new gesture always invalidates it.
+        this.shouldSuppressNextRegionClickSelection = false;
+
         if (this.frame.regionSet.mode === RegionMode.CREATING) {
             this.handleMouseDown(konvaEvent);
             return;
@@ -892,15 +895,17 @@ export class RegionViewComponent extends React.Component<RegionViewComponentProp
     @action private finishRegionSelection = () => {
         const selectionRect = this.getRegionSelectionRect();
         const isLargeEnough = !!selectionRect && this.isSelectionRectLargeEnough(selectionRect);
-        this.shouldSuppressNextRegionClickSelection = this.didRegionSelectionStartOnRegion && isLargeEnough;
+        this.shouldSuppressNextRegionClickSelection = isLargeEnough;
         this.didRegionSelectionStartOnRegion = false;
         this.regionSelectionBox = null;
         this.restoreRegionSelectionDragNode();
-        this.clearSuppressedClick();
 
         if (!selectionRect || !isLargeEnough) {
+            this.clearSuppressedClick();
             return;
         }
+
+        this.suppressNextClick(0);
 
         const selectionGeometryContext = {
             frame: this.frame,


### PR DESCRIPTION
**Description**

Closes #2917.

Fixes a regression where Shift-drag region box selections could be immediately cleared or cause the next region click to be ignored.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)
