### PR TITLE
refactor: improve error handling for missing targets in scripting service

### DIFF
--- a/src/services/ScriptingService.test.ts
+++ b/src/services/ScriptingService.test.ts
@@ -1,0 +1,96 @@
+const MOCK_UNDEFINED_TARGET = Object.create({value: undefined});
+
+const MOCK_APP_STORE = {
+    acceptUndefined: (value: unknown) => value === undefined,
+    fetchParameter: (value: unknown) => value,
+    noResponse: () => undefined,
+    nullResponse: () => null,
+    objectResponse: () => ({nested: {value: 42, undefinedValue: undefined}}),
+    undefinedTargets: [MOCK_UNDEFINED_TARGET]
+};
+
+jest.mock("stores", () => ({
+    AppStore: {Instance: MOCK_APP_STORE}
+}));
+
+import {ScriptingService} from "./ScriptingService";
+
+const MakeRequest = (action: string, parameters: unknown[] = [], returnPath = "") => ({
+    scriptingRequestId: 1,
+    target: "",
+    action,
+    parameters: JSON.stringify(parameters),
+    async: false,
+    returnPath
+});
+
+describe("ScriptingService", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test.each([
+        [{macroTarget: "", macroVariable: "missingAttribute"}, "missingAttribute"],
+        [{macroTarget: "missingAttribute", macroVariable: "nested"}, "missingAttribute.nested"]
+    ])("rejects a missing macro target", async (macro, target) => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("fetchParameter", [macro]));
+
+        expect(response).toMatchObject({
+            scriptingRequestId: 1,
+            success: false,
+            message: `Missing macro target: ${target}`
+        });
+        expect(response.response).toBeUndefined();
+    });
+
+    test("preserves an explicit undefined macro", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("acceptUndefined", [{macroTarget: "", macroVariable: "undefined"}]));
+
+        expect(response).toMatchObject({success: true, response: "true"});
+    });
+
+    test("serializes an existing undefined macro target as null", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("fetchParameter", [{macroTarget: "undefinedTargets[0]", macroVariable: "value"}]));
+
+        expect(response).toMatchObject({success: true, response: "null"});
+    });
+
+    test("rejects a missing response path", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("objectResponse", [], "nested.missing"));
+
+        expect(response).toMatchObject({
+            success: false,
+            message: "Missing response path: nested.missing"
+        });
+        expect(response.response).toBeUndefined();
+    });
+
+    test("returns an existing response path", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("objectResponse", [], "nested.value"));
+
+        expect(response).toMatchObject({success: true, response: "42"});
+    });
+
+    test("serializes an existing undefined response path as null", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("objectResponse", [], "nested.undefinedValue"));
+
+        expect(response).toMatchObject({success: true, response: "null"});
+    });
+
+    test("allows an action with no response", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("noResponse"));
+
+        expect(response).toMatchObject({success: true});
+        expect(response.response).toBeUndefined();
+    });
+
+    test("serializes a null response", async () => {
+        const response = await ScriptingService.Instance.handleScriptingRequest(MakeRequest("nullResponse"));
+
+        expect(response).toMatchObject({success: true, response: "null"});
+    });
+});

