### PR TITLE
refactor(catalog): separate panel state from display settings

### DIFF
--- a/src/components/CatalogOverlay/CatalogOverlayComponent.test.ts
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.test.ts
@@ -1,8 +1,8 @@
 import {CARTA} from "carta-protobuf";
 import {runInAction} from "mobx";
 
-import {CatalogOverlay, CatalogPlotType, CatalogSystemType, CatalogType, CatalogUpdateMode} from "enums";
-import {CatalogDisplayStore, CatalogProfileStore, CatalogStore} from "stores";
+import {CatalogOverlay, CatalogPlotType, CatalogSettingsTabs, CatalogSystemType, CatalogType, CatalogUpdateMode} from "enums";
+import {CatalogDisplayStore, CatalogProfileStore, CatalogStore, WidgetsStore} from "stores";
 
 import {CatalogOverlayComponent} from "./CatalogOverlayComponent";
 
@@ -584,6 +584,18 @@ describe("CatalogOverlayComponent", () => {
             expect(widgetStore.xAxis).toBe("_RAJ2000");
             expect(widgetStore.yAxis).toBe("_DEJ2000");
         });
+    });
+
+    test("resets the size-axis tab when a settings shortcut is opened", () => {
+        const {component, componentId, widgetStore} = CreateConstructedComponentHarness(CatalogSystemType.ICRS, [{name: "ra"}, {name: "dec"}]);
+        const panelStore = WidgetsStore.Instance.catalogPanelWidgets.get(componentId);
+        widgetStore.setSizeAxisTab(CatalogSettingsTabs.SIZE_MINOR);
+        jest.spyOn(WidgetsStore.Instance, "createFloatingSettingsWidget").mockImplementation(jest.fn());
+
+        component["shortcutoOnClick"](CatalogSettingsTabs.COLOR);
+
+        expect(panelStore?.settingsTabId).toBe(CatalogSettingsTabs.COLOR);
+        expect(widgetStore.sizeAxisTabId).toBe(CatalogSettingsTabs.SIZE_MAJOR);
     });
 
     describe("isImageOverlaySelectionDirty", () => {

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -13,7 +13,7 @@ import {ClearableNumericInputComponent, FilterableTableComponent, type Filterabl
 import {CatalogOverlay, CatalogPlotType, CatalogSettingsTabs, CatalogSystemType, CatalogUpdateMode, HeaderTableColumnName, HelpType, ImageViewLayer, PreferenceKeys, RegionMode} from "enums";
 import {AbstractCatalogProfileStore} from "models";
 import {AppStore, CatalogDisplayStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore, type DefaultWidgetConfig, PreferenceStore, type WidgetProps, WidgetsStore} from "stores";
-import {type CatalogPlotWidgetStoreProps} from "stores/Widgets";
+import {type CatalogPanelStore, type CatalogPlotWidgetStoreProps} from "stores/Widgets";
 import {clamp, findAutoSelectedCatalogAxisColumn, getCatalogDataTypeDisplayName, isCatalogAxisDataType, isExcludedCoordinateName, type ProcessedColumnData, toFixed} from "utilities";
 
 import "./CatalogOverlayComponent.scss";
@@ -48,7 +48,11 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
     }
 
     @computed get catalogFileId() {
-        return CatalogStore.Instance.catalogProfiles?.get(this.widgetId);
+        return this.panelStore?.selectedCatalogId;
+    }
+
+    @computed get panelStore(): CatalogPanelStore | undefined {
+        return WidgetsStore.Instance.catalogPanelWidgets.get(this.widgetId);
     }
 
     @computed get displayStore(): CatalogDisplayStore | undefined {
@@ -66,7 +70,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
     }
 
     @action handleCatalogFileChange = (fileId: number) => {
-        CatalogStore.Instance.catalogProfiles.set(this.widgetId, fileId);
+        WidgetsStore.Instance.setCatalogPanelSelection(this.widgetId, fileId);
     };
 
     @action handleFileCloseClick = () => {
@@ -133,9 +137,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         makeObservable(this);
         this.widgetId = props.id;
 
-        if (!CatalogStore.Instance.catalogProfiles.has(this.widgetId)) {
-            CatalogStore.Instance.catalogProfiles.set(this.widgetId, 1);
-        }
+        WidgetsStore.Instance.getCatalogPanelStore(this.widgetId, CatalogStore.Instance.catalogProfiles.get(this.widgetId) ?? 1);
         this.catalogFileNames = new Map<number, string>();
 
         this.disposers.push(
@@ -813,7 +815,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
         if (position) {
             this.isShowHeader = position === 100 ? false : true;
             this.prevPosition = position < 60 ? position : 60;
-            this.displayStore?.setTableSeparatorPosition(`${position.toPrecision(4)}%`);
+            this.panelStore?.setTableSeparatorPosition(`${position.toPrecision(4)}%`);
             PreferenceStore.Instance.setPreference(PreferenceKeys.CATALOG_TABLE_SEPARATOR_POSITION, `${position.toPrecision(4)}%`);
         }
 
@@ -827,10 +829,9 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
     };
 
     @action private handleHideHeader = () => {
-        const displayStore = this.displayStore;
-        const position = displayStore?.tableSeparatorPosition !== "100%" ? 100 : this.prevPosition;
+        const position = this.panelStore?.tableSeparatorPosition !== "100%" ? 100 : this.prevPosition;
         this.isShowHeader = position === 100 ? false : true;
-        displayStore?.setTableSeparatorPosition(`${position}%`);
+        this.panelStore?.setTableSeparatorPosition(`${position}%`);
     };
 
     private renderSystemPopOver = (system: CatalogSystemType, itemProps: ItemRendererProps) => {
@@ -858,7 +859,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
     };
 
     private shortcutoOnClick = (type: CatalogSettingsTabs) => {
-        this.displayStore?.setSettingsTabId(type);
+        this.panelStore?.setSettingsTabId(type);
         AppStore.Instance.widgetsStore.createFloatingSettingsWidget(CatalogOverlayComponent.WidgetConfig.title ?? "", this.widgetId, CatalogOverlayComponent.WidgetConfig.type);
     };
 
@@ -1047,7 +1048,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
                             className={"catalog-overlay-data-container"}
                             minSize={`${CatalogDisplayStore.MIN_TABLE_SEPARATOR_POSITION}%`}
                             maxSize={`${CatalogDisplayStore.MAX_TABLE_SEPARATOR_POSITION}%`}
-                            size={catalogDisplayStore.tableSeparatorPosition}
+                            size={this.panelStore?.tableSeparatorPosition}
                         >
                             <FilterableTableComponent {...dataTableProps} />
                         </Pane>

--- a/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayComponent.tsx
@@ -860,6 +860,7 @@ export class CatalogOverlayComponent extends React.Component<WidgetProps> {
 
     private shortcutoOnClick = (type: CatalogSettingsTabs) => {
         this.panelStore?.setSettingsTabId(type);
+        this.displayStore?.setSizeAxisTab(CatalogSettingsTabs.SIZE_MAJOR);
         AppStore.Instance.widgetsStore.createFloatingSettingsWidget(CatalogOverlayComponent.WidgetConfig.title ?? "", this.widgetId, CatalogOverlayComponent.WidgetConfig.type);
     };
 

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.test.ts
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.test.ts
@@ -1,5 +1,5 @@
-import {FrameScaling} from "enums";
-import {type CatalogDisplayStore} from "stores";
+import {CatalogSettingsTabs, FrameScaling} from "enums";
+import {type CatalogDisplayStore, type CatalogPanelStore} from "stores";
 
 import {CatalogOverlayPlotSettingsPanelComponent} from "./CatalogOverlayPlotSettingsPanelComponent";
 
@@ -14,6 +14,7 @@ interface TestableCatalogSettingsComponent {
     handleColormapHovered: (widgetStore: CatalogDisplayStore, colormap: string) => void;
     handleColormapSelected: (widgetStore: CatalogDisplayStore, colormap: string) => void;
     handleColormapDropdownOpenChange: (isOpen: boolean) => void;
+    handleSelectedTabChanged: (newTabId: string | number) => void;
     renderScalingParameter: (
         scaling: FrameScaling,
         value: number,
@@ -124,5 +125,20 @@ describe("CatalogOverlayPlotSettingsPanelComponent colormap preview", () => {
         component.handleColormapDropdownOpenChange(false);
 
         expect(widgetStore.colorMap).toBe("magma");
+    });
+});
+
+describe("CatalogOverlayPlotSettingsPanelComponent settings tabs", () => {
+    test("returns to the major size axis when the top-level tab changes", () => {
+        const displayStore = {setSizeAxisTab: jest.fn()} as unknown as CatalogDisplayStore;
+        const panelStore = {setSettingsTabId: jest.fn()} as unknown as CatalogPanelStore;
+        const component = createComponent();
+        Object.defineProperty(component, "displayStore", {configurable: true, get: () => displayStore});
+        Object.defineProperty(component, "panelStore", {configurable: true, get: () => panelStore});
+
+        component.handleSelectedTabChanged(CatalogSettingsTabs.COLOR);
+
+        expect(panelStore.setSettingsTabId).toHaveBeenCalledWith(CatalogSettingsTabs.COLOR);
+        expect(displayStore.setSizeAxisTab).toHaveBeenCalledWith(CatalogSettingsTabs.SIZE_MAJOR);
     });
 });

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -1047,9 +1047,10 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
         return <MenuItem icon={shapeItem} key={shape} text={""} onClick={itemProps.handleClick} active={itemProps.modifiers.active} data-testid={"catalog-settings-shape-" + CatalogOverlayShape[shape].toLowerCase().replaceAll("_", "-")} />;
     };
 
-    private handleSelectedTabChanged = (newTabId: string | number) => {
+    private handleSelectedTabChanged(newTabId: string | number) {
         this.panelStore?.setSettingsTabId(Number.parseInt(newTabId.toString()) as CatalogSettingsTabs);
-    };
+        this.displayStore?.setSizeAxisTab(CatalogSettingsTabs.SIZE_MAJOR);
+    }
 
     private handleSelectedAxisTabChanged = (newTabId: string | number) => {
         this.displayStore?.setSizeAxisTab(Number.parseInt(newTabId.toString()));

--- a/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogOverlayPlotSettingsPanelComponent/CatalogOverlayPlotSettingsPanelComponent.tsx
@@ -7,7 +7,8 @@ import {observer} from "mobx-react";
 
 import {AutoColorPickerComponent, ClearableNumericInputComponent, ColormapComponent, SafeNumericInput, ScalingParameterControlComponent, ScalingSelectComponent, ScrollShadow} from "components/Shared";
 import {AngularSizeUnit, CatalogDisplayMode, CatalogOverlay, CatalogOverlayShape, CatalogSettingsTabs, CatalogSizeUnits, FrameScaling, HelpType, ValueClip} from "enums";
-import {AppStore, CatalogDisplayStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore, type DefaultWidgetConfig, type WidgetProps} from "stores";
+import {AppStore, CatalogDisplayStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore, type DefaultWidgetConfig, type WidgetProps, WidgetsStore} from "stores";
+import {type CatalogPanelStore} from "stores/Widgets";
 import {getColorForTheme, getScalingParameterConfig, isCatalogAxisDataType, SWATCH_COLORS} from "utilities";
 
 import "./CatalogOverlayPlotSettingsPanelComponent.scss";
@@ -90,7 +91,11 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
     }
 
     @computed get catalogFileId() {
-        return CatalogStore.Instance.catalogProfiles?.get(this.widgetId);
+        return this.panelStore?.selectedCatalogId;
+    }
+
+    @computed get panelStore(): CatalogPanelStore | undefined {
+        return WidgetsStore.Instance.catalogPanelWidgets.get(this.widgetId);
     }
 
     @computed get profileStore(): CatalogProfileStore | CatalogOnlineQueryProfileStore | undefined {
@@ -130,6 +135,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                 const catalogFileId = this.catalogFileId;
                 if (catalogFileId !== undefined) {
                     const activeFiles = catalogStore.activeCatalogFiles;
+                    WidgetsStore.Instance.getCatalogPanelStore(this.widgetId, catalogFileId);
                     catalogStore.getOrCreateCatalogDisplayStore(catalogFileId);
 
                     if (activeFiles?.includes(catalogFileId)) {
@@ -258,7 +264,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
     }
 
     @action handleCatalogFileChange = (fileId: number) => {
-        CatalogStore.Instance.catalogProfiles?.set(this.widgetId, fileId);
+        WidgetsStore.Instance.setCatalogPanelSelection(this.widgetId, fileId);
     };
 
     private renderScalingParameter(scaling: FrameScaling, value: number, onValueChange: (value: number) => void, isDisabled: boolean): React.ReactNode {
@@ -948,7 +954,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
                             />
                         </ButtonGroup>
                     </FormGroup>
-                    <Tabs id="catalogSettings" vertical={false} selectedTabId={displayStore.settingsTabId} onChange={tabId => this.handleSelectedTabChanged(tabId)}>
+                    <Tabs id="catalogSettings" vertical={false} selectedTabId={this.panelStore?.settingsTabId} onChange={tabId => this.handleSelectedTabChanged(tabId)}>
                         <Tab id={CatalogSettingsTabs.SIZE} title="Size" panel={displayStore.catalogDisplayMode === CatalogDisplayMode.WORLD ? angularSizePanel : sizeMap} disabled={isOverlayPanelDisabled} />
                         <Tab id={CatalogSettingsTabs.COLOR} title="Color" panel={colorMap} disabled={isOverlayPanelDisabled} data-testid="catalog-settings-color-tab-title" />
                         <Tab id={CatalogSettingsTabs.ORIENTATION} title="Orientation" panel={orientationMap} disabled={isOverlayPanelDisabled} data-testid="catalog-settings-orientation-tab-title" />
@@ -1042,7 +1048,7 @@ export class CatalogOverlayPlotSettingsPanelComponent extends React.Component<Wi
     };
 
     private handleSelectedTabChanged = (newTabId: string | number) => {
-        this.displayStore?.setSettingsTabId(Number.parseInt(newTabId.toString()));
+        this.panelStore?.setSettingsTabId(Number.parseInt(newTabId.toString()) as CatalogSettingsTabs);
     };
 
     private handleSelectedAxisTabChanged = (newTabId: string | number) => {

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.test.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.test.tsx
@@ -1,0 +1,42 @@
+import {CatalogPlotType} from "enums";
+import {CatalogStore, WidgetsStore} from "stores";
+
+import {CatalogPlotComponent} from "./CatalogPlotComponent";
+
+describe("CatalogPlotComponent catalog selection", () => {
+    afterEach(() => {
+        WidgetsStore.Instance.catalogPanelWidgets.clear();
+        jest.restoreAllMocks();
+    });
+
+    test("updates the panel selection when a plot selection is made", () => {
+        const catalogStore = CatalogStore.Instance;
+        const widgetsStore = WidgetsStore.Instance;
+        const profileStore = {
+            catalogInfo: {fileId: 7, fileInfo: {name: "test-catalog"}},
+            getOriginIndices: jest.fn(() => [12]),
+            setSelectedPointIndices: jest.fn()
+        };
+        const catalogDisplayStore = {
+            setCatalogTableAutoScroll: jest.fn()
+        };
+        const widgetStore = {
+            dragMode: "lasso",
+            plotType: CatalogPlotType.D2Scatter
+        };
+        catalogStore.catalogProfileStores.set(7, profileStore as any);
+        catalogStore.setCatalogPlots("catalog-plot-component-0", 7, "catalog-plot-0");
+        widgetsStore.catalogPlotWidgets.set("catalog-plot-0", widgetStore as any);
+        catalogStore.catalogDisplayStores.set(7, catalogDisplayStore as any);
+        const panel = widgetsStore.getCatalogPanelStore("catalog-overlay-component-0", 1);
+        const component = new CatalogPlotComponent({id: "catalog-plot-0", docked: false} as any);
+
+        component["onLassoSelected"]({points: [{pointIndex: 3}]} as any);
+        component.componentWillUnmount();
+
+        expect(panel.selectedCatalogId).toBe(7);
+        expect(profileStore.getOriginIndices).toHaveBeenCalledWith([3]);
+        expect(profileStore.setSelectedPointIndices).toHaveBeenCalledWith([12], true);
+        expect(catalogDisplayStore.setCatalogTableAutoScroll).toHaveBeenCalledWith(true);
+    });
+});

--- a/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
+++ b/src/components/CatalogOverlay/CatalogPlotComponent/CatalogPlotComponent.tsx
@@ -588,7 +588,6 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
     // region selection
     private onLassoSelected = (event: Plotly.PlotSelectionEvent) => {
         if (event && event.points && event.points.length > 0) {
-            const catalogStore = CatalogStore.Instance;
             const profileStore = this.profileStore;
             const catalogDisplayStore = this.catalogDisplayStore;
             const widgetStore = this.widgetStore;
@@ -596,7 +595,7 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
                 return;
             }
             const catalogFileId = profileStore.catalogInfo.fileId;
-            catalogStore.updateCatalogProfiles(catalogFileId);
+            WidgetsStore.Instance.updateCatalogPanelSelection(catalogFileId);
 
             let selectedPointIndices;
             if (widgetStore.plotType === CatalogPlotType.D2Scatter) {
@@ -633,11 +632,10 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
     };
 
     private onDeselect = () => {
-        const catalogStore = CatalogStore.Instance;
         const profileStore = this.profileStore;
         const widgetsStore = this.widgetStore;
         const catalogDisplayStore = this.catalogDisplayStore;
-        catalogStore.updateCatalogProfiles(this.catalogFileId);
+        WidgetsStore.Instance.updateCatalogPanelSelection(this.catalogFileId);
         profileStore?.setSelectedPointIndices([], false);
         catalogDisplayStore?.setShowSelectedData(false);
         widgetsStore?.initLinearFitting();
@@ -653,9 +651,8 @@ export class CatalogPlotComponent extends React.Component<WidgetProps> {
         const profileStore = this.profileStore;
         const catalogDisplayStore = this.catalogDisplayStore;
         if (event?.points?.length > 0 && isInDragMode && profileStore && catalogDisplayStore) {
-            const catalogStore = CatalogStore.Instance;
             const catalogFileId = profileStore.catalogInfo.fileId;
-            catalogStore.updateCatalogProfiles(catalogFileId);
+            WidgetsStore.Instance.updateCatalogPanelSelection(catalogFileId);
             let selectedPointIndex: number[] = [];
             const selectedPoint = event.points[0] as any;
             if (widgetStore.plotType === CatalogPlotType.D2Scatter) {

--- a/src/components/FloatingWidget/FloatingWidgetComponent.tsx
+++ b/src/components/FloatingWidget/FloatingWidgetComponent.tsx
@@ -8,7 +8,7 @@ import {PlaceholderComponent, PvPreviewComponent, RenderConfigComponent} from "c
 import {HelpType, ImageType} from "enums";
 import {CustomIcon} from "icons/CustomIcons";
 import {canPopoutWidget} from "models/Layout/FlexLayoutModelFactory";
-import {AppStore, CatalogStore, HelpStore, LayoutStore, type WidgetConfig} from "stores";
+import {AppStore, HelpStore, LayoutStore, type WidgetConfig} from "stores";
 
 import "./FloatingWidgetComponent.scss";
 
@@ -96,13 +96,7 @@ export class FloatingWidgetComponent extends React.Component<FloatingWidgetCompo
     };
 
     private getCatalogOverlaySettingsTab = (parentId: string): number | undefined => {
-        const catalogStore = CatalogStore.Instance;
-        const catalogFileId = catalogStore.catalogProfiles.get(parentId);
-        if (!catalogFileId) {
-            return undefined;
-        }
-
-        return catalogStore.getCatalogDisplayStore(catalogFileId)?.settingsTabId;
+        return AppStore.Instance.widgetsStore.catalogPanelWidgets.get(parentId)?.settingsTabId;
     };
 
     private getSettingsTab = (parentId: string, parentType?: string): number | undefined => {

--- a/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.test.tsx
+++ b/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.test.tsx
@@ -1,0 +1,29 @@
+import {CatalogOverlayComponent} from "components/CatalogOverlay/CatalogOverlayComponent";
+import {CatalogStore, WidgetsStore} from "stores";
+
+import {FloatingWidgetManagerComponent} from "./FloatingWidgetManagerComponent";
+
+describe("FloatingWidgetManagerComponent catalog panels", () => {
+    afterEach(() => {
+        WidgetsStore.Instance.catalogPanelWidgets.clear();
+        WidgetsStore.Instance.floatingWidgets = [];
+        CatalogStore.Instance.catalogProfiles.clear();
+        jest.restoreAllMocks();
+    });
+
+    test("removes the panel store when a floating catalog overlay closes", () => {
+        const widgetsStore = WidgetsStore.Instance;
+        const catalogStore = CatalogStore.Instance;
+        const componentId = "catalog-overlay-component-0";
+        const panelStore = widgetsStore.getCatalogPanelStore(componentId, 7);
+        catalogStore.catalogProfiles.set(componentId, 7);
+        widgetsStore.floatingWidgets.push({componentId, id: componentId, type: CatalogOverlayComponent.WidgetConfig.type} as any);
+
+        new FloatingWidgetManagerComponent({}).onFloatingWidgetClosed({componentId, id: componentId, type: CatalogOverlayComponent.WidgetConfig.type} as any);
+
+        expect(widgetsStore.catalogPanelWidgets.has(componentId)).toBe(false);
+        expect(catalogStore.catalogProfiles.has(componentId)).toBe(false);
+        expect(widgetsStore.floatingWidgets).toHaveLength(0);
+        expect(panelStore.selectedCatalogId).toBe(7);
+    });
+});

--- a/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
+++ b/src/components/FloatingWidgetManager/FloatingWidgetManagerComponent.tsx
@@ -69,6 +69,7 @@ export class FloatingWidgetManagerComponent extends React.Component {
 
         const widgetsStore = WidgetsStore.Instance;
         widgetsStore.removeFloatingWidgetComponent(componentId);
+        widgetsStore.catalogPanelWidgets.delete(componentId);
         CatalogStore.Instance.catalogProfiles.delete(componentId);
     };
 

--- a/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
+++ b/src/components/ImageView/CatalogView/CatalogViewGLComponent.tsx
@@ -6,7 +6,7 @@ import tinycolor from "tinycolor2";
 import {canvasToTransformedImagePos} from "components/ImageView/RegionView/shared";
 import {CatalogOverlayShape, CatalogTextureType, ImageViewLayer} from "enums";
 import {CatalogWebGLService} from "services";
-import {AppStore, CatalogStore} from "stores";
+import {AppStore, CatalogStore, WidgetsStore} from "stores";
 import {type FrameStore} from "stores/Frame";
 import {closestCatalogIndexToCursor, COLOR_MAPS_ALL, GL2, rotate2D, scale2D, subtract2D} from "utilities";
 
@@ -375,7 +375,7 @@ export class CatalogViewGLComponent extends React.Component<CatalogViewGLCompone
             const catalogProfileStore = catalogStore.catalogProfileStores.get(selectedPoint.fileId);
             if (catalogProfileStore) {
                 const catalogDisplayStore = catalogStore.getCatalogDisplayStore(selectedPoint.fileId);
-                catalogStore.updateCatalogProfiles(selectedPoint.fileId);
+                WidgetsStore.Instance.updateCatalogPanelSelection(selectedPoint.fileId);
                 const matched = catalogProfileStore.getOriginIndices([selectedPoint.minIndex]);
                 catalogProfileStore.setSelectedPointIndices(matched, false);
                 catalogDisplayStore?.setCatalogTableAutoScroll(true);

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -1,8 +1,8 @@
 import type {RgbaColor} from "@uiw/react-color";
 import {type CARTA} from "carta-protobuf";
 
-import {type ContourDashMode, FrameScaling, type VectorOverlaySource} from "enums";
-import {sanitizeScalingParameter} from "utilities/scaling/scaling";
+import {type AngularSizeUnit, type CatalogDisplayMode, type CatalogOverlayShape, type CatalogPlotType, type CatalogSizeUnits, type ContourDashMode, FrameScaling, type VectorOverlaySource} from "enums";
+import {sanitizeScalingParameter, type ScalingParameters} from "utilities/scaling/scaling";
 
 import {type Point2D} from "./Point2D/Point2D";
 
@@ -67,6 +67,69 @@ export interface WorkspaceVectorOverlayConfig {
     intensityMin: number | undefined;
     intensityMax: number | undefined;
     rotationOffset: number;
+}
+
+/** One catalog size axis: the major axis, or the minor axis of an ellipse. */
+export interface WorkspaceCatalogSizeAxisConfig {
+    mapColumn?: string;
+    /** Lower end of the mapped data range, as clipped by the user. */
+    columnMinClip?: number;
+    /** Upper end of the mapped data range, as clipped by the user. */
+    columnMaxClip?: number;
+    min?: {area: number; diameter: number};
+    max?: {area: number; diameter: number};
+    areaMode?: boolean;
+    scalingType?: FrameScaling;
+    scalingParameters?: ScalingParameters;
+    /** Whether the minor axis follows this axis at the lower end. */
+    columnMinLocked?: boolean;
+    /** Whether the minor axis follows this axis at the upper end. */
+    columnMaxLocked?: boolean;
+}
+
+export interface WorkspaceCatalogColorAxisConfig {
+    mapColumn?: string;
+    columnMinClip?: number;
+    columnMaxClip?: number;
+    colorMap?: string;
+    inverted?: boolean;
+    scalingType?: FrameScaling;
+    scalingParameters?: ScalingParameters;
+}
+
+export interface WorkspaceCatalogOrientationAxisConfig {
+    mapColumn?: string;
+    columnMinClip?: number;
+    columnMaxClip?: number;
+    /** Lower end of the angle range the mapped data is spread over, in degrees. */
+    angleMin?: number;
+    /** Upper end of the angle range the mapped data is spread over, in degrees. */
+    angleMax?: number;
+    scalingType?: FrameScaling;
+    scalingParameters?: ScalingParameters;
+}
+
+/**
+ * How one catalog is drawn. Holds only what the user authored: the state a panel keeps for its
+ * own presentation, and the values recomputed from the catalog data, are deliberately absent.
+ */
+export interface WorkspaceCatalogConfig {
+    color?: string;
+    highlightColor?: string;
+    shape?: CatalogOverlayShape;
+    /** Source size in the current size unit, as entered by the user. */
+    size?: number;
+    thickness?: number;
+    displayMode?: CatalogDisplayMode;
+    canvasSizeUnit?: CatalogSizeUnits;
+    worldSizeUnit?: AngularSizeUnit;
+    plotType?: CatalogPlotType;
+    xAxis?: string;
+    yAxis?: string;
+    sizeAxis?: WorkspaceCatalogSizeAxisConfig;
+    sizeMinorAxis?: WorkspaceCatalogSizeAxisConfig;
+    colorAxis?: WorkspaceCatalogColorAxisConfig;
+    orientationAxis?: WorkspaceCatalogOrientationAxisConfig;
 }
 
 export interface WorkspaceRegion {

--- a/src/models/Workspace.ts
+++ b/src/models/Workspace.ts
@@ -72,9 +72,9 @@ export interface WorkspaceVectorOverlayConfig {
 /** One catalog size axis: the major axis, or the minor axis of an ellipse. */
 export interface WorkspaceCatalogSizeAxisConfig {
     mapColumn?: string;
-    /** Lower end of the mapped data range, as clipped by the user. */
+    /** Lower end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMinClip?: number;
-    /** Upper end of the mapped data range, as clipped by the user. */
+    /** Upper end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMaxClip?: number;
     min?: {area: number; diameter: number};
     max?: {area: number; diameter: number};
@@ -89,7 +89,9 @@ export interface WorkspaceCatalogSizeAxisConfig {
 
 export interface WorkspaceCatalogColorAxisConfig {
     mapColumn?: string;
+    /** Lower end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMinClip?: number;
+    /** Upper end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMaxClip?: number;
     colorMap?: string;
     inverted?: boolean;
@@ -99,7 +101,9 @@ export interface WorkspaceCatalogColorAxisConfig {
 
 export interface WorkspaceCatalogOrientationAxisConfig {
     mapColumn?: string;
+    /** Lower end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMinClip?: number;
+    /** Upper end of the mapped data range, as clipped by the user. Absent while it follows the data. */
     columnMaxClip?: number;
     /** Lower end of the angle range the mapped data is spread over, in degrees. */
     angleMin?: number;

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -80,7 +80,7 @@ export class BackendService {
     readonly spectralProfileStream: Subject<CARTA.SpectralProfileData>;
     readonly statsStream: Subject<CARTA.RegionStatsData>;
     readonly contourStream: Subject<CARTA.ContourImageData>;
-    readonly catalogStream: Subject<CARTA.CatalogFilterResponse>;
+    readonly catalogStream: Subject<CARTA.CatalogFilterResponse & {eventId?: number}>;
     readonly momentProgressStream: Subject<CARTA.MomentProgress>;
     readonly scriptingStream: Subject<CARTA.ScriptingRequest>;
     readonly listProgressStream: Subject<CARTA.ListProgress>;
@@ -577,11 +577,12 @@ export class BackendService {
     }
 
     @action("set catalog filter")
-    setCatalogFilterRequest(filterRequest: CARTA.CatalogFilterRequest.$Properties) {
+    setCatalogFilterRequest(filterRequest: CARTA.CatalogFilterRequest.$Properties): number | false {
         if (this.connectionStatus === ConnectionStatus.ACTIVE) {
-            this.logEvent(CARTA.EventType.CATALOG_FILTER_REQUEST, this.eventCounter, filterRequest, false);
+            const requestId = this.eventCounter;
+            this.logEvent(CARTA.EventType.CATALOG_FILTER_REQUEST, requestId, filterRequest, false);
             if (this.sendEvent(CARTA.EventType.CATALOG_FILTER_REQUEST, CARTA.CatalogFilterRequest.encode(filterRequest).finish())) {
-                return true;
+                return requestId;
             }
         }
         return false;
@@ -1025,7 +1026,8 @@ export class BackendService {
         this.scriptingStream.next(scriptingRequest);
     }
 
-    private onStreamedCatalogData(_eventId: number, catalogFilter: CARTA.CatalogFilterResponse) {
+    private onStreamedCatalogData(eventId: number, catalogFilter: CARTA.CatalogFilterResponse) {
+        Object.defineProperty(catalogFilter, "eventId", {configurable: true, enumerable: false, value: eventId});
         this.catalogStream.next(catalogFilter);
     }
 

--- a/src/stores/AppStore/AppStore.test.ts
+++ b/src/stores/AppStore/AppStore.test.ts
@@ -7,11 +7,28 @@ import {ProtobufProcessing} from "utilities";
 describe("AppStore.handleCatalogFilterStream", () => {
     const appStore = AppStore.Instance;
     const catalogStore = appStore.catalogStore;
+    const widgetsStore = appStore.widgetsStore;
 
     beforeEach(() => {
         jest.restoreAllMocks();
         catalogStore.catalogProfileStores.clear();
         catalogStore.catalogDisplayStores.clear();
+        catalogStore.catalogProfiles.clear();
+        catalogStore.imageAssociatedCatalogId.clear();
+        widgetsStore.catalogPanelWidgets.clear();
+    });
+
+    test("updates an existing panel when loading a catalog after the panel store exists", () => {
+        const panel = widgetsStore.getCatalogPanelStore("catalog-overlay-component-0", 1);
+        catalogStore.imageAssociatedCatalogId.set(100, [1]);
+
+        jest.spyOn(widgetsStore, "createFloatingCatalogWidget");
+
+        const componentId = appStore.updateCatalogProfile(2, {frameInfo: {fileId: 100}} as any);
+
+        expect(componentId).toBe("catalog-overlay-component-0");
+        expect(widgetsStore.createFloatingCatalogWidget).not.toHaveBeenCalled();
+        expect(panel.selectedCatalogId).toBe(2);
     });
 
     test("skips coordinate conversion when the selected x axis is CatalogOverlay.NONE", () => {

--- a/src/stores/AppStore/AppStore.test.ts
+++ b/src/stores/AppStore/AppStore.test.ts
@@ -31,6 +31,18 @@ describe("AppStore.handleCatalogFilterStream", () => {
         expect(panel.selectedCatalogId).toBe(2);
     });
 
+    test("updates every panel when the first catalog is loaded for a new image", () => {
+        const firstPanel = widgetsStore.getCatalogPanelStore("catalog-overlay-component-0", 1);
+        const secondPanel = widgetsStore.getCatalogPanelStore("catalog-overlay-component-1", 1);
+        catalogStore.imageAssociatedCatalogId.set(101, []);
+
+        const componentId = appStore.updateCatalogProfile(3, {frameInfo: {fileId: 101}} as any);
+
+        expect(componentId).toBe("catalog-overlay-component-0");
+        expect(firstPanel.selectedCatalogId).toBe(3);
+        expect(secondPanel.selectedCatalogId).toBe(3);
+    });
+
     test("skips coordinate conversion when the selected x axis is CatalogOverlay.NONE", () => {
         const processedData = new Map<number, unknown>();
         const profileStore = {

--- a/src/stores/AppStore/AppStore.test.ts
+++ b/src/stores/AppStore/AppStore.test.ts
@@ -174,6 +174,21 @@ describe("AppStore.handleCatalogFilterStream", () => {
         expect(convertSpy).not.toHaveBeenCalled();
         expect(widgetStore.setPlottedImageOverlayState).not.toHaveBeenCalled();
     });
+
+    test("completes a request when its profile store was removed before the final response", () => {
+        catalogStore.registerCatalogRequest(7, 42);
+
+        appStore.handleCatalogFilterStream({
+            columns: [],
+            eventId: 42,
+            fileId: 7,
+            progress: 1,
+            subsetDataSize: 0,
+            subsetEndIndex: 0
+        } as unknown as CARTA.CatalogFilterResponse);
+
+        expect(catalogStore.acceptsCatalogResponse(7, 42)).toBe(false);
+    });
 });
 
 describe("scaleZoomForImageRatio", () => {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -2472,6 +2472,9 @@ export class AppStore {
         const catalogProfileStore = this.catalogStore.catalogProfileStores.get(catalogFileId);
 
         const progress = catalogFilter.progress;
+        if (progress === 1) {
+            this.catalogStore.completeCatalogRequest(catalogFileId, catalogFilter.eventId);
+        }
         if (catalogProfileStore) {
             const isColumnUpdateMode = catalogProfileStore.isUpdateColumnMode;
             const catalogData = ProtobufProcessing.processCatalogData(catalogFilter.columns);
@@ -2480,7 +2483,6 @@ export class AppStore {
             if (progress === 1) {
                 catalogProfileStore.setLoadingDataStatus(false);
                 catalogProfileStore.setUpdatingDataStream(false);
-                this.catalogStore.completeCatalogRequest(catalogFileId, catalogFilter.eventId);
             }
 
             if (!isColumnUpdateMode && catalogProfileStore.updateMode === CatalogUpdateMode.ViewUpdate) {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1245,9 +1245,7 @@ export class AppStore {
             associatedCatalogFiles = currentAssociatedCatalogFile;
         } else {
             // new image append
-            catalogStore.catalogProfiles.forEach((value, componentId) => {
-                catalogStore.catalogProfiles.set(componentId, fileId);
-            });
+            this.widgetsStore.resetCatalogPanelSelections([fileId]);
         }
         associatedCatalogFiles.push(fileId);
         if (AppStore.Instance.activeFrame) {

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1239,7 +1239,7 @@ export class AppStore {
         // update image associated catalog file
         let associatedCatalogFiles: number[] = [];
         const catalogStore = CatalogStore.Instance;
-        const catalogComponentSize = catalogStore.catalogProfiles.size;
+        const catalogComponentSize = this.widgetsStore.catalogPanelWidgets.size;
         const currentAssociatedCatalogFile = catalogStore.imageAssociatedCatalogId.get(frame.frameInfo.fileId);
         if (currentAssociatedCatalogFile?.length) {
             associatedCatalogFiles = currentAssociatedCatalogFile;
@@ -1259,10 +1259,7 @@ export class AppStore {
             catalogComponentId = this.widgetsStore.createFloatingCatalogWidget(fileId);
             catalogStore.catalogProfiles.set(catalogComponentId, fileId);
         } else {
-            catalogComponentId = catalogStore.catalogProfiles.keys().next().value;
-            if (catalogComponentId) {
-                catalogStore.catalogProfiles.set(catalogComponentId, fileId);
-            }
+            catalogComponentId = this.widgetsStore.updateCatalogPanelSelection(fileId);
         }
         return catalogComponentId;
     };

--- a/src/stores/AppStore/AppStore.ts
+++ b/src/stores/AppStore/AppStore.ts
@@ -1285,11 +1285,15 @@ export class AppStore {
         }
     }
 
-    @action sendCatalogFilter(catalogFilter: CARTA.CatalogFilterRequest.$Properties) {
+    @action sendCatalogFilter(catalogFilter: CARTA.CatalogFilterRequest.$Properties): number | false {
         if (!this.activeFrame) {
-            return;
+            return false;
         }
-        this.backendService.setCatalogFilterRequest(catalogFilter);
+        const requestId = this.backendService.setCatalogFilterRequest(catalogFilter);
+        if (typeof requestId === "number" && catalogFilter.fileId !== null && catalogFilter.fileId !== undefined) {
+            this.catalogStore.registerCatalogRequest(catalogFilter.fileId, requestId);
+        }
+        return requestId;
     }
 
     /**
@@ -2465,8 +2469,11 @@ export class AppStore {
         }
     };
 
-    @action handleCatalogFilterStream = (catalogFilter: CARTA.CatalogFilterResponse) => {
+    @action handleCatalogFilterStream = (catalogFilter: CARTA.CatalogFilterResponse & {eventId?: number}) => {
         const catalogFileId = catalogFilter.fileId;
+        if (!this.catalogStore.acceptsCatalogResponse(catalogFileId, catalogFilter.eventId)) {
+            return;
+        }
         const catalogProfileStore = this.catalogStore.catalogProfileStores.get(catalogFileId);
 
         const progress = catalogFilter.progress;
@@ -2478,6 +2485,7 @@ export class AppStore {
             if (progress === 1) {
                 catalogProfileStore.setLoadingDataStatus(false);
                 catalogProfileStore.setUpdatingDataStream(false);
+                this.catalogStore.completeCatalogRequest(catalogFileId, catalogFilter.eventId);
             }
 
             if (!isColumnUpdateMode && catalogProfileStore.updateMode === CatalogUpdateMode.ViewUpdate) {

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -1,5 +1,6 @@
 import {Colors} from "@blueprintjs/core";
 import * as CARTACompute from "carta_computation";
+import {CARTA} from "carta-protobuf";
 import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {AngularSizeUnit, CatalogDisplayMode, CatalogMapType, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogSizeUnits, type CatalogSystemType, CatalogTextureType, ColorMap, FrameScaling} from "enums";
@@ -62,6 +63,25 @@ function normalizeOrientationAxis(axis: WorkspaceCatalogOrientationAxisConfig | 
         scalingType: axis?.scalingType ?? FrameScaling.LINEAR,
         scalingParameters: scalingParametersFromConfig(axis?.scalingParameters)
     };
+}
+
+/**
+ * Whether the clipped bounds a config asks for are the config's own. An unmapped column has no
+ * bounds, and a config that states bounds authored them, so both survive a recompute. A mapped
+ * column with no stated bounds asks for the bounds of the catalog data instead, which the store
+ * recomputes for itself, so those must not be held across the recompute.
+ */
+function configDefinesClip(axis: {mapColumn: string; columnMinClip?: number; columnMaxClip?: number}): boolean {
+    return axis.mapColumn === CatalogOverlay.NONE || axis.columnMinClip !== undefined || axis.columnMaxClip !== undefined;
+}
+
+/**
+ * The clipped bound worth keeping in a config. Until the user clips a bound it holds the range of
+ * the catalog data, which the store recomputes whenever that data changes, so only a bound that
+ * differs from its data-derived default was authored by the user and belongs in a config.
+ */
+function authoredClip(bound: {default: number | undefined; clipd: number | undefined}): number | undefined {
+    return bound.clipd === bound.default ? undefined : bound.clipd;
 }
 
 export class CatalogDisplayStore {
@@ -1235,7 +1255,7 @@ export class CatalogDisplayStore {
         const colorAxis = normalizeColorAxis(config?.colorAxis);
         const orientationAxis = normalizeOrientationAxis(config?.orientationAxis);
 
-        const errors = [
+        const mappedColumnErrors = [
             ["size", sizeAxis.mapColumn],
             ["minor size", sizeMinorAxis.mapColumn],
             ["color", colorAxis.mapColumn],
@@ -1252,6 +1272,30 @@ export class CatalogDisplayStore {
                 return undefined;
             })
             .filter((error): error is string => error !== undefined);
+
+        // The image overlay dereferences its x and y columns' headers directly, so a config naming
+        // a column this catalog does not have, or one that cannot hold a coordinate, is rejected
+        // rather than left to fail when the overlay is drawn. Unlike a mapped column, the data
+        // itself need not be loaded yet: the overlay is plotted from whatever streams in later.
+        const overlayColumnErrors = [
+            ["x", config?.xAxis ?? CatalogOverlay.NONE],
+            ["y", config?.yAxis ?? CatalogOverlay.NONE]
+        ]
+            .filter(([, column]) => column !== CatalogOverlay.NONE)
+            .map(([axis, column]) => {
+                const controlHeader = profileStore.catalogControlHeader.get(column);
+                const header = profileStore.catalogHeader[controlHeader?.dataIndex ?? NaN];
+                if (!header) {
+                    return `The ${axis} axis is set to "${column}", which this catalog does not have`;
+                }
+                if (header.dataType === CARTA.ColumnType.String || header.dataType === CARTA.ColumnType.Bool) {
+                    return `The ${axis} axis is set to "${column}", which is not a numeric column`;
+                }
+                return undefined;
+            })
+            .filter((error): error is string => error !== undefined);
+
+        const errors = [...mappedColumnErrors, ...overlayColumnErrors];
         if (errors.length) {
             return {success: false, errors};
         }
@@ -1307,10 +1351,10 @@ export class CatalogDisplayStore {
         this.angleMin = orientationAxis.angleMin;
         this.angleMax = orientationAxis.angleMax;
 
-        this.setClip("sizeMajor", this.resolveClip(profileStore, sizeAxis), hasSizeColumnChanged);
-        this.setClip("sizeMinor", this.resolveClip(profileStore, sizeMinorAxis), hasSizeMinorColumnChanged);
-        this.setClip("color", this.resolveClip(profileStore, colorAxis), hasColorColumnChanged);
-        this.setClip("orientation", this.resolveClip(profileStore, orientationAxis), hasOrientationColumnChanged);
+        this.setClip("sizeMajor", this.resolveClip(profileStore, sizeAxis), hasSizeColumnChanged && configDefinesClip(sizeAxis));
+        this.setClip("sizeMinor", this.resolveClip(profileStore, sizeMinorAxis), hasSizeMinorColumnChanged && configDefinesClip(sizeMinorAxis));
+        this.setClip("color", this.resolveClip(profileStore, colorAxis), hasColorColumnChanged && configDefinesClip(colorAxis));
+        this.setClip("orientation", this.resolveClip(profileStore, orientationAxis), hasOrientationColumnChanged && configDefinesClip(orientationAxis));
 
         // 4. locks last
         this.isSizeColumnMinLocked = sizeAxis.columnMinLocked;
@@ -1345,8 +1389,8 @@ export class CatalogDisplayStore {
             yAxis: this.yAxis,
             sizeAxis: {
                 mapColumn: this.sizeMapColumn,
-                columnMinClip: this.sizeColumnMin.clipd,
-                columnMaxClip: this.sizeColumnMax.clipd,
+                columnMinClip: authoredClip(this.sizeColumnMin),
+                columnMaxClip: authoredClip(this.sizeColumnMax),
                 min: {...this.sizeMin},
                 max: {...this.sizeMax},
                 areaMode: this.isSizeAreaMode,
@@ -1357,8 +1401,8 @@ export class CatalogDisplayStore {
             },
             sizeMinorAxis: {
                 mapColumn: this.sizeMinorMapColumn,
-                columnMinClip: this.sizeMinorColumnMin.clipd,
-                columnMaxClip: this.sizeMinorColumnMax.clipd,
+                columnMinClip: authoredClip(this.sizeMinorColumnMin),
+                columnMaxClip: authoredClip(this.sizeMinorColumnMax),
                 min: {...this.sizeMinorMin},
                 max: {...this.sizeMinorMax},
                 areaMode: this.isSizeMinorAreaMode,
@@ -1369,8 +1413,8 @@ export class CatalogDisplayStore {
             },
             colorAxis: {
                 mapColumn: this.colorMapColumn,
-                columnMinClip: this.colorColumnMin.clipd,
-                columnMaxClip: this.colorColumnMax.clipd,
+                columnMinClip: authoredClip(this.colorColumnMin),
+                columnMaxClip: authoredClip(this.colorColumnMax),
                 colorMap: this.colorMap,
                 inverted: this.isInvertedColorMap,
                 scalingType: this.colorScalingType,
@@ -1378,8 +1422,8 @@ export class CatalogDisplayStore {
             },
             orientationAxis: {
                 mapColumn: this.orientationMapColumn,
-                columnMinClip: this.orientationMin.clipd,
-                columnMaxClip: this.orientationMax.clipd,
+                columnMinClip: authoredClip(this.orientationMin),
+                columnMaxClip: authoredClip(this.orientationMax),
                 angleMin: this.angleMin,
                 angleMax: this.angleMax,
                 scalingType: this.orientationScalingType,
@@ -1415,10 +1459,10 @@ export class CatalogDisplayStore {
     }
 
     /**
-     * Set the clipped bounds of one mapped column. When the column itself has just changed, the
-     * bounds are also held for the data-derived defaults to recompute against.
+     * Set the clipped bounds of one mapped column. Bounds a config authored are also held while the
+     * column's data-derived defaults recompute, so that the recompute does not overwrite them.
      */
-    private setClip(group: ClipGroup, clip: ClipRestore, hasColumnChanged: boolean) {
+    private setClip(group: ClipGroup, clip: ClipRestore, shouldHoldForRecompute: boolean) {
         const {min, max} = clip;
         switch (group) {
             case "sizeMajor":
@@ -1439,7 +1483,7 @@ export class CatalogDisplayStore {
                 break;
         }
 
-        if (hasColumnChanged) {
+        if (shouldHoldForRecompute) {
             this.pendingClipRestore.set(group, clip);
         } else {
             this.pendingClipRestore.delete(group);

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -3,21 +3,65 @@ import * as CARTACompute from "carta_computation";
 import {action, computed, type IReactionDisposer, makeObservable, observable, reaction} from "mobx";
 
 import {AngularSizeUnit, CatalogDisplayMode, CatalogMapType, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogSizeUnits, type CatalogSystemType, CatalogTextureType, ColorMap, FrameScaling} from "enums";
-import {FACTOR_TO_ARCSEC} from "models";
+import {FACTOR_TO_ARCSEC, type WorkspaceCatalogColorAxisConfig, type WorkspaceCatalogConfig, type WorkspaceCatalogOrientationAxisConfig, type WorkspaceCatalogSizeAxisConfig} from "models";
 import {CatalogWebGLService} from "services";
-import {AppStore, CatalogStore, PreferenceStore} from "stores";
-import {clamp, getDefaultScalingParameter, minMaxArray, sanitizeScalingParameter} from "utilities";
+import {AppStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore, PreferenceStore} from "stores";
+import {clamp, createScalingParameters, getScalingParameter, minMaxArray, sanitizeScalingParameter, scalingParametersFromConfig, scalingParametersToConfig} from "utilities";
 
 type CatalogSourceRadiusMode = "diameter" | "radius";
 
-const PARAMETERIZED_SCALINGS = [FrameScaling.LOG, FrameScaling.GAMMA, FrameScaling.POWER, FrameScaling.SINH, FrameScaling.ASINH];
-
-function createScalingParameters(): Map<FrameScaling, number> {
-    return new Map(PARAMETERIZED_SCALINGS.map(scaling => [scaling, getDefaultScalingParameter(scaling)]));
+/** The clipped bounds of one mapped column, held while the data-derived defaults are recomputed. */
+interface ClipRestore {
+    min: number | undefined;
+    max: number | undefined;
 }
 
-function getScalingParameter(parameters: Map<FrameScaling, number>, scaling: FrameScaling): number {
-    return parameters.get(scaling) ?? getDefaultScalingParameter(scaling);
+type ClipGroup = "sizeMajor" | "sizeMinor" | "color" | "orientation";
+
+/** Outcome of applying a display config. A rejected config leaves the store untouched. */
+export interface CatalogConfigApplyResult {
+    success: boolean;
+    /** Why the config was rejected. Empty when it applied. */
+    errors: string[];
+}
+
+function normalizeSizeAxis(axis: WorkspaceCatalogSizeAxisConfig | undefined) {
+    return {
+        mapColumn: axis?.mapColumn ?? CatalogOverlay.NONE,
+        columnMinClip: axis?.columnMinClip,
+        columnMaxClip: axis?.columnMaxClip,
+        min: {area: axis?.min?.area ?? 100, diameter: axis?.min?.diameter ?? 5},
+        max: {area: axis?.max?.area ?? 200, diameter: axis?.max?.diameter ?? 20},
+        areaMode: axis?.areaMode ?? false,
+        scalingType: axis?.scalingType ?? FrameScaling.LINEAR,
+        scalingParameters: scalingParametersFromConfig(axis?.scalingParameters),
+        columnMinLocked: axis?.columnMinLocked ?? false,
+        columnMaxLocked: axis?.columnMaxLocked ?? false
+    };
+}
+
+function normalizeColorAxis(axis: WorkspaceCatalogColorAxisConfig | undefined) {
+    return {
+        mapColumn: axis?.mapColumn ?? CatalogOverlay.NONE,
+        columnMinClip: axis?.columnMinClip,
+        columnMaxClip: axis?.columnMaxClip,
+        colorMap: axis?.colorMap ?? ColorMap.Viridis,
+        inverted: axis?.inverted ?? false,
+        scalingType: axis?.scalingType ?? FrameScaling.LINEAR,
+        scalingParameters: scalingParametersFromConfig(axis?.scalingParameters)
+    };
+}
+
+function normalizeOrientationAxis(axis: WorkspaceCatalogOrientationAxisConfig | undefined) {
+    return {
+        mapColumn: axis?.mapColumn ?? CatalogOverlay.NONE,
+        columnMinClip: axis?.columnMinClip,
+        columnMaxClip: axis?.columnMaxClip,
+        angleMin: clamp(axis?.angleMin ?? CatalogDisplayStore.MIN_ANGLE, CatalogDisplayStore.MIN_ANGLE, CatalogDisplayStore.MAX_ANGLE),
+        angleMax: clamp(axis?.angleMax ?? CatalogDisplayStore.MAX_ANGLE, CatalogDisplayStore.MIN_ANGLE, CatalogDisplayStore.MAX_ANGLE),
+        scalingType: axis?.scalingType ?? FrameScaling.LINEAR,
+        scalingParameters: scalingParametersFromConfig(axis?.scalingParameters)
+    };
 }
 
 export class CatalogDisplayStore {
@@ -130,6 +174,13 @@ export class CatalogDisplayStore {
 
     private readonly disposers: IReactionDisposer[] = [];
 
+    /**
+     * Clipped bounds supplied by {@link applyConfig} for a column that has just changed. Changing a
+     * mapped column makes the data-derived defaults recompute, which resets the clip to the full
+     * data range; a clip that came from a config outlives that reset.
+     */
+    private readonly pendingClipRestore = new Map<ClipGroup, ClipRestore>();
+
     constructor(catalogFileId: number) {
         this.catalogFileId = catalogFileId;
         makeObservable(this);
@@ -141,6 +192,7 @@ export class CatalogDisplayStore {
                     const result = minMaxArray(column);
                     this.setSizeColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
                     this.setSizeColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    this.restorePendingClip("sizeMajor");
                 }
             )
         );
@@ -185,6 +237,7 @@ export class CatalogDisplayStore {
                     const result = minMaxArray(column);
                     this.setSizeMinorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
                     this.setSizeMinorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    this.restorePendingClip("sizeMinor");
                 }
             )
         );
@@ -229,6 +282,7 @@ export class CatalogDisplayStore {
                     const result = minMaxArray(column);
                     this.setColorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
                     this.setColorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    this.restorePendingClip("color");
                 }
             )
         );
@@ -251,6 +305,7 @@ export class CatalogDisplayStore {
                     const result = minMaxArray(column);
                     this.setOrientationMin(isFinite(result.minVal) ? result.minVal : 0, "default");
                     this.setOrientationMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    this.restorePendingClip("orientation");
                 }
             )
         );
@@ -1145,7 +1200,197 @@ export class CatalogDisplayStore {
         return config;
     }
 
-    public applyConfig = (widgetSettings): void => {
+    /**
+     * Set the display config to exactly what `config` describes. Anything the config leaves out
+     * returns to its default, so the same config always produces the same overlay.
+     *
+     * The order the fields are set in is deliberate and load bearing:
+     *
+     * 1. display mode and size units, because the allowed source size depends on both
+     * 2. mapped columns, whose change resets the clipped bounds of their own group
+     * 3. scaling, sizes and the clipped bounds themselves
+     * 4. the column locks last, so that restoring the minor axis is not overwritten by the major
+     *
+     * Values recomputed from the catalog data, and state a panel keeps for its own presentation,
+     * are not part of a config and are left alone.
+     */
+    @action applyConfig = (config: WorkspaceCatalogConfig | undefined | null): CatalogConfigApplyResult => {
+        const profileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
+        if (!profileStore) {
+            return {success: false, errors: ["The catalog data has not been loaded"]};
+        }
+        if (profileStore.isLoadingOntoImage) {
+            return {success: false, errors: ["The catalog data is still loading"]};
+        }
+
+        const sizeAxis = normalizeSizeAxis(config?.sizeAxis);
+        const sizeMinorAxis = normalizeSizeAxis(config?.sizeMinorAxis);
+        const colorAxis = normalizeColorAxis(config?.colorAxis);
+        const orientationAxis = normalizeOrientationAxis(config?.orientationAxis);
+
+        const errors = [
+            ["size", sizeAxis.mapColumn],
+            ["minor size", sizeMinorAxis.mapColumn],
+            ["color", colorAxis.mapColumn],
+            ["orientation", orientationAxis.mapColumn]
+        ]
+            .filter(([, column]) => column !== CatalogOverlay.NONE)
+            .map(([axis, column]) => {
+                if (!profileStore.catalogControlHeader.has(column)) {
+                    return `The ${axis} axis is mapped to "${column}", which this catalog does not have`;
+                }
+                if (!profileStore.get1DPlotData(column).wcsData?.length) {
+                    return `The ${axis} axis is mapped to "${column}", which has no data to map`;
+                }
+                return undefined;
+            })
+            .filter((error): error is string => error !== undefined);
+        if (errors.length) {
+            return {success: false, errors};
+        }
+
+        // 1. display mode and units first: the source size is validated against them
+        this.catalogDisplayMode = config?.displayMode ?? CatalogDisplayMode.CANVAS;
+        this.canvasSizeUnit = config?.canvasSizeUnit ?? CatalogSizeUnits.SCREENPIXEL;
+        this.worldSizeUnit = config?.worldSizeUnit ?? AngularSizeUnit.ARCSEC;
+
+        this.catalogPlotType = config?.plotType ?? CatalogPlotType.ImageOverlay;
+        this.catalogColor = config?.color ?? Colors.TURQUOISE3;
+        this.highlightColor = config?.highlightColor ?? Colors.RED2;
+        this.catalogShape = config?.shape ?? CatalogOverlayShape.CIRCLE_LINED;
+        this.thickness = clamp(config?.thickness ?? 2.0, CatalogDisplayStore.MIN_THICKNESS, CatalogDisplayStore.MAX_THICKNESS);
+        this.xAxis = config?.xAxis ?? CatalogOverlay.NONE;
+        this.yAxis = config?.yAxis ?? CatalogOverlay.NONE;
+
+        const showedCatalogSize = clamp(config?.size ?? 10.0, this.minOverlaySize, this.maxOverlaySize);
+        this.showedCatalogSize = showedCatalogSize;
+        this.catalogSize = showedCatalogSize * this.pixelSizeFactor;
+
+        // 2. mapped columns
+        const hasSizeColumnChanged = this.sizeMapColumn !== sizeAxis.mapColumn;
+        const hasSizeMinorColumnChanged = this.sizeMinorMapColumn !== sizeMinorAxis.mapColumn;
+        const hasColorColumnChanged = this.colorMapColumn !== colorAxis.mapColumn;
+        const hasOrientationColumnChanged = this.orientationMapColumn !== orientationAxis.mapColumn;
+
+        this.sizeMapColumn = sizeAxis.mapColumn;
+        this.sizeMinorMapColumn = sizeMinorAxis.mapColumn;
+        this.colorMapColumn = colorAxis.mapColumn;
+        this.orientationMapColumn = orientationAxis.mapColumn;
+
+        // 3. scaling, sizes and clipped bounds
+        this.isSizeAreaMode = sizeAxis.areaMode;
+        this.sizeScalingType = sizeAxis.scalingType;
+        this.sizeScalingParameters = sizeAxis.scalingParameters;
+        this.sizeMin = sizeAxis.min;
+        this.sizeMax = sizeAxis.max;
+
+        this.isSizeMinorAreaMode = sizeMinorAxis.areaMode;
+        this.sizeMinorScalingType = sizeMinorAxis.scalingType;
+        this.sizeMinorScalingParameters = sizeMinorAxis.scalingParameters;
+        this.sizeMinorMin = sizeMinorAxis.min;
+        this.sizeMinorMax = sizeMinorAxis.max;
+
+        this.colorMap = colorAxis.colorMap;
+        this.isInvertedColorMap = colorAxis.inverted;
+        this.colorScalingType = colorAxis.scalingType;
+        this.colorScalingParameters = colorAxis.scalingParameters;
+
+        this.orientationScalingType = orientationAxis.scalingType;
+        this.orientationScalingParameters = orientationAxis.scalingParameters;
+        this.angleMin = orientationAxis.angleMin;
+        this.angleMax = orientationAxis.angleMax;
+
+        this.setClip("sizeMajor", this.resolveClip(profileStore, sizeAxis), hasSizeColumnChanged);
+        this.setClip("sizeMinor", this.resolveClip(profileStore, sizeMinorAxis), hasSizeMinorColumnChanged);
+        this.setClip("color", this.resolveClip(profileStore, colorAxis), hasColorColumnChanged);
+        this.setClip("orientation", this.resolveClip(profileStore, orientationAxis), hasOrientationColumnChanged);
+
+        // 4. locks last
+        this.isSizeColumnMinLocked = sizeAxis.columnMinLocked;
+        this.isSizeColumnMaxLocked = sizeAxis.columnMaxLocked;
+        this.isSizeMinorColumnMinLocked = sizeMinorAxis.columnMinLocked;
+        this.isSizeMinorColumnMaxLocked = sizeMinorAxis.columnMaxLocked;
+
+        return {success: true, errors: []};
+    };
+
+    public toConfig = (): WorkspaceCatalogConfig => {
+        return {
+            color: this.catalogColor,
+            highlightColor: this.highlightColor,
+            shape: this.catalogShape,
+            size: this.showedCatalogSize,
+            thickness: this.thickness,
+            displayMode: this.catalogDisplayMode,
+            canvasSizeUnit: this.canvasSizeUnit,
+            worldSizeUnit: this.worldSizeUnit,
+            plotType: this.catalogPlotType,
+            xAxis: this.xAxis,
+            yAxis: this.yAxis,
+            sizeAxis: {
+                mapColumn: this.sizeMapColumn,
+                columnMinClip: this.sizeColumnMin.clipd,
+                columnMaxClip: this.sizeColumnMax.clipd,
+                min: {...this.sizeMin},
+                max: {...this.sizeMax},
+                areaMode: this.isSizeAreaMode,
+                scalingType: this.sizeScalingType,
+                scalingParameters: scalingParametersToConfig(this.sizeScalingParameters),
+                columnMinLocked: this.isSizeColumnMinLocked,
+                columnMaxLocked: this.isSizeColumnMaxLocked
+            },
+            sizeMinorAxis: {
+                mapColumn: this.sizeMinorMapColumn,
+                columnMinClip: this.sizeMinorColumnMin.clipd,
+                columnMaxClip: this.sizeMinorColumnMax.clipd,
+                min: {...this.sizeMinorMin},
+                max: {...this.sizeMinorMax},
+                areaMode: this.isSizeMinorAreaMode,
+                scalingType: this.sizeMinorScalingType,
+                scalingParameters: scalingParametersToConfig(this.sizeMinorScalingParameters),
+                columnMinLocked: this.isSizeMinorColumnMinLocked,
+                columnMaxLocked: this.isSizeMinorColumnMaxLocked
+            },
+            colorAxis: {
+                mapColumn: this.colorMapColumn,
+                columnMinClip: this.colorColumnMin.clipd,
+                columnMaxClip: this.colorColumnMax.clipd,
+                colorMap: this.colorMap,
+                inverted: this.isInvertedColorMap,
+                scalingType: this.colorScalingType,
+                scalingParameters: scalingParametersToConfig(this.colorScalingParameters)
+            },
+            orientationAxis: {
+                mapColumn: this.orientationMapColumn,
+                columnMinClip: this.orientationMin.clipd,
+                columnMaxClip: this.orientationMax.clipd,
+                angleMin: this.angleMin,
+                angleMax: this.angleMax,
+                scalingType: this.orientationScalingType,
+                scalingParameters: scalingParametersToConfig(this.orientationScalingParameters)
+            }
+        };
+    };
+
+    /**
+     * The slice of a catalog panel that a layout keeps: which catalog it shows, and the geometry of
+     * the panel itself. Everything else a panel displays is display config and belongs to the
+     * catalog, not to the layout.
+     */
+    public toLayoutSettings = () => {
+        return {
+            catalogFileId: this.catalogFileId,
+            catalogColor: this.catalogColor,
+            highlightColor: this.highlightColor,
+            catalogSize: this.catalogSize,
+            catalogShape: this.catalogShape,
+            tableSeparatorPosition: this.tableSeparatorPosition,
+            thickness: this.thickness
+        };
+    };
+
+    /** Counterpart of {@link toLayoutSettings}, applied when a saved layout is restored. */
+    @action applyLayoutSettings = (widgetSettings): void => {
         if (!widgetSettings) {
             return;
         }
@@ -1164,15 +1409,83 @@ export class CatalogDisplayStore {
         this.thickness = widgetSettings.thickness;
     };
 
-    public toConfig = () => {
+    /**
+     * The clipped bounds a config asks for. A mapped column with no stated bounds is clipped to the
+     * full range of its data, so that the result depends on the config and the data alone, rather
+     * than on whether a reaction happened to fill the bounds in.
+     */
+    private resolveClip(profileStore: CatalogProfileStore | CatalogOnlineQueryProfileStore, axis: {mapColumn: string; columnMinClip?: number; columnMaxClip?: number}): ClipRestore {
+        if (axis.mapColumn === CatalogOverlay.NONE) {
+            return {min: undefined, max: undefined};
+        }
+        if (axis.columnMinClip !== undefined && axis.columnMaxClip !== undefined) {
+            return {min: axis.columnMinClip, max: axis.columnMaxClip};
+        }
+
+        // applyConfig has already established that a mapped column carries data.
+        const range = minMaxArray(profileStore.get1DPlotData(axis.mapColumn).wcsData ?? new Float32Array(0));
         return {
-            catalogFileId: this.catalogFileId,
-            catalogColor: this.catalogColor,
-            highlightColor: this.highlightColor,
-            catalogSize: this.catalogSize,
-            catalogShape: this.catalogShape,
-            tableSeparatorPosition: this.tableSeparatorPosition,
-            thickness: this.thickness
+            min: axis.columnMinClip ?? (isFinite(range.minVal) ? range.minVal : 0),
+            max: axis.columnMaxClip ?? (isFinite(range.maxVal) ? range.maxVal : 0)
         };
-    };
+    }
+
+    /**
+     * Set the clipped bounds of one mapped column. When the column itself has just changed, the
+     * bounds are also held for the data-derived defaults to recompute against.
+     */
+    private setClip(group: ClipGroup, clip: ClipRestore, hasColumnChanged: boolean) {
+        const {min, max} = clip;
+        switch (group) {
+            case "sizeMajor":
+                this.sizeColumnMin.clipd = min;
+                this.sizeColumnMax.clipd = max;
+                break;
+            case "sizeMinor":
+                this.sizeMinorColumnMin.clipd = min;
+                this.sizeMinorColumnMax.clipd = max;
+                break;
+            case "color":
+                this.colorColumnMin.clipd = min;
+                this.colorColumnMax.clipd = max;
+                break;
+            case "orientation":
+                this.orientationMin.clipd = min;
+                this.orientationMax.clipd = max;
+                break;
+        }
+
+        if (hasColumnChanged) {
+            this.pendingClipRestore.set(group, clip);
+        } else {
+            this.pendingClipRestore.delete(group);
+        }
+    }
+
+    @action private restorePendingClip(group: ClipGroup) {
+        const pending = this.pendingClipRestore.get(group);
+        if (!pending) {
+            return;
+        }
+        this.pendingClipRestore.delete(group);
+
+        switch (group) {
+            case "sizeMajor":
+                this.sizeColumnMin.clipd = pending.min;
+                this.sizeColumnMax.clipd = pending.max;
+                break;
+            case "sizeMinor":
+                this.sizeMinorColumnMin.clipd = pending.min;
+                this.sizeMinorColumnMax.clipd = pending.max;
+                break;
+            case "color":
+                this.colorColumnMin.clipd = pending.min;
+                this.colorColumnMax.clipd = pending.max;
+                break;
+            case "orientation":
+                this.orientationMin.clipd = pending.min;
+                this.orientationMax.clipd = pending.max;
+                break;
+        }
+    }
 }

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -178,10 +178,28 @@ export class CatalogDisplayStore {
      * data range; a clip that came from a config outlives that reset.
      */
     private readonly pendingClipRestore = new Map<ClipGroup, ClipRestore>();
+    /** Layout display settings waiting for the catalog data they validate against. */
+    private pendingConfig: WorkspaceCatalogConfig | undefined;
 
     constructor(catalogFileId: number) {
         this.catalogFileId = catalogFileId;
         makeObservable(this);
+
+        this.disposers.push(
+            reaction(
+                () => {
+                    const profileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
+                    return Boolean(profileStore && !profileStore.isLoadingOntoImage);
+                },
+                isReady => {
+                    if (isReady && this.pendingConfig) {
+                        const config = this.pendingConfig;
+                        this.pendingConfig = undefined;
+                        this.applyConfig(config);
+                    }
+                }
+            )
+        );
 
         this.disposers.push(
             reaction(
@@ -1301,6 +1319,15 @@ export class CatalogDisplayStore {
         this.isSizeMinorColumnMaxLocked = sizeMinorAxis.columnMaxLocked;
 
         return {success: true, errors: []};
+    };
+
+    /** Apply layout settings now, or retry them once the catalog data is ready. */
+    @action applyConfigWhenReady = (config: WorkspaceCatalogConfig): CatalogConfigApplyResult => {
+        const profileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
+        const shouldDefer = !profileStore || profileStore.isLoadingOntoImage;
+        const result = this.applyConfig(config);
+        this.pendingConfig = shouldDefer ? config : undefined;
+        return result;
     };
 
     public toConfig = (): WorkspaceCatalogConfig => {

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -5,7 +5,7 @@ import {action, computed, type IReactionDisposer, makeObservable, observable, re
 import {AngularSizeUnit, CatalogDisplayMode, CatalogMapType, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogSizeUnits, type CatalogSystemType, CatalogTextureType, ColorMap, FrameScaling} from "enums";
 import {FACTOR_TO_ARCSEC, type WorkspaceCatalogColorAxisConfig, type WorkspaceCatalogConfig, type WorkspaceCatalogOrientationAxisConfig, type WorkspaceCatalogSizeAxisConfig} from "models";
 import {CatalogWebGLService} from "services";
-import {AppStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore, PreferenceStore} from "stores";
+import {AppStore, type CatalogOnlineQueryProfileStore, type CatalogProfileStore, CatalogStore} from "stores";
 import {clamp, createScalingParameters, getScalingParameter, minMaxArray, sanitizeScalingParameter, scalingParametersFromConfig, scalingParametersToConfig} from "utilities";
 
 type CatalogSourceRadiusMode = "diameter" | "radius";
@@ -124,9 +124,7 @@ export class CatalogDisplayStore {
     @observable plottedImageOverlayYAxis: string = CatalogOverlay.NONE;
     @observable plottedImageOverlaySystem: CatalogSystemType | undefined = undefined;
     @observable plottedImageOverlayMaxRows: number | undefined = undefined;
-    @observable tableSeparatorPosition: string = PreferenceStore.Instance.catalogTableSeparatorPosition;
     @observable highlightColor: string = Colors.RED2;
-    @observable settingsTabId: CatalogSettingsTabs = CatalogSettingsTabs.SIZE;
     @observable thickness: number = 2.0;
     @observable catalogDisplayMode: CatalogDisplayMode = CatalogDisplayMode.CANVAS;
     // size map
@@ -960,10 +958,6 @@ export class CatalogDisplayStore {
         this.plottedImageOverlayMaxRows = undefined;
     }
 
-    @action setTableSeparatorPosition(position: string) {
-        this.tableSeparatorPosition = position;
-    }
-
     /**
      * Set the color of highlighted catalog source
      * @param color - color of highlight
@@ -971,11 +965,6 @@ export class CatalogDisplayStore {
     @action setHighlightColor(color: string) {
         this.highlightColor = color;
     }
-
-    @action setSettingsTabId = (tabId: CatalogSettingsTabs) => {
-        this.settingsTabId = tabId;
-        this.sizeAxisTabId = CatalogSettingsTabs.SIZE_MAJOR;
-    };
 
     /**
      * Set the thickness of catalog source
@@ -1377,38 +1366,6 @@ export class CatalogDisplayStore {
      * the panel itself. Everything else a panel displays is display config and belongs to the
      * catalog, not to the layout.
      */
-    public toLayoutSettings = () => {
-        return {
-            catalogFileId: this.catalogFileId,
-            catalogColor: this.catalogColor,
-            highlightColor: this.highlightColor,
-            catalogSize: this.catalogSize,
-            catalogShape: this.catalogShape,
-            tableSeparatorPosition: this.tableSeparatorPosition,
-            thickness: this.thickness
-        };
-    };
-
-    /** Counterpart of {@link toLayoutSettings}, applied when a saved layout is restored. */
-    @action applyLayoutSettings = (widgetSettings): void => {
-        if (!widgetSettings) {
-            return;
-        }
-        const catalogFileId = widgetSettings.catalogFileId;
-        if (typeof catalogFileId === "number" && catalogFileId > 0) {
-            this.catalogFileId = catalogFileId;
-        }
-        const catalogSize = widgetSettings.catalogSize;
-        if (typeof catalogSize === "number" && catalogSize >= CatalogDisplayStore.MIN_OVERLAY_SIZE && catalogSize <= CatalogDisplayStore.MAX_OVERLAY_SIZE) {
-            this.catalogSize = catalogSize;
-        }
-        this.catalogShape = widgetSettings.catalogShape;
-        this.catalogColor = widgetSettings.catalogColor;
-        this.highlightColor = widgetSettings.highlightColor;
-        this.tableSeparatorPosition = widgetSettings.tableSeparatorPosition;
-        this.thickness = widgetSettings.thickness;
-    };
-
     /**
      * The clipped bounds a config asks for. A mapped column with no stated bounds is clipped to the
      * full range of its data, so that the result depends on the config and the data alone, rather

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -1300,7 +1300,6 @@ export class CatalogDisplayStore {
             return {success: false, errors};
         }
 
-        // 1. display mode and units first: the source size is validated against them
         this.catalogDisplayMode = config?.displayMode ?? CatalogDisplayMode.CANVAS;
         this.canvasSizeUnit = config?.canvasSizeUnit ?? CatalogSizeUnits.SCREENPIXEL;
         this.worldSizeUnit = config?.worldSizeUnit ?? AngularSizeUnit.ARCSEC;
@@ -1317,7 +1316,6 @@ export class CatalogDisplayStore {
         this.showedCatalogSize = showedCatalogSize;
         this.catalogSize = showedCatalogSize * this.pixelSizeFactor;
 
-        // 2. mapped columns
         const hasSizeColumnChanged = this.sizeMapColumn !== sizeAxis.mapColumn;
         const hasSizeMinorColumnChanged = this.sizeMinorMapColumn !== sizeMinorAxis.mapColumn;
         const hasColorColumnChanged = this.colorMapColumn !== colorAxis.mapColumn;
@@ -1328,7 +1326,6 @@ export class CatalogDisplayStore {
         this.colorMapColumn = colorAxis.mapColumn;
         this.orientationMapColumn = orientationAxis.mapColumn;
 
-        // 3. scaling, sizes and clipped bounds
         this.isSizeAreaMode = sizeAxis.areaMode;
         this.sizeScalingType = sizeAxis.scalingType;
         this.sizeScalingParameters = sizeAxis.scalingParameters;
@@ -1356,7 +1353,6 @@ export class CatalogDisplayStore {
         this.setClip("color", this.resolveClip(profileStore, colorAxis), hasColorColumnChanged && configDefinesClip(colorAxis));
         this.setClip("orientation", this.resolveClip(profileStore, orientationAxis), hasOrientationColumnChanged && configDefinesClip(orientationAxis));
 
-        // 4. locks last
         this.isSizeColumnMinLocked = sizeAxis.columnMinLocked;
         this.isSizeColumnMaxLocked = sizeAxis.columnMaxLocked;
         this.isSizeMinorColumnMinLocked = sizeMinorAxis.columnMinLocked;
@@ -1365,7 +1361,7 @@ export class CatalogDisplayStore {
         return {success: true, errors: []};
     };
 
-    /** Apply layout settings now, or retry them once the catalog data is ready. */
+    /** Apply catalog display settings now, or retry them once the catalog data is ready. */
     @action applyConfigWhenReady = (config: WorkspaceCatalogConfig): CatalogConfigApplyResult => {
         const profileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
         const shouldDefer = !profileStore || profileStore.isLoadingOntoImage;
@@ -1432,11 +1428,6 @@ export class CatalogDisplayStore {
         };
     };
 
-    /**
-     * The slice of a catalog panel that a layout keeps: which catalog it shows, and the geometry of
-     * the panel itself. Everything else a panel displays is display config and belongs to the
-     * catalog, not to the layout.
-     */
     /**
      * The clipped bounds a config asks for. A mapped column with no stated bounds is clipped to the
      * full range of its data, so that the result depends on the config and the data alone, rather

--- a/src/stores/Catalog/CatalogRequestTracking.test.ts
+++ b/src/stores/Catalog/CatalogRequestTracking.test.ts
@@ -1,0 +1,28 @@
+import {CatalogStore} from "stores";
+
+describe("CatalogStore request tracking", () => {
+    const catalogStore = CatalogStore.Instance;
+    const catalogFileId = 901;
+
+    afterEach(() => {
+        catalogStore.completeCatalogRequest(catalogFileId);
+    });
+
+    test("accepts the current request and rejects a superseded response", () => {
+        catalogStore.registerCatalogRequest(catalogFileId, 11);
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 11)).toBe(true);
+
+        catalogStore.registerCatalogRequest(catalogFileId, 12);
+
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 11)).toBe(false);
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 12)).toBe(true);
+    });
+
+    test("rejects responses after the current request is complete", () => {
+        catalogStore.registerCatalogRequest(catalogFileId, 21);
+        catalogStore.completeCatalogRequest(catalogFileId, 21);
+
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 21)).toBe(false);
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId)).toBe(true);
+    });
+});

--- a/src/stores/Catalog/CatalogRequestTracking.test.ts
+++ b/src/stores/Catalog/CatalogRequestTracking.test.ts
@@ -18,6 +18,14 @@ describe("CatalogStore request tracking", () => {
         expect(catalogStore.acceptsCatalogResponse(catalogFileId, 12)).toBe(true);
     });
 
+    test("rejects a response that was not registered for the catalog", () => {
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 10)).toBe(false);
+
+        catalogStore.registerCatalogRequest(catalogFileId, 11);
+
+        expect(catalogStore.acceptsCatalogResponse(catalogFileId, 10)).toBe(false);
+    });
+
     test("rejects responses after the current request is complete", () => {
         catalogStore.registerCatalogRequest(catalogFileId, 21);
         catalogStore.completeCatalogRequest(catalogFileId, 21);

--- a/src/stores/Catalog/CatalogStore.test.ts
+++ b/src/stores/Catalog/CatalogStore.test.ts
@@ -1,0 +1,39 @@
+import {CatalogStore, WidgetsStore} from "stores";
+
+describe("CatalogStore panel selection compatibility", () => {
+    const catalogStore = CatalogStore.Instance;
+    const widgetsStore = WidgetsStore.Instance;
+
+    afterEach(() => {
+        catalogStore.imageAssociatedCatalogId.clear();
+        catalogStore.catalogProfiles.clear();
+        widgetsStore.catalogPanelWidgets.clear();
+    });
+
+    test("resets panel selections even when the legacy map is empty", () => {
+        catalogStore.updateImageAssociatedCatalogId(101, [7, 8]);
+        const panel = widgetsStore.getCatalogPanelStore("catalog-panel-0", 99);
+
+        catalogStore.resetActiveCatalogFile(101);
+
+        expect(panel.selectedCatalogId).toBe(7);
+        expect(catalogStore.catalogProfiles.get("catalog-panel-0")).toBe(7);
+    });
+
+    test("removes stale legacy entries and mirrors every live panel", () => {
+        catalogStore.updateImageAssociatedCatalogId(102, [7, 8]);
+        const firstPanel = widgetsStore.getCatalogPanelStore("catalog-panel-0", 7);
+        const secondPanel = widgetsStore.getCatalogPanelStore("catalog-panel-1", 8);
+        catalogStore.catalogProfiles.set("catalog-panel-0", 99);
+        catalogStore.catalogProfiles.set("closed-panel", 8);
+
+        catalogStore.resetActiveCatalogFile(102);
+
+        expect(firstPanel.selectedCatalogId).toBe(7);
+        expect(secondPanel.selectedCatalogId).toBe(8);
+        expect(Array.from(catalogStore.catalogProfiles.entries())).toEqual([
+            ["catalog-panel-0", 7],
+            ["catalog-panel-1", 8]
+        ]);
+    });
+});

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -40,7 +40,6 @@ export class CatalogStore {
     @observable catalogDisplayStores: Map<number, CatalogDisplayStore> = new Map();
     /** Latest filter request per catalog; streamed responses from older requests are discarded. */
     private readonly catalogRequestIds: Map<number, number> = new Map();
-    private readonly staleCatalogRequestIds: Map<number, Set<number>> = new Map();
 
     private constructor() {
         makeObservable(this);
@@ -134,15 +133,6 @@ export class CatalogStore {
 
     /** Associate a catalog filter request with the catalog it updates. */
     @action registerCatalogRequest = (catalogFileId: number, requestId: number) => {
-        const previousRequestId = this.catalogRequestIds.get(catalogFileId);
-        if (previousRequestId !== undefined && previousRequestId !== requestId) {
-            let staleRequestIds = this.staleCatalogRequestIds.get(catalogFileId);
-            if (!staleRequestIds) {
-                staleRequestIds = new Set<number>();
-                this.staleCatalogRequestIds.set(catalogFileId, staleRequestIds);
-            }
-            staleRequestIds.add(previousRequestId);
-        }
         this.catalogRequestIds.set(catalogFileId, requestId);
     };
 
@@ -151,11 +141,8 @@ export class CatalogStore {
         if (requestId === undefined) {
             return true;
         }
-        if (this.staleCatalogRequestIds.get(catalogFileId)?.has(requestId)) {
-            return false;
-        }
         const currentRequestId = this.catalogRequestIds.get(catalogFileId);
-        return currentRequestId === undefined || currentRequestId === requestId;
+        return currentRequestId === requestId;
     };
 
     /** Mark the current request as finished so late responses cannot mutate the catalog. */
@@ -163,14 +150,6 @@ export class CatalogStore {
         const currentRequestId = this.catalogRequestIds.get(catalogFileId);
         if (requestId !== undefined && currentRequestId !== requestId) {
             return;
-        }
-        if (currentRequestId !== undefined) {
-            let staleRequestIds = this.staleCatalogRequestIds.get(catalogFileId);
-            if (!staleRequestIds) {
-                staleRequestIds = new Set<number>();
-                this.staleCatalogRequestIds.set(catalogFileId, staleRequestIds);
-            }
-            staleRequestIds.add(currentRequestId);
         }
         this.catalogRequestIds.delete(catalogFileId);
     };

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -123,6 +123,7 @@ export class CatalogStore {
 
         // update catalogProfiles fileId
         if (catalogComponentId && associatedCatalogId.length) {
+            WidgetsStore.Instance.replaceCatalogPanelSelection(fileId, associatedCatalogId[0]);
             this.catalogProfiles.forEach((catalogFileId, componentId) => {
                 if (catalogFileId === fileId) {
                     this.catalogProfiles.set(componentId, associatedCatalogId[0]);
@@ -182,6 +183,7 @@ export class CatalogStore {
         const fileIds = this.imageAssociatedCatalogId.get(imageFileId);
         const activeCatalogFileIds = fileIds ? fileIds : [];
         if (this.catalogProfiles.size && activeCatalogFileIds?.length) {
+            WidgetsStore.Instance.resetCatalogPanelSelections(activeCatalogFileIds);
             this.catalogProfiles.forEach((value, componentId) => {
                 this.catalogProfiles.set(componentId, activeCatalogFileIds[0]);
             });

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -161,9 +161,29 @@ export class CatalogStore {
     @action resetActiveCatalogFile(imageFileId: number) {
         const fileIds = this.imageAssociatedCatalogId.get(imageFileId);
         const activeCatalogFileIds = fileIds ? fileIds : [];
-        if (this.catalogProfiles.size && activeCatalogFileIds?.length) {
+        if (!activeCatalogFileIds.length) {
+            return;
+        }
+
+        // CatalogPanelStore is the source of truth for the refactored catalog panels.
+        // Keep the legacy map synchronized while it remains for compatibility with
+        // callers that have not migrated yet.
+        if (WidgetsStore.Instance.catalogPanelWidgets.size) {
             WidgetsStore.Instance.resetCatalogPanelSelections(activeCatalogFileIds);
-            this.catalogProfiles.forEach((value, componentId) => {
+            this.catalogProfiles.forEach((_value, componentId) => {
+                if (!WidgetsStore.Instance.catalogPanelWidgets.has(componentId)) {
+                    this.catalogProfiles.delete(componentId);
+                }
+            });
+            WidgetsStore.Instance.catalogPanelWidgets.forEach((panelStore, componentId) => {
+                this.catalogProfiles.set(componentId, panelStore.selectedCatalogId);
+            });
+            return;
+        }
+
+        // Legacy-only callers still need the previous behavior during migration.
+        if (this.catalogProfiles.size) {
+            this.catalogProfiles.forEach((_value, componentId) => {
                 this.catalogProfiles.set(componentId, activeCatalogFileIds[0]);
             });
         }

--- a/src/stores/Catalog/CatalogStore.ts
+++ b/src/stores/Catalog/CatalogStore.ts
@@ -38,6 +38,9 @@ export class CatalogStore {
     @observable catalogProfileStores: Map<number, CatalogProfileStore | CatalogOnlineQueryProfileStore> = new Map();
     // catalog file Id : catalog display store
     @observable catalogDisplayStores: Map<number, CatalogDisplayStore> = new Map();
+    /** Latest filter request per catalog; streamed responses from older requests are discarded. */
+    private readonly catalogRequestIds: Map<number, number> = new Map();
+    private readonly staleCatalogRequestIds: Map<number, Set<number>> = new Map();
 
     private constructor() {
         makeObservable(this);
@@ -104,6 +107,7 @@ export class CatalogStore {
     }
 
     @action removeCatalog(fileId: number, catalogComponentId?: string) {
+        this.completeCatalogRequest(fileId);
         this.catalogGLData.delete(fileId);
         CatalogWebGLService.Instance.clearTexture(fileId);
         // update associated image
@@ -126,6 +130,49 @@ export class CatalogStore {
             });
         }
     }
+
+    /** Associate a catalog filter request with the catalog it updates. */
+    @action registerCatalogRequest = (catalogFileId: number, requestId: number) => {
+        const previousRequestId = this.catalogRequestIds.get(catalogFileId);
+        if (previousRequestId !== undefined && previousRequestId !== requestId) {
+            let staleRequestIds = this.staleCatalogRequestIds.get(catalogFileId);
+            if (!staleRequestIds) {
+                staleRequestIds = new Set<number>();
+                this.staleCatalogRequestIds.set(catalogFileId, staleRequestIds);
+            }
+            staleRequestIds.add(previousRequestId);
+        }
+        this.catalogRequestIds.set(catalogFileId, requestId);
+    };
+
+    /** Return false for a response belonging to a superseded or completed request. */
+    public acceptsCatalogResponse = (catalogFileId: number, requestId?: number): boolean => {
+        if (requestId === undefined) {
+            return true;
+        }
+        if (this.staleCatalogRequestIds.get(catalogFileId)?.has(requestId)) {
+            return false;
+        }
+        const currentRequestId = this.catalogRequestIds.get(catalogFileId);
+        return currentRequestId === undefined || currentRequestId === requestId;
+    };
+
+    /** Mark the current request as finished so late responses cannot mutate the catalog. */
+    @action completeCatalogRequest = (catalogFileId: number, requestId?: number) => {
+        const currentRequestId = this.catalogRequestIds.get(catalogFileId);
+        if (requestId !== undefined && currentRequestId !== requestId) {
+            return;
+        }
+        if (currentRequestId !== undefined) {
+            let staleRequestIds = this.staleCatalogRequestIds.get(catalogFileId);
+            if (!staleRequestIds) {
+                staleRequestIds = new Set<number>();
+                this.staleCatalogRequestIds.set(catalogFileId, staleRequestIds);
+            }
+            staleRequestIds.add(currentRequestId);
+        }
+        this.catalogRequestIds.delete(catalogFileId);
+    };
 
     @action updateImageAssociatedCatalogId(activeFrameIndex: number, associatedCatalogFiles: number[]) {
         this.imageAssociatedCatalogId.set(activeFrameIndex, associatedCatalogFiles);

--- a/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
@@ -265,12 +265,44 @@ describe("CatalogDisplayStore display config", () => {
             panelId: "catalog-panel-primary",
             catalogFileId: 7,
             tableSeparatorPosition: "40%",
-            settingsTabId: CatalogSettingsTabs.COLOR
+            settingsTabIdByCatalog: {"7": CatalogSettingsTabs.COLOR}
         });
 
         const restored = new CatalogPanelStore();
         restored.applyLayoutSettings(panel.toLayoutSettings());
         expect(restored.selectedCatalogId).toBe(7);
+        expect(restored.settingsTabId).toBe(CatalogSettingsTabs.COLOR);
         expect(restored.toLayoutSettings()).toEqual(panel.toLayoutSettings());
+    });
+
+    test("remembers the settings section of each catalog the panel has shown", () => {
+        const panel = new CatalogPanelStore(1, "catalog-panel-primary");
+        panel.setSettingsTabId(CatalogSettingsTabs.ORIENTATION);
+
+        panel.setSelectedCatalogId(2);
+        expect(panel.settingsTabId).toBe(CatalogSettingsTabs.SIZE);
+        panel.setSettingsTabId(CatalogSettingsTabs.COLOR);
+
+        panel.setSelectedCatalogId(1);
+        expect(panel.settingsTabId).toBe(CatalogSettingsTabs.ORIENTATION);
+        panel.setSelectedCatalogId(2);
+        expect(panel.settingsTabId).toBe(CatalogSettingsTabs.COLOR);
+    });
+
+    test("keeps the settings section of each panel separate", () => {
+        const first = new CatalogPanelStore(7, "catalog-panel-primary");
+        const second = new CatalogPanelStore(7, "catalog-panel-secondary");
+
+        first.setSettingsTabId(CatalogSettingsTabs.COLOR);
+
+        expect(second.settingsTabId).toBe(CatalogSettingsTabs.SIZE);
+    });
+
+    test("restores the settings section from a layout written before it was kept per catalog", () => {
+        const restored = new CatalogPanelStore();
+        restored.applyLayoutSettings({catalogFileId: 3, settingsTabId: CatalogSettingsTabs.ORIENTATION});
+
+        expect(restored.settingsTabId).toBe(CatalogSettingsTabs.ORIENTATION);
+        expect(restored.toLayoutSettings().settingsTabIdByCatalog).toEqual({"3": CatalogSettingsTabs.ORIENTATION});
     });
 });

--- a/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
@@ -19,24 +19,35 @@ const COLUMNS: ReadonlyArray<{name: string; values: number[]}> = [
     {name: "Fmag", values: [1, 4, 7, 10]},
     {name: "Bmag", values: [2, 5, 8, 11]},
     {name: "Vmag", values: [3, 6, 9, 12]},
-    {name: "PA", values: [0, 45, 90, 135]}
+    {name: "PA", values: [0, 45, 90, 135]},
+    {name: "RA", values: [10, 20, 30, 40]},
+    {name: "DEC", values: [-10, -5, 0, 5]}
 ];
+
+/** A column no axis can be plotted against, for configs that name the wrong kind of column. */
+const STRING_COLUMN = "Name";
 
 let nextCatalogFileId = 0;
 const CREATED_STORES: CatalogDisplayStore[] = [];
 
-function createProfileStore(catalogFileId: number): CatalogProfileStore {
+function createProfileStore(catalogFileId: number, scale: number = 1): CatalogProfileStore {
     const catalogHeader = COLUMNS.map((column, index) => new CARTA.CatalogHeader({columnIndex: index, dataType: CARTA.ColumnType.Double, name: column.name}));
-    const catalogData = new Map<number, ProcessedColumnData>(COLUMNS.map((column, index) => [index, {dataType: CARTA.ColumnType.Double, data: Float64Array.from(column.values)}]));
+    const catalogData = new Map<number, ProcessedColumnData>(COLUMNS.map((column, index) => [index, {dataType: CARTA.ColumnType.Double, data: Float64Array.from(column.values.map(value => value * scale))}]));
+
+    catalogHeader.push(new CARTA.CatalogHeader({columnIndex: COLUMNS.length, dataType: CARTA.ColumnType.String, name: STRING_COLUMN}));
+    catalogData.set(COLUMNS.length, {dataType: CARTA.ColumnType.String, data: ["a", "b", "c", "d"]});
 
     return new CatalogProfileStore({dataSize: COLUMNS[0].values.length, directory: "", fileId: catalogFileId, fileInfo: new CARTA.CatalogFileInfo({name: "test-catalog"})}, catalogHeader, catalogData, CatalogType.FILE);
 }
 
-/** A store whose catalog data is loaded, as {@link CatalogDisplayStore.applyConfig} requires. */
-function createStore(): CatalogDisplayStore {
+/**
+ * A store whose catalog data is loaded, as {@link CatalogDisplayStore.applyConfig} requires. The
+ * scale multiplies every column, for a catalog holding the same columns over a different range.
+ */
+function createStore(scale: number = 1): CatalogDisplayStore {
     nextCatalogFileId += 1;
     const catalogFileId = nextCatalogFileId;
-    runInAction(() => CatalogStore.Instance.catalogProfileStores.set(catalogFileId, createProfileStore(catalogFileId)));
+    runInAction(() => CatalogStore.Instance.catalogProfileStores.set(catalogFileId, createProfileStore(catalogFileId, scale)));
 
     const store = new CatalogDisplayStore(catalogFileId);
     CREATED_STORES.push(store);
@@ -173,6 +184,49 @@ describe("CatalogDisplayStore display config", () => {
         expect(store.sizeColumnMax.clipd).toBe(10);
     });
 
+    test("leaves out the clipped bounds of a column the user has not clipped", () => {
+        const store = createStore();
+
+        store.applyConfig({sizeAxis: {mapColumn: "Fmag"}, colorAxis: {mapColumn: "Vmag"}});
+
+        // The bounds hold the full data range, which the store recomputes from the data itself.
+        expect(store.sizeColumnMin.clipd).toBe(1);
+        expect(store.toConfig().sizeAxis?.columnMinClip).toBeUndefined();
+        expect(store.toConfig().sizeAxis?.columnMaxClip).toBeUndefined();
+        expect(store.toConfig().colorAxis?.columnMinClip).toBeUndefined();
+        expect(store.toConfig().colorAxis?.columnMaxClip).toBeUndefined();
+
+        store.setSizeColumnMin(2, "clipd");
+
+        expect(store.toConfig().sizeAxis?.columnMinClip).toBe(2);
+        expect(store.toConfig().sizeAxis?.columnMaxClip).toBeUndefined();
+    });
+
+    test("clips to the data of the catalog a config is restored onto, rather than the data it was written from", () => {
+        const source = createStore();
+        source.applyConfig({sizeAxis: {mapColumn: "Fmag"}});
+
+        // The same columns, over ten times the range.
+        const target = createStore(10);
+        expect(target.applyConfig(source.toConfig())).toEqual({success: true, errors: []});
+
+        expect(target.sizeColumnMin.clipd).toBe(10);
+        expect(target.sizeColumnMax.clipd).toBe(100);
+    });
+
+    test("keeps a clip the user authored when the data behind it differs", () => {
+        const source = createStore();
+        source.applyConfig({sizeAxis: {mapColumn: "Fmag"}});
+        source.setSizeColumnMin(2, "clipd");
+        source.setSizeColumnMax(8, "clipd");
+
+        const target = createStore(10);
+        target.applyConfig(source.toConfig());
+
+        expect(target.sizeColumnMin.clipd).toBe(2);
+        expect(target.sizeColumnMax.clipd).toBe(8);
+    });
+
     test("restores both size axes when the major axis is locked", () => {
         const store = createStore();
         const config: WorkspaceCatalogConfig = {
@@ -222,6 +276,37 @@ describe("CatalogDisplayStore display config", () => {
         expect(result.success).toBe(false);
         expect(result.errors).toEqual(['The color axis is mapped to "Missing", which this catalog does not have']);
         expect(store.toConfig()).toEqual(before);
+    });
+
+    test("rejects a config whose image overlay axis the catalog does not have, without changing anything", () => {
+        const store = createStore();
+        const before = store.toConfig();
+
+        const result = store.applyConfig({color: "#123456", xAxis: "RA", yAxis: "Missing"});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual(['The y axis is set to "Missing", which this catalog does not have']);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("rejects a config whose image overlay axis cannot hold a coordinate, without changing anything", () => {
+        const store = createStore();
+        const before = store.toConfig();
+
+        const result = store.applyConfig({color: "#123456", xAxis: STRING_COLUMN, yAxis: "DEC"});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual([`The x axis is set to "${STRING_COLUMN}", which is not a numeric column`]);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("restores image overlay axes the catalog has", () => {
+        const store = createStore();
+
+        expect(store.applyConfig({xAxis: "RA", yAxis: "DEC"})).toEqual({success: true, errors: []});
+
+        expect(store.xAxis).toBe("RA");
+        expect(store.yAxis).toBe("DEC");
     });
 
     test("rejects a config while the catalog data is reloading, without changing anything", () => {

--- a/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
@@ -201,6 +201,18 @@ describe("CatalogDisplayStore display config", () => {
         expect(store.toConfig()).toEqual(before);
     });
 
+    test("retries deferred layout config when catalog data becomes available", () => {
+        const store = createStoreWithoutData();
+        const catalogFileId = store.catalogFileId;
+
+        expect(store.applyConfigWhenReady({color: "#123456"})).toEqual({success: false, errors: ["The catalog data has not been loaded"]});
+        expect(store.catalogColor).not.toBe("#123456");
+
+        runInAction(() => CatalogStore.Instance.catalogProfileStores.set(catalogFileId, createProfileStore(catalogFileId)));
+
+        expect(store.catalogColor).toBe("#123456");
+    });
+
     test("rejects a config mapped to a column the catalog does not have, without changing anything", () => {
         const store = createStore();
         const before = store.toConfig();

--- a/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
@@ -9,9 +9,9 @@ jest.mock("services/CatalogWebGLService", () => ({
 import {CARTA} from "carta-protobuf";
 import {runInAction} from "mobx";
 
-import {AngularSizeUnit, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogType, ColorMap, FrameScaling} from "enums";
+import {AngularSizeUnit, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogSettingsTabs, CatalogType, ColorMap, FrameScaling} from "enums";
 import {type WorkspaceCatalogConfig} from "models/Workspace";
-import {CatalogDisplayStore, CatalogProfileStore, CatalogStore} from "stores";
+import {CatalogDisplayStore, CatalogPanelStore, CatalogProfileStore, CatalogStore} from "stores";
 import {type ProcessedColumnData} from "utilities";
 
 /** Column data every catalog in these tests carries, so that mapped columns resolve to a range. */
@@ -244,18 +244,20 @@ describe("CatalogDisplayStore display config", () => {
         expect(store.toConfig()).toEqual(before);
     });
 
-    test("keeps a layout to the catalog it shows and the panel's own geometry", () => {
-        const store = createConfiguredStore();
-        store.setTableSeparatorPosition("40%");
+    test("keeps panel selection and presentation state out of display config", () => {
+        const panel = new CatalogPanelStore(7, "catalog-panel-primary");
+        panel.setTableSeparatorPosition("40%");
+        panel.setSettingsTabId(CatalogSettingsTabs.COLOR);
 
-        expect(store.toLayoutSettings()).toEqual({
-            catalogFileId: store.catalogFileId,
-            catalogColor: "#112233",
-            highlightColor: "#445566",
-            catalogSize: store.catalogSize,
-            catalogShape: CatalogOverlayShape.BOX_LINED,
+        expect(panel.toLayoutSettings()).toEqual({
+            panelId: "catalog-panel-primary",
             tableSeparatorPosition: "40%",
-            thickness: 4
+            settingsTabId: CatalogSettingsTabs.COLOR
         });
+
+        const restored = new CatalogPanelStore();
+        restored.applyLayoutSettings(panel.toLayoutSettings());
+        expect(restored.selectedCatalogId).toBe(1);
+        expect(restored.toLayoutSettings()).toEqual(panel.toLayoutSettings());
     });
 });

--- a/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogDisplayStoreConfig.test.ts
@@ -244,20 +244,21 @@ describe("CatalogDisplayStore display config", () => {
         expect(store.toConfig()).toEqual(before);
     });
 
-    test("keeps panel selection and presentation state out of display config", () => {
+    test("round-trips panel selection and presentation state through layout config", () => {
         const panel = new CatalogPanelStore(7, "catalog-panel-primary");
         panel.setTableSeparatorPosition("40%");
         panel.setSettingsTabId(CatalogSettingsTabs.COLOR);
 
         expect(panel.toLayoutSettings()).toEqual({
             panelId: "catalog-panel-primary",
+            catalogFileId: 7,
             tableSeparatorPosition: "40%",
             settingsTabId: CatalogSettingsTabs.COLOR
         });
 
         const restored = new CatalogPanelStore();
         restored.applyLayoutSettings(panel.toLayoutSettings());
-        expect(restored.selectedCatalogId).toBe(1);
+        expect(restored.selectedCatalogId).toBe(7);
         expect(restored.toLayoutSettings()).toEqual(panel.toLayoutSettings());
     });
 });

--- a/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
@@ -1,0 +1,63 @@
+import {action, makeObservable, observable} from "mobx";
+
+import {CatalogSettingsTabs} from "enums";
+import {PreferenceStore} from "stores";
+
+/** State owned by one catalog panel rather than by the catalog it displays. */
+export interface CatalogPanelLayoutSettings {
+    panelId?: string;
+    /** Kept for layouts written before panel state was separated from display state. */
+    catalogFileId?: number;
+    tableSeparatorPosition?: string;
+    settingsTabId?: CatalogSettingsTabs;
+}
+
+export class CatalogPanelStore {
+    @observable panelId: string;
+    @observable selectedCatalogId: number = 1;
+    @observable tableSeparatorPosition: string = PreferenceStore.Instance.catalogTableSeparatorPosition;
+    @observable settingsTabId: CatalogSettingsTabs = CatalogSettingsTabs.SIZE;
+
+    constructor(selectedCatalogId: number = 1, panelId: string = "") {
+        this.selectedCatalogId = selectedCatalogId;
+        this.panelId = panelId;
+        makeObservable(this);
+    }
+
+    @action setPanelId = (panelId: string) => {
+        this.panelId = panelId;
+    };
+
+    @action setSelectedCatalogId = (catalogFileId: number) => {
+        this.selectedCatalogId = catalogFileId;
+    };
+
+    @action setTableSeparatorPosition = (position: string) => {
+        this.tableSeparatorPosition = position;
+    };
+
+    @action setSettingsTabId = (tabId: CatalogSettingsTabs) => {
+        this.settingsTabId = tabId;
+    };
+
+    public toLayoutSettings = (): CatalogPanelLayoutSettings => ({
+        ...(this.panelId ? {panelId: this.panelId} : {}),
+        tableSeparatorPosition: this.tableSeparatorPosition,
+        settingsTabId: this.settingsTabId
+    });
+
+    @action applyLayoutSettings = (settings: CatalogPanelLayoutSettings | null | undefined) => {
+        if (!settings) {
+            return;
+        }
+        if (typeof settings.panelId === "string" && settings.panelId) {
+            this.panelId = settings.panelId;
+        }
+        if (typeof settings.tableSeparatorPosition === "string") {
+            this.tableSeparatorPosition = settings.tableSeparatorPosition;
+        }
+        if (typeof settings.settingsTabId === "number") {
+            this.settingsTabId = settings.settingsTabId;
+        }
+    };
+}

--- a/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
@@ -42,6 +42,7 @@ export class CatalogPanelStore {
 
     public toLayoutSettings = (): CatalogPanelLayoutSettings => ({
         ...(this.panelId ? {panelId: this.panelId} : {}),
+        catalogFileId: this.selectedCatalogId,
         tableSeparatorPosition: this.tableSeparatorPosition,
         settingsTabId: this.settingsTabId
     });
@@ -52,6 +53,9 @@ export class CatalogPanelStore {
         }
         if (typeof settings.panelId === "string" && settings.panelId) {
             this.panelId = settings.panelId;
+        }
+        if (typeof settings.catalogFileId === "number") {
+            this.selectedCatalogId = settings.catalogFileId;
         }
         if (typeof settings.tableSeparatorPosition === "string") {
             this.tableSeparatorPosition = settings.tableSeparatorPosition;

--- a/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPanelStore.ts
@@ -1,4 +1,4 @@
-import {action, makeObservable, observable} from "mobx";
+import {action, computed, makeObservable, observable} from "mobx";
 
 import {CatalogSettingsTabs} from "enums";
 import {PreferenceStore} from "stores";
@@ -9,6 +9,9 @@ export interface CatalogPanelLayoutSettings {
     /** Kept for layouts written before panel state was separated from display state. */
     catalogFileId?: number;
     tableSeparatorPosition?: string;
+    /** The settings section this panel was left on, per catalog file ID. */
+    settingsTabIdByCatalog?: Record<string, CatalogSettingsTabs>;
+    /** Kept for layouts written while the settings section belonged to the panel alone. */
     settingsTabId?: CatalogSettingsTabs;
 }
 
@@ -16,7 +19,12 @@ export class CatalogPanelStore {
     @observable panelId: string;
     @observable selectedCatalogId: number = 1;
     @observable tableSeparatorPosition: string = PreferenceStore.Instance.catalogTableSeparatorPosition;
-    @observable settingsTabId: CatalogSettingsTabs = CatalogSettingsTabs.SIZE;
+    /**
+     * The settings section for each catalog this panel has shown. The section belongs to the panel,
+     * so two panels showing one catalog keep their own, but it is remembered per catalog so that a
+     * panel returning to a catalog returns to the section that catalog was left on.
+     */
+    @observable private settingsTabIdByCatalog = new Map<number, CatalogSettingsTabs>();
 
     constructor(selectedCatalogId: number = 1, panelId: string = "") {
         this.selectedCatalogId = selectedCatalogId;
@@ -36,15 +44,19 @@ export class CatalogPanelStore {
         this.tableSeparatorPosition = position;
     };
 
+    @computed get settingsTabId(): CatalogSettingsTabs {
+        return this.settingsTabIdByCatalog.get(this.selectedCatalogId) ?? CatalogSettingsTabs.SIZE;
+    }
+
     @action setSettingsTabId = (tabId: CatalogSettingsTabs) => {
-        this.settingsTabId = tabId;
+        this.settingsTabIdByCatalog.set(this.selectedCatalogId, tabId);
     };
 
     public toLayoutSettings = (): CatalogPanelLayoutSettings => ({
         ...(this.panelId ? {panelId: this.panelId} : {}),
         catalogFileId: this.selectedCatalogId,
         tableSeparatorPosition: this.tableSeparatorPosition,
-        settingsTabId: this.settingsTabId
+        settingsTabIdByCatalog: Object.fromEntries(Array.from(this.settingsTabIdByCatalog, ([catalogFileId, tabId]) => [String(catalogFileId), tabId]))
     });
 
     @action applyLayoutSettings = (settings: CatalogPanelLayoutSettings | null | undefined) => {
@@ -60,8 +72,14 @@ export class CatalogPanelStore {
         if (typeof settings.tableSeparatorPosition === "string") {
             this.tableSeparatorPosition = settings.tableSeparatorPosition;
         }
-        if (typeof settings.settingsTabId === "number") {
-            this.settingsTabId = settings.settingsTabId;
+        if (settings.settingsTabIdByCatalog) {
+            for (const [catalogFileId, tabId] of Object.entries(settings.settingsTabIdByCatalog)) {
+                if (Number.isFinite(Number(catalogFileId)) && typeof tabId === "number") {
+                    this.settingsTabIdByCatalog.set(Number(catalogFileId), tabId);
+                }
+            }
+        } else if (typeof settings.settingsTabId === "number") {
+            this.settingsTabIdByCatalog.set(this.selectedCatalogId, settings.settingsTabId);
         }
     };
 }

--- a/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.test.ts
@@ -1,0 +1,27 @@
+import {CatalogPlotType} from "enums";
+import {CatalogPlotWidgetStore} from "stores";
+
+describe("CatalogPlotWidgetStore config", () => {
+    test("round-trips user plot settings", () => {
+        const store = new CatalogPlotWidgetStore({xColumnName: "Fmag", yColumnName: "Bmag", plotType: CatalogPlotType.D2Scatter});
+        store.setStatisticColumn("Vmag");
+        store.setLogScaleY(false);
+        store.setNumBinsX(25);
+        store.setDragMode("zoom");
+        store.setScatterborder({xMin: 1, xMax: 10, yMin: 2, yMax: 11});
+
+        const restored = new CatalogPlotWidgetStore({xColumnName: "None", yColumnName: "None", plotType: CatalogPlotType.D2Scatter});
+        restored.applyConfig(store.toConfig());
+
+        expect(restored.toConfig()).toEqual(store.toConfig());
+    });
+
+    test("ignores invalid optional values", () => {
+        const store = new CatalogPlotWidgetStore({xColumnName: "Fmag", yColumnName: "Bmag", plotType: CatalogPlotType.D2Scatter});
+
+        store.applyConfig({nBinX: 0, isLogScaleY: false});
+
+        expect(store.nBinX).toBeUndefined();
+        expect(store.isLogScaleY).toBe(false);
+    });
+});

--- a/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.ts
@@ -14,6 +14,18 @@ export type Border = {xMin: number; xMax: number; yMin: number; yMax: number};
 export type XBorder = {xMin: number; xMax: number};
 export type DragMode = "zoom" | "pan" | "select" | "lasso" | "orbit" | "turntable" | false;
 
+export interface CatalogPlotWidgetConfig {
+    plotType: CatalogPlotType;
+    xColumnName: string;
+    yColumnName?: string;
+    statisticColumnName?: string;
+    isLogScaleY?: boolean;
+    nBinX?: number;
+    dragMode?: DragMode;
+    scatterBorder?: Border;
+    histogramBorder?: XBorder;
+}
+
 type Fitting = {intercept: number; slope: number; cov00: number; cov01: number; cov11: number; rss: number};
 type Statistic = {mean: number; count: number; validCount: number; std: number; min: number; max: number; rms: number};
 
@@ -38,6 +50,45 @@ export class CatalogPlotWidgetStore {
         this.xColumnName = props.xColumnName;
         this.yColumnName = props.yColumnName;
         makeObservable(this);
+    }
+
+    public toConfig = (): CatalogPlotWidgetConfig => ({
+        plotType: this.plotType,
+        xColumnName: this.xColumnName,
+        yColumnName: this.yColumnName,
+        statisticColumnName: this.statisticColumnName,
+        isLogScaleY: this.isLogScaleY,
+        nBinX: this.nBinX,
+        dragMode: this.dragMode,
+        scatterBorder: this.scatterBorder,
+        histogramBorder: this.histogramBorder
+    });
+
+    @action applyConfig(config: Partial<CatalogPlotWidgetConfig>) {
+        if (typeof config.xColumnName === "string") {
+            this.xColumnName = config.xColumnName;
+        }
+        if (typeof config.yColumnName === "string") {
+            this.yColumnName = config.yColumnName;
+        }
+        if (typeof config.statisticColumnName === "string") {
+            this.statisticColumnName = config.statisticColumnName;
+        }
+        if (typeof config.isLogScaleY === "boolean") {
+            this.isLogScaleY = config.isLogScaleY;
+        }
+        if (Number.isInteger(config.nBinX) && (config.nBinX as number) > 0) {
+            this.nBinX = config.nBinX;
+        }
+        if (config.dragMode !== undefined) {
+            this.dragMode = config.dragMode;
+        }
+        if (config.scatterBorder) {
+            this.scatterBorder = config.scatterBorder;
+        }
+        if (config.histogramBorder) {
+            this.histogramBorder = config.histogramBorder;
+        }
     }
 
     @action setStatisticColumn(columnName: string) {

--- a/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogPlotWidgetStore.ts
@@ -16,6 +16,8 @@ export type DragMode = "zoom" | "pan" | "select" | "lasso" | "orbit" | "turntabl
 
 export interface CatalogPlotWidgetConfig {
     plotType: CatalogPlotType;
+    /** The catalog this plot belongs to. Its columns mean nothing against any other catalog. */
+    catalogFileId?: number;
     xColumnName: string;
     yColumnName?: string;
     statisticColumnName?: string;

--- a/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.test.ts
+++ b/src/stores/Widgets/CatalogWidget/CatalogWidgetStore.test.ts
@@ -1,0 +1,261 @@
+jest.mock("services/CatalogWebGLService", () => ({
+    CatalogWebGLService: {
+        Instance: {
+            updateDataTexture: jest.fn()
+        }
+    }
+}));
+
+import {CARTA} from "carta-protobuf";
+import {runInAction} from "mobx";
+
+import {AngularSizeUnit, CatalogOverlay, CatalogOverlayShape, CatalogPlotType, CatalogType, ColorMap, FrameScaling} from "enums";
+import {type WorkspaceCatalogConfig} from "models/Workspace";
+import {CatalogDisplayStore, CatalogProfileStore, CatalogStore} from "stores";
+import {type ProcessedColumnData} from "utilities";
+
+/** Column data every catalog in these tests carries, so that mapped columns resolve to a range. */
+const COLUMNS: ReadonlyArray<{name: string; values: number[]}> = [
+    {name: "Fmag", values: [1, 4, 7, 10]},
+    {name: "Bmag", values: [2, 5, 8, 11]},
+    {name: "Vmag", values: [3, 6, 9, 12]},
+    {name: "PA", values: [0, 45, 90, 135]}
+];
+
+let nextCatalogFileId = 0;
+const CREATED_STORES: CatalogDisplayStore[] = [];
+
+function createProfileStore(catalogFileId: number): CatalogProfileStore {
+    const catalogHeader = COLUMNS.map((column, index) => new CARTA.CatalogHeader({columnIndex: index, dataType: CARTA.ColumnType.Double, name: column.name}));
+    const catalogData = new Map<number, ProcessedColumnData>(COLUMNS.map((column, index) => [index, {dataType: CARTA.ColumnType.Double, data: Float64Array.from(column.values)}]));
+
+    return new CatalogProfileStore({dataSize: COLUMNS[0].values.length, directory: "", fileId: catalogFileId, fileInfo: new CARTA.CatalogFileInfo({name: "test-catalog"})}, catalogHeader, catalogData, CatalogType.FILE);
+}
+
+/** A store whose catalog data is loaded, as {@link CatalogDisplayStore.applyConfig} requires. */
+function createStore(): CatalogDisplayStore {
+    nextCatalogFileId += 1;
+    const catalogFileId = nextCatalogFileId;
+    runInAction(() => CatalogStore.Instance.catalogProfileStores.set(catalogFileId, createProfileStore(catalogFileId)));
+
+    const store = new CatalogDisplayStore(catalogFileId);
+    CREATED_STORES.push(store);
+    return store;
+}
+
+/** A store with no catalog data behind it. */
+function createStoreWithoutData(): CatalogDisplayStore {
+    nextCatalogFileId += 1;
+    const store = new CatalogDisplayStore(nextCatalogFileId);
+    CREATED_STORES.push(store);
+    return store;
+}
+
+/** A store with something set in every group of the display config. */
+function createConfiguredStore(): CatalogDisplayStore {
+    const store = createStore();
+
+    store.setCatalogColor("#112233");
+    store.setHighlightColor("#445566");
+    store.setCatalogShape(CatalogOverlayShape.BOX_LINED);
+    store.setCatalogSize(12);
+    store.setThickness(4);
+    store.setCatalogPlotType(CatalogPlotType.D2Scatter);
+    store.setWorldSizeUnit(AngularSizeUnit.ARCMIN);
+    store.setxAxis("RA");
+    store.setyAxis("DEC");
+
+    store.setSizeMap("Fmag");
+    store.setSizeArea(true);
+    store.setSizeScalingType(FrameScaling.LOG);
+    store.setSizeScalingParameter(500);
+    store.setSizeColumnMin(2, "clipd");
+    store.setSizeColumnMax(8, "clipd");
+
+    store.setSizeMinorMap("Bmag");
+    store.setSizeMinorScalingType(FrameScaling.POWER);
+    store.setSizeMinorColumnMin(3, "clipd");
+    store.setSizeMinorColumnMax(9, "clipd");
+
+    store.setColorMapColumn("Vmag");
+    store.setColorMap(ColorMap.Inferno);
+    store.setColorMapDirection(true);
+    store.setColorScalingType(FrameScaling.SQRT);
+    store.setColorColumnMin(4, "clipd");
+    store.setColorColumnMax(10, "clipd");
+
+    store.setOrientationMapColumn("PA");
+    store.setOrientationScalingType(FrameScaling.GAMMA);
+    store.setOrientationMin(5, "clipd");
+    store.setOrientationMax(11, "clipd");
+    store.setAngleMin(30);
+    store.setAngleMax(300);
+
+    return store;
+}
+
+afterEach(() => {
+    CREATED_STORES.forEach(store => store.dispose());
+    CREATED_STORES.length = 0;
+    runInAction(() => CatalogStore.Instance.catalogProfileStores.clear());
+});
+
+describe("CatalogDisplayStore display config", () => {
+    test("round-trips a configured store through another store", () => {
+        const config = createConfiguredStore().toConfig();
+
+        const restored = createStore();
+        expect(restored.applyConfig(config)).toEqual({success: true, errors: []});
+
+        expect(restored.toConfig()).toEqual(config);
+    });
+
+    test("returns fields the config leaves out to their defaults", () => {
+        const store = createConfiguredStore();
+
+        store.applyConfig({color: "#123456"});
+
+        expect(store.catalogColor).toBe("#123456");
+        expect(store.catalogShape).toBe(CatalogOverlayShape.CIRCLE_LINED);
+        expect(store.thickness).toBe(2);
+        expect(store.showedCatalogSize).toBe(10);
+        expect(store.catalogPlotType).toBe(CatalogPlotType.ImageOverlay);
+        expect(store.xAxis).toBe(CatalogOverlay.NONE);
+        expect(store.sizeMapColumn).toBe(CatalogOverlay.NONE);
+        expect(store.sizeColumnMin.clipd).toBeUndefined();
+        expect(store.isSizeAreaMode).toBe(false);
+        expect(store.sizeScalingType).toBe(FrameScaling.LINEAR);
+        expect(store.sizeMinorMapColumn).toBe(CatalogOverlay.NONE);
+        expect(store.colorMapColumn).toBe(CatalogOverlay.NONE);
+        expect(store.colorMap).toBe(ColorMap.Viridis);
+        expect(store.isInvertedColorMap).toBe(false);
+        expect(store.orientationMapColumn).toBe(CatalogOverlay.NONE);
+        expect(store.angleMin).toBe(CatalogDisplayStore.MIN_ANGLE);
+        expect(store.angleMax).toBe(CatalogDisplayStore.MAX_ANGLE);
+    });
+
+    test("keeps the clipped bounds a config carries when the mapped column changes", () => {
+        const store = createStore();
+
+        // Changing a mapped column makes the data-derived defaults recompute, which on its own
+        // resets the clip to the full data range.
+        store.applyConfig({
+            sizeAxis: {mapColumn: "Fmag", columnMinClip: 2, columnMaxClip: 8},
+            colorAxis: {mapColumn: "Vmag", columnMinClip: 4, columnMaxClip: 10},
+            orientationAxis: {mapColumn: "PA", columnMinClip: 5, columnMaxClip: 11}
+        });
+
+        expect(store.sizeColumnMin.clipd).toBe(2);
+        expect(store.sizeColumnMax.clipd).toBe(8);
+        expect(store.colorColumnMin.clipd).toBe(4);
+        expect(store.colorColumnMax.clipd).toBe(10);
+        expect(store.orientationMin.clipd).toBe(5);
+        expect(store.orientationMax.clipd).toBe(11);
+    });
+
+    test("clips a mapped column with no stated bounds to the full data range, however often it is applied", () => {
+        const store = createStore();
+        const config: WorkspaceCatalogConfig = {colorAxis: {mapColumn: "Vmag"}, sizeAxis: {mapColumn: "Fmag"}};
+
+        store.applyConfig(config);
+
+        expect(store.colorColumnMin.clipd).toBe(3);
+        expect(store.colorColumnMax.clipd).toBe(12);
+        expect(store.sizeColumnMin.clipd).toBe(1);
+        expect(store.sizeColumnMax.clipd).toBe(10);
+
+        // The mapped columns no longer change, so nothing recomputes the bounds on our behalf.
+        store.applyConfig(config);
+
+        expect(store.colorColumnMin.clipd).toBe(3);
+        expect(store.colorColumnMax.clipd).toBe(12);
+        expect(store.sizeColumnMin.clipd).toBe(1);
+        expect(store.sizeColumnMax.clipd).toBe(10);
+    });
+
+    test("restores both size axes when the major axis is locked", () => {
+        const store = createStore();
+        const config: WorkspaceCatalogConfig = {
+            sizeAxis: {mapColumn: "Fmag", columnMinClip: 2, columnMaxClip: 8, columnMinLocked: true, columnMaxLocked: true},
+            sizeMinorAxis: {mapColumn: "Bmag", columnMinClip: 2, columnMaxClip: 8}
+        };
+
+        store.applyConfig(config);
+
+        expect(store.isSizeColumnMinLocked).toBe(true);
+        expect(store.isSizeColumnMaxLocked).toBe(true);
+        expect(store.sizeColumnMin.clipd).toBe(2);
+        expect(store.sizeColumnMax.clipd).toBe(8);
+        expect(store.sizeMinorColumnMin.clipd).toBe(2);
+        expect(store.sizeMinorColumnMax.clipd).toBe(8);
+    });
+
+    test("rejects a config when the catalog data is not loaded, without changing anything", () => {
+        const store = createStoreWithoutData();
+        const before = store.toConfig();
+
+        const result = store.applyConfig({color: "#123456", sizeAxis: {mapColumn: "Fmag", columnMinClip: 2, columnMaxClip: 8}});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual(["The catalog data has not been loaded"]);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("rejects a config mapped to a column the catalog does not have, without changing anything", () => {
+        const store = createStore();
+        const before = store.toConfig();
+
+        const result = store.applyConfig({color: "#123456", colorAxis: {mapColumn: "Missing"}});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual(['The color axis is mapped to "Missing", which this catalog does not have']);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("rejects a config while the catalog data is reloading, without changing anything", () => {
+        const store = createStore();
+        const before = store.toConfig();
+
+        // A filter change clears the rows and puts the catalog back into loading; the headers stay,
+        // so the columns a config names still look resolvable.
+        CatalogStore.Instance.catalogProfileStores.get(store.catalogFileId)?.resetFilterRequest();
+
+        const result = store.applyConfig({color: "#123456", sizeAxis: {mapColumn: "Fmag", columnMinClip: 2, columnMaxClip: 8}});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual(["The catalog data is still loading"]);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("rejects a config mapped to a column with no data, without changing anything", () => {
+        const store = createStore();
+        const before = store.toConfig();
+
+        const profileStore = CatalogStore.Instance.catalogProfileStores.get(store.catalogFileId);
+        runInAction(() => {
+            profileStore?.clearData();
+            profileStore?.setLoadingDataStatus(false);
+        });
+
+        const result = store.applyConfig({color: "#123456", sizeAxis: {mapColumn: "Fmag"}});
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual(['The size axis is mapped to "Fmag", which has no data to map']);
+        expect(store.toConfig()).toEqual(before);
+    });
+
+    test("keeps a layout to the catalog it shows and the panel's own geometry", () => {
+        const store = createConfiguredStore();
+        store.setTableSeparatorPosition("40%");
+
+        expect(store.toLayoutSettings()).toEqual({
+            catalogFileId: store.catalogFileId,
+            catalogColor: "#112233",
+            highlightColor: "#445566",
+            catalogSize: store.catalogSize,
+            catalogShape: CatalogOverlayShape.BOX_LINED,
+            tableSeparatorPosition: "40%",
+            thickness: 4
+        });
+    });
+});

--- a/src/stores/Widgets/WidgetsStore.test.tsx
+++ b/src/stores/Widgets/WidgetsStore.test.tsx
@@ -212,13 +212,41 @@ describe("WidgetsStore PV preview test ids", () => {
 
     test("applies catalog display settings while restoring a catalog panel", () => {
         const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
-        const displayStore = {applyConfig: jest.fn()};
-        const widgetSettings = {catalogFileId: 7, color: "#123456", shape: "circle"};
+        const displayStore = {applyConfigWhenReady: jest.fn()};
+        const widgetSettings = {catalogFileId: 7, catalogColor: "#123456", catalogShape: "circle", catalogSize: 14, panelPosition: "top"};
 
         CatalogStore.Instance.catalogDisplayStores.set(7, displayStore as any);
 
         expect((widgetsStore as any).initializeCatalogOverlayWidget(widgetSettings, "catalog-overlay-7")).toBe("catalog-overlay-7");
-        expect(displayStore.applyConfig).toHaveBeenCalledWith(widgetSettings);
+        expect(displayStore.applyConfigWhenReady).toHaveBeenCalledWith({
+            ...widgetSettings,
+            color: "#123456",
+            shape: "circle",
+            size: 14
+        });
+
+        CatalogStore.Instance.catalogDisplayStores.delete(7);
+        CatalogStore.Instance.catalogProfiles.delete("catalog-overlay-7");
+    });
+
+    test("prefers current catalog display fields over legacy fields when restoring", () => {
+        const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
+        const displayStore = {applyConfigWhenReady: jest.fn()};
+        const widgetSettings = {
+            catalogFileId: 7,
+            catalogColor: "#123456",
+            catalogShape: "circle",
+            catalogSize: 14,
+            color: "#abcdef",
+            shape: "box",
+            size: 9
+        };
+
+        CatalogStore.Instance.catalogDisplayStores.set(7, displayStore as any);
+
+        (widgetsStore as any).initializeCatalogOverlayWidget(widgetSettings, "catalog-overlay-7");
+
+        expect(displayStore.applyConfigWhenReady).toHaveBeenCalledWith(widgetSettings);
 
         CatalogStore.Instance.catalogDisplayStores.delete(7);
         CatalogStore.Instance.catalogProfiles.delete("catalog-overlay-7");

--- a/src/stores/Widgets/WidgetsStore.test.tsx
+++ b/src/stores/Widgets/WidgetsStore.test.tsx
@@ -3,6 +3,7 @@ import {Actions} from "flexlayout-react";
 
 import {IsoTimePrecision, RelativeTimeReference, RelativeTimeUnit, TimeLabelFormat, TimeScale, TimeZoneMode} from "enums";
 import {AppStore} from "stores/AppStore/AppStore";
+import {CatalogStore} from "stores/Catalog/CatalogStore";
 import {LayoutStore} from "stores/LayoutStore/LayoutStore";
 
 import {WidgetsStore} from "./WidgetsStore";
@@ -191,5 +192,35 @@ describe("WidgetsStore PV preview test ids", () => {
             relativeReferenceMjdUtc: 58000,
             relativeTimeUnit: RelativeTimeUnit.DAY
         });
+    });
+
+    test("persists catalog display settings alongside panel layout settings", () => {
+        const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
+        const panelStore = widgetsStore.getCatalogPanelStore("catalog-overlay-7", 7);
+        const displayConfig = {color: "#123456", shape: "circle", size: 12, thickness: 3};
+        const displayStore = {toConfig: () => displayConfig};
+
+        CatalogStore.Instance.catalogDisplayStores.set(7, displayStore as any);
+
+        expect(widgetsStore.toWidgetSettingsConfig("catalog-overlay", "catalog-overlay-7")).toEqual({
+            ...displayConfig,
+            ...panelStore.toLayoutSettings()
+        });
+
+        CatalogStore.Instance.catalogDisplayStores.delete(7);
+    });
+
+    test("applies catalog display settings while restoring a catalog panel", () => {
+        const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
+        const displayStore = {applyConfig: jest.fn()};
+        const widgetSettings = {catalogFileId: 7, color: "#123456", shape: "circle"};
+
+        CatalogStore.Instance.catalogDisplayStores.set(7, displayStore as any);
+
+        expect((widgetsStore as any).initializeCatalogOverlayWidget(widgetSettings, "catalog-overlay-7")).toBe("catalog-overlay-7");
+        expect(displayStore.applyConfig).toHaveBeenCalledWith(widgetSettings);
+
+        CatalogStore.Instance.catalogDisplayStores.delete(7);
+        CatalogStore.Instance.catalogProfiles.delete("catalog-overlay-7");
     });
 });

--- a/src/stores/Widgets/WidgetsStore.test.tsx
+++ b/src/stores/Widgets/WidgetsStore.test.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import {Actions} from "flexlayout-react";
 
-import {IsoTimePrecision, RelativeTimeReference, RelativeTimeUnit, TimeLabelFormat, TimeScale, TimeZoneMode} from "enums";
+import {CatalogPlotType, IsoTimePrecision, RelativeTimeReference, RelativeTimeUnit, TimeLabelFormat, TimeScale, TimeZoneMode} from "enums";
 import {AppStore} from "stores/AppStore/AppStore";
 import {CatalogStore} from "stores/Catalog/CatalogStore";
 import {LayoutStore} from "stores/LayoutStore/LayoutStore";
@@ -227,6 +227,34 @@ describe("WidgetsStore PV preview test ids", () => {
 
         CatalogStore.Instance.catalogDisplayStores.delete(7);
         CatalogStore.Instance.catalogProfiles.delete("catalog-overlay-7");
+    });
+
+    test("keeps a restored plot with the catalog it was saved against", () => {
+        const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
+        const widgetSettings = {plotType: CatalogPlotType.D2Scatter, xColumnName: "Fmag", yColumnName: "Bmag", catalogFileId: 3};
+
+        const widgetStoreId = (widgetsStore as any).initializeCatalogPlotWidget({xColumnName: "None", yColumnName: "None", plotType: CatalogPlotType.D2Scatter}, "catalog-plot-0", widgetSettings);
+        const {catalogFileId, catalogPlotComponentId} = CatalogStore.Instance.getAssociatedIdByWidgetId(widgetStoreId);
+
+        expect(catalogFileId).toBe(3);
+        expect(widgetsStore.toWidgetSettingsConfig("catalog-plot", widgetStoreId)).toEqual({
+            ...widgetsStore.catalogPlotWidgets.get(widgetStoreId)?.toConfig(),
+            catalogFileId: 3
+        });
+
+        CatalogStore.Instance.catalogPlots.delete(catalogPlotComponentId);
+    });
+
+    test("restores a plot from a layout written before the catalog association was saved", () => {
+        const widgetsStore = new (WidgetsStore as any)() as WidgetsStore;
+        const widgetSettings = {plotType: CatalogPlotType.D2Scatter, xColumnName: "Fmag", yColumnName: "Bmag"};
+
+        const widgetStoreId = (widgetsStore as any).initializeCatalogPlotWidget({xColumnName: "None", yColumnName: "None", plotType: CatalogPlotType.D2Scatter}, "catalog-plot-0", widgetSettings);
+        const {catalogFileId, catalogPlotComponentId} = CatalogStore.Instance.getAssociatedIdByWidgetId(widgetStoreId);
+
+        expect(catalogFileId).toBe(1);
+
+        CatalogStore.Instance.catalogPlots.delete(catalogPlotComponentId);
     });
 
     test("prefers current catalog display fields over legacy fields when restoring", () => {

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -1580,16 +1580,17 @@ export class WidgetsStore {
         return true;
     };
 
-    /** Select a catalog in the first panel when an image-view interaction identifies it. */
-    @action updateCatalogPanelSelection = (catalogFileId: number) => {
-        const panel = Array.from(this.catalogPanelWidgets.values()).find(panelStore => panelStore.selectedCatalogId === catalogFileId) ?? Array.from(this.catalogPanelWidgets.values())[0];
-        if (panel) {
-            panel.setSelectedCatalogId(catalogFileId);
-            const componentId = Array.from(this.catalogPanelWidgets.entries()).find(([, panelStore]) => panelStore === panel)?.[0];
-            if (componentId) {
-                CatalogStore.Instance.catalogProfiles.set(componentId, catalogFileId);
-            }
+    /** Select a catalog in the first panel when an image-view interaction identifies it, and return that panel's ID. */
+    @action updateCatalogPanelSelection = (catalogFileId: number): string | undefined => {
+        const panels = Array.from(this.catalogPanelWidgets.entries());
+        const panel = panels.find(([, panelStore]) => panelStore.selectedCatalogId === catalogFileId) ?? panels[0];
+        if (!panel) {
+            return undefined;
         }
+        const [componentId, panelStore] = panel;
+        panelStore.setSelectedCatalogId(catalogFileId);
+        CatalogStore.Instance.catalogProfiles.set(componentId, catalogFileId);
+        return componentId;
     };
 
     /** Replace a catalog only in panels that were showing it. */

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -549,7 +549,15 @@ export class WidgetsStore {
             // Ensure catalogProfiles is set to the saved fileId so the component can look
             // up the correct file (the component constructor only defaults to fileId 1).
             CatalogStore.Instance.catalogProfiles.set(componentId, selectedCatalogId);
-            CatalogStore.Instance.getOrCreateCatalogDisplayStore(selectedCatalogId).applyConfig(widgetSettings);
+            // PR2 stored display settings with catalog-prefixed names. Normalize them at the
+            // restore boundary while allowing the current workspace names to take precedence.
+            const displaySettings = {
+                ...widgetSettings,
+                color: widgetSettings["color"] ?? widgetSettings["catalogColor"],
+                shape: widgetSettings["shape"] ?? widgetSettings["catalogShape"],
+                size: widgetSettings["size"] ?? widgetSettings["catalogSize"]
+            };
+            CatalogStore.Instance.getOrCreateCatalogDisplayStore(selectedCatalogId).applyConfigWhenReady(displaySettings);
             return componentId;
         }
         const itemId = preAssignedId || this.getNextComponentId(CatalogOverlayComponent.WidgetConfig);

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -570,7 +570,11 @@ export class WidgetsStore {
         const itemId = this.addCatalogPlotWidget(props, preAssignedId, widgetSettings);
         if (itemId) {
             const componentId = this.getNextComponentId(CatalogPlotComponent.WidgetConfig);
-            CatalogStore.Instance.setCatalogPlots(componentId, 1, itemId);
+            // The restored columns belong to the catalog the plot was saved against, so the plot is
+            // registered under that catalog. Layouts written before the association was saved fall
+            // back to the first catalog.
+            const savedCatalogFileId = widgetSettings?.["catalogFileId"];
+            CatalogStore.Instance.setCatalogPlots(componentId, typeof savedCatalogFileId === "number" ? savedCatalogFileId : 1, itemId);
         }
         return itemId;
     };
@@ -1117,7 +1121,7 @@ export class WidgetsStore {
             };
         }
 
-        let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | CatalogPlotWidgetStore | AnimatorWidgetStore | null | undefined = null;
+        let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | AnimatorWidgetStore | null | undefined = null;
         switch (widgetType) {
             case RenderConfigComponent.WidgetConfig.type:
                 widgetStore = this.renderConfigWidgets.get(widgetID);
@@ -1134,9 +1138,16 @@ export class WidgetsStore {
             case StokesAnalysisComponent.WidgetConfig.type:
                 widgetStore = this.stokesAnalysisWidgets.get(widgetID);
                 break;
-            case CatalogPlotComponent.WidgetConfig.type:
-                widgetStore = this.catalogPlotWidgets.get(widgetID);
-                break;
+            case CatalogPlotComponent.WidgetConfig.type: {
+                const plotStore = this.catalogPlotWidgets.get(widgetID);
+                if (!plotStore) {
+                    return undefined;
+                }
+                // The catalog association lives in CatalogStore rather than in the plot store, but
+                // without it the restored columns cannot be matched back to their catalog.
+                const {catalogFileId} = CatalogStore.Instance.getAssociatedIdByWidgetId(widgetID);
+                return {...plotStore.toConfig(), ...(typeof catalogFileId === "number" ? {catalogFileId} : {})};
+            }
             case AnimatorComponent.WidgetConfig.type:
                 widgetStore = this.animatorWidgets.get(widgetID);
                 break;

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -1592,6 +1592,30 @@ export class WidgetsStore {
         }
     };
 
+    /** Replace a catalog only in panels that were showing it. */
+    @action replaceCatalogPanelSelection = (catalogFileId: number, replacementCatalogFileId: number) => {
+        this.catalogPanelWidgets.forEach((panelStore, componentId) => {
+            if (panelStore.selectedCatalogId === catalogFileId) {
+                panelStore.setSelectedCatalogId(replacementCatalogFileId);
+                CatalogStore.Instance.catalogProfiles.set(componentId, replacementCatalogFileId);
+            }
+        });
+    };
+
+    /** Keep panel selections valid when the active image changes. */
+    @action resetCatalogPanelSelections = (activeCatalogFileIds: number[]) => {
+        if (activeCatalogFileIds.length === 0) {
+            return;
+        }
+        const activeCatalogFileIdSet = new Set(activeCatalogFileIds);
+        this.catalogPanelWidgets.forEach((panelStore, componentId) => {
+            if (!activeCatalogFileIdSet.has(panelStore.selectedCatalogId)) {
+                panelStore.setSelectedCatalogId(activeCatalogFileIds[0]);
+                CatalogStore.Instance.catalogProfiles.set(componentId, activeCatalogFileIds[0]);
+            }
+        });
+    };
+
     // endregion
 
     // region Catalog Plot Widgets

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -549,7 +549,7 @@ export class WidgetsStore {
             // Ensure catalogProfiles is set to the saved fileId so the component can look
             // up the correct file (the component constructor only defaults to fileId 1).
             CatalogStore.Instance.catalogProfiles.set(componentId, selectedCatalogId);
-            CatalogStore.Instance.getOrCreateCatalogDisplayStore(selectedCatalogId);
+            CatalogStore.Instance.getOrCreateCatalogDisplayStore(selectedCatalogId).applyConfig(widgetSettings);
             return componentId;
         }
         const itemId = preAssignedId || this.getNextComponentId(CatalogOverlayComponent.WidgetConfig);
@@ -1097,9 +1097,16 @@ export class WidgetsStore {
         }
 
         if (widgetType === CatalogOverlayComponent.WidgetConfig.type) {
-            // A layout keeps only the catalog a panel shows and the panel's own geometry; the
-            // rest of a catalog's appearance is display config and belongs to the workspace.
-            return this.catalogPanelWidgets.get(widgetID)?.toLayoutSettings();
+            const panelStore = this.catalogPanelWidgets.get(widgetID);
+            if (!panelStore) {
+                return undefined;
+            }
+            const catalogDisplayStore = CatalogStore.Instance.getCatalogDisplayStore(panelStore.selectedCatalogId);
+            // Keep the legacy flat layout shape until workspace persistence owns display state.
+            return {
+                ...(catalogDisplayStore?.toConfig() ?? {}),
+                ...panelStore.toLayoutSettings()
+            };
         }
 
         let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | CatalogPlotWidgetStore | AnimatorWidgetStore | null | undefined = null;

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -36,6 +36,7 @@ import {
     AnimatorWidgetStore,
     type CatalogPanelLayoutSettings,
     CatalogPanelStore,
+    type CatalogPlotWidgetConfig,
     CatalogPlotWidgetStore,
     type CatalogPlotWidgetStoreProps,
     EmptyWidgetStore,
@@ -523,10 +524,10 @@ export class WidgetsStore {
                 itemId = this.initializeCatalogOverlayWidget(widgetSettings, preAssignedId);
                 break;
             case CatalogPlotType.D2Scatter:
-                itemId = this.initializeCatalogPlotWidget({xColumnName: "None", yColumnName: "None", plotType: CatalogPlotType.D2Scatter}, preAssignedId);
+                itemId = this.initializeCatalogPlotWidget({xColumnName: "None", yColumnName: "None", plotType: CatalogPlotType.D2Scatter}, preAssignedId, widgetSettings);
                 break;
             case CatalogPlotType.Histogram:
-                itemId = this.initializeCatalogPlotWidget({xColumnName: "None", yColumnName: undefined, plotType: CatalogPlotType.Histogram}, preAssignedId);
+                itemId = this.initializeCatalogPlotWidget({xColumnName: "None", yColumnName: undefined, plotType: CatalogPlotType.Histogram}, preAssignedId, widgetSettings);
                 break;
             default:
                 // Remove it from the floating widget array, while preserving its store
@@ -557,8 +558,8 @@ export class WidgetsStore {
         return itemId;
     };
 
-    private initializeCatalogPlotWidget = (props: CatalogPlotWidgetStoreProps, preAssignedId: string | null): string | null => {
-        const itemId = this.addCatalogPlotWidget(props, preAssignedId);
+    private initializeCatalogPlotWidget = (props: CatalogPlotWidgetStoreProps, preAssignedId: string | null, widgetSettings: object | null = null): string | null => {
+        const itemId = this.addCatalogPlotWidget(props, preAssignedId, widgetSettings);
         if (itemId) {
             const componentId = this.getNextComponentId(CatalogPlotComponent.WidgetConfig);
             CatalogStore.Instance.setCatalogPlots(componentId, 1, itemId);
@@ -1101,7 +1102,7 @@ export class WidgetsStore {
             return this.catalogPanelWidgets.get(widgetID)?.toLayoutSettings();
         }
 
-        let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | AnimatorWidgetStore | null | undefined = null;
+        let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | CatalogPlotWidgetStore | AnimatorWidgetStore | null | undefined = null;
         switch (widgetType) {
             case RenderConfigComponent.WidgetConfig.type:
                 widgetStore = this.renderConfigWidgets.get(widgetID);
@@ -1117,6 +1118,9 @@ export class WidgetsStore {
                 break;
             case StokesAnalysisComponent.WidgetConfig.type:
                 widgetStore = this.stokesAnalysisWidgets.get(widgetID);
+                break;
+            case CatalogPlotComponent.WidgetConfig.type:
+                widgetStore = this.catalogPlotWidgets.get(widgetID);
                 break;
             case AnimatorComponent.WidgetConfig.type:
                 widgetStore = this.animatorWidgets.get(widgetID);
@@ -1605,14 +1609,18 @@ export class WidgetsStore {
         return {widgetStoreId, widgetComponentId};
     };
 
-    @action addCatalogPlotWidget(props: CatalogPlotWidgetStoreProps, id: string | null = null) {
+    @action addCatalogPlotWidget(props: CatalogPlotWidgetStoreProps, id: string | null = null, widgetSettings: object | null = null) {
         // Generate new id if none passed in
         if (!id) {
             id = this.getNextId(CatalogPlotComponent.WidgetConfig.type);
         }
 
         if (id) {
-            this.catalogPlotWidgets.set(id, new CatalogPlotWidgetStore(props));
+            const widgetStore = new CatalogPlotWidgetStore(props);
+            if (widgetSettings) {
+                widgetStore.applyConfig(widgetSettings as Partial<CatalogPlotWidgetConfig>);
+            }
+            this.catalogPlotWidgets.set(id, widgetStore);
         }
         return id;
     }

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -543,7 +543,7 @@ export class WidgetsStore {
             const itemId = preAssignedId || this.getNextId(CatalogOverlayComponent.WidgetConfig.type);
             if (itemId) {
                 this.catalogOverlayWidgets.set(itemId, new EmptyWidgetStore());
-                CatalogStore.Instance.getOrCreateCatalogDisplayStore(catalogFileId).applyConfig(widgetSettings);
+                CatalogStore.Instance.getOrCreateCatalogDisplayStore(catalogFileId).applyLayoutSettings(widgetSettings);
                 // Ensure catalogProfiles is set to the saved fileId so the component can look
                 // up the correct file (the component constructor only defaults to fileId 1).
                 CatalogStore.Instance.catalogProfiles.set(itemId, catalogFileId);
@@ -1094,8 +1094,10 @@ export class WidgetsStore {
         }
 
         if (widgetType === CatalogOverlayComponent.WidgetConfig.type) {
+            // A layout keeps only the catalog a panel shows and the panel's own geometry; the
+            // rest of a catalog's appearance is display config and belongs to the workspace.
             const catalogFileId = CatalogStore.Instance.catalogProfiles.get(widgetID);
-            return catalogFileId !== undefined ? CatalogStore.Instance.getCatalogDisplayStore(catalogFileId)?.toConfig() : undefined;
+            return catalogFileId !== undefined ? CatalogStore.Instance.getCatalogDisplayStore(catalogFileId)?.toLayoutSettings() : undefined;
         }
 
         let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | AnimatorWidgetStore | null | undefined = null;

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -34,6 +34,8 @@ import {AppStore, CatalogStore, HelpStore, LayoutStore, PreferenceStore} from "s
 import {
     ACTIVE_FILE_ID,
     AnimatorWidgetStore,
+    type CatalogPanelLayoutSettings,
+    CatalogPanelStore,
     CatalogPlotWidgetStore,
     type CatalogPlotWidgetStoreProps,
     EmptyWidgetStore,
@@ -146,7 +148,7 @@ export class WidgetsStore {
     @observable channelMapControlWidgets: Map<string, EmptyWidgetStore> = new Map<string, EmptyWidgetStore>();
     @observable stokesAnalysisWidgets: Map<string, StokesAnalysisWidgetStore> = new Map<string, StokesAnalysisWidgetStore>();
     @observable floatingSettingsWidgets: Map<string, string> = new Map<string, string>();
-    @observable catalogOverlayWidgets: Map<string, EmptyWidgetStore> = new Map<string, EmptyWidgetStore>();
+    @observable catalogPanelWidgets: Map<string, CatalogPanelStore> = new Map<string, CatalogPanelStore>();
     @observable catalogPlotWidgets: Map<string, CatalogPlotWidgetStore> = new Map<string, CatalogPlotWidgetStore>();
     @observable spectralLineQueryWidgets: Map<string, SpectralLineQueryWidgetStore> = new Map<string, SpectralLineQueryWidgetStore>();
     @observable cursorInfoWidgets: Map<string, EmptyWidgetStore> = new Map<string, EmptyWidgetStore>();
@@ -363,7 +365,7 @@ export class WidgetsStore {
             [LogComponent.WidgetConfig.type, this.logWidgets],
             [RegionListComponent.WidgetConfig.type, this.regionListWidgets],
             [StokesAnalysisComponent.WidgetConfig.type, this.stokesAnalysisWidgets],
-            [CatalogOverlayComponent.WidgetConfig.type, this.catalogOverlayWidgets],
+            [CatalogOverlayComponent.WidgetConfig.type, this.catalogPanelWidgets],
             [CatalogPlotComponent.WidgetConfig.type, this.catalogPlotWidgets],
             [SpectralLineQueryComponent.WidgetConfig.type, this.spectralLineQueryWidgets],
             [CursorInfoComponent.WidgetConfig.type, this.cursorInfoWidgets],
@@ -540,17 +542,17 @@ export class WidgetsStore {
     private initializeCatalogOverlayWidget = (widgetSettings: object | null, preAssignedId: string | null): string | null => {
         if (widgetSettings && widgetSettings["catalogFileId"] !== undefined) {
             const catalogFileId = widgetSettings["catalogFileId"];
-            const itemId = preAssignedId || this.getNextId(CatalogOverlayComponent.WidgetConfig.type);
-            if (itemId) {
-                this.catalogOverlayWidgets.set(itemId, new EmptyWidgetStore());
-                CatalogStore.Instance.getOrCreateCatalogDisplayStore(catalogFileId).applyLayoutSettings(widgetSettings);
-                // Ensure catalogProfiles is set to the saved fileId so the component can look
-                // up the correct file (the component constructor only defaults to fileId 1).
-                CatalogStore.Instance.catalogProfiles.set(itemId, catalogFileId);
-            }
-            return itemId;
+            const selectedCatalogId = typeof catalogFileId === "number" ? catalogFileId : 1;
+            const componentId = preAssignedId || this.getNextComponentId(CatalogOverlayComponent.WidgetConfig);
+            this.getCatalogPanelStore(componentId, selectedCatalogId).applyLayoutSettings(widgetSettings as CatalogPanelLayoutSettings);
+            // Ensure catalogProfiles is set to the saved fileId so the component can look
+            // up the correct file (the component constructor only defaults to fileId 1).
+            CatalogStore.Instance.catalogProfiles.set(componentId, selectedCatalogId);
+            CatalogStore.Instance.getOrCreateCatalogDisplayStore(selectedCatalogId);
+            return componentId;
         }
         const itemId = preAssignedId || this.getNextComponentId(CatalogOverlayComponent.WidgetConfig);
+        this.getCatalogPanelStore(itemId);
         CatalogStore.Instance.catalogProfiles.set(itemId, 1);
         return itemId;
     };
@@ -1070,7 +1072,7 @@ export class WidgetsStore {
                             this.removeWidget(id, component);
                         }
                         if (isCatalogTable) {
-                            CatalogStore.Instance.catalogProfiles.delete(id);
+                            this.catalogPanelWidgets.delete(id);
                             this.removeAssociatedFloatingSetting(id);
                         }
                         if (isCatalogPlot) {
@@ -1096,8 +1098,7 @@ export class WidgetsStore {
         if (widgetType === CatalogOverlayComponent.WidgetConfig.type) {
             // A layout keeps only the catalog a panel shows and the panel's own geometry; the
             // rest of a catalog's appearance is display config and belongs to the workspace.
-            const catalogFileId = CatalogStore.Instance.catalogProfiles.get(widgetID);
-            return catalogFileId !== undefined ? CatalogStore.Instance.getCatalogDisplayStore(catalogFileId)?.toLayoutSettings() : undefined;
+            return this.catalogPanelWidgets.get(widgetID)?.toLayoutSettings();
         }
 
         let widgetStore: RenderConfigWidgetStore | SpatialProfileWidgetStore | SpectralProfileWidgetStore | HistogramWidgetStore | StokesAnalysisWidgetStore | AnimatorWidgetStore | null | undefined = null;
@@ -1515,7 +1516,7 @@ export class WidgetsStore {
         if (config.type === CatalogPlotComponent.WidgetConfig.type) {
             CatalogStore.Instance.catalogPlots.forEach((_v, componentId) => componentIds.push(componentId));
         } else if (config.type === CatalogOverlayComponent.WidgetConfig.type) {
-            CatalogStore.Instance.catalogProfiles.forEach((_v, componentId) => componentIds.push(componentId));
+            this.catalogPanelWidgets.forEach((_v, componentId) => componentIds.push(componentId));
         }
 
         while (true) {
@@ -1530,8 +1531,10 @@ export class WidgetsStore {
     createFloatingCatalogWidget = (catalogFileId: number): string => {
         CatalogStore.Instance.getOrCreateCatalogDisplayStore(catalogFileId);
         const widgetComponentId = this.getNextComponentId(CatalogOverlayComponent.WidgetConfig);
+        this.getCatalogPanelStore(widgetComponentId, catalogFileId);
         const config = new WidgetConfig(widgetComponentId, CatalogOverlayComponent.WidgetConfig);
         config.componentId = widgetComponentId;
+        CatalogStore.Instance.catalogProfiles.set(widgetComponentId, catalogFileId);
         this.addFloatingWidget(config);
         return widgetComponentId;
     };
@@ -1543,9 +1546,46 @@ export class WidgetsStore {
         const config = new WidgetConfig(componentId, CatalogOverlayComponent.WidgetConfig);
         config.componentId = componentId;
         if (catalogFileNum) {
+            this.getCatalogPanelStore(componentId, catalogFileNum);
             CatalogStore.Instance.catalogProfiles.set(componentId, catalogFileNum);
         }
         this.addFloatingWidget(config);
+    };
+
+    /** Get or create the panel-scoped state for one catalog overlay component. */
+    @action getCatalogPanelStore = (componentId: string, selectedCatalogId: number = 1): CatalogPanelStore => {
+        let panelStore = this.catalogPanelWidgets.get(componentId);
+        if (!panelStore) {
+            panelStore = new CatalogPanelStore(selectedCatalogId, componentId);
+            this.catalogPanelWidgets.set(componentId, panelStore);
+        }
+        return panelStore;
+    };
+
+    /** Select a loaded catalog in one panel by its component ID. */
+    @action setCatalogPanelSelection = (componentId: string, catalogFileId: number): boolean => {
+        if (!CatalogStore.Instance.catalogProfileStores.has(catalogFileId)) {
+            return false;
+        }
+        const panelStore = this.catalogPanelWidgets.get(componentId);
+        if (!panelStore) {
+            return false;
+        }
+        panelStore.setSelectedCatalogId(catalogFileId);
+        CatalogStore.Instance.catalogProfiles.set(componentId, catalogFileId);
+        return true;
+    };
+
+    /** Select a catalog in the first panel when an image-view interaction identifies it. */
+    @action updateCatalogPanelSelection = (catalogFileId: number) => {
+        const panel = Array.from(this.catalogPanelWidgets.values()).find(panelStore => panelStore.selectedCatalogId === catalogFileId) ?? Array.from(this.catalogPanelWidgets.values())[0];
+        if (panel) {
+            panel.setSelectedCatalogId(catalogFileId);
+            const componentId = Array.from(this.catalogPanelWidgets.entries()).find(([, panelStore]) => panelStore === panel)?.[0];
+            if (componentId) {
+                CatalogStore.Instance.catalogProfiles.set(componentId, catalogFileId);
+            }
+        }
     };
 
     // endregion

--- a/src/stores/Widgets/WidgetsStore.ts
+++ b/src/stores/Widgets/WidgetsStore.ts
@@ -549,8 +549,8 @@ export class WidgetsStore {
             // Ensure catalogProfiles is set to the saved fileId so the component can look
             // up the correct file (the component constructor only defaults to fileId 1).
             CatalogStore.Instance.catalogProfiles.set(componentId, selectedCatalogId);
-            // PR2 stored display settings with catalog-prefixed names. Normalize them at the
-            // restore boundary while allowing the current workspace names to take precedence.
+            // Older workspace layouts stored display settings with catalog-prefixed names. Normalize
+            // them at the restore boundary while allowing the current workspace names to take precedence.
             const displaySettings = {
                 ...widgetSettings,
                 color: widgetSettings["color"] ?? widgetSettings["catalogColor"],

--- a/src/stores/Widgets/index.ts
+++ b/src/stores/Widgets/index.ts
@@ -1,4 +1,5 @@
 export * from "./AnimatorWidgetStore/AnimatorWidgetStore";
+export * from "./CatalogWidget/CatalogPanelStore";
 export * from "./CatalogWidget/CatalogPlotWidgetStore";
 export * from "./EmptyWidgetStore";
 export * from "./HistogramWidgetStore/HistogramWidgetStore";

--- a/src/utilities/scaling/scaling.ts
+++ b/src/utilities/scaling/scaling.ts
@@ -63,6 +63,61 @@ export function getScalingForParameterPreference(preferenceKey: PreferenceKeys):
     return undefined;
 }
 
+/** A set of scaling parameters in serialisable form, one entry per scaling that takes a parameter. */
+export interface ScalingParameters {
+    log?: number;
+    gamma?: number;
+    power?: number;
+    sinh?: number;
+    asinh?: number;
+}
+
+/**
+ * The serialised name of each scaling that takes a parameter. These names are part of the stored
+ * format, so they are written out rather than derived from the enum.
+ */
+export const SCALING_PARAMETER_KEYS: ReadonlyArray<[keyof ScalingParameters, FrameScaling]> = [
+    ["log", FrameScaling.LOG],
+    ["gamma", FrameScaling.GAMMA],
+    ["power", FrameScaling.POWER],
+    ["sinh", FrameScaling.SINH],
+    ["asinh", FrameScaling.ASINH]
+];
+
+export const PARAMETERIZED_SCALINGS: ReadonlyArray<FrameScaling> = SCALING_PARAMETER_KEYS.map(([, scaling]) => scaling);
+
+/** A parameter map holding the default for every scaling that takes one. */
+export function createScalingParameters(): Map<FrameScaling, number> {
+    return new Map(PARAMETERIZED_SCALINGS.map(scaling => [scaling, getDefaultScalingParameter(scaling)]));
+}
+
+export function getScalingParameter(parameters: Map<FrameScaling, number>, scaling: FrameScaling): number {
+    return parameters.get(scaling) ?? getDefaultScalingParameter(scaling);
+}
+
+export function scalingParametersToConfig(parameters: Map<FrameScaling, number>): ScalingParameters {
+    const config: ScalingParameters = {};
+    for (const [key, scaling] of SCALING_PARAMETER_KEYS) {
+        const value = parameters.get(scaling);
+        if (value !== undefined) {
+            config[key] = value;
+        }
+    }
+    return config;
+}
+
+/** Parameters a config leaves out fall back to their defaults, and the rest are range checked. */
+export function scalingParametersFromConfig(config: ScalingParameters | undefined): Map<FrameScaling, number> {
+    const parameters = createScalingParameters();
+    for (const [key, scaling] of SCALING_PARAMETER_KEYS) {
+        const value = config?.[key];
+        if (value !== undefined) {
+            parameters.set(scaling, sanitizeScalingParameter(scaling, value));
+        }
+    }
+    return parameters;
+}
+
 export function sanitizeScalingParameter(scaling: FrameScaling, value: number, fallback: number = getDefaultScalingParameter(scaling)): number {
     const config = getScalingParameterConfig(scaling);
     if (!config) {


### PR DESCRIPTION
**Description**

This PR separates catalog panel state from catalog display settings, consolidates catalog and plot configuration handling, and prepares workspace persistence for multiple catalogs and panels.

Known behaviour changes:
1. When two catalog widgets show the same catalog and both settings panels are open, switching the settings tab in one widget no longer switches the other widget's tab. Each panel now owns its settings tab.
2. When two catalog widgets show different catalogs (A and B) and an image is appended, both widgets temporarily become empty. After switching back to the original image, each widget restores its own catalog selection (A and B) instead of both switching to A.

What is implemented:
- Separate catalog display configuration from panel-scoped layout state, while retaining compatibility with older workspace layouts.
- Restore each catalog overlay and plot against the catalog it was saved with, including mapped columns, scaling parameters, clipping, colors, sizes, and axes.
- Preserve panel-specific state such as the selected catalog, table separator, and settings section; remember settings sections independently for each catalog shown in a panel.
- Track catalog filter request IDs to ignore stale streamed responses; defer display configuration until catalog data is ready and reject invalid configs without partial mutation.
- Add unit coverage for configuration round trips, catalog selection synchronization, filter request tracking, and workspace restoration.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] ~~changelog updated~~ / no changelog update needed
- [x] unit test added (for functions with no dependenies)
- [x] API documentation added (for public variables and methods in stores)

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~~protobuf version bumped~~ / no protobuf version bumped needed
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~corresponding ICD test fix added (`BackendService` changed)~~ / no ICD test fix needed (`BackendService` unchanged)
- [ ] user manual prepared (for large new features)