### PR TITLE
Fix catalog overlay color mapping after replotting with a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed persistent scrollbars in the region list and catalog scatter plot, and fixed the catalog plot widget toolbar being clipped without a scrollbar when the widget is too narrow ([#2848](https://github.com/CARTAvis/carta-frontend/issues/2848)).
 * Fixed incorrect color mapping in the Stokes QU scatter plot after applying data smoothing ([#2851](https://github.com/CARTAvis/carta-frontend/issues/2851)).
 * Fixed workspaces failing to load images from a non-zeroth HDU with "does not exist" ([#2934](https://github.com/CARTAvis/carta-frontend/issues/2934)).
+* Fixed incorrect color, size, and orientation mapping of catalog overlay sources after replotting with a new column filter ([#2849](https://github.com/CARTAvis/carta-frontend/issues/2849)).
 ### Changed
 * Replaced both axes zooming with independent X and Y axis zooming in PV images, PV preview, and rotated cubes ([#2408](https://github.com/CARTAvis/carta-frontend/issues/2408)).
 

--- a/src/stores/Catalog/CatalogDisplayStore.test.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.test.ts
@@ -153,4 +153,40 @@ describe("CatalogDisplayStore overlay maps after replotting", () => {
         expect(displayStore.sizeColumnMax.default).toBe(30);
         expect(updateDataTexture).toHaveBeenLastCalledWith(fileId, Float32Array.from([20, 30]), CatalogTextureType.Size);
     });
+
+    test("keeps the canvas size range when the sources are replotted", () => {
+        displayStore.setSizeMap("FLUX");
+        displayStore.setSizeMax(30);
+        displayStore.setSizeMin(8);
+
+        columnData = Float32Array.from([20, 30]);
+        replot(columnData.length);
+        expect([displayStore.sizeMin.diameter, displayStore.sizeMax.diameter]).toEqual([8, 30]);
+    });
+
+    // In world mode the columns are used as they are: the output range has to follow the data range (PR #2965 review)
+    test("keeps the angular size range equal to the data range when the sources are replotted", () => {
+        displayStore.setCatalogDisplayMode(CatalogDisplayMode.WORLD);
+        displayStore.setSizeMap("MAJOR_AXIS");
+        expect([displayStore.sizeMin.diameter, displayStore.sizeMax.diameter]).toEqual([10, 40]);
+
+        columnData = Float32Array.from([20, 30]);
+        replot(columnData.length);
+        expect([displayStore.sizeColumnMin.clipd, displayStore.sizeColumnMax.clipd]).toEqual([20, 30]);
+        expect([displayStore.sizeMin.diameter, displayStore.sizeMax.diameter]).toEqual([20, 30]);
+        expect(CARTACompute.CalculateCatalogSize).toHaveBeenLastCalledWith(expect.any(Float32Array), 20, 30, 20, 30, expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything());
+    });
+
+    test("keeps the position angle range equal to the data range when the sources are replotted", () => {
+        jest.spyOn(CARTACompute, "CalculateCatalogOrientation").mockImplementation((column: Float32Array) => Float32Array.from(column));
+        displayStore.setCatalogDisplayMode(CatalogDisplayMode.WORLD);
+        displayStore.setOrientationMapColumn("PA");
+        expect([displayStore.angleMin, displayStore.angleMax]).toEqual([10, 40]);
+
+        columnData = Float32Array.from([20, 30]);
+        replot(columnData.length);
+        expect([displayStore.orientationMin.clipd, displayStore.orientationMax.clipd]).toEqual([20, 30]);
+        expect([displayStore.angleMin, displayStore.angleMax]).toEqual([20, 30]);
+        expect(CARTACompute.CalculateCatalogOrientation).toHaveBeenLastCalledWith(expect.any(Float32Array), 20, 30, 20, 30, expect.anything(), expect.anything(), expect.anything());
+    });
 });

--- a/src/stores/Catalog/CatalogDisplayStore.test.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.test.ts
@@ -1,6 +1,8 @@
 import * as CARTACompute from "carta_computation";
+import {runInAction} from "mobx";
 
-import {CatalogDisplayMode, CatalogSizeUnits} from "enums";
+import {CatalogDisplayMode, CatalogSizeUnits, CatalogTextureType} from "enums";
+import {CatalogWebGLService} from "services";
 import {CatalogDisplayStore, type CatalogProfileStore, CatalogStore} from "stores";
 
 describe("CatalogDisplayStore angular size axis type", () => {
@@ -64,5 +66,91 @@ describe("CatalogDisplayStore angular size axis type", () => {
             }
             calculateCatalogSize.mockRestore();
         }
+    });
+});
+
+describe("CatalogDisplayStore overlay maps after replotting", () => {
+    const fileId = 246810;
+    const catalogStore = CatalogStore.Instance;
+    let columnData: Float32Array;
+    let previousProfileStore: CatalogProfileStore | undefined;
+    let displayStore: CatalogDisplayStore;
+    let updateDataTexture: jest.SpyInstance;
+
+    // Rebuilding the overlay positions (Plot, a filter, streamed data) resets and refills the plotted source count
+    const replot = (sourceCount: number) => {
+        runInAction(() => {
+            catalogStore.catalogCounts.set(fileId, 0);
+            catalogStore.catalogCounts.set(fileId, sourceCount);
+        });
+    };
+
+    beforeEach(() => {
+        columnData = Float32Array.from([10, 20, 30, 40]);
+        // the catalog data of the profile store is not observable: the accessor returns whatever data is currently loaded
+        const profileStore = {get1DPlotData: jest.fn(() => ({wcsData: columnData}))};
+        previousProfileStore = catalogStore.catalogProfileStores.get(fileId) as CatalogProfileStore | undefined;
+        runInAction(() => {
+            catalogStore.catalogProfileStores.set(fileId, profileStore as unknown as CatalogProfileStore);
+            catalogStore.catalogCounts.set(fileId, columnData.length);
+        });
+        updateDataTexture = jest.spyOn(CatalogWebGLService.Instance, "updateDataTexture").mockImplementation(() => {});
+        jest.spyOn(CARTACompute, "CalculateCatalogColor").mockImplementation((column: Float32Array) => Float32Array.from(column));
+        jest.spyOn(CARTACompute, "CalculateCatalogSize").mockImplementation((column: Float32Array) => Float32Array.from(column));
+        displayStore = new CatalogDisplayStore(fileId);
+    });
+
+    afterEach(() => {
+        displayStore.dispose();
+        runInAction(() => {
+            if (previousProfileStore) {
+                catalogStore.catalogProfileStores.set(fileId, previousProfileStore);
+            } else {
+                catalogStore.catalogProfileStores.delete(fileId);
+            }
+            catalogStore.catalogCounts.delete(fileId);
+        });
+        jest.restoreAllMocks();
+    });
+
+    test("recomputes the color texture from the current catalog data when the sources are replotted", () => {
+        displayStore.setColorMapColumn("ANG_DIST");
+        expect(displayStore.colorColumnMin.default).toBe(10);
+        expect(displayStore.colorColumnMax.default).toBe(40);
+        expect(updateDataTexture).toHaveBeenLastCalledWith(fileId, Float32Array.from([10, 20, 30, 40]), CatalogTextureType.Color);
+
+        // a filter replaces the loaded catalog data without any observable change (#2849)
+        updateDataTexture.mockClear();
+        columnData = Float32Array.from([20, 30]);
+        expect(updateDataTexture).not.toHaveBeenCalled();
+
+        replot(columnData.length);
+        expect(displayStore.colorColumnMin.default).toBe(20);
+        expect(displayStore.colorColumnMax.default).toBe(30);
+        expect(updateDataTexture).toHaveBeenLastCalledWith(fileId, Float32Array.from([20, 30]), CatalogTextureType.Color);
+    });
+
+    test("keeps a customized color range when the same sources are replotted", () => {
+        displayStore.setColorMapColumn("ANG_DIST");
+        displayStore.setColorColumnMin(15, "clipd");
+        displayStore.setColorColumnMax(35, "clipd");
+
+        replot(columnData.length);
+        expect(displayStore.colorColumnMin.default).toBe(10);
+        expect(displayStore.colorColumnMin.clipd).toBe(15);
+        expect(displayStore.colorColumnMax.default).toBe(40);
+        expect(displayStore.colorColumnMax.clipd).toBe(35);
+        expect(CARTACompute.CalculateCatalogColor).toHaveBeenLastCalledWith(expect.any(Float32Array), false, 15, 35, expect.anything(), expect.anything(), expect.anything());
+    });
+
+    test("recomputes the size texture from the current catalog data when the sources are replotted", () => {
+        displayStore.setSizeMap("FLUX");
+        expect(updateDataTexture).toHaveBeenLastCalledWith(fileId, Float32Array.from([10, 20, 30, 40]), CatalogTextureType.Size);
+
+        columnData = Float32Array.from([20, 30]);
+        replot(columnData.length);
+        expect(displayStore.sizeColumnMin.default).toBe(20);
+        expect(displayStore.sizeColumnMax.default).toBe(30);
+        expect(updateDataTexture).toHaveBeenLastCalledWith(fileId, Float32Array.from([20, 30]), CatalogTextureType.Size);
     });
 });

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -139,16 +139,23 @@ export class CatalogDisplayStore {
         this.catalogFileId = catalogFileId;
         makeObservable(this);
 
+        // In world (angular size) mode the size and orientation columns are used as they are: the output ranges are kept equal to the
+        // data range, as when the column is selected, so that the mapping stays an identity when the data changes (e.g. a filter)
         this.disposers.push(
             reaction(
                 () => this.sizeMapData,
                 column => {
                     const {minVal, maxVal} = getDefaultRange(column);
+                    const isRangeChanged = minVal !== this.sizeColumnMin.default || maxVal !== this.sizeColumnMax.default;
                     if (minVal !== this.sizeColumnMin.default) {
                         this.setSizeColumnMin(minVal, "default");
                     }
                     if (maxVal !== this.sizeColumnMax.default) {
                         this.setSizeColumnMax(maxVal, "default");
+                    }
+                    if (isRangeChanged && column.length && this.catalogDisplayMode === CatalogDisplayMode.WORLD) {
+                        this.setSizeMax(maxVal);
+                        this.setSizeMin(minVal);
                     }
                 }
             )
@@ -192,11 +199,16 @@ export class CatalogDisplayStore {
                 () => this.sizeMinorMapData,
                 column => {
                     const {minVal, maxVal} = getDefaultRange(column);
+                    const isRangeChanged = minVal !== this.sizeMinorColumnMin.default || maxVal !== this.sizeMinorColumnMax.default;
                     if (minVal !== this.sizeMinorColumnMin.default) {
                         this.setSizeMinorColumnMin(minVal, "default");
                     }
                     if (maxVal !== this.sizeMinorColumnMax.default) {
                         this.setSizeMinorColumnMax(maxVal, "default");
+                    }
+                    if (isRangeChanged && column.length && this.catalogDisplayMode === CatalogDisplayMode.WORLD) {
+                        this.setMinorSizeMax(maxVal);
+                        this.setMinorSizeMin(minVal);
                     }
                 }
             )
@@ -266,11 +278,16 @@ export class CatalogDisplayStore {
                 () => this.orientationMapData,
                 column => {
                     const {minVal, maxVal} = getDefaultRange(column);
+                    const isRangeChanged = minVal !== this.orientationMin.default || maxVal !== this.orientationMax.default;
                     if (minVal !== this.orientationMin.default) {
                         this.setOrientationMin(minVal, "default");
                     }
                     if (maxVal !== this.orientationMax.default) {
                         this.setOrientationMax(maxVal, "default");
+                    }
+                    if (isRangeChanged && column.length && this.catalogDisplayMode === CatalogDisplayMode.WORLD) {
+                        this.setAngleMax(maxVal);
+                        this.setAngleMin(minVal);
                     }
                 }
             )

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -139,8 +139,6 @@ export class CatalogDisplayStore {
         this.catalogFileId = catalogFileId;
         makeObservable(this);
 
-        // In world (angular size) mode the size and orientation columns are used as they are: the output ranges are kept equal to the
-        // data range, as when the column is selected, so that the mapping stays an identity when the data changes (e.g. a filter)
         this.disposers.push(
             reaction(
                 () => this.sizeMapData,

--- a/src/stores/Catalog/CatalogDisplayStore.ts
+++ b/src/stores/Catalog/CatalogDisplayStore.ts
@@ -20,6 +20,11 @@ function getScalingParameter(parameters: Map<FrameScaling, number>, scaling: Fra
     return parameters.get(scaling) ?? getDefaultScalingParameter(scaling);
 }
 
+function getDefaultRange(column: Float32Array): {minVal: number; maxVal: number} {
+    const result = minMaxArray(column);
+    return {minVal: isFinite(result.minVal) ? result.minVal : 0, maxVal: isFinite(result.maxVal) ? result.maxVal : 0};
+}
+
 export class CatalogDisplayStore {
     public static readonly MIN_OVERLAY_SIZE = 1;
     public static readonly MAX_OVERLAY_SIZE = 50;
@@ -138,9 +143,13 @@ export class CatalogDisplayStore {
             reaction(
                 () => this.sizeMapData,
                 column => {
-                    const result = minMaxArray(column);
-                    this.setSizeColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                    this.setSizeColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    const {minVal, maxVal} = getDefaultRange(column);
+                    if (minVal !== this.sizeColumnMin.default) {
+                        this.setSizeColumnMin(minVal, "default");
+                    }
+                    if (maxVal !== this.sizeColumnMax.default) {
+                        this.setSizeColumnMax(maxVal, "default");
+                    }
                 }
             )
         );
@@ -182,9 +191,13 @@ export class CatalogDisplayStore {
             reaction(
                 () => this.sizeMinorMapData,
                 column => {
-                    const result = minMaxArray(column);
-                    this.setSizeMinorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                    this.setSizeMinorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    const {minVal, maxVal} = getDefaultRange(column);
+                    if (minVal !== this.sizeMinorColumnMin.default) {
+                        this.setSizeMinorColumnMin(minVal, "default");
+                    }
+                    if (maxVal !== this.sizeMinorColumnMax.default) {
+                        this.setSizeMinorColumnMax(maxVal, "default");
+                    }
                 }
             )
         );
@@ -226,9 +239,13 @@ export class CatalogDisplayStore {
             reaction(
                 () => this.colorMapData,
                 column => {
-                    const result = minMaxArray(column);
-                    this.setColorColumnMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                    this.setColorColumnMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    const {minVal, maxVal} = getDefaultRange(column);
+                    if (minVal !== this.colorColumnMin.default) {
+                        this.setColorColumnMin(minVal, "default");
+                    }
+                    if (maxVal !== this.colorColumnMax.default) {
+                        this.setColorColumnMax(maxVal, "default");
+                    }
                 }
             )
         );
@@ -248,9 +265,13 @@ export class CatalogDisplayStore {
             reaction(
                 () => this.orientationMapData,
                 column => {
-                    const result = minMaxArray(column);
-                    this.setOrientationMin(isFinite(result.minVal) ? result.minVal : 0, "default");
-                    this.setOrientationMax(isFinite(result.maxVal) ? result.maxVal : 0, "default");
+                    const {minVal, maxVal} = getDefaultRange(column);
+                    if (minVal !== this.orientationMin.default) {
+                        this.setOrientationMin(minVal, "default");
+                    }
+                    if (maxVal !== this.orientationMax.default) {
+                        this.setOrientationMax(maxVal, "default");
+                    }
                 }
             )
         );
@@ -945,16 +966,26 @@ export class CatalogDisplayStore {
     }
 
     /**
+     * Column data of a size, color, or orientation map for the plotted catalog sources
+     */
+    private getMapColumnData(column: string, isDisabled: boolean): Float32Array {
+        const catalogStore = CatalogStore.Instance;
+        // dummy value to trigger update when the overlay positions are rebuilt, since profileStore.catalogData is not observable
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const plottedSourceCount = catalogStore.catalogCounts.get(this.catalogFileId);
+        const catalogProfileStore = catalogStore.catalogProfileStores.get(this.catalogFileId);
+        if (!isDisabled && catalogProfileStore) {
+            const data = catalogProfileStore.get1DPlotData(column).wcsData;
+            return data ? Float32Array.from(data) : new Float32Array(0);
+        }
+        return new Float32Array(0);
+    }
+
+    /**
      * Orientation data for catalog sources
      */
     @computed get orientationMapData(): Float32Array {
-        const catalogProfileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
-        if (!this.isOrientationMapDisabled && catalogProfileStore) {
-            const column = catalogProfileStore.get1DPlotData(this.orientationMapColumn).wcsData;
-            return column ? Float32Array.from(column) : new Float32Array(0);
-        } else {
-            return new Float32Array(0);
-        }
+        return this.getMapColumnData(this.orientationMapColumn, this.isOrientationMapDisabled);
     }
 
     orientationArray(): Float32Array {
@@ -978,13 +1009,7 @@ export class CatalogDisplayStore {
      * Color data for catalog sources
      */
     @computed get colorMapData(): Float32Array {
-        const catalogProfileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
-        if (!this.isColorMapDisabled && catalogProfileStore) {
-            const column = catalogProfileStore.get1DPlotData(this.colorMapColumn).wcsData;
-            return column ? Float32Array.from(column) : new Float32Array(0);
-        } else {
-            return new Float32Array(0);
-        }
+        return this.getMapColumnData(this.colorMapColumn, this.isColorMapDisabled);
     }
 
     colorArray(): Float32Array {
@@ -999,26 +1024,14 @@ export class CatalogDisplayStore {
      * Size data for catalog sources
      */
     @computed get sizeMapData(): Float32Array {
-        const catalogProfileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
-        if (!this.isSizeMapDisabled && catalogProfileStore) {
-            const column = catalogProfileStore.get1DPlotData(this.sizeMapColumn).wcsData;
-            return column ? Float32Array.from(column) : new Float32Array(0);
-        } else {
-            return new Float32Array(0);
-        }
+        return this.getMapColumnData(this.sizeMapColumn, this.isSizeMapDisabled);
     }
 
     /**
      * Minor size data for catalog sources
      */
     @computed get sizeMinorMapData(): Float32Array {
-        const catalogProfileStore = CatalogStore.Instance.catalogProfileStores.get(this.catalogFileId);
-        if (!this.isSizeMinorMapDisabled && catalogProfileStore) {
-            const column = catalogProfileStore.get1DPlotData(this.sizeMinorMapColumn).wcsData;
-            return column ? Float32Array.from(column) : new Float32Array(0);
-        } else {
-            return new Float32Array(0);
-        }
+        return this.getMapColumnData(this.sizeMinorMapColumn, this.isSizeMinorMapDisabled);
     }
 
     /**


### PR DESCRIPTION
**Description**

Fixes #2849. With a catalog image overlay colored by a column (e.g., `ANG_DIST` with `tab10`), applying a column filter and clicking Plot again leaves the sources with the wrong colors. The same applies to size and orientation mapping.

Root cause: the map textures uploaded to WebGL (`colorArray`, `sizeArray`, `sizeMinorArray`, `orientationArray` in `CatalogDisplayStore`) are derived from `@computed` getters that read the column values from the profile store's catalog data. That data is a plain, non-observable `Map` which the filter response mutates in place, so nothing invalidates the computed values: the color texture keeps the unfiltered values while the overlay positions are rebuilt for the filtered sources. The shader looks both textures up by source index, so filtered source *i* is drawn with the color of unfiltered row *i*.

**How to fix**

- `CatalogDisplayStore` reads the number of plotted sources (`CatalogStore.catalogCounts`) as an observable dependency of the four map-data computations, through a shared `getMapColumnData` helper. That count is reset and refilled whenever the overlay positions are rebuilt (Plot, a filter, each streamed chunk in view-update mode), which is exactly when the map textures have to follow the current data. The same trick is already used in `CatalogPlotComponent` (`numVisibleRows` as a dummy dependency) for the same non-observable data.

- The reactions that recompute the default min/max of each map now only reset the range when the data range actually changed. Without this, every replot of unchanged data would have discarded a user's clipped min/max, which was not the case before the fix.

- Unit tests for the color and size textures being recomputed from the current data on replot, and for a clipped color range surviving a replot of the same sources.

**Checklist**

For linked issues (if there are):
- [x] assignee and label added
- [x] GitHub Project estimate added

For the pull request:
- [x] reviewers and assignee added
- [x] GitHub Project estimate added
- [x] changelog updated ~/ no changelog update needed~
- [x] unit test added ~(for functions with no dependenies)~
- [x] ~API documentation added (for public variables and methods in stores)~

For dependencies:
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf version bumped /~ no protobuf version bumped needed
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~corresponding ICD test fix added (`BackendService` changed) /~ no ICD test fix needed (`BackendService` unchanged)
- [x] ~user manual prepared (for large new features)~