--- a/src/services/ScriptingService.ts
+++ b/src/services/ScriptingService.ts
@@ -10,6 +10,7 @@ export class ExecutionEntry {
     parameters: any[];
     isValid: boolean;
     isAsync: boolean | null | undefined;
+    hasResolvedUndefinedMacro = false;
 
     public static fromString(entryString: string): ExecutionEntry {
         const executionEntry = new ExecutionEntry();
@@ -61,8 +62,8 @@ export class ExecutionEntry {
     }
 
     async execute() {
-        const targetObject = ExecutionEntry.getTargetObject(AppStore.Instance, this.target);
-        if (targetObject == null) {
+        const {hasTarget, value: targetObject} = ExecutionEntry.resolveTargetObject(AppStore.Instance, this.target);
+        if (!hasTarget || targetObject == null) {
             throw new Error(`Missing target object: ${this.target}`);
         }
         const currentParameters = this.parameters.map(this.mapMacro);
@@ -80,9 +81,9 @@ export class ExecutionEntry {
         return response;
     }
 
-    private static getTargetObject(baseObject: any, targetString: string | null | undefined) {
+    private static resolveTargetObject(baseObject: any, targetString: string | null | undefined): {hasTarget: boolean; value: any} {
         if (!targetString) {
-            return baseObject;
+            return {hasTarget: true, value: baseObject};
         }
 
         let target = baseObject;
@@ -93,26 +94,35 @@ export class ExecutionEntry {
             const matches = arrayRegex.exec(targetEntry);
             // Check if there's an array index in this parameter
             if (matches && matches.length === 3 && matches[2] !== undefined) {
+                if (!_.hasIn(target, matches[1])) {
+                    return {hasTarget: false, value: undefined};
+                }
                 target = target[matches[1]];
                 if (target == null) {
-                    return null;
+                    return {hasTarget: false, value: undefined};
                 }
                 if (target instanceof Map) {
                     const key = JSON.parse(matches[2]);
+                    if (!target.has(key)) {
+                        return {hasTarget: false, value: undefined};
+                    }
                     target = target.get(key);
                 } else if (Array.isArray(target)) {
+                    if (!(Number(matches[2]) in target)) {
+                        return {hasTarget: false, value: undefined};
+                    }
                     target = target[matches[2]];
                 } else {
-                    return null;
+                    return {hasTarget: false, value: undefined};
                 }
             } else {
+                if (!_.hasIn(target, targetEntry)) {
+                    return {hasTarget: false, value: undefined};
+                }
                 target = target[targetEntry];
             }
-            if (target === null) {
-                return null;
-            }
         }
-        return target;
+        return {hasTarget: true, value: target};
     }
 
     private mapMacro = (parameter: any) => {
@@ -124,7 +134,14 @@ export class ExecutionEntry {
                 return undefined;
             }
             const targetString = parameter?.macroTarget ? `${parameter.macroTarget}.${parameter.macroVariable}` : parameter.macroVariable;
-            return ExecutionEntry.getTargetObject(AppStore.Instance, targetString);
+            const {hasTarget, value} = ExecutionEntry.resolveTargetObject(AppStore.Instance, targetString);
+            if (!hasTarget) {
+                throw new Error(`Missing macro target: ${targetString}`);
+            }
+            if (value === undefined) {
+                this.hasResolvedUndefinedMacro = true;
+            }
+            return value;
         }
         return parameter;
     };
@@ -166,8 +183,24 @@ export class ScriptingService {
             }
 
             // Adjust the response to just the specified path if it is non-empty
-            if (typeof response === "object" && requestMessage.returnPath) {
+            if (requestMessage.returnPath) {
+                if (response === null || typeof response !== "object") {
+                    throw new Error(`Cannot read response path from a non-object response: ${requestMessage.returnPath}`);
+                }
+                const hasResponsePath = _.hasIn(response, requestMessage.returnPath);
                 response = _.get(response, requestMessage.returnPath);
+                if (!hasResponsePath) {
+                    throw new Error(`Missing response path: ${requestMessage.returnPath}`);
+                }
+                // JSON cannot represent undefined. Preserve the distinction between a
+                // missing path and an existing path without a value by returning null.
+                if (response === undefined) {
+                    response = null;
+                }
+            }
+
+            if (response === undefined && entry.hasResolvedUndefinedMacro) {
+                response = null;
             }
 
             return {
@@ -180,7 +213,7 @@ export class ScriptingService {
             return {
                 scriptingRequestId: requestMessage.scriptingRequestId,
                 success: false,
-                message: err?.toString()
+                message: err instanceof Error ? err.message : String(err)
             };
         }
     };


### PR DESCRIPTION
**Description**

Closes #2920.

Companion carta-python PR: https://github.com/CARTAvis/carta-python/pull/168

This PR improves scripting request handling by distinguishing missing targets from existing values that resolve to `undefined` and by reporting missing response paths explicitly.

What is implemented:
- Detect missing object properties, map keys, and array indices while resolving scripting targets and macro values.
- Preserve valid `undefined` and `null` values by serializing them as `null`, while rejecting genuinely missing macro targets.
- Validate requested response paths and return clear errors for missing paths or non-object responses.
- Add unit coverage for missing targets, undefined/null serialization, response paths, and actions with no response.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)
