### PR TITLE
refactor: standardize widget configuration APIs

### DIFF
--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -2,7 +2,6 @@ import type {RgbaColor} from "@uiw/react-color";
 import {type CARTA} from "carta-protobuf";
 
 import {type ContourDashMode, FrameScaling, type VectorOverlaySource} from "enums";
-import {type ContourConfigStore, type RenderConfigStore, type VectorOverlayConfigStore} from "stores/Frame";
 import {sanitizeScalingParameter} from "utilities/scaling/scaling";
 
 import {type Point2D} from "./Point2D/Point2D";
@@ -172,111 +171,6 @@ export class WorkspaceConfig {
 
                 return {...file, renderConfig};
             })
-        };
-    }
-
-    public static createRenderConfig(renderConfig: RenderConfigStore): WorkspaceRenderConfig {
-        const {scaling, colorMap, bias, contrast, gamma, alphaLog, alphaPower, alphaSinh, alphaAsinh, isInverted, isUsingCubeHistogram, isUsingCubeHistogramContours, selectedPercentile, scaleMin, scaleMax, isVisible} = renderConfig;
-
-        return {
-            scaling,
-            colorMap,
-            bias,
-            contrast,
-            gamma,
-            alphaLog,
-            alphaPower,
-            alphaSinh,
-            alphaAsinh,
-            inverted: isInverted,
-            useCubeHistogram: isUsingCubeHistogram,
-            useCubeHistogramContours: isUsingCubeHistogramContours,
-            selectedPercentile,
-            scaleMin,
-            scaleMax,
-            visible: isVisible
-        };
-    }
-
-    public static createContourConfig(contourConfig: ContourConfigStore): WorkspaceContourConfig | undefined {
-        const {isEnabled, levels, smoothingMode, smoothingFactor, color, isColormapEnabled, isColormapInverted, colormap, colormapContrast, colormapBias, dashMode, thickness, isVisible} = contourConfig;
-
-        if (!isEnabled) {
-            return undefined;
-        }
-
-        return {
-            levels,
-            smoothingMode,
-            smoothingFactor,
-            color,
-            colormapEnabled: isColormapEnabled,
-            colormapInverted: isColormapInverted,
-            colormap,
-            colormapContrast,
-            colormapBias,
-            dashMode,
-            thickness,
-            visible: isVisible
-        };
-    }
-
-    public static createVectorOverlayConfig(vectorOverlayConfig: VectorOverlayConfigStore): WorkspaceVectorOverlayConfig | undefined {
-        const {
-            isEnabled,
-            angularSource,
-            intensitySource,
-            isFractionalIntensity,
-            pixelAveraging,
-            isThresholdEnabled,
-            threshold,
-            isDebiasing,
-            qError,
-            uError,
-            thresholdOption,
-            isVisible,
-            thickness,
-            isColormapEnabled,
-            isColormapInverted,
-            color,
-            colormap,
-            colormapContrast,
-            colormapBias,
-            lengthMin,
-            lengthMax,
-            intensityMin,
-            intensityMax,
-            rotationOffset
-        } = vectorOverlayConfig;
-
-        if (!isEnabled) {
-            return undefined;
-        }
-
-        return {
-            angularSource,
-            intensitySource,
-            fractionalIntensity: isFractionalIntensity,
-            pixelAveraging,
-            thresholdEnabled: isThresholdEnabled,
-            threshold,
-            debiasing: isDebiasing,
-            qError,
-            uError,
-            thresholdOption,
-            visible: isVisible,
-            thickness,
-            colormapEnabled: isColormapEnabled,
-            colormapInverted: isColormapInverted,
-            color,
-            colormap,
-            colormapContrast,
-            colormapBias,
-            lengthMin,
-            lengthMax,
-            intensityMin,
-            intensityMax,
-            rotationOffset
         };
     }
 }

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -45,7 +45,6 @@ import {
     type TileCoordinate,
     ToFileListFilterMode,
     type Workspace,
-    WorkspaceConfig,
     type WorkspaceFile
 } from "models";
 import {ApiService, BackendService, ScriptingService, TelemetryService, TileService, type TileStreamDetails} from "services";
