### PR TITLE
support color blending in channel map

### DIFF
--- a/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
+++ b/src/components/ImageView/ChannelMapView/ChannelMapViewComponent.tsx
@@ -75,14 +75,12 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
         frame?.setCenter(cursorInfo.posImageSpace.x, cursorInfo.posImageSpace.y);
     };
 
-    if (image?.type === ImageType.COLOR_BLENDING) {
-        return <NonIdealState icon={"error"} title={"Not supported"} description={"Color blending images in channel map view is not supported"} />;
-    }
-
     if (!image) {
         return <NonIdealState icon={"folder-open"} title={"No image available"} description={"No image data to display"} />;
     }
 
+    const isColorBlending = image.type === ImageType.COLOR_BLENDING;
+    const shouldShowRaster = !isColorBlending || image.store.isRasterVisible;
     const overlayComponents = channelMapStore.channelArray.map((channel, index) => {
         const column = index % channelMapStore.numColumns;
         const row = Math.floor(index / channelMapStore.numColumns);
@@ -102,10 +100,7 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
                 >
                     {frame?.frameInfo.fileInfoExtended.depth > 1 && (
                         <ChannelMapLabelComponent
-                            image={{
-                                type: ImageType.FRAME,
-                                store: frame
-                            }}
+                            image={image}
                             overlaySettings={overlaySettings}
                             top={top}
                             left={left}
@@ -127,7 +122,7 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
                         dragPanningEnabled={appStore.preferenceStore.isDragPanning}
                         docked={props.isDocked}
                     />
-                    {isCornerOverlay && <BeamProfileOverlayComponent frame={frame} top={top} left={left} docked={props.isDocked} padding={10} />}
+                    {isCornerOverlay && !isColorBlending && <BeamProfileOverlayComponent frame={frame} top={top} left={left} docked={props.isDocked} padding={10} />}
                 </div>
             )
         );
@@ -147,33 +142,37 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
         >
             <ChannelMapInnerOverlayComponent frame={frame} docked={props.isDocked} />
             {overlayComponents}
-            <RasterViewComponent
-                key={"raster-view-component-channel-map"}
-                image={image}
-                isDocked={props.isDocked}
-                pixelHighlightValue={channelMapStore.pixelHighlightValue}
-                row={0}
-                column={0}
-                renderWidth={outerRenderWidth}
-                renderHeight={outerRenderHeight}
-                channel={channelMapStore.channelArray}
-            />
-            <CursorOverlayComponent
-                cursorInfo={frame.cursorInfo}
-                cursorValue={frame.cursorInfo?.isInsideImage ? (frame.cursorValue?.value ?? 0) : 0}
-                isValueCurrent={frame.isCursorValueCurrent}
-                spectralInfo={frame.spectralInfo}
-                width={outerViewWidth}
-                left={outerPadding.left}
-                right={outerPadding.right}
-                isDocked={props.isDocked}
-                unit={frame.requiredUnit}
-                top={outerPadding.top}
-                currentStokes={AppStore.Instance.activeFrame?.requiredPolarizationInfo}
-                hasCursorValueToPercentage={frame.requiredUnit === "%"}
-                isPreview={frame.isPreview}
-                isVisible={isImageToolbarVisible}
-            />
+            {shouldShowRaster && (
+                <RasterViewComponent
+                    key={"raster-view-component-channel-map"}
+                    image={image}
+                    isDocked={props.isDocked}
+                    pixelHighlightValue={channelMapStore.pixelHighlightValue}
+                    row={0}
+                    column={0}
+                    renderWidth={outerRenderWidth}
+                    renderHeight={outerRenderHeight}
+                    channel={channelMapStore.channelArray}
+                />
+            )}
+            {!isColorBlending && (
+                <CursorOverlayComponent
+                    cursorInfo={frame.cursorInfo}
+                    cursorValue={frame.cursorInfo?.isInsideImage ? (frame.cursorValue?.value ?? 0) : 0}
+                    isValueCurrent={frame.isCursorValueCurrent}
+                    spectralInfo={frame.spectralInfo}
+                    width={outerViewWidth}
+                    left={outerPadding.left}
+                    right={outerPadding.right}
+                    isDocked={props.isDocked}
+                    unit={frame.requiredUnit}
+                    top={outerPadding.top}
+                    currentStokes={AppStore.Instance.activeFrame?.requiredPolarizationInfo}
+                    hasCursorValueToPercentage={frame.requiredUnit === "%"}
+                    isPreview={frame.isPreview}
+                    isVisible={isImageToolbarVisible}
+                />
+            )}
             <ToolbarComponent
                 isDocked={props.isDocked}
                 isVisible={isImageToolbarVisible}
@@ -183,18 +182,8 @@ export const ChannelMapViewComponent: React.FC<ChannelMapViewComponentProps> = o
                 onRegionViewZoom={zoom => onRegionViewZoom(frame, zoom)}
                 onZoomToFit={() => fitZoomFrameAndRegion(frame)}
             />
-            {overlaySettings.colorbar.isVisible && <ColorbarComponent frame={frame} onCursorHoverValueChanged={channelMapStore.setPixelHighlightValue} />}
-            <OverlayComponent
-                key={`overlay-view-component-outer`}
-                image={{
-                    type: ImageType.FRAME,
-                    store: frame
-                }}
-                overlaySettings={overlaySettings}
-                overlayStore={frame.channelMapOuterOverlayStore}
-                isDocked={props.isDocked}
-                isUnscaled={true}
-            />
+            {overlaySettings.colorbar.isVisible && !isColorBlending && <ColorbarComponent frame={frame} onCursorHoverValueChanged={channelMapStore.setPixelHighlightValue} />}
+            <OverlayComponent key={`overlay-view-component-outer`} image={image} overlaySettings={overlaySettings} overlayStore={frame.channelMapOuterOverlayStore} isDocked={props.isDocked} isUnscaled={true} />
         </div>
     );
 });

