### PR TITLE
Add selectable statistic quantities

### DIFF
--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.scss
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.scss
@@ -50,6 +50,12 @@
         }
     }
 
+    .statistics-list {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(130px, 1fr));
+        gap: 8px 24px;
+    }
+
     .wcs-matching {
         .#{$ns}-form-content {
             display: flex;

--- a/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
+++ b/src/components/Dialogs/PreferenceDialog/PreferenceDialogComponent.tsx
@@ -22,7 +22,7 @@ import {
     ScrollShadow
 } from "components/Shared";
 import {BeamType, ContourGeneratorType, ConvertToGB, CursorInfoVisibility, DialogId, FileFilterMode, FrameScaling, HelpType, PasteOffsetUnit, PreferenceDialogTabs, PreferenceKeys, TelemetryMode} from "enums";
-import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
+import {CompressionQuality, CursorPosition, Event, RegionCreationMode, SPECTRAL_MATCHING_TYPES, SPECTRAL_TYPE_STRING, STATISTICS_NAME_MAP, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
 import {AppStore, MirrorSiteStore, PreferenceStore} from "stores";
 import {RegionStore, RenderConfigStore} from "stores/Frame";
 import {clamp, getScalingParameterConfig, SWATCH_COLORS} from "utilities";
@@ -140,6 +140,9 @@ export class PreferenceDialogComponent extends React.Component {
             case PreferenceDialogTabs.CATALOG:
                 preference.resetCatalogSettings();
                 MirrorSiteStore.Instance.resetAllSettings();
+                break;
+            case PreferenceDialogTabs.STATISTICS:
+                preference.resetStatisticsSettings();
                 break;
             case PreferenceDialogTabs.TELEMETRY:
                 preference.resetTelemetrySettings();
@@ -988,6 +991,16 @@ export class PreferenceDialogComponent extends React.Component {
             </div>
         );
 
+        const statisticsPanel = (
+            <FormGroup className="statistics-panel" label="Displayed quantities" helperText="Median and quartile quantities may be slower for large regions." inline={true}>
+                <div className="statistics-list">
+                    {Array.from(STATISTICS_NAME_MAP, ([type, name]) => (
+                        <Checkbox key={type} checked={preference.statistics.includes(type)} label={name} onChange={() => preference.toggleStatistic(type)} />
+                    ))}
+                </div>
+            </FormGroup>
+        );
+
         const className = classNames("preference-dialog", {[Classes.DARK]: appStore.isDarkTheme});
 
         const dialogProps: DialogProps = {
@@ -1020,6 +1033,7 @@ export class PreferenceDialogComponent extends React.Component {
                         <Tab id={PreferenceDialogTabs.WCS_OVERLAY_CONFIG} title="WCS and Image Overlay" panel={<ScrollShadow>{overlayConfigPanel}</ScrollShadow>} />
                         <Tab id={PreferenceDialogTabs.LAYOUT} title="Layout" panel={<ScrollShadow>{layoutPanel}</ScrollShadow>} />
                         <Tab id={PreferenceDialogTabs.CATALOG} title="Catalog" panel={<ScrollShadow>{catalogPanel}</ScrollShadow>} />
+                        <Tab id={PreferenceDialogTabs.STATISTICS} title="Statistics" panel={<ScrollShadow>{statisticsPanel}</ScrollShadow>} />
                         <Tab id={PreferenceDialogTabs.REGION} title="Region" panel={<ScrollShadow>{regionSettingsPanel}</ScrollShadow>} />
                         <Tab id={PreferenceDialogTabs.ANNOTATION} title="Annotation" panel={<ScrollShadow>{annotationSettingsPanel}</ScrollShadow>} />
                         <Tab id={PreferenceDialogTabs.PERFORMANCE} title="Performance" panel={<ScrollShadow>{performancePanel}</ScrollShadow>} />

--- a/src/components/Stats/StatsComponent.tsx
+++ b/src/components/Stats/StatsComponent.tsx
@@ -8,19 +8,15 @@ import {observer} from "mobx-react";
 import {RegionSelectorComponent, ResizeDetector} from "components/Shared";
 import {ToolbarComponent} from "components/Shared/LinePlot/Toolbar/ToolbarComponent";
 import {HelpType, Polarizations} from "enums";
-import {FULL_POLARIZATIONS} from "models";
+import {BEAM_AREA_STATS_TYPE, BEAM_PIXELS_STATS_TYPE, FULL_POLARIZATIONS, NUM_BEAMS_STATS_TYPE, STATISTICS_NAME_MAP, type StatsDisplayType} from "models";
 import {AppStore, type DefaultWidgetConfig, type WidgetProps} from "stores";
 import {StatsWidgetStore} from "stores/Widgets";
 import {exportTsvFile, pixelToFluxDensityUnit, toExponential} from "utilities";
 
 import "./StatsComponent.scss";
 
-type StatsDisplayType = CARTA.StatsType | "BeamArea" | "NumBeams" | "BeamAreaPixels";
 type StatsTableValue = {num: string; unit: string};
 type StatsTableRow = {name: string; type: StatsDisplayType; value: StatsTableValue};
-const NUM_BEAMS_STATS_TYPE = "NumBeams";
-const BEAM_AREA_STATS_TYPE = "BeamArea";
-const BEAM_PIXELS_STATS_TYPE = "BeamAreaPixels";
 
 @observer
 export class StatsComponent extends React.Component<WidgetProps> {
@@ -84,22 +80,6 @@ export class StatsComponent extends React.Component<WidgetProps> {
     private handleCoordinateChanged = (changeEvent: React.ChangeEvent<HTMLSelectElement>) => {
         this.widgetStore.setCoordinate(changeEvent.target.value);
     };
-
-    private static readonly StatsNameMap = new Map<StatsDisplayType, string>([
-        [CARTA.StatsType.NumPixels, "NumPixels"],
-        [NUM_BEAMS_STATS_TYPE, "NumBeams"],
-        [BEAM_AREA_STATS_TYPE, "BeamArea"],
-        [BEAM_PIXELS_STATS_TYPE, "BeamAreaPixels"],
-        [CARTA.StatsType.Sum, "Sum"],
-        [CARTA.StatsType.FluxDensity, "FluxDensity"],
-        [CARTA.StatsType.Mean, "Mean"],
-        [CARTA.StatsType.Sigma, "StdDev"],
-        [CARTA.StatsType.Min, "Min"],
-        [CARTA.StatsType.Max, "Max"],
-        [CARTA.StatsType.Extrema, "Extrema"],
-        [CARTA.StatsType.RMS, "RMS"],
-        [CARTA.StatsType.SumSq, "SumSq"]
-    ]);
 
     private static readonly NameColumnWidth = 90;
 
@@ -263,7 +243,10 @@ export class StatsComponent extends React.Component<WidgetProps> {
 
     private getTableRows = (): StatsTableRow[] => {
         const rows: StatsTableRow[] = [];
-        StatsComponent.StatsNameMap.forEach((name, type) => {
+        STATISTICS_NAME_MAP.forEach((name, type) => {
+            if (!AppStore.Instance.preferenceStore.statistics.includes(type)) {
+                return;
+            }
             const value = this.getTableValue(type);
             if (value) {
                 rows.push({name, type, value});

--- a/src/enums/preference.ts
+++ b/src/enums/preference.ts
@@ -121,6 +121,8 @@ export enum PreferenceKeys {
     STATS_PANEL_ENABLED = "statsPanelEnabled",
     STATS_PANEL_MODE = "statsPanelMode",
 
+    STATISTICS = "statistics",
+
     TELEMETRY_UUID = "telemetryUuid",
     TELEMETRY_MODE = "telemetryMode",
     TELEMETRY_CONSENT_SHOWN = "telemetryConsentShown",

--- a/src/enums/tab.ts
+++ b/src/enums/tab.ts
@@ -67,6 +67,7 @@ export enum PreferenceDialogTabs {
     PERFORMANCE,
     LOG_EVENT,
     CATALOG,
+    STATISTICS,
     TELEMETRY,
     COMPATIBILITY
 }

--- a/src/models/StatisticsDefinition/StatisticsDefinition.ts
+++ b/src/models/StatisticsDefinition/StatisticsDefinition.ts
@@ -1,5 +1,10 @@
 import {CARTA} from "carta-protobuf";
 
+export const NUM_BEAMS_STATS_TYPE = "NumBeams";
+export const BEAM_AREA_STATS_TYPE = "BeamArea";
+export const BEAM_PIXELS_STATS_TYPE = "BeamAreaPixels";
+export type StatsDisplayType = CARTA.StatsType | typeof NUM_BEAMS_STATS_TYPE | typeof BEAM_AREA_STATS_TYPE | typeof BEAM_PIXELS_STATS_TYPE;
+
 export const SUPPORTED_STATISTICS_TYPES = [
     CARTA.StatsType.Sum,
     CARTA.StatsType.FluxDensity,
@@ -12,18 +17,31 @@ export const SUPPORTED_STATISTICS_TYPES = [
     CARTA.StatsType.Extrema
 ];
 
-export const STATISTICS_TEXT = new Map<CARTA.StatsType, string>([
+export const STATISTICS_NAME_MAP = new Map<StatsDisplayType, string>([
+    [CARTA.StatsType.NumPixels, "NumPixels"],
+    [NUM_BEAMS_STATS_TYPE, "NumBeams"],
+    [BEAM_AREA_STATS_TYPE, "BeamArea"],
+    [BEAM_PIXELS_STATS_TYPE, "BeamAreaPixels"],
     [CARTA.StatsType.Sum, "Sum"],
     [CARTA.StatsType.FluxDensity, "FluxDensity"],
     [CARTA.StatsType.Mean, "Mean"],
-    [CARTA.StatsType.RMS, "RMS"],
     [CARTA.StatsType.Sigma, "StdDev"],
-    [CARTA.StatsType.SumSq, "SumSq"],
     [CARTA.StatsType.Min, "Min"],
     [CARTA.StatsType.Max, "Max"],
-    [CARTA.StatsType.Extrema, "Extrema"]
+    [CARTA.StatsType.Extrema, "Extrema"],
+    [CARTA.StatsType.RMS, "RMS"],
+    [CARTA.StatsType.SumSq, "SumSq"],
+    [CARTA.StatsType.Median, "Median"],
+    [CARTA.StatsType.MedAbsDevMed, "MedAbsDevMed"],
+    [CARTA.StatsType.Quartile, "Quartile"],
+    [CARTA.StatsType.Q1, "Q1"],
+    [CARTA.StatsType.Q3, "Q3"]
 ]);
 
+export const DEFAULT_STATS_DISPLAY_TYPES = Array.from(STATISTICS_NAME_MAP.keys()).filter(
+    type => ![CARTA.StatsType.Median, CARTA.StatsType.MedAbsDevMed, CARTA.StatsType.Quartile, CARTA.StatsType.Q1, CARTA.StatsType.Q3].includes(type as CARTA.StatsType)
+);
+
 export const StatsTypeString = (statsType: CARTA.StatsType): string => {
-    return STATISTICS_TEXT.get(statsType) ?? "Not Implemented";
+    return STATISTICS_NAME_MAP.get(statsType) ?? "Not Implemented";
 };

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1751,18 +1751,6 @@ export class AppStore {
         this.isCanvasUpdated = isUpdated;
     };
 
-    public static readonly DEFAULT_STATS_TYPES = [
-        CARTA.StatsType.NumPixels,
-        CARTA.StatsType.Sum,
-        CARTA.StatsType.FluxDensity,
-        CARTA.StatsType.Mean,
-        CARTA.StatsType.RMS,
-        CARTA.StatsType.Sigma,
-        CARTA.StatsType.SumSq,
-        CARTA.StatsType.Min,
-        CARTA.StatsType.Max,
-        CARTA.StatsType.Extrema
-    ];
     private static readonly CursorThrottleTime = 200;
     private static readonly CursorThrottleTimeRotated = 100;
     private static readonly ImageThrottleTime = 50;

--- a/src/stores/PreferenceStore/PreferenceStore.ts
+++ b/src/stores/PreferenceStore/PreferenceStore.ts
@@ -3,7 +3,24 @@ import {CARTA} from "carta-protobuf";
 import {action, computed, flow, makeObservable, observable} from "mobx";
 
 import {BeamType, ColorMap, ContourGeneratorType, CursorInfoVisibility, FileFilteringType, FileFilterMode, FrameScaling, ImagePanelMode, PasteOffsetUnit, PreferenceKeys, SpectralType, TelemetryMode, WCSMatchingType} from "enums";
-import {CARTA_INFO, CompressionQuality, CursorPosition, Event, getEventList, PresetLayout, RegionCreationMode, Theme, TileCache, WCSMatching, WCSType, Zoom, ZoomPoint} from "models";
+import {
+    CARTA_INFO,
+    CompressionQuality,
+    CursorPosition,
+    DEFAULT_STATS_DISPLAY_TYPES,
+    Event,
+    getEventList,
+    PresetLayout,
+    RegionCreationMode,
+    STATISTICS_NAME_MAP,
+    type StatsDisplayType,
+    Theme,
+    TileCache,
+    WCSMatching,
+    WCSType,
+    Zoom,
+    ZoomPoint
+} from "models";
 import {ApiService} from "services";
 import {getScalingForParameterPreference, getScalingParameterConfig, isSupportedFrameScaling, sanitizeScalingParameter} from "utilities/scaling/scaling";
 
@@ -135,6 +152,9 @@ const DEFAULTS = {
     STATS_PANEL: {
         statsPanelEnabled: false,
         statsPanelMode: 0
+    },
+    STATISTICS: {
+        statistics: DEFAULT_STATS_DISPLAY_TYPES
     },
     TELEMETRY: {
         telemetryConsentShown: false,
@@ -635,6 +655,16 @@ export class PreferenceStore {
         return this.preferences.get(PreferenceKeys.STATS_PANEL_MODE) ?? DEFAULTS.STATS_PANEL.statsPanelMode;
     }
 
+    @computed get statistics(): StatsDisplayType[] {
+        return this.preferences.get(PreferenceKeys.STATISTICS) ?? DEFAULTS.STATISTICS.statistics;
+    }
+
+    @action toggleStatistic = (type: StatsDisplayType) => {
+        const isSelected = this.statistics.includes(type);
+        const statistics = Array.from(STATISTICS_NAME_MAP.keys()).filter(item => (item === type ? !isSelected : this.statistics.includes(item)));
+        this.setPreference(PreferenceKeys.STATISTICS, statistics);
+    };
+
     // getters for telemetry
     @computed get hasTelemetryConsentShown(): boolean {
         return this.preferences.get(PreferenceKeys.TELEMETRY_CONSENT_SHOWN) ?? DEFAULTS.TELEMETRY.telemetryConsentShown;
@@ -946,6 +976,10 @@ export class PreferenceStore {
      */
     @action resetCatalogSettings = () => {
         this.clearPreferences([PreferenceKeys.CATALOG_DISPLAYED_COLUMN_SIZE, PreferenceKeys.CATALOG_TABLE_SEPARATOR_POSITION, PreferenceKeys.CATALOG_AUTO_SELECT_IMAGE_OVERLAY_COLUMNS]);
+    };
+
+    @action resetStatisticsSettings = () => {
+        this.clearPreferences([PreferenceKeys.STATISTICS]);
     };
 
     /**

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileSelectionStore.ts
@@ -2,7 +2,7 @@ import {CARTA} from "carta-protobuf";
 import {action, autorun, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {MultiProfileCategory, Polarizations, RegionId} from "enums";
-import {GetIntensityOptions, type IntensityConfig, type LineKey, type LineOption, POLARIZATION_LABELS, STATISTICS_TEXT, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
+import {GetIntensityOptions, type IntensityConfig, type LineKey, type LineOption, POLARIZATION_LABELS, STATISTICS_NAME_MAP, StatsTypeString, SUPPORTED_STATISTICS_TYPES, VALID_COORDINATES} from "models";
 import {AppStore} from "stores";
 import {type FrameStore} from "stores/Frame";
 import {ACTIVE_FILE_ID, SpectralProfileWidgetStore} from "stores/Widgets";
@@ -338,11 +338,9 @@ export class SpectralProfileSelectionStore {
     }
 
     @computed get statsTypeOptions(): LineOption[] {
-        const sortedKeys = Array.from(STATISTICS_TEXT.keys())?.sort((a, b) => {
-            return a - b;
-        });
-        return sortedKeys?.map(key => {
-            return {value: key, label: STATISTICS_TEXT.get(key)};
+        const sortedKeys = [...SUPPORTED_STATISTICS_TYPES].sort((a, b) => a - b);
+        return sortedKeys.map(key => {
+            return {value: key, label: STATISTICS_NAME_MAP.get(key)};
         });
     }
 

--- a/src/stores/Widgets/StatsWidgetStore/StatsWidgetStore.test.ts
+++ b/src/stores/Widgets/StatsWidgetStore/StatsWidgetStore.test.ts
@@ -1,0 +1,45 @@
+import {CARTA} from "carta-protobuf";
+
+import {StatsWidgetStore} from "./StatsWidgetStore";
+
+jest.mock("enums", () => ({Polarizations: {}, RegionsType: {CLOSED: 0}}));
+jest.mock("models", () => ({VALID_COORDINATES: ["z"]}));
+jest.mock("stores", () => ({AppStore: {Instance: {preferenceStore: {statistics: []}}}}));
+jest.mock("stores/Widgets", () => ({RegionWidgetStore: class {}}));
+
+describe("StatsWidgetStore requirements", () => {
+    test("detects changes to requested statistic types", () => {
+        const originalRequirements = new Map([
+            [
+                0,
+                new Map([
+                    [
+                        -1,
+                        new CARTA.SetStatsRequirements({
+                            fileId: 0,
+                            regionId: -1,
+                            statsConfigs: [{coordinate: "z", statsTypes: [CARTA.StatsType.Mean]}]
+                        })
+                    ]
+                ])
+            ]
+        ]);
+        const updatedRequirements = new Map([
+            [
+                0,
+                new Map([
+                    [
+                        -1,
+                        new CARTA.SetStatsRequirements({
+                            fileId: 0,
+                            regionId: -1,
+                            statsConfigs: [{coordinate: "z", statsTypes: [CARTA.StatsType.Mean, CARTA.StatsType.Median]}]
+                        })
+                    ]
+                ])
+            ]
+        ]);
+
+        expect(StatsWidgetStore.diffStatsRequirements(originalRequirements, updatedRequirements)).toEqual([updatedRequirements.get(0)?.get(-1)]);
+    });
+});

--- a/src/stores/Widgets/StatsWidgetStore/StatsWidgetStore.ts
+++ b/src/stores/Widgets/StatsWidgetStore/StatsWidgetStore.ts
@@ -58,9 +58,17 @@ export class StatsWidgetStore extends RegionWidgetStore {
                     regionRequirements.statsConfigs = [];
                 }
 
-                const histogramConfig = regionRequirements?.statsConfigs.find(config => config.coordinate === coordinate);
-                if (!histogramConfig) {
-                    regionRequirements?.statsConfigs.push({coordinate: coordinate, statsTypes: AppStore.DEFAULT_STATS_TYPES});
+                const statsConfig = regionRequirements?.statsConfigs.find(config => config.coordinate === coordinate);
+                if (!statsConfig) {
+                    const selectedStatistics = AppStore.Instance.preferenceStore.statistics;
+                    const statsTypes = selectedStatistics.filter(type => typeof type === "number") as CARTA.StatsType[];
+                    const hasDerivedStatistic = selectedStatistics.some(type => typeof type === "string");
+                    if (hasDerivedStatistic && !statsTypes.includes(CARTA.StatsType.NumPixels)) {
+                        statsTypes.unshift(CARTA.StatsType.NumPixels);
+                    }
+                    if (statsTypes.length) {
+                        regionRequirements?.statsConfigs.push({coordinate, statsTypes});
+                    }
                 }
             }
         });
@@ -117,13 +125,20 @@ export class StatsWidgetStore extends RegionWidgetStore {
                         if (configCount === 0) {
                             return;
                         }
-                        const sortedUpdatedConfigs = updatedRegionRequirements.statsConfigs.sort((a, b) => ((a.coordinate ?? NaN) > (b.coordinate ?? NaN) ? 1 : -1));
-                        const sortedConfigs = regionRequirements.statsConfigs.sort((a, b) => ((a.coordinate ?? NaN) > (b.coordinate ?? NaN) ? 1 : -1));
+                        const sortedUpdatedConfigs = [...updatedRegionRequirements.statsConfigs].sort((a, b) => (a.coordinate ?? "").localeCompare(b.coordinate ?? ""));
+                        const sortedConfigs = [...regionRequirements.statsConfigs].sort((a, b) => (a.coordinate ?? "").localeCompare(b.coordinate ?? ""));
 
                         for (let i = 0; i < updatedConfigCount; i++) {
                             const updatedConfig = sortedUpdatedConfigs[i];
                             const config = sortedConfigs[i];
                             if (updatedConfig.coordinate !== config.coordinate) {
+                                diffList.push(updatedRegionRequirements);
+                                return;
+                            }
+
+                            const updatedStatsTypes = [...(updatedConfig.statsTypes ?? [])].sort((a, b) => a - b);
+                            const statsTypes = [...(config.statsTypes ?? [])].sort((a, b) => a - b);
+                            if (updatedStatsTypes.length !== statsTypes.length || updatedStatsTypes.some((type, index) => type !== statsTypes[index])) {
                                 diffList.push(updatedRegionRequirements);
                                 return;
                             }


### PR DESCRIPTION
**Description**

Closes #2501 and closes #1027.

The preference dialog now has a Statistics tab where users choose the quantities shown in the statistics widget. The widget sends updated statistic requirements immediately when selections change, including robust metrics and derived beam quantities. Newly selected quantities therefore trigger computation instead of displaying NaN. Spectral-profile statistic options continue to use the supported statistic subset.

Companion PRs:
- Protobuf: https://github.com/CARTAvis/carta-protobuf/pull/114
- Backend: https://github.com/CARTAvis/carta-backend/pull/1625

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependencies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] no protobuf version bump needed
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [x] no corresponding ICD test fix needed (BackendService unchanged)
- [ ] user manual prepared (for large new features)