@@ -2830,7 +2829,7 @@ export class AppStore {
                     }
 
                     if (fileInfo.renderConfig) {
-                        frame.renderConfig.updateFromWorkspace(fileInfo.renderConfig);
+                        frame.renderConfig.applyConfig(fileInfo.renderConfig);
                     }
 
                     if (workspace.references && fileInfo.references) {
@@ -2846,11 +2845,11 @@ export class AppStore {
                     }
 
                     if (fileInfo.contourConfig) {
-                        frame.contourConfig.updateFromWorkspace(fileInfo.contourConfig);
+                        frame.contourConfig.applyConfig(fileInfo.contourConfig);
                         frame.applyContours();
                     }
                     if (fileInfo.vectorOverlayConfig) {
-                        frame.vectorOverlayConfig.updateFromWorkspace(fileInfo.vectorOverlayConfig);
+                        frame.vectorOverlayConfig.applyConfig(fileInfo.vectorOverlayConfig);
                         frame.applyVectorOverlay();
                     }
 
@@ -3025,14 +3024,14 @@ export class AppStore {
             }
 
             // Render config (TODO: A more extensible way of saving/loading state for simple stores)
-            workspaceFile.renderConfig = WorkspaceConfig.createRenderConfig(frame.renderConfig);
+            workspaceFile.renderConfig = frame.renderConfig.toConfig();
 
-            const contourConfig = WorkspaceConfig.createContourConfig(frame.contourConfig);
+            const contourConfig = frame.contourConfig.toConfig();
             if (contourConfig) {
                 workspaceFile.contourConfig = contourConfig;
             }
 
-            const vectorOverlayConfig = WorkspaceConfig.createVectorOverlayConfig(frame.vectorOverlayConfig);
+            const vectorOverlayConfig = frame.vectorOverlayConfig.toConfig();
             if (vectorOverlayConfig) {
                 workspaceFile.vectorOverlayConfig = vectorOverlayConfig;
             }

--- a/src/stores/Frame/ContourStore/ContourConfigStore.test.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.test.ts
@@ -40,7 +40,7 @@ describe("ContourConfigStore workspace colormap inversion", () => {
     test("uses the historical non-inverted behavior when a legacy workspace omits the setting", () => {
         const store = createStore(true);
 
-        store.updateFromWorkspace(createWorkspaceConfig());
+        store.applyConfig(createWorkspaceConfig());
 
         expect(store.isColormapInverted).toBe(false);
     });
@@ -48,8 +48,28 @@ describe("ContourConfigStore workspace colormap inversion", () => {
     test("restores an explicit inverted workspace setting", () => {
         const store = createStore(false);
 
-        store.updateFromWorkspace(createWorkspaceConfig(true));
+        store.applyConfig(createWorkspaceConfig(true));
 
         expect(store.isColormapInverted).toBe(true);
+    });
+});
+
+describe("ContourConfigStore workspace round trip", () => {
+    test("returns the applied config", () => {
+        const store = createStore(false);
+        store.setEnabled(true);
+        const config = createWorkspaceConfig(true);
+
+        store.applyConfig(config);
+
+        expect(store.toConfig()).toEqual({...config, color: store.color});
+    });
+
+    test("returns nothing when contours are disabled", () => {
+        const store = createStore(false);
+
+        store.applyConfig(createWorkspaceConfig(true));
+
+        expect(store.toConfig()).toBeUndefined();
     });
 });

--- a/src/stores/Frame/ContourStore/ContourConfigStore.ts
+++ b/src/stores/Frame/ContourStore/ContourConfigStore.ts
@@ -92,7 +92,7 @@ export class ContourConfigStore {
         this.isVisible = !this.isVisible;
     };
 
-    @action updateFromWorkspace = (config: WorkspaceContourConfig) => {
+    @action applyConfig = (config: WorkspaceContourConfig) => {
         this.levels = config.levels;
         this.smoothingMode = config.smoothingMode;
         this.smoothingFactor = config.smoothingFactor;
@@ -110,5 +110,26 @@ export class ContourConfigStore {
         if (config.colormap) {
             this.colormap = config.colormap;
         }
+    };
+
+    public toConfig = (): WorkspaceContourConfig | undefined => {
+        if (!this.isEnabled) {
+            return undefined;
+        }
+
+        return {
+            levels: this.levels,
+            smoothingMode: this.smoothingMode,
+            smoothingFactor: this.smoothingFactor,
+            color: this.color,
+            colormapEnabled: this.isColormapEnabled,
+            colormapInverted: this.isColormapInverted,
+            colormap: this.colormap,
+            colormapContrast: this.colormapContrast,
+            colormapBias: this.colormapBias,
+            dashMode: this.dashMode,
+            thickness: this.thickness,
+            visible: this.isVisible
+        };
     };
 }

--- a/src/stores/Frame/RenderConfigStore/RenderConfigStore.test.ts
+++ b/src/stores/Frame/RenderConfigStore/RenderConfigStore.test.ts
@@ -108,7 +108,7 @@ describe("RenderConfigStore alpha validation", () => {
     test("sanitizes current workspace alpha values", () => {
         const renderConfig = createRenderConfig();
 
-        renderConfig.updateFromWorkspace({alphaLog: 1e300, alphaPower: 1e300, alphaSinh: 1e-300, alphaAsinh: Number.POSITIVE_INFINITY, gamma: 1e300});
+        renderConfig.applyConfig({alphaLog: 1e300, alphaPower: 1e300, alphaSinh: 1e-300, alphaAsinh: Number.POSITIVE_INFINITY, gamma: 1e300});
 
         expect(renderConfig.alphaLog).toBe(1_000_000);
         expect(renderConfig.alphaPower).toBe(1_000_000);
@@ -121,10 +121,36 @@ describe("RenderConfigStore alpha validation", () => {
         const renderConfig = createRenderConfig();
         renderConfig.setScaling(FrameScaling.LOG);
 
-        renderConfig.updateFromWorkspace({scaling: FrameScaling.EXP});
+        renderConfig.applyConfig({scaling: FrameScaling.EXP});
         expect(renderConfig.scaling).toBe(FrameScaling.LOG);
 
-        renderConfig.updateFromWorkspace({scaling: FrameScaling.ASINH});
+        renderConfig.applyConfig({scaling: FrameScaling.ASINH});
         expect(renderConfig.scaling).toBe(FrameScaling.ASINH);
+    });
+});
+
+describe("RenderConfigStore workspace round trip", () => {
+    test("returns the applied config", () => {
+        const renderConfig = createRenderConfig();
+        const config = {
+            scaling: FrameScaling.LOG,
+            colorMap: "viridis",
+            bias: 0.1,
+            contrast: 1.2,
+            gamma: 2,
+            alphaLog: 500,
+            alphaPower: 500,
+            alphaSinh: 0.2,
+            alphaAsinh: 0.2,
+            inverted: true,
+            selectedPercentile: [90],
+            scaleMin: [0],
+            scaleMax: [1],
+            visible: false
+        };
+
+        renderConfig.applyConfig(config);
+
+        expect(renderConfig.toConfig()).toEqual({...config, useCubeHistogram: false, useCubeHistogramContours: false});
     });
 });

--- a/src/stores/Frame/RenderConfigStore/RenderConfigStore.ts
+++ b/src/stores/Frame/RenderConfigStore/RenderConfigStore.ts
@@ -562,7 +562,7 @@ export class RenderConfigStore {
         this.isInverted = other.isInverted;
     };
 
-    @action updateFromWorkspace = (config: WorkspaceRenderConfig) => {
+    @action applyConfig = (config: WorkspaceRenderConfig) => {
         if (isSupportedFrameScaling(config.scaling)) {
             this.scaling = config.scaling;
         }
@@ -588,5 +588,26 @@ export class RenderConfigStore {
         this.isUsingCubeHistogram = false;
         this.isUsingCubeHistogramContours = false;
         this.updateSiblings();
+    };
+
+    public toConfig = (): WorkspaceRenderConfig => {
+        return {
+            scaling: this.scaling,
+            colorMap: this.colorMap,
+            bias: this.bias,
+            contrast: this.contrast,
+            gamma: this.gamma,
+            alphaLog: this.alphaLog,
+            alphaPower: this.alphaPower,
+            alphaSinh: this.alphaSinh,
+            alphaAsinh: this.alphaAsinh,
+            inverted: this.isInverted,
+            useCubeHistogram: this.isUsingCubeHistogram,
+            useCubeHistogramContours: this.isUsingCubeHistogramContours,
+            selectedPercentile: this.selectedPercentile,
+            scaleMin: this.scaleMin,
+            scaleMax: this.scaleMax,
+            visible: this.isVisible
+        };
     };
 }

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.test.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.test.ts
@@ -53,7 +53,7 @@ describe("VectorOverlayConfigStore workspace colormap inversion", () => {
     test("uses the historical non-inverted behavior when a legacy workspace omits the setting", () => {
         const store = createStore(true);
 
-        store.updateFromWorkspace(createWorkspaceConfig());
+        store.applyConfig(createWorkspaceConfig());
 
         expect(store.isColormapInverted).toBe(false);
     });
@@ -61,8 +61,28 @@ describe("VectorOverlayConfigStore workspace colormap inversion", () => {
     test("restores an explicit inverted workspace setting", () => {
         const store = createStore(false);
 
-        store.updateFromWorkspace(createWorkspaceConfig(true));
+        store.applyConfig(createWorkspaceConfig(true));
 
         expect(store.isColormapInverted).toBe(true);
+    });
+});
+
+describe("VectorOverlayConfigStore workspace round trip", () => {
+    test("returns the applied config", () => {
+        const store = createStore(false);
+        store.setEnabled(true);
+        const config = createWorkspaceConfig(true);
+
+        store.applyConfig(config);
+
+        expect(store.toConfig()).toEqual({...config, color: store.color});
+    });
+
+    test("returns nothing when the vector overlay is disabled", () => {
+        const store = createStore(false);
+
+        store.applyConfig(createWorkspaceConfig(true));
+
+        expect(store.toConfig()).toBeUndefined();
     });
 });

--- a/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
+++ b/src/stores/Frame/VectorOverlayStore/VectorOverlayConfigStore.ts
@@ -147,7 +147,7 @@ export class VectorOverlayConfigStore {
         this.isVisible = !this.isVisible;
     };
 
-    @action updateFromWorkspace = (config: WorkspaceVectorOverlayConfig) => {
+    @action applyConfig = (config: WorkspaceVectorOverlayConfig) => {
         this.angularSource = config.angularSource;
         this.intensitySource = config.intensitySource;
         this.pixelAveraging = config.pixelAveraging;
@@ -177,5 +177,37 @@ export class VectorOverlayConfigStore {
         if (config.colormap) {
             this.colormap = config.colormap;
         }
+    };
+
+    public toConfig = (): WorkspaceVectorOverlayConfig | undefined => {
+        if (!this.isEnabled) {
+            return undefined;
+        }
+
+        return {
+            angularSource: this.angularSource,
+            intensitySource: this.intensitySource,
+            fractionalIntensity: this.isFractionalIntensity,
+            pixelAveraging: this.pixelAveraging,
+            thresholdEnabled: this.isThresholdEnabled,
+            threshold: this.threshold,
+            debiasing: this.isDebiasing,
+            qError: this.qError,
+            uError: this.uError,
+            thresholdOption: this.thresholdOption,
+            visible: this.isVisible,
+            thickness: this.thickness,
+            colormapEnabled: this.isColormapEnabled,
+            colormapInverted: this.isColormapInverted,
+            color: this.color,
+            colormap: this.colormap,
+            colormapContrast: this.colormapContrast,
+            colormapBias: this.colormapBias,
+            lengthMin: this.lengthMin,
+            lengthMax: this.lengthMax,
+            intensityMin: this.intensityMin,
+            intensityMax: this.intensityMax,
+            rotationOffset: this.rotationOffset
+        };
     };
 }

--- a/src/stores/Widgets/AnimatorWidgetStore/AnimatorWidgetStore.test.ts
+++ b/src/stores/Widgets/AnimatorWidgetStore/AnimatorWidgetStore.test.ts
@@ -19,7 +19,7 @@ describe("AnimatorWidgetStore", () => {
 
     test("restores valid settings from a layout config", () => {
         const store = new AnimatorWidgetStore();
-        store.init({
+        store.applyConfig({
             timeLabelFormat: TimeLabelFormat.RELATIVE,
             timeZoneMode: TimeZoneMode.IANA,
             ianaTimeZone: "Asia/Taipei",
@@ -46,7 +46,7 @@ describe("AnimatorWidgetStore", () => {
 
     test("ignores invalid persisted values", () => {
         const store = new AnimatorWidgetStore();
-        store.init({
+        store.applyConfig({
             timeLabelFormat: "invalid",
             timeZoneMode: "invalid",
             timeScale: "invalid",
@@ -72,7 +72,7 @@ describe("AnimatorWidgetStore", () => {
 
     test("restores a time-series image reference", () => {
         const store = new AnimatorWidgetStore();
-        store.init({
+        store.applyConfig({
             relativeTimeReference: RelativeTimeReference.IMAGE,
             relativeReferenceMjdUtc: 59000
         });
@@ -83,7 +83,7 @@ describe("AnimatorWidgetStore", () => {
 
     test("preserves an explicitly configured UTC IANA time zone", () => {
         const store = new AnimatorWidgetStore();
-        store.init({timeZoneMode: TimeZoneMode.IANA, ianaTimeZone: "UTC"});
+        store.applyConfig({timeZoneMode: TimeZoneMode.IANA, ianaTimeZone: "UTC"});
 
         store.setIanaTimeZoneIfUnset("Asia/Taipei");
 

--- a/src/stores/Widgets/AnimatorWidgetStore/AnimatorWidgetStore.ts
+++ b/src/stores/Widgets/AnimatorWidgetStore/AnimatorWidgetStore.ts
@@ -93,7 +93,7 @@ export class AnimatorWidgetStore implements AnimatorWidgetConfig {
         this.relativeTimeUnit = unit;
     };
 
-    @action init = (config: PersistedAnimatorWidgetConfig) => {
+    @action applyConfig = (config: PersistedAnimatorWidgetConfig) => {
         if (isEnumValue(TimeLabelFormat, config.timeLabelFormat)) {
             this.timeLabelFormat = config.timeLabelFormat;
         }

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.ts
@@ -1146,7 +1146,7 @@ export class CatalogWidgetStore {
         return config;
     }
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
+++ b/src/stores/Widgets/HistogramWidgetStore/HistogramWidgetStore.ts
@@ -410,7 +410,7 @@ export class HistogramWidgetStore extends RegionWidgetStore {
         this.cachedNumBins = numBins;
     };
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/RenderConfigWidgetStore/RenderConfigWidgetStore.ts
+++ b/src/stores/Widgets/RenderConfigWidgetStore/RenderConfigWidgetStore.ts
@@ -108,7 +108,7 @@ export class RenderConfigWidgetStore {
         this.linePlotInitXYBoundaries = {minXVal: minXVal, maxXVal: maxXVal, minYVal: minYVal, maxYVal: maxYVal};
     }
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpatialProfileWidgetStore/SpatialProfileWidgetStore.ts
@@ -342,7 +342,7 @@ export class SpatialProfileWidgetStore extends RegionWidgetStore {
         this.selectedStokes = stokes;
     };
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.test.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.test.ts
@@ -530,7 +530,7 @@ describe("SpectralProfileWidgetStore rest-frame coordinates", () => {
 
     test("rejects invalid redshifts and persists the new X/Y rest-frame settings", () => {
         const {widgetStore} = createWidgetStore();
-        runInAction(() => widgetStore.init({xAxisRestFrameEnabled: true, restFrameRedshift: 0.25, yAxisRestFrameEnabled: true}));
+        runInAction(() => widgetStore.applyConfig({xAxisRestFrameEnabled: true, restFrameRedshift: 0.25, yAxisRestFrameEnabled: true}));
 
         expect(widgetStore.isXAxisRestFrameEnabled).toBe(true);
         expect(widgetStore.restFrameRedshift).toBe(0.25);
@@ -602,25 +602,25 @@ describe("SpectralProfileWidgetStore rest-frame coordinates", () => {
 
     test("restores the shift mode while keeping legacy redshift configs valid", () => {
         const {widgetStore} = createWidgetStore();
-        runInAction(() => widgetStore.init({restFrameRedshift: -0.001, restFrameShiftMode: RestFrameShiftMode.RADIAL_VELOCITY}));
+        runInAction(() => widgetStore.applyConfig({restFrameRedshift: -0.001, restFrameShiftMode: RestFrameShiftMode.RADIAL_VELOCITY}));
 
         expect(widgetStore.restFrameShiftMode).toBe(RestFrameShiftMode.RADIAL_VELOCITY);
         expect(widgetStore.restFrameRadialVelocity).toBeCloseTo(-300.093, 1);
 
-        runInAction(() => widgetStore.init({restFrameRedshift: 0.25}));
+        runInAction(() => widgetStore.applyConfig({restFrameRedshift: 0.25}));
         expect(widgetStore.restFrameShiftMode).toBe(RestFrameShiftMode.RADIAL_VELOCITY);
         expect(widgetStore.restFrameRedshift).toBe(0.25);
     });
 
     test("restores the velocity convention while defaulting legacy configs to radio", () => {
         const {widgetStore} = createWidgetStore();
-        runInAction(() => widgetStore.init({restFrameShiftMode: RestFrameShiftMode.RADIAL_VELOCITY, restFrameVelocityConvention: VelocityConvention.OPTICAL}));
+        runInAction(() => widgetStore.applyConfig({restFrameShiftMode: RestFrameShiftMode.RADIAL_VELOCITY, restFrameVelocityConvention: VelocityConvention.OPTICAL}));
 
         expect(widgetStore.restFrameVelocityConvention).toBe(VelocityConvention.OPTICAL);
         expect(widgetStore.restFrameRadialVelocity).toBe(0);
 
         const {widgetStore: legacyWidgetStore} = createWidgetStore();
-        runInAction(() => legacyWidgetStore.init({restFrameRedshift: 0.25}));
+        runInAction(() => legacyWidgetStore.applyConfig({restFrameRedshift: 0.25}));
         expect(legacyWidgetStore.restFrameVelocityConvention).toBe(VelocityConvention.RADIO);
         expect(legacyWidgetStore.restFrameRadialVelocity).toBeCloseTo(59958.4916, 3);
     });

--- a/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
+++ b/src/stores/Widgets/SpectralProfileWidget/SpectralProfileWidgetStore.ts
@@ -1168,7 +1168,7 @@ export class SpectralProfileWidgetStore extends RegionWidgetStore {
         this.linePlotInitXYBoundaries = {minXVal: minXVal, maxXVal: maxXVal, minYVal: minYVal, maxYVal: maxYVal};
     }
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/StokesAnalysisWidgetStore/StokesAnalysisWidgetStore.ts
+++ b/src/stores/Widgets/StokesAnalysisWidgetStore/StokesAnalysisWidgetStore.ts
@@ -376,7 +376,7 @@ export class StokesAnalysisWidgetStore extends RegionWidgetStore {
         return AppStore.Instance.isDarkTheme ? Colors.GRAY2 : Colors.GRAY3;
     }
 
-    public init = (widgetSettings): void => {
+    public applyConfig = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -1738,7 +1738,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new AnimatorWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.animatorWidgets.set(id, widgetStore);
         }

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -1441,7 +1441,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new SpatialProfileWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.spatialProfileWidgets.set(id, widgetStore);
         }
@@ -1461,7 +1461,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new SpectralProfileWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.spectralProfileWidgets.set(id, widgetStore);
         }
@@ -1500,7 +1500,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new StokesAnalysisWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.stokesAnalysisWidgets.set(id, widgetStore);
         }
@@ -1568,7 +1568,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new CatalogWidgetStore(catalogFileId);
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.catalogWidgets.set(id, widgetStore);
             catalogStore.catalogWidgets.set(catalogFileId, id);
@@ -1684,7 +1684,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new HistogramWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.histogramWidgets.set(id, widgetStore);
         }
@@ -1704,7 +1704,7 @@ export class WidgetsStore {
         if (id) {
             const widgetStore = new RenderConfigWidgetStore();
             if (widgetSettings) {
-                widgetStore.init(widgetSettings);
+                widgetStore.applyConfig(widgetSettings);
             }
             this.renderConfigWidgets.set(id, widgetStore);
         }


### PR DESCRIPTION
**Description**

Closes #2926.

Standardize configuration application and serialization ownership across widget and frame stores while preserving existing workspace formats and runtime behavior.

What is implemented:
- Rename widget and frame configuration entry points to the consistent `applyConfig` API, including animator and spectral widget call sites.
- Move render, contour, and vector-overlay `toConfig` serialization from `WorkspaceConfig` into their owning stores.
- Update the affected unit tests and workspace restoration paths to use the shared configuration API.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [ ] API documentation added (for public variables and methods in stores)

For dependencies:
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)
