### PR TITLE
Show CASA per-channel beam overlays in channel map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added Astropy-style sinh and asinh image scaling options with hover previews in the scaling dropdown ([#1992](https://github.com/CARTAvis/carta-frontend/issues/1992)).
 * Added colormap inversion controls for image rendering, contours, and vector overlays, including preferences and workspace support ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
+* Added beam overlays to every channel in channel map mode ([#2942](https://github.com/CARTAvis/carta-frontend/issues/2942)).
 ### Fixed
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added Astropy-style sinh and asinh image scaling options with hover previews in the scaling dropdown ([#1992](https://github.com/CARTAvis/carta-frontend/issues/1992)).
 * Added colormap inversion controls for image rendering, contours, and vector overlays, including preferences and workspace support ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
-* Added beam overlays to every channel in channel map mode ([#2942](https://github.com/CARTAvis/carta-frontend/issues/2942)).
+* Added support for displaying beam overlays on every channel when per-channel beam data is available([#2942](https://github.com/CARTAvis/carta-frontend/issues/2942)).
 ### Fixed
 * Fixed the catalog overlay colormap preview not reflecting the selected inversion direction ([#2030](https://github.com/CARTAvis/carta-frontend/issues/2030)).
 * Fixed image animation ignoring the selected playback mode in the Animator widget ([#2855](https://github.com/CARTAvis/carta-frontend/issues/2855)).

--- a/src/components/ChannelMapControl/ChannelMapControlComponent.tsx
+++ b/src/components/ChannelMapControl/ChannelMapControlComponent.tsx
@@ -186,6 +186,9 @@ export class ChannelMapControlComponent extends React.Component<WidgetProps> {
                         )}
                     </div>
                 </FormGroup>
+                <FormGroup className="channel-map-control-label" inline={true} label="Show beam overlay" disabled={!channelMapSettings.isChannelMapEnabled}>
+                    <Switch checked={channelMapSettings.shouldShowBeamOverlay} onChange={ev => channelMapSettings.setShowBeamOverlay(ev.currentTarget.checked)} disabled={!channelMapSettings.isChannelMapEnabled} />
+                </FormGroup>
                 <Collapse isOpen={isChannelMapLabelVisible}>
                     <FormGroup className={classNames("channel-map-control-label", "font-group")} inline={true} label="Font" disabled={!channelMapSettings.isChannelMapEnabled}>
                         {fontSelect(channelMapSettings.isChannelMapEnabled, channelMapSettings.font, channelMapSettings.setFont)}

--- a/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
+++ b/src/components/ImageView/BeamProfileOverlay/BeamProfileOverlayComponent.tsx
@@ -17,6 +17,7 @@ interface BeamProfileOverlayComponentProps {
     frame: FrameStore;
     top: number;
     left: number;
+    channel?: number;
     padding?: number;
 }
 
@@ -41,10 +42,6 @@ export class BeamProfileOverlayComponent extends React.Component<BeamProfileOver
     }
 
     private getPlotProps = (frame: FrameStore, basePosition?: Point2D): BeamPlotProps | null => {
-        if (!frame.hasVisibleBeam) {
-            return null;
-        }
-
         const id = frame.frameInfo.fileId;
         const zoomLevel = (frame.spatialReference ? frame.spatialReference.zoomLevel * (frame.spatialTransform?.scale ?? 1) : frame.zoomLevel) / AppStore.Instance.imageRatio;
         const beamSettings = frame.overlayBeamSettings;
@@ -56,13 +53,14 @@ export class BeamProfileOverlayComponent extends React.Component<BeamProfileOver
         const shiftX = beamSettings.shiftX;
         const shiftY = beamSettings.shiftY;
 
-        if (!frame.beamProperties) {
+        const beamProperties = frame.getBeamProperties(frame === this.props.frame ? this.props.channel : undefined);
+        if (!beamProperties || !beamProperties.overlayBeamSettings.isVisible) {
             return null;
         }
 
-        const a = ((frame.beamProperties.x / 2.0) * zoomLevel) / devicePixelRatio;
-        const b = ((frame.beamProperties.y / 2.0) * zoomLevel) / devicePixelRatio;
-        let theta = ((90.0 - frame.beamProperties.angle) * Math.PI) / 180.0;
+        const a = ((beamProperties.x / 2.0) * zoomLevel) / devicePixelRatio;
+        const b = ((beamProperties.y / 2.0) * zoomLevel) / devicePixelRatio;
+        let theta = ((90.0 - beamProperties.angle) * Math.PI) / 180.0;
         if (frame.spatialTransform) {
             theta -= frame.spatialTransform.rotation;
         }
@@ -118,17 +116,13 @@ export class BeamProfileOverlayComponent extends React.Component<BeamProfileOver
         const appStore = AppStore.Instance;
         const baseFrame = this.props.frame;
         const contourFrames = appStore.contourFrames.get(baseFrame)?.filter(frame => frame !== baseFrame && frame.hasVisibleBeam);
+        const baseBeamPlotProps = this.getPlotProps(baseFrame);
 
-        if (!baseFrame.hasVisibleBeam && !contourFrames?.length) {
+        if (!baseBeamPlotProps && !contourFrames?.length) {
             return null;
         }
 
         appStore.updateLayerPixelRatio(this.layerRef);
-
-        let baseBeamPlotProps: BeamPlotProps | null = null;
-        if (baseFrame.hasVisibleBeam) {
-            baseBeamPlotProps = this.getPlotProps(baseFrame);
-        }
 
         const contourBeams: React.JSX.Element[] = [];
         contourFrames?.forEach(contourFrame => {

--- a/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
+++ b/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
@@ -46,8 +46,6 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
     const gapX = frame.channelMapInnerOverlayStore.gapX;
     const gapY = frame.channelMapInnerOverlayStore.gapY;
 
-    const lastRow = Math.floor((channelMapStore.channelArray.length - 1) / channelMapStore.numColumns);
-
     const onMouseEnter = () => {
         setImageToolbarVisible(true);
     };
@@ -88,7 +86,6 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
         const row = Math.floor(index / channelMapStore.numColumns);
         const left = outerPadding.left + (innerRenderWidth + gapX) * column;
         const top = outerPadding.top + (innerRenderHeight + gapY) * row;
-        const isCornerOverlay = column === 0 && (row === channelMapStore.numRows - 1 || row === lastRow);
 
         return (
             channel < frame?.frameInfo.fileInfoExtended.depth && (
@@ -127,7 +124,7 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
                         dragPanningEnabled={appStore.preferenceStore.isDragPanning}
                         docked={props.isDocked}
                     />
-                    {isCornerOverlay && <BeamProfileOverlayComponent frame={frame} top={top} left={left} docked={props.isDocked} padding={10} />}
+                    {channelMapStore.shouldShowBeamOverlay && <BeamProfileOverlayComponent frame={frame} channel={channel} top={top} left={left} docked={props.isDocked} padding={10} />}
                 </div>
             )
         );

--- a/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
+++ b/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
@@ -45,6 +45,8 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
     const innerRenderHeight = frame.channelMapInnerOverlayStore.renderHeight;
     const gapX = frame.channelMapInnerOverlayStore.gapX;
     const gapY = frame.channelMapInnerOverlayStore.gapY;
+    const lastRow = Math.floor((channelMapStore.channelArray.length - 1) / channelMapStore.numColumns);
+    const shouldShowBeamForAllChannels = frame.shouldShowBeamForAllChannels;
 
     const onMouseEnter = () => {
         setImageToolbarVisible(true);
@@ -86,6 +88,7 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
         const row = Math.floor(index / channelMapStore.numColumns);
         const left = outerPadding.left + (innerRenderWidth + gapX) * column;
         const top = outerPadding.top + (innerRenderHeight + gapY) * row;
+        const isBottomLeftChannel = column === 0 && (row === channelMapStore.numRows - 1 || row === lastRow);
 
         return (
             channel < frame?.frameInfo.fileInfoExtended.depth && (
@@ -124,7 +127,9 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
                         dragPanningEnabled={appStore.preferenceStore.isDragPanning}
                         docked={props.isDocked}
                     />
-                    {channelMapStore.shouldShowBeamOverlay && <BeamProfileOverlayComponent frame={frame} channel={channel} top={top} left={left} docked={props.isDocked} padding={10} />}
+                    {channelMapStore.shouldShowBeamOverlay && (shouldShowBeamForAllChannels || isBottomLeftChannel) && (
+                        <BeamProfileOverlayComponent frame={frame} channel={channel} top={top} left={left} docked={props.isDocked} padding={10} />
+                    )}
                 </div>
             )
         );

--- a/src/stores/ChannelMapStore/ChannelMapStore.test.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.test.ts
@@ -66,6 +66,18 @@ describe("ChannelMapStore", () => {
     afterEach(() => {
         jest.useRealTimers();
         store.setChannelStep(1);
+        store.setShowBeamOverlay(true);
+    });
+
+    describe("beam overlay", () => {
+        it("is enabled by default", () => {
+            expect(store.shouldShowBeamOverlay).toBe(true);
+        });
+
+        it("can be toggled", () => {
+            store.setShowBeamOverlay(false);
+            expect(store.shouldShowBeamOverlay).toBe(false);
+        });
     });
 
     describe("setChannelMapEnabled", () => {

--- a/src/stores/ChannelMapStore/ChannelMapStore.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.ts
@@ -79,6 +79,8 @@ export class ChannelMapStore {
     @observable shouldShowFrequencyString: boolean = false;
     /** Indicates whether to show the velocity string. */
     @observable shouldShowVelocityString: boolean = false;
+    /** Indicates whether to show the beam overlay. */
+    @observable shouldShowBeamOverlay: boolean = true;
     /** Indicates whether to show the unit of the frequency string. */
     @observable shouldShowFrequencyStringUnit: boolean = true;
     /** Indicates whether to show the unit of the velocity string. */
@@ -248,6 +250,11 @@ export class ChannelMapStore {
      */
     @action setShowVelocityString = (shouldShow: boolean) => {
         this.shouldShowVelocityString = shouldShow;
+    };
+
+    /** Show or hide the beam overlay. */
+    @action setShowBeamOverlay = (shouldShow: boolean) => {
+        this.shouldShowBeamOverlay = shouldShow;
     };
 
     /**

--- a/src/stores/Frame/FrameStore.test.ts
+++ b/src/stores/Frame/FrameStore.test.ts
@@ -138,6 +138,14 @@ describe("FrameStore", () => {
             expect(beam).toHaveProperty("minorAxis", 0.8433393239974976);
             expect(beam).toHaveProperty("angle", 42.576087951660156);
         });
+
+        test("returns the beam for a specified channel", () => {
+            const frame = new FrameStore(STOKES_CUBEFRAME_INFO);
+            const beam = frame.getBeamProperties(2);
+            expect(beam).toHaveProperty("majorAxis", 0.9315680265426636);
+            expect(beam).toHaveProperty("minorAxis", 0.843326985836029);
+            expect(beam).toHaveProperty("angle", 42.57808303833008);
+        });
     });
 
     describe("beamAllChannels", () => {

--- a/src/stores/Frame/FrameStore.test.ts
+++ b/src/stores/Frame/FrameStore.test.ts
@@ -148,6 +148,32 @@ describe("FrameStore", () => {
         });
     });
 
+    describe("shouldShowBeamForAllChannels", () => {
+        const createFrameWithHeaders = (...additionalHeaders: CARTA.HeaderEntry.$Properties[]) =>
+            new FrameStore({
+                ...STOKES_CUBEFRAME_INFO,
+                fileInfoExtended: {
+                    ...STOKES_CUBEFRAME_INFO.fileInfoExtended,
+                    headerEntries: [...STOKES_CUBEFRAME_INFO.fileInfoExtended.headerEntries, ...additionalHeaders]
+                }
+            } as FrameInfo);
+
+        test("returns true for CASA per-channel beam metadata", () => {
+            const frame = createFrameWithHeaders({name: "CASAMBM", value: "T"});
+            expect(frame.shouldShowBeamForAllChannels).toBe(true);
+        });
+
+        test("returns false without the CASA beam table marker", () => {
+            const frame = createFrameWithHeaders();
+            expect(frame.shouldShowBeamForAllChannels).toBe(false);
+        });
+
+        test.each(["BMAJ", "BMIN", "BPA"])("returns false when %s is present", headerName => {
+            const frame = createFrameWithHeaders({name: "CASAMBM", value: "T"}, {name: headerName, value: "1"});
+            expect(frame.shouldShowBeamForAllChannels).toBe(false);
+        });
+    });
+
     describe("beamAllChannels", () => {
         test("returns a list of beams from all channels with the current stokes", () => {
             const frame = new FrameStore(STOKES_CUBEFRAME_INFO);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -471,6 +471,17 @@ export class FrameStore {
         return undefined;
     }
 
+    @computed get shouldShowBeamForAllChannels(): boolean {
+        const headerEntries = this.frameInfo?.fileInfoExtended?.headerEntries;
+        if (!headerEntries) {
+            return false;
+        }
+
+        const hasStandardBeamHeader = ["BMAJ", "BMIN", "BPA"].some(name => headerEntries.some(entry => entry.name === name));
+        const hasCasaBeamTable = headerEntries.some(entry => entry.name === "CASAMBM" && trimFitsComment(entry.value).trim().toUpperCase() === "T");
+        return hasCasaBeamTable && !hasStandardBeamHeader;
+    }
+
     getBeamProperties(channel: number = this.requiredChannel): {x: number; y: number; majorAxis: number; minorAxis: number; angle: number; overlayBeamSettings: OverlayBeamStore} | null {
         const unitHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name?.indexOf(`CUNIT${this.renderedAxesNumbers[0]}`) !== -1);
         const deltaHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name?.indexOf(`CDELT${this.renderedAxesNumbers[0]}`) !== -1);

--- a/src/stores/Frame/FrameStore.ts
+++ b/src/stores/Frame/FrameStore.ts
@@ -471,7 +471,7 @@ export class FrameStore {
         return undefined;
     }
 
-    @computed get beamProperties(): {x: number; y: number; majorAxis: number; minorAxis: number; angle: number; overlayBeamSettings: OverlayBeamStore} | null {
+    getBeamProperties(channel: number = this.requiredChannel): {x: number; y: number; majorAxis: number; minorAxis: number; angle: number; overlayBeamSettings: OverlayBeamStore} | null {
         const unitHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name?.indexOf(`CUNIT${this.renderedAxesNumbers[0]}`) !== -1);
         const deltaHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name?.indexOf(`CDELT${this.renderedAxesNumbers[0]}`) !== -1);
 
@@ -480,7 +480,7 @@ export class FrameStore {
             const delta = getHeaderNumericValue(deltaHeader);
             if (isFinite(delta) && (unit === "deg" || unit === "rad")) {
                 if (this.frameInfo.beamTable && this.frameInfo.beamTable.length > 0) {
-                    const beam = this.getBeam(this.requiredChannel, this.requiredStokes);
+                    const beam = this.getBeam(channel, this.requiredStokes);
                     if (beam && beam.majorAxis != null && isFinite(beam.majorAxis) && beam.majorAxis > 0 && beam.minorAxis != null && isFinite(beam.minorAxis) && beam.minorAxis > 0 && beam.pa != null && isFinite(beam.pa)) {
                         return {
                             x: beam.majorAxis / (unit === "deg" ? 3600 : (180 * 3600) / Math.PI) / Math.abs(delta),
@@ -495,6 +495,10 @@ export class FrameStore {
             }
         }
         return null;
+    }
+
+    @computed get beamProperties(): {x: number; y: number; majorAxis: number; minorAxis: number; angle: number; overlayBeamSettings: OverlayBeamStore} | null {
+        return this.getBeamProperties();
     }
 
     @computed get beamAllChannels(): CARTA.Beam.$Properties[] {


### PR DESCRIPTION
**Description**

Closes #2942.

Show beam overlays on every channel when the image has `CASAMBM = T` and no `BMAJ`, `BMIN`, or `BPA` image-header keywords. Other images continue to show the beam on the bottom-left channel only. The channel map settings dialog includes a beam-overlay toggle that defaults to on.

Verified with the FrameStore unit tests, TypeScript build, ESLint, Prettier, and the full test suite.

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [x] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] protobuf version bumped / no protobuf version bumped needed
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [x] user manual prepared (for large new features)