--- a/src/components/ImageView/RasterView/RasterViewComponent.test.ts
+++ b/src/components/ImageView/RasterView/RasterViewComponent.test.ts
@@ -116,4 +116,58 @@ describe("RasterViewComponent", () => {
         expect(readHistStokesIndex).toHaveBeenCalled();
         expect(readIsUsingCubeHistogram).toHaveBeenCalled();
     });
+
+    test("composites every channel-map layer without clearing earlier layers", () => {
+        const clearRect = jest.fn();
+        const compositeStates: Array<{alpha: number; operation: string}> = [];
+        const context = {
+            clearRect,
+            globalAlpha: 1,
+            globalCompositeOperation: "source-over",
+            drawImage: jest.fn(() => compositeStates.push({alpha: context.globalAlpha, operation: context.globalCompositeOperation}))
+        };
+        const makeFrame = (channel: number) => ({
+            channel,
+            stokes: 0,
+            polarizations: [],
+            isPreview: false,
+            renderWidth: 10,
+            renderHeight: 10,
+            renderConfig: {
+                histChannel: channel,
+                stokesIndex: 0,
+                isUsingCubeHistogram: false
+            }
+        });
+        const baseFrame = makeFrame(0);
+        const secondFrame = makeFrame(2);
+        const image = {type: ImageType.COLOR_BLENDING, store: {baseFrame, frames: [baseFrame, secondFrame], alpha: [0.25, 0.75]}};
+        const component = new RasterViewComponent({image, channel: [0, 1], column: 0, row: 0, pixelHighlightValue: NaN} as any) as any;
+        component.canvas = {width: 10, height: 10, getContext: () => context};
+        component.gl = {canvas: {height: 10}};
+        component.updateCanvasSize = jest.fn();
+        component.updateUniforms = jest.fn();
+        component.renderMultipleCanvas = jest.fn();
+        jest.spyOn(AppStore, "Instance", "get").mockReturnValue({
+            setCanvasUpdated: jest.fn(),
+            imageViewConfigStore: {numImageColumns: 1, numImageRows: 1},
+            channelMapStore: {isChannelMapEnabled: true, getChannelsForFrame: frame => (frame === baseFrame ? [0, 1] : [2, 2])},
+            pixelRatio: 1
+        } as any);
+
+        component.updateCanvas();
+
+        expect(clearRect).toHaveBeenCalledTimes(1);
+        expect(component.renderMultipleCanvas).toHaveBeenNthCalledWith(1, baseFrame, [0, 1]);
+        expect(component.renderMultipleCanvas).toHaveBeenNthCalledWith(2, secondFrame, [2, 2]);
+        expect(compositeStates).toEqual([
+            {alpha: 0.25, operation: "lighter"},
+            {alpha: 0.75, operation: "lighter"}
+        ]);
+
+        component.props = {...component.props, image: {type: ImageType.FRAME, store: baseFrame}, channel: undefined};
+        component.renderCanvas = jest.fn();
+        component.updateCanvas();
+        expect(compositeStates.at(-1)).toEqual({alpha: 1, operation: "source-over"});
+    });
 });

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -22,7 +22,7 @@ export class RasterViewComponentProps {
     column: number;
     renderWidth?: number;
     renderHeight?: number;
-    channel?: number[];
+    channel?: Array<number | null>;
 }
 
 @observer
@@ -33,7 +33,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
     private updateCanvasFrame: number | undefined;
     private static readonly Float32Max = 3.402823466e38;
 
-    @observable private channels: number[] | undefined;
+    @observable private channels: Array<number | null> | undefined;
     @observable private image: ImageItem | undefined;
     @observable private imageStore: FrameStore | undefined;
 
@@ -60,8 +60,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
             }
         }
 
-        this.sub = TileService.Instance.tileStream.subscribe(tileMessage => {
-            if ((!isFinite(this.channels?.length ?? NaN) && (!AppStore.Instance.channelMapStore.isChannelMapEnabled || this.imageStore?.isPreview)) || this.channels?.includes(tileMessage.channel ?? 0)) {
+        this.sub = TileService.Instance.tileStream.subscribe(() => {
+            if (this.channels !== undefined || !AppStore.Instance.channelMapStore.isChannelMapEnabled || this.imageStore?.isPreview) {
                 this.scheduleCanvasUpdate();
             }
         });
@@ -100,17 +100,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         });
     };
 
-    private renderMultipleCanvas = (frame: FrameStore) => {
-        const canvas = this.canvas;
-        const channels = this.props.channel;
-        const ctx = canvas.getContext("2d");
-        if (!ctx || !channels) {
-            return;
-        }
-
-        const w = canvas.width;
-        const h = canvas.height;
-        ctx.clearRect(0, 0, w, h);
+    private renderMultipleCanvas = (frame: FrameStore, channels: Array<number | null>) => {
         this.gl.clear(GL2.COLOR_BUFFER_BIT | GL2.DEPTH_BUFFER_BIT);
 
         if (!channels.length) {
@@ -124,6 +114,9 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const gapY = frame.channelMapInnerOverlayStore.gapY;
 
         channels.forEach((channel, index) => {
+            if (channel === null) {
+                return;
+            }
             const appStore = AppStore.Instance;
             const channelMapStore = appStore.channelMapStore;
             const column = index % channelMapStore.numColumns;
@@ -181,9 +174,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const h = canvas.height;
         let isCanvasCleared = false;
 
-        if (image?.type === ImageType.COLOR_BLENDING) {
-            ctx.globalCompositeOperation = "lighter";
-        }
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = image?.type === ImageType.COLOR_BLENDING ? "lighter" : "source-over";
 
         const frames = this.props.image?.type === ImageType.COLOR_BLENDING ? this.props.image?.store?.frames : [this.props.image?.store];
         frames.forEach((frame, index) => {
@@ -198,8 +190,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                         isCanvasCleared = true;
                     }
                     this.updateUniforms(frame, Math.floor(frame.renderWidth), Math.floor(frame.renderHeight), this.props.pixelHighlightValue);
-                    if (channel && isFinite((channel as number[]).length)) {
-                        this.renderMultipleCanvas(frame);
+                    if (channel) {
+                        this.renderMultipleCanvas(frame, AppStore.Instance.channelMapStore.getChannelsForFrame(frame));
                     } else {
                         this.renderCanvas(frame, xOffset, yOffset, renderWidth, renderHeight, frame.channel);
                     }
@@ -212,6 +204,7 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                 }
             }
         });
+        ctx.globalAlpha = 1;
     };
 
     private updateCanvasSize(frame: FrameStore, renderWidth: number, renderHeight: number, numImageColumns: number, numImageRows: number) {
@@ -551,6 +544,9 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
                     pixelGridColor: getColorForTheme(appStore.preferenceStore.pixelGridColor)
                 };
                 const ratio = appStore.imageRatio;
+                if (this.props.channel) {
+                    const channelMapChannels = appStore.channelMapStore.getChannelsForFrame(frame);
+                }
             }
         }
         if (this.props.image?.type === ImageType.COLOR_BLENDING) {

--- a/src/services/TileService.test.ts
+++ b/src/services/TileService.test.ts
@@ -32,6 +32,7 @@ type TestTileService = {
             timeout?: ReturnType<typeof setTimeout>;
             desiredStokes?: number;
             confirmedStokes?: number;
+            requestedChannels?: Set<number>;
             generation: number;
         }
     >;
@@ -193,6 +194,7 @@ describe("TileService channel map request queue", () => {
 
         expect(service.backendService.setChannels).toHaveBeenCalledTimes(1);
         expect(service.backendService.setChannels).toHaveBeenCalledWith(1, 1, 0, {}, true, [0, 1, 2]);
+        expect(GetChannelMapState(service)?.requestedChannels).toEqual(new Set([0, 1, 2]));
     });
 
     test("queues the active channel histogram when its tile request is already in flight", () => {
@@ -605,6 +607,24 @@ describe("TileService channel map request queue", () => {
 
         service.resolveChannelMapTile(1, 0, 2, 4);
         expect(service.channelMapRemainingTiles).toBe(0);
+    });
+
+    test("tracks pending channel-map tiles independently across files", () => {
+        const service = CreateService();
+        const tile = {layer: 0, encode: () => 4};
+
+        service.setChannelMapTargetTiles([tile], 1, 0, [0, 1]);
+        service.setChannelMapTargetTiles([tile], 2, 0, [3]);
+
+        expect(service.channelMapPendingTiles).toEqual(new Set(["1_0_0_4", "1_0_1_4", "2_0_3_4"]));
+        expect(service.channelMapRemainingTiles).toBe(3);
+
+        service.setChannelMapTargetTiles([tile], 1, 0, [1]);
+        expect(service.channelMapPendingTiles).toEqual(new Set(["1_0_1_4", "2_0_3_4"]));
+
+        service.cancelChannelMapRequests(1);
+        expect(service.channelMapPendingTiles).toEqual(new Set(["2_0_3_4"]));
+        expect(service.channelMapRemainingTiles).toBe(1);
     });
 
     test("completes a synchronized stream when no requested tiles succeed", () => {

--- a/src/services/TileService.ts
+++ b/src/services/TileService.ts
@@ -125,6 +125,7 @@ interface ChannelMapFileState {
     timeout?: ReturnType<typeof setTimeout>;
     desiredStokes?: number;
     confirmedStokes?: number;
+    requestedChannels?: Set<number>;
     generation: number;
 }
 
@@ -340,7 +341,7 @@ export class TileService {
     }
 
     private setChannelMapTargetTiles(tiles: TileCoordinate[], fileId: number, stokes: number, channels: number[]) {
-        this.channelMapPendingTiles.clear();
+        this.resetChannelMapLoading(fileId);
         for (const channel of channels) {
             for (const tile of tiles) {
                 if (tile.layer < 0) {
@@ -361,9 +362,17 @@ export class TileService {
         }
     }
 
-    private resetChannelMapLoading() {
-        this.channelMapPendingTiles.clear();
-        this.channelMapPendingTileCount = 0;
+    private resetChannelMapLoading(fileId?: number) {
+        if (fileId === undefined) {
+            this.channelMapPendingTiles.clear();
+        } else {
+            this.channelMapPendingTiles.forEach(key => {
+                if (isTileKeyForFile(key, fileId)) {
+                    this.channelMapPendingTiles.delete(key);
+                }
+            });
+        }
+        this.channelMapPendingTileCount = this.channelMapPendingTiles.size;
     }
 
     private setNormalViewTargetTiles(tiles: TileCoordinate[], fileId: number, stokes: number, channel: number) {
@@ -560,6 +569,7 @@ export class TileService {
         const currentTiles = tiles.map(tile => tile.encode());
         const previousStokes = this.fileStateMap.get(fileId)?.stokes;
         const channelMapState = this.getChannelMapState(fileId);
+        channelMapState.requestedChannels = new Set(requestedChannels);
         if (channelMapState.confirmedStokes === undefined) {
             channelMapState.confirmedStokes = previousStokes ?? stokes;
         }
@@ -698,7 +708,7 @@ export class TileService {
             channelMapState.queue = [];
             this.dismissChannelMapTimeoutAlert(request.batchTiming);
             this.clearChannelMapSynchronization(fileId);
-            this.resetChannelMapLoading();
+            this.resetChannelMapLoading(fileId);
         }
     }
 
@@ -725,6 +735,7 @@ export class TileService {
             channelMapState.queue = [];
             this.dismissChannelMapTimeoutAlert(activeRequest.batchTiming);
             this.clearChannelMapSynchronization(fileId);
+            this.resetChannelMapLoading(fileId);
             return;
         }
 
@@ -783,6 +794,7 @@ export class TileService {
         this.clearRequestQueue(fileId);
         channelMapState.queue = [];
         this.clearChannelMapSynchronization(fileId);
+        this.resetChannelMapLoading(fileId);
         const selectedChannels = this.fileStateMap.get(fileId);
         if (selectedChannels?.channel !== null && selectedChannels?.channel !== undefined && selectedChannels.stokes !== null && selectedChannels.stokes !== undefined) {
             this.backendService.setChannels(fileId, selectedChannels.channel, selectedChannels.stokes, {});
@@ -818,6 +830,8 @@ export class TileService {
             channelMapState.activeRequest = undefined;
             channelMapState.desiredStokes = undefined;
             channelMapState.confirmedStokes = undefined;
+            channelMapState.requestedChannels = undefined;
+            this.resetChannelMapLoading(id);
         });
     }
 
@@ -860,6 +874,7 @@ export class TileService {
             state.timeout = undefined;
             state.desiredStokes = undefined;
             state.confirmedStokes = undefined;
+            state.requestedChannels = undefined;
             state.generation++;
         });
         this.pendingRequests.clear();
@@ -919,7 +934,7 @@ export class TileService {
             this.pendingRequests.clear();
         }
 
-        this.resetChannelMapLoading();
+        this.resetChannelMapLoading(fileId);
         this.resetNormalViewLoading(fileId);
     }
 
@@ -1069,7 +1084,9 @@ export class TileService {
             return;
         }
 
-        if (!syncState && appStore.channelMapStore.isChannelMapEnabled && !appStore.channelMapStore.channelArray.includes(tileMessage?.channel ?? NaN)) {
+        const channelMapChannels = this.channelMapStates.get(tileMessage.fileId ?? NaN)?.requestedChannels;
+        const isRequestedChannel = channelMapChannels ? channelMapChannels.has(tileMessage?.channel ?? NaN) : appStore.channelMapStore.channelArray.includes(tileMessage?.channel ?? NaN);
+        if (!syncState && appStore.channelMapStore.isChannelMapEnabled && !isRequestedChannel) {
             console.log(`Skipping stale tile during channel map for key=${key}`);
             return;
         }
@@ -1251,8 +1268,9 @@ export class TileService {
         });
         const currentFileState = this.fileStateMap.get(fileId ?? NaN);
         const appStore = AppStore.Instance;
+        const channelMapChannels = this.channelMapStates.get(fileId ?? NaN)?.requestedChannels;
         const isCurrentView = appStore.channelMapStore.isChannelMapEnabled
-            ? appStore.channelMapStore.channelArray.includes(channel ?? NaN) && currentFileState?.stokes === stokes
+            ? (channelMapChannels ? channelMapChannels.has(channel ?? NaN) : appStore.channelMapStore.channelArray.includes(channel ?? NaN)) && currentFileState?.stokes === stokes
             : currentFileState?.channel === channel && currentFileState?.stokes === stokes;
         const isLatestView = syncState.viewGeneration === this.rasterViewGenerations.get(key) && isCurrentView;
         this.tileStream.next({tileCount, fileId, channel, stokes, flush: isLatestView});

--- a/src/stores/ChannelMapStore/ChannelMapStore.test.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.test.ts
@@ -32,26 +32,34 @@ jest.mock("stores", () => {
                 preferenceStore: {
                     imageCompressionQuality: 11
                 },
-                imageViewConfigStore: {
-                    visibleImages: [
-                        {
-                            type: 0,
-                            store: observable.object(
-                                {
-                                    channel: 0,
-                                    requiredChannel: 0,
-                                    frameInfo: {fileInfoExtended: {depth: 12}},
-                                    requiredFrameView: false,
-                                    requiredTiles: [[], {x: 0, y: 0}],
-                                    setChannel: jest.fn()
-                                },
-                                {},
-                                {deep: false}
-                            )
-                        }
-                    ],
-                    visibleFrames: []
-                },
+                imageViewConfigStore: observable.object(
+                    {
+                        visibleImages: [
+                            {
+                                type: 0,
+                                store: observable.object(
+                                    {
+                                        channel: 0,
+                                        stokes: 0,
+                                        requiredChannel: 0,
+                                        frameInfo: {fileId: 1, fileInfoExtended: {depth: 12}},
+                                        requiredFrameView: false,
+                                        requiredTiles: [[], {x: 0, y: 0}],
+                                        spectralSiblings: [],
+                                        wcsInfo3D: {},
+                                        setChannel: jest.fn()
+                                    },
+                                    {},
+                                    {deep: false}
+                                )
+                            }
+                        ],
+                        visibleFrames: []
+                    },
+                    {},
+                    {deep: false}
+                ),
+                spectralMatchingType: "CHANNEL",
                 updateChannels: jest.fn()
             }
         }
@@ -336,6 +344,54 @@ describe("ChannelMapStore", () => {
     describe("totalChannelNum", () => {
         it("returns number of channels of the active image", () => {
             expect(store.totalChannelNum).toBe(12);
+        });
+    });
+
+    describe("color blending", () => {
+        const setDisplayedImage = image => {
+            runInAction(() => {
+                jest.requireMock("stores").AppStore.Instance.imageViewConfigStore.visibleImages = [image];
+            });
+        };
+
+        it("maps matched layers and leaves cells outside their spectral range empty", () => {
+            const frameImage = jest.requireMock("stores").AppStore.Instance.imageViewConfigStore.visibleImages[0];
+            const baseFrame = frameImage.store;
+            store.setNumColumns(2);
+            store.setNumRows(2);
+            store.setStartChannel(0);
+            const matchedFrame = {...baseFrame, channel: 1, frameInfo: {fileId: 2, fileInfoExtended: {depth: 3}}, spectralSiblings: [baseFrame]};
+            baseFrame.spectralSiblings = [matchedFrame];
+            setDisplayedImage({type: 1, store: {frames: [baseFrame, matchedFrame]}});
+
+            expect(store.getChannelsForFrame(matchedFrame)).toEqual([0, 1, 2, null]);
+
+            baseFrame.spectralSiblings = [];
+            setDisplayedImage(frameImage);
+        });
+
+        it("repeats an unmatched layer channel and requests it only once", () => {
+            const frameImage = jest.requireMock("stores").AppStore.Instance.imageViewConfigStore.visibleImages[0];
+            const baseFrame = frameImage.store;
+            store.setNumColumns(2);
+            store.setNumRows(2);
+            store.setStartChannel(0);
+            const unmatchedFrame = {...baseFrame, channel: 7, frameInfo: {fileId: 2, fileInfoExtended: {depth: 12}}, spectralSiblings: []};
+            const requestChannelMapTiles = TileService.Instance.requestChannelMapTiles as jest.Mock;
+            const testStore = store as unknown as {requestDisplayedChannels: () => void};
+            setDisplayedImage({type: 1, store: {frames: [baseFrame, unmatchedFrame]}});
+            store.setChannelMapEnabled(true);
+            requestChannelMapTiles.mockClear();
+
+            expect(store.getChannelsForFrame(unmatchedFrame)).toEqual([7, 7, 7, 7]);
+            testStore.requestDisplayedChannels();
+
+            expect(requestChannelMapTiles).toHaveBeenCalledTimes(2);
+            expect(requestChannelMapTiles.mock.calls[0][4]).toEqual([0, 1, 2, 3]);
+            expect(requestChannelMapTiles.mock.calls[1][4]).toEqual([7]);
+
+            store.setChannelMapEnabled(false);
+            setDisplayedImage(frameImage);
         });
     });
 });

--- a/src/stores/ChannelMapStore/ChannelMapStore.ts
+++ b/src/stores/ChannelMapStore/ChannelMapStore.ts
@@ -1,10 +1,11 @@
 import {debounce, throttle} from "lodash";
 import {action, autorun, computed, makeObservable, observable, reaction} from "mobx";
 
-import {ImageType} from "enums";
+import {ImageType, SpectralType} from "enums";
 import {type ImageViewItem} from "models";
 import {TileService} from "services";
 import {AppStore, type FrameStore} from "stores";
+import {getTransformedChannelList} from "utilities";
 
 export class ChannelMapStore {
     private static staticInstance: ChannelMapStore;
@@ -25,19 +26,23 @@ export class ChannelMapStore {
 
         autorun(() => {
             if (this.displayedFrame?.requiredFrameView && this.isChannelMapEnabled) {
-                /* eslint-disable @typescript-eslint/no-unused-vars */
-                const startChannel = this.startChannel;
-                const numColumns = this.numColumns;
-                const numRows = this.numRows;
-                const endChannel = this.endChannel;
-                const center = this.displayedFrame.center;
-                const requiredFrameView = this.displayedFrame.requiredFrameView;
-                const requiredTiles = this.displayedFrame.requiredTiles;
-                const zoomLevel = this.displayedFrame.zoomLevel;
-                const spatialReference = this.displayedFrame.spatialReference;
-                const channel = this.displayedFrame.channel;
+                // Track every value that can change the tiles required by any displayed layer.
+                void this.channelArray;
+                void this.displayedFrame.spectralSiblings;
+                void AppStore.Instance.spectralMatchingType;
+                this.displayedFrames.forEach(frame => {
+                    void frame.center;
+                    void frame.requiredFrameView;
+                    void frame.requiredTiles;
+                    void frame.zoomLevel;
+                    void frame.spatialReference;
+                    void frame.channel;
+                    void frame.stokes;
+                    void frame.wcsInfo3D;
+                    void frame.frameInfo.fileInfoExtended.depth;
+                });
 
-                this.throttledRequestChannels(this.displayedFrame);
+                this.throttledRequestChannels();
             }
         });
 
@@ -97,30 +102,53 @@ export class ChannelMapStore {
         return AppStore.Instance.animatorStore.step;
     }
 
-    private throttledRequestChannels = throttle((frame: FrameStore) => this.requestChannels(frame), 100);
+    private requestedFileIds = new Set<number>();
+    private throttledRequestChannels = throttle(() => this.requestDisplayedChannels(), 100);
     private debouncedSetActiveChannel = debounce((channel: number) => this.displayedFrame?.setChannel(channel), 200);
 
     /**
      * Clears the cache and requests new tiles when the polarization changes.
      * @param frame - the frame to request tiles for.
      */
-    handlePolarizationChanged = (frame: FrameStore) => this.requestChannels(frame, true);
+    handlePolarizationChanged = (frame: FrameStore) => {
+        if (this.displayedFrames.includes(frame)) {
+            this.requestChannels(frame, true);
+        }
+    };
 
     private requestChannels = (frame: FrameStore, isPolarizationChanged: boolean = false) => {
         if (!this.isChannelMapEnabled) {
+            return;
+        }
+        const requestedChannels = Array.from(new Set(this.getChannelsForFrame(frame).filter((channel): channel is number => channel !== null)));
+        if (!requestedChannels.length) {
+            TileService.Instance.cancelChannelMapRequests(frame.frameInfo.fileId);
             return;
         }
         const [tiles, midPointTileCoords] = frame.requiredTiles;
         const preferenceStore = AppStore.Instance.preferenceStore;
         const bunitVariant = ["km/s", "km s-1", "km s^-1", "km.s-1"];
         const compressionQuality = frame.headerUnit && bunitVariant.includes(frame.headerUnit) ? Math.max(preferenceStore.imageCompressionQuality, 32) : preferenceStore.imageCompressionQuality;
-        TileService.Instance.requestChannelMapTiles(tiles, frame, midPointTileCoords, compressionQuality, this.channelArray, isPolarizationChanged);
+        TileService.Instance.requestChannelMapTiles(tiles, frame, midPointTileCoords, compressionQuality, requestedChannels, isPolarizationChanged);
+    };
+
+    private requestDisplayedChannels = () => {
+        if (!this.isChannelMapEnabled) {
+            return;
+        }
+
+        const displayedFileIds = new Set(this.displayedFrames.map(frame => frame.frameInfo.fileId));
+        this.requestedFileIds.forEach(fileId => {
+            if (!displayedFileIds.has(fileId)) {
+                TileService.Instance.cancelChannelMapRequests(fileId);
+            }
+        });
+        this.requestedFileIds = displayedFileIds;
+        this.displayedFrames.forEach(frame => this.requestChannels(frame));
     };
 
     requestTilesAfterSessionResume = () => {
-        if (this.displayedFrame) {
-            this.requestChannels(this.displayedFrame);
-        }
+        this.requestDisplayedChannels();
     };
 
     /**
@@ -137,6 +165,7 @@ export class ChannelMapStore {
             this.throttledRequestChannels.cancel();
             this.debouncedSetActiveChannel.cancel();
             TileService.Instance.cancelChannelMapRequests();
+            this.requestedFileIds.clear();
             if (isDisablingChannelMap) {
                 const updates = AppStore.Instance.imageViewConfigStore.visibleFrames.map(frame => ({frame, channel: frame.channel, stokes: frame.stokes}));
                 AppStore.Instance.updateChannels(updates);
@@ -306,18 +335,49 @@ export class ChannelMapStore {
 
     /** The frame of the displayed image in the image view. */
     @computed get displayedFrame(): FrameStore | null {
-        if (!this.displayedImage) {
-            return null;
+        return this.displayedFrames[0] ?? null;
+    }
+
+    /** The frames contributing raster layers to the displayed image. */
+    @computed get displayedFrames(): FrameStore[] {
+        if (this.displayedImage?.type === ImageType.FRAME) {
+            return [this.displayedImage.store];
+        }
+        if (this.displayedImage?.type === ImageType.COLOR_BLENDING) {
+            return this.displayedImage.store.frames;
+        }
+        return [];
+    }
+
+    /**
+     * The channel rendered by a frame in each channel-map cell.
+     * Spectrally matched frames follow the base frame; unmatched frames keep their selected channel.
+     * A null entry means that the matched channel falls outside the frame.
+     */
+    getChannelsForFrame(frame: FrameStore): Array<number | null> {
+        const baseFrame = this.displayedFrame;
+        if (!baseFrame || frame === baseFrame) {
+            return this.channelArray;
+        }
+        if (!baseFrame.spectralSiblings.includes(frame)) {
+            return this.channelArray.map(() => frame.channel);
         }
 
-        const type = this.displayedImage.type;
-        if (type === ImageType.FRAME) {
-            return this.displayedImage.store;
-        } else if (type === ImageType.COLOR_BLENDING) {
-            return this.displayedImage.store.baseFrame;
+        if (AppStore.Instance.spectralMatchingType === SpectralType.CHANNEL) {
+            return this.channelArray.map(channel => (channel < frame.frameInfo.fileInfoExtended.depth ? channel : null));
         }
 
-        return null;
+        const depth = frame.frameInfo.fileInfoExtended.depth;
+        const firstChannel = this.channelArray[0];
+        const lastChannel = this.channelArray[this.channelArray.length - 1];
+        const transformedChannels = getTransformedChannelList(baseFrame.wcsInfo3D, frame.wcsInfo3D, AppStore.Instance.spectralMatchingType, firstChannel, lastChannel);
+        return this.channelArray.map(channel => {
+            const transformedChannel = transformedChannels[channel - firstChannel];
+            if (!isFinite(transformedChannel) || transformedChannel < -0.5 || transformedChannel > depth - 0.5) {
+                return null;
+            }
+            return Math.round(transformedChannel);
+        });
     }
 
     /** The number of channels of the displayed image. Returns 1 if the information is unavailable. */


### PR DESCRIPTION
**Description**

Closes #2944.

Adds color-blending support to channel map mode. Spectrally matched layers follow transformed base-frame channels; spectrally unmatched layers repeat their selected channel. Invalid matched channels render transparently. Tile loading, cancellation, and progress tracking are isolated per file, and raster compositing preserves all blend layers.

The channel-map view now respects blend visibility and uses the existing blend colormaps, alpha values, and render configurations.

**Testing**

- `npm test` — 58 suites, 527 tests passed
- Focused channel-map, tile-service, and raster-view tests passed
- TypeScript compilation passed
- ESLint and Prettier checks passed

**Checklist**

For linked issues (if there are):
- [ ] assignee and label added
- [ ] GitHub Project estimate added

For the pull request:
- [ ] reviewers and assignee added
- [ ] GitHub Project estimate added
- [ ] changelog updated / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] protobuf version bumped / no protobuf version bumped needed
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] corresponding ICD test fix added (`BackendService` changed) / